### PR TITLE
Remove using `feature` context.

### DIFF
--- a/app/dialplan/resources/switch/conf/dialplan/380_hold_music.xml
+++ b/app/dialplan/resources/switch/conf/dialplan/380_hold_music.xml
@@ -3,12 +3,12 @@
 		<condition field="destination_number" expression="^\*9664$"/>
 		<condition field="${sip_has_crypto}" expression="^(AES_CM_128_HMAC_SHA1_32|AES_CM_128_HMAC_SHA1_80)$">
 			<action application="answer"/>
-			<action application="execute_extension" data="is_secure XML features"/>
+			<action application="execute_extension" data="is_secure XML ${context}"/>
 			<action application="playback" data="$${hold_music}"/>
 			<anti-action application="set" data="zrtp_secure_media=true"/>
 			<anti-action application="answer"/>
 			<anti-action application="playback" data="silence_stream://2000"/>
-			<anti-action application="execute_extension" data="is_zrtp_secure XML features"/>
+			<anti-action application="execute_extension" data="is_zrtp_secure XML ${context}"/>
 			<anti-action application="playback" data="$${hold_music}"/>
 		</condition>
 	</extension>

--- a/app/dialplan/resources/switch/conf/dialplan/480_operator.xml
+++ b/app/dialplan/resources/switch/conf/dialplan/480_operator.xml
@@ -2,8 +2,8 @@
 	<extension name="operator" number="0" continue="false" app_uuid="0e1cd2d7-9d84-4959-8b6c-0cb23de4de59">
 		<condition field="destination_number" expression="^0$|^operator$">
 			<action application="export" data="transfer_context={v_context}" />
-			<action application="bind_meta_app" data="4 ab s execute_extension::att_xfer XML features" />
-			<action application="bind_meta_app" data="5 ab s execute_extension::xfer_vm XML features" />
+			<action application="bind_meta_app" data="4 ab s execute_extension::att_xfer XML ${context}" />
+			<action application="bind_meta_app" data="5 ab s execute_extension::xfer_vm XML ${context}" />
 			<action application="set" data="domain_name={v_context}" />
 			<action application="transfer" data="1001 XML {v_context}"/>
 		</condition>


### PR DESCRIPTION
Default dilplan context contains all needed extension to does not use `feature` context.