### PR TITLE
Update contacts.php

### DIFF
--- a/app/contacts/contacts.php
+++ b/app/contacts/contacts.php
@@ -22,6 +22,7 @@
 
 	Contributor(s):
 	Mark J Crane <markjcrane@fusionpbx.com>
+	Luis Daniel Lucio Quiroz <dlucio@okay.com.mx>
 */
 require_once "root.php";
 require_once "resources/require.php";
@@ -53,7 +54,8 @@ else {
 
 //retrieve current user's assigned groups (uuids)
 	foreach ($_SESSION['groups'] as $group_data) {
-		$user_group_uuids[] = $group_data['group_uuid'];
+		if (strlen($group_data['group_uuid'])>0)
+			$user_group_uuids[] = $group_data['group_uuid'];
 	}
 	//add user's uuid to group uuid list to include private (non-shared) contacts
 	$user_group_uuids[] = $_SESSION["user_uuid"];


### PR DESCRIPTION
In some cases, the $_SESSION['groups'] array has a '' elemenl (null element). This makes PostgreSQL to break (Mysql/Mariadb are tolerant to this) at like 80 when doing the SQLsentence: .....where group_uuid in ('".implode("','", $user_group_uuids)."') ";  as it will create a query like: group_uuid in ('','XXXXXXX'.......) which it wont work.