### PR TITLE
Add. Ability to invite new users to existing page.

### DIFF
--- a/app/dialplan/resources/switch/conf/dialplan/250_page-extension.xml
+++ b/app/dialplan/resources/switch/conf/dialplan/250_page-extension.xml
@@ -1,11 +1,55 @@
 <context name="{v_context}">
 	<extension name="page-extension" number="*8[ext]" continue="false" app_uuid="1b224444-de8b-448d-b2d1-19feaac3effa">
-		<condition field="destination_number" expression="^\*8(\d{2,7})$">
+		<condition field="destination_number" expression="^\*8(\d{2,7})$" break="on-true">
 			<action application="set" data="extension_list=$1"/>
+			<action application="set" data="page_extension=page-*8$1%${domain_name}" inline="true"/>
+			<action application="set" data="page_allow_access=true"/>
 			<action application="set" data="pin_number={v_pin_number}"/>
 			<action application="set" data="mute=true"/>
-			<action application="set" data="moderator=false" />
+			<action application="set" data="moderator=false"/>
+			<action application="bind_digit_action" data="page,*#,exec:execute_extension,page_add_begin XML ${domain_name}"/>
+			<action application="digit_action_set_realm" data="page"/>
 			<action application="lua" data="page.lua"/>
+		</condition>
+		<condition field="destination_number" expression="^page_add_begin$" break="on-true">
+			<action application="set" data="api_result=${conference(${page_extension} unmute ${conference_member_id} quiet)}"/>
+			<action application="bind_digit_action" data="page-xfer,*0,api:lua,page_transfer_to.lua ${uuid}"/>
+			<action application="bind_digit_action" data="page-xfer,*#,api:lua,unbridge.lua ${uuid}"/>
+			<action application="bind_digit_action" data="none,NONE,api:sleep,1"/>
+			<action application="set" data="continue_on_fail=true"/>
+			<action application="execute_extension" data="page_enter_number"/>
+		</condition>
+		<condition field="destination_number" expression="^page_add_end$" break="on-true">
+			<action application="digit_action_set_realm" data="page"/>
+			<action application="set" data="api_result=${conference(${page_extension} mute ${conference_member_id})}"/>
+		</condition>
+		<condition field="destination_number" expression="^page_enter_number$" break="on-true">
+			<action application="digit_action_set_realm" data="none"/>
+			<action application="read" data="2 11 'tone_stream://%(10000,0,350,440)' target_num 30000 #"/>
+			<action application="execute_extension" data="page_bridge_${target_num}"/>
+		</condition>
+		<condition field="destination_number" expression="^page_bridge_$" break="on-true">
+			<action application="execute_extension" data="page_add_end"/>
+		</condition>
+		<condition field="destination_number" expression="^page_bridge_\*$" break="on-true">
+			<action application="execute_extension" data="page_add_end"/>
+		</condition>
+		<condition field="destination_number" expression="^page_bridge_(\d{2,7})$" break="on-true">
+			<action application="digit_action_set_realm" data="page-xfer"/>
+			<action application="bridge" data="{page_allow_access=true,page_extension=${page_extension}}user/$1@${domain_name}"/>
+			<action application="execute_extension" data="page_enter_number"/>
+		</condition>
+		<condition field="destination_number" expression="^page_bridge_" break="on-true">
+			<action application="playback" data="voicemail/vm-that_was_an_invalid_ext.wav"/>
+			<action application="execute_extension" data="page_enter_number"/>
+		</condition>
+		<condition field="${page_allow_access}" expression="^true$" break="on-false"/>
+		<condition field="destination_number" expression="^page_enter_to$" break="on-true">
+			<action application="unbind_meta_app" data=""/>
+			<action application="bind_digit_action" data="page,*#,exec:execute_extension,page_add_begin XML ${domain_name}"/>
+			<action application="digit_action_set_realm" data="page"/>
+			<action application="answer" data=""/>
+			<action application="conference" data="${page_extension}@page"/>
 		</condition>
 	</extension>
 </context>

--- a/resources/install/scripts/page_transfer_to.lua
+++ b/resources/install/scripts/page_transfer_to.lua
@@ -1,0 +1,20 @@
+local api = freeswitch.API()
+local uuid = argv[1]
+
+freeswitch.consoleLog("NOTICE", "[page_enter_to] session " .. tostring(uuid) .. "\n");
+
+local other_leg_uuid = api:executeString("uuid_getvar "..uuid.." signal_bond")
+local domain_name    = api:executeString("uuid_getvar "..uuid.." domain_name")
+
+freeswitch.consoleLog("NOTICE", "[page_enter_to] " ..
+  tostring(other_leg_uuid) ..
+  " => " ..
+  tostring(domain_name) ..
+  "\n"
+)
+
+if (not other_leg_uuid) or other_leg_uuid == '' then return end
+
+local res = api:executeString("uuid_transfer " .. other_leg_uuid .. " page_enter_to XML " .. domain_name)
+
+freeswitch.consoleLog("NOTICE", "[page_enter_to] transfer:" .. tostring(res) .. "\n")

--- a/resources/install/scripts/page_transfer_to.lua
+++ b/resources/install/scripts/page_transfer_to.lua
@@ -1,6 +1,8 @@
 local api = freeswitch.API()
 local uuid = argv[1]
 
+assert(uuid and #uuid > 0, "No A-Leg uuid provided")
+
 freeswitch.consoleLog("NOTICE", "[page_enter_to] session " .. tostring(uuid) .. "\n");
 
 local other_leg_uuid = api:executeString("uuid_getvar "..uuid.." signal_bond")

--- a/resources/install/scripts/unbridge.lua
+++ b/resources/install/scripts/unbridge.lua
@@ -1,0 +1,22 @@
+scripts_dir = string.sub(debug.getinfo(1).source,2,string.len(debug.getinfo(1).source)-(string.len(argv[0])+1))
+
+dofile(scripts_dir.."/resources/functions/config.lua")
+dofile(config())
+
+dofile(scripts_dir.."/resources/functions/database_handle.lua")
+local dbh = database_handle('switch')
+
+local api   = freeswitch.API()
+local uuid  = argv[1]
+local cause = argv[2] or 'CALL_REJECTED'
+
+assert(uuid and #uuid > 0, "No A-Leg uuid provided")
+
+freeswitch.consoleLog("NOTICE", "[unbridge] session " .. tostring(uuid) .. "\n");
+
+local sql = ("select uuid from channels where call_uuid='%s' and uuid<>'%s'"):format(uuid, uuid)
+
+dbh:query(sql, function(row)
+  local res = api:executeString("uuid_kill " .. row.uuid .. " " .. cause)
+  freeswitch.consoleLog("NOTICE", "[unbridge] kill " .. tostring(row.uuid) .. ":" .. tostring(res) .. "\n");
+end)


### PR DESCRIPTION
How it works
When user in page conference it can press `*#` and after that it can enter number.
To add new user to conference he should press `*0` after callstart.
To discard outbound call he should press `*#`. After that he can enter new number or press `*#` to return back to conference.

What can be done.
Put all page_XXX condition in separate context. But I have no Idea how to do this in FusionPBX.
Move user to conference insteade to number dialing afte press `*0` but I do not know how to check this condition after `bridge`.

Also I use `transfer -both page_enter_to XML ${context}` in `local_extension` to replace `attr_xfer` to make confirencies.

I am totally new in FreeSwitch so plese check this PR meticulously.