### PR TITLE
Use os.time instead of mysql native function

### DIFF
--- a/resources/install/scripts/app/xml_handler/resources/scripts/directory/directory.lua
+++ b/resources/install/scripts/app/xml_handler/resources/scripts/directory/directory.lua
@@ -170,7 +170,8 @@
 								sql = sql .. "WHERE reg_user = '"..dialed_extension.."' ";
 								sql = sql .. "AND realm = '"..domain_name.."' ";
 								if (database["type"] == "mysql") then
-									sql = sql .. "AND expires > unix_timestamp(NOW())";
+									now = os.time();
+									sql = sql .. "AND expires > "..now;
 								else
 									sql = sql .. "AND to_timestamp(expires) > NOW()";
 								end


### PR DESCRIPTION
Odd, but on some deployments LUA wont accept unixtime stamp functions (regardless it works on CLI). So, to workaround this, lets use os.time() which it returns the same value expected.