### PR TITLE
Bind digit action

### DIFF
--- a/app/devices/device_edit.php
+++ b/app/devices/device_edit.php
@@ -880,7 +880,7 @@ require_once "resources/require.php";
 				if (strtolower($device_vendor) == "aastra" || strlen($device_vendor) == 0 || strlen($device_username) > 0) {
 					echo "<optgroup label='Aastra'>";
 					?>
-<option value='blf' <?php if ($row['device_key_type'] == "blf") { echo $selected;$found=true; } ?>><?php echo $text['label-blf'] ?></option>
+					<option value='blf' <?php if ($row['device_key_type'] == "blf") { echo $selected;$found=true; } ?>><?php echo $text['label-blf'] ?></option>
 					<option value='blfxfer' <?php if ($row['device_key_type'] == "blfxfer") { echo $selected;$found=true; } ?>><?php echo $text['label-blf_xfer'] ?></option>
 					<option value='callers' <?php if ($row['device_key_type'] == "callers") { echo $selected;$found=true; } ?>><?php echo $text['label-callers'] ?></option>
 

--- a/app/dialplan/resources/switch/conf/dialplan/999_local_extension.xml
+++ b/app/dialplan/resources/switch/conf/dialplan/999_local_extension.xml
@@ -9,7 +9,8 @@
 		<!--Allow transfer/record only for internal users-->
 		<condition field="${sip_authorized}" expression="true" break="never">
 			<action application="set" data="bind_target=both" inline="true"/>
-			<anti-action application="set" data="bind_target=peer" inline="true"/>
+			<!-- set to `peer` to prevent manipulate of call by callee -->
+			<anti-action application="set" data="bind_target=both" inline="true"/>
 		</condition>
 
 		<condition>

--- a/app/dialplan/resources/switch/conf/dialplan/999_local_extension.xml
+++ b/app/dialplan/resources/switch/conf/dialplan/999_local_extension.xml
@@ -42,7 +42,7 @@
 			<action application="sleep" data="1000"/>
 			<!--<action application="voicemail" data="default ${domain_name} ${dialed_extension}"/>-->
 			<action application="set" data="voicemail_action=save"/>
-			<action application="set" data="voicemail_id=dialed_extension"/>
+			<action application="set" data="voicemail_id=${dialed_extension}"/>
 			<action application="set" data="voicemail_profile=default"/>
 			<action application="lua" data="app.lua voicemail"/>
 		</condition>

--- a/app/dialplan/resources/switch/conf/dialplan/999_local_extension.xml
+++ b/app/dialplan/resources/switch/conf/dialplan/999_local_extension.xml
@@ -2,14 +2,25 @@
 	<extension name="local_extension" number="[ext]" continue="false" app_uuid="71cf1310-b6e3-415b-8745-3cbdc8e15212">
 		<condition field="destination_number" expression="(^\d{2,7}$)">
 			<!--<action application="pre_answer"/>-->
-			<action application="set" data="dialed_extension=$1"/>
-			<action application="export" data="dialed_extension=$1"/>
+			<action application="export" data="dialed_extension=$1" inline="true"/>
 			<action application="limit" data="hash ${domain_name} $1 ${limit_max} ${limit_destination}"/>
-			<!-- bind_meta_app can have these args <key> [a|b|ab] [a|b|o|s] <app> -->
-			<action application="bind_meta_app" data="1 ab s execute_extension::dx XML ${context}"/>
-			<action application="bind_meta_app" data="2 ab s record_session::$${recordings_dir}/${domain_name}/archive/${strftime(%Y)}/${strftime(%b)}/${strftime(%d)}/${uuid}.${record_ext}"/>
-			<action application="bind_meta_app" data="3 ab s execute_extension::cf XML ${context}"/>
-			<action application="bind_meta_app" data="4 ab s execute_extension::att_xfer XML ${context}"/>
+		</condition>
+
+		<!--Allow transfer/record only for internal users-->
+		<condition field="${sip_authorized}" expression="true" break="never">
+			<action application="set" data="bind_target=both" inline="true"/>
+			<anti-action application="set" data="bind_target=peer" inline="true"/>
+		</condition>
+
+		<condition>
+			<action application="bind_digit_action" data="local,*1,exec:execute_extension,dx XML ${context},${bind_target}"/>
+			<action application="bind_digit_action" data="local,*2,exec:record_session,$${recordings_dir}/${domain_name}/archive/${strftime(%Y)}/${strftime(%b)}/${strftime(%d)}/${uuid}.${record_ext},${bind_target}"/>
+			<action application="bind_digit_action" data="local,*3,exec:execute_extension,cf XML ${context},${bind_target}"/>
+			<action application="bind_digit_action" data="local,*4,exec:execute_extension,att_xfer XML ${context},${bind_target}"/>
+			<action application="digit_action_set_realm" data="local"/>
+		</condition>
+
+		<condition>
 			<!--<action application="set" data="ringback=${ringback}"/>-->
 			<action application="set" data="hangup_after_bridge=true"/>
 			<!--<action application="set" data="continue_on_fail=NORMAL_TEMPORARY_FAILURE,USER_BUSY,NO_ANSWER,TIMEOUT,NO_ROUTE_DESTINATION"/> -->
@@ -31,7 +42,7 @@
 			<action application="sleep" data="1000"/>
 			<!--<action application="voicemail" data="default ${domain_name} ${dialed_extension}"/>-->
 			<action application="set" data="voicemail_action=save"/>
-			<action application="set" data="voicemail_id=$1"/>
+			<action application="set" data="voicemail_id=dialed_extension"/>
 			<action application="set" data="voicemail_profile=default"/>
 			<action application="lua" data="app.lua voicemail"/>
 		</condition>

--- a/resources/install/scripts/app/ring_groups/index.lua
+++ b/resources/install/scripts/app/ring_groups/index.lua
@@ -490,10 +490,10 @@
 					session:execute("set", "hangup_after_bridge=true");
 					session:execute("set", "continue_on_fail=true");
 
-					local bind_target = 'peer'
-					if session:getVariable("sip_authorized") == "true" then
-						bind_target = 'both'
-					end
+					local bind_target = 'both'
+					-- if session:getVariable("sip_authorized") ~= "true" then
+					-- 	bind_target = 'peer'
+					-- end
 
 				--set bind digit action
 					local record_file = recordings_dir.."/archive/"..os.date("%Y").."/"..os.date("%m").."/"..os.date("%d").."}/"..uuid.."."..record_ext

--- a/resources/install/scripts/app/ring_groups/index.lua
+++ b/resources/install/scripts/app/ring_groups/index.lua
@@ -496,7 +496,7 @@
 					end
 
 				--set bind digit action
-					local record_file = recordings_dir.."/archive/"..os.date("%Y").."/"..os.date("%m").."/"..os.date("%d").."}/"..uuid..".".record_ext
+					local record_file = recordings_dir.."/archive/"..os.date("%Y").."/"..os.date("%m").."/"..os.date("%d").."}/"..uuid.."."..record_ext
 					local bindings = {
 						"local,*1,exec:execute_extension,dx XML " .. context,
 						"local,*2,exec:record_session," .. record_file,


### PR DESCRIPTION
Change. Use bind_bind_digit instead of bind_meta_app.
Change. Allow transfer and turn on recordings only for authorized users.
Fix. Use record_ext in recording in ring_group.

This allow configure other dtmf sequence like `*#` and `##`