### PR TITLE
Fix. Start record when b-leg answer.

### DIFF
--- a/app/dialplan/resources/switch/conf/dialplan/050_user_record.xml
+++ b/app/dialplan/resources/switch/conf/dialplan/050_user_record.xml
@@ -46,7 +46,7 @@
 			<action application="set" data="record_session=true" inline="true"/>
 		</condition>
 		<condition field="${record_session}" expression="^true$">
-			<action application="set" data="api_on_answer=uuid_record ${uuid} start ${recordings_dir}/${domain_name}/archive/${strftime(%Y)}/${strftime(%b)}/${strftime(%d)}/${uuid}.${record_ext}"/>
+			<action application="export" data="nolocal:api_on_answer=uuid_record ${uuid} start ${recordings_dir}/${domain_name}/archive/${strftime(%Y)}/${strftime(%b)}/${strftime(%d)}/${uuid}.${record_ext}"/>
 		</condition>
 	</extension>
 </context>


### PR DESCRIPTION
This fix problem when DID transfers to IVR.
After that user make direct-dial to extension.
IVR do transfer but a-leg already answered and
api_on_answer did not call.