### PR TITLE
Allow provisioning with internal addressbook and update snom320 tpl

### DIFF
--- a/app/provision/resources/classes/provision.php
+++ b/app/provision/resources/classes/provision.php
@@ -661,6 +661,14 @@ include "root.php";
 					}
 					unset ($prep_statement);
 
+				//populate internal address book
+					$sql = "SELECT extension as , effective_caller_id_name, effective_caller_id_number, outbound_caller_id_name, outbound_caller_id_number, directory_full_name FROM v_extensions";
+					$prep_statement = $this->db->prepare(check_sql($sql));
+					$prep_statement->execute();
+					$internal_addressbook = $prep_statement->fetchAll(PDO::FETCH_NAMED);
+					$view->assign("internal_addressbook",$internal_addressbook);
+					unset ($prep_statement);
+
 				//set the mac address in the correct format
 					switch (strtolower($device_vendor)) {
 					case "aastra":

--- a/resources/templates/provision/snom/320/{$mac}.xml
+++ b/resources/templates/provision/snom/320/{$mac}.xml
@@ -100,19 +100,30 @@
 <codec_priority_list idx="12" perm="">g722,pcmu,pcma,gsm,g726-32,aal2-g726-32,g723,g729,telephone-event</codec_priority_list>
 </phone-settings>
 <functionKeys e="2">
-<fkey idx="0" context="active" label="" perm="">line</fkey>
-<fkey idx="1" context="active" label="" perm="">line</fkey>
-<fkey idx="2" context="active" label="" perm="">line</fkey>
-<fkey idx="3" context="active" label="" perm="">line</fkey>
-<fkey idx="4" context="active" label="" perm="">line</fkey>
-<fkey idx="5" context="active" label="" perm="">line</fkey>
-<fkey idx="6" context="active" label="" perm="">line</fkey>
-<fkey idx="7" context="active" label="" perm="">line</fkey>
-<fkey idx="8" context="active" label="" perm="">line</fkey>
-<fkey idx="9" context="active" label="" perm="">line</fkey>
-<fkey idx="10" context="active" label="" perm="">line</fkey>
-<fkey idx="11" context="active" label="" perm="">line</fkey>
+{foreach $keys as $row}
+{if $row.device_key_line == ""}
+    {if $row.device_key_category == "line"}
+    <fkey idx="{$row.device_key_id-1}" context="active" label="{$row.device_key_label}" perm="">{$row.device_key_type} {$row.device_key_value} {$row.device_key_extension}</fkey>
+    {else}
+    <fkey idx="{$row.device_key_id}" context="active" label="" perm="">line</fkey>
+    {/if}
+{else}
+    {if $row.device_key_category == "line"}
+    <fkey idx="{$row.device_key_id-1}" context="{$row.device_key_line}" label="{$row.device_key_label}" perm="">{$row.device_key_type} {$row.device_key_value} {$row.device_key_extension}</fkey>
+    {else}
+    <fkey idx="{$row.device_key_id}" context="active" label="" perm="">line</fkey>
+    {/if}
+{/if}
+{/foreach}
 </functionKeys>
-<tbook e="2">
+<tbook e="2" complete="true">
+{foreach $internal_addressbook as $address}
+    <item context="active" type="" fav="false">
+        <number>{$address.extension}</number>
+        <number_type>sip</number_type>
+        <first_name>{$address.directory_full_name} ({$address.extension})</first_name>
+    </item>
+{/foreach}
+
 </tbook>
 </settings>


### PR DESCRIPTION
We wanted to populate the addressbook of our snom320 phones from the list of available extensions and found out, that the provided xml templates only provide an empty address book. Also, we didn't want to base the address book on the contacts. This commit adds another template variable internal_addressbook from the extensions table.

The snom320 template was modified to support the function keys (like the 7xx template) and populates the tbook array. 