### PR TITLE
Add Log and Cache classes

### DIFF
--- a/resources/install/scripts/app/xml_handler/resources/scripts/dialplan/dialplan.lua
+++ b/resources/install/scripts/app/xml_handler/resources/scripts/dialplan/dialplan.lua
@@ -25,15 +25,16 @@
 --	POSSIBILITY OF SUCH DAMAGE.
 
 	local cache = require"resources.functions.cache"
+	local log = require"resources.functions.log"["xml_handler"]
 
 --get the cache
 	XML_STRING, err = cache.get("dialplan:" .. call_context)
 
 	if debug['cache'] then
 		if XML_STRING then
-			freeswitch.consoleLog("notice", "[xml_handler] dialplan:"..call_context.." source: memcache\n");
+			log.notice("dialplan:"..call_context.." source: memcache");
 		elseif err ~= 'NOT FOUND' then
-			freeswitch.consoleLog("notice", "[xml_handler] error get element form cache: " .. err .. "\n");
+			log.notice("error get element form cache: " .. err);
 		end
 	end
 
@@ -105,7 +106,7 @@
 			sql = sql .. "ELSE 100 END, ";
 			sql = sql .. "s.dialplan_detail_order asc ";
 			if (debug["sql"]) then
-				freeswitch.consoleLog("notice", "[xml_handler] SQL: " .. sql .. "\n");
+				log.notice("SQL: " .. sql);
 			end
 			x = 0;
 			dbh:query(sql, function(row)
@@ -306,7 +307,7 @@
 
 		--send to the console
 			if (debug["cache"]) then
-				freeswitch.consoleLog("notice", "[xml_handler] dialplan:"..call_context.." source: database\n");
+				log.notice("dialplan:"..call_context.." source: database");
 			end
 
 		--close the database connection

--- a/resources/install/scripts/resources/functions/cache.lua
+++ b/resources/install/scripts/resources/functions/cache.lua
@@ -56,7 +56,12 @@ end
 
 function Cache.del(key)
   local result, err = check_error(api:execute("memcache", "set " .. key .. " '" .. value .. "' " .. expire))
-  if not result then return nil, err end
+  if not result then
+    if err == 'NOT FOUND' then
+      return true
+    end
+    return nil, err
+  end
   return result == '+OK'
 end
 

--- a/resources/install/scripts/resources/functions/cache.lua
+++ b/resources/install/scripts/resources/functions/cache.lua
@@ -1,0 +1,63 @@
+-- @usage cache = require "resources.functions.cache"
+-- value = cache.get(key)
+-- if not value then
+--   ...
+--   cache.set(key, value, expire)
+-- end
+--
+
+require "resources.functions.trim";
+
+local api = api or freeswitch.API();
+
+local Cache = {}
+
+local function check_error(result)
+  result = trim(result or '')
+
+  if result and result:sub(1, 4) == '-ERR' then
+    return nil, trim(result:sub(5))
+  end
+
+  if result == 'INVALID COMMAND!' and not Cache.support() then
+      return nil, 'INVALID COMMAND'
+  end
+
+  return result
+end
+
+function Cache.support()
+  -- assume it is not unloadable
+  if Cache._support then
+    return true
+  end
+  Cache._support = (trim(api:execute('module_exists', 'mod_memcache')) == 'true')
+  return Cache._support
+end
+
+--- Get element from cache
+--
+-- @tparam key string
+-- @return[1] string value
+-- @return[2] nil
+-- @return[2] error string `e.g. 'NOT FOUND'
+-- @note error string does not contain `-ERR` prefix
+function Cache.get(key)
+  local result, err = check_error(api:execute('memcache', 'get ' .. key))
+  if not result then return nil, err end
+  return (result:gsub("&#39;", "'"))
+end
+
+function Cache.set(key, value, expire)
+  value = value:gsub("'", "&#39;"):gsub("\\", "\\\\")
+  expire = expire and tostring(expire) or ""
+  return check_error(api:execute("memcache", "set " .. key .. " '" .. value .. "' " .. expire))
+end
+
+function Cache.del(key)
+  local result, err = check_error(api:execute("memcache", "set " .. key .. " '" .. value .. "' " .. expire))
+  if not result then return nil, err end
+  return result == '+OK'
+end
+
+return Cache

--- a/resources/install/scripts/resources/functions/log.lua
+++ b/resources/install/scripts/resources/functions/log.lua
@@ -1,0 +1,70 @@
+-- @usage local log = require"resources.functions.log"["xml_handler"]
+-- log.notice("hello world")
+-- log.noticef("%s %s", "hello", "world")
+-- -- log if debug.SQL or debug.xml_handler.SQL then
+-- log.tracef("SQL", "SQL is %s", sql)
+
+local function log(name, level, msg)
+	freeswitch.consoleLog(level, "[" .. name .. "] " .. msg .. "\n")
+end
+
+local function logf(name, level, ...)
+	return log(name, level, string.format(...))
+end
+
+local function trace(type, name, ...)
+	local t = debug[name]
+	if t and t[type] ~= nil then
+		if t[type] then
+			return log(name, ...)
+		end
+	end
+	if debug[type] then
+		log(name, ...)
+	end
+end
+
+local function tracef(type, name, level, ...)
+	local t = debug[name]
+	if t and t[type] ~= nil then
+		if t[type] then
+			return logf(name, ...)
+		end
+	end
+	if debug[type] then
+		logf(name, ...)
+	end
+end
+
+local LEVELS = {
+	'error',
+	'warning',
+	'notice',
+	'info',
+}
+
+local TRACE_LEVEL = 'notice'
+
+local function make_log(name)
+	local logger = {}
+	for i = 1, #LEVELS do
+		logger[ LEVELS[i] ] = function(...) return log(name, LEVELS[i], ...) end;
+		logger[ LEVELS[i] .. "f" ] = function(...) return logf(name, LEVELS[i], ...) end;
+	end
+
+	logger.trace = function(type, ...)
+		trace(type, name, TRACE_LEVEL, ...)
+	end
+
+	logger.tracef = function(type, ...)
+		tracef(type, name, TRACE_LEVEL, ...)
+	end
+
+	return logger
+end
+
+return setmetatable({}, {__index = function(self, name)
+	local logger = make_log(name)
+	self[name] = logger
+	return logger
+end})


### PR DESCRIPTION
This is just suggestion about make code easy to write/read.
`dialplan.lua` is just example of how to use this classes.
Log class replace
```Lua
freeswitch.consoleLog("notice", "[xml_handler] " ....)
```
to
```Lua
-- `local` here is mondatory
local log = require"resources.functions.log"["xml_handler"]
log.notice(....)
log.noticef("%s", "message") -- formatted version
```

Cache class escape symbols `\` and `'` automatically

