### PR TITLE
Fix. Intercept enterprise ring group.

### DIFF
--- a/resources/install/scripts/app/ring_groups/index.lua
+++ b/resources/install/scripts/app/ring_groups/index.lua
@@ -27,6 +27,8 @@
 --	Mark J Crane <markjcrane@fusionpbx.com>
 --	Luis Daniel Lucio Qurioz <dlucio@okay.com.mx>
 
+local log = require "resources.functions.log".ring_group
+
 --connect to the database
 	require "resources.functions.database_handle";
 	dbh = database_handle('system');
@@ -618,10 +620,23 @@
 							end
 							freeswitch.consoleLog("NOTICE", "[ring group] app_data: "..app_data.."\n");
 							session:execute("bridge", app_data);
+							-- log.noticef("bridge done: originate_disposition:%s answered:%s ready:%s bridged:%s", session:getVariable("originate_disposition"), session:answered() and "true" or "false", session:ready() and "true" or "false", session:bridged() and "true" or "false")
 						end
 
 					--timeout destination
 						if (app_data ~= nil) then
+							if ring_group_strategy == "enterprise"
+								and ( true
+									--- I see 2 errors here `failure` and `PICKED_OFF` 
+									--- but they be more. I think check `answered` is enough.
+									-- or session:getVariable("originate_disposition") == "failure"
+									-- or session:getVariable("originate_disposition") == "PICKED_OFF"
+								)
+								and session:answered() then
+									-- for enterprise calls when intercept we get "failure" but session answered
+									return
+							end
+
 							if (session:getVariable("originate_disposition") == "ALLOTTED_TIMEOUT" 
 								or session:getVariable("originate_disposition") == "NO_ANSWER" 
 								or session:getVariable("originate_disposition") == "NO_USER_RESPONSE" 

--- a/resources/install/scripts/intercept.lua
+++ b/resources/install/scripts/intercept.lua
@@ -140,6 +140,7 @@ if ( session:ready() ) then
 			if result.uuid == result.call_uuid then
 				uuid = channel_variable(result.uuid, 'ent_originate_aleg_uuid') or
 						channel_variable(result.uuid, 'cc_member_session_uuid') or
+						channel_variable(result.uuid, 'fifo_bridge_uuid') or
 						result.uuid
 			else
 				uuid = result.call_uuid;

--- a/resources/install/scripts/intercept.lua
+++ b/resources/install/scripts/intercept.lua
@@ -138,7 +138,9 @@ if ( session:ready() ) then
 			--	freeswitch.consoleLog("NOTICE", "result "..key.." "..val.."\n");
 			--end
 			if result.uuid == result.call_uuid then
-				uuid = channel_variable(result.uuid, 'ent_originate_aleg_uuid') or row.uuid
+				uuid = channel_variable(result.uuid, 'ent_originate_aleg_uuid') or
+						channel_variable(result.uuid, 'cc_member_session_uuid') or
+						result.uuid
 			else
 				uuid = result.call_uuid;
 			end

--- a/resources/install/scripts/intercept_group.lua
+++ b/resources/install/scripts/intercept_group.lua
@@ -198,7 +198,9 @@
 				--	freeswitch.consoleLog("NOTICE", "row "..key.." "..val.."\n");
 				--end
 				if row.uuid == row.call_uuid then
-					uuid = channel_variable(row.uuid, 'ent_originate_aleg_uuid') or row.uuid
+					uuid = channel_variable(row.uuid, 'ent_originate_aleg_uuid') or
+							channel_variable(row.uuid, 'cc_member_session_uuid') or
+							row.uuid
 				else
 					uuid = row.call_uuid;
 				end

--- a/resources/install/scripts/intercept_group.lua
+++ b/resources/install/scripts/intercept_group.lua
@@ -35,10 +35,18 @@
 
 --add the function
 	require "resources.functions.explode";
+	require "resources.functions.trim";
+	require "resources.functions.channel_utils";
+
+--prepare the api object
+	api = freeswitch.API();
 
 --connect to the database
 	require "resources.functions.database_handle";
 	dbh = database_handle('system');
+
+--get the hostname
+	hostname = trim(api:execute("switchname", ""));
 
 --check if the session is ready
 	if ( session:ready() ) then
@@ -163,7 +171,7 @@
 
 		--check the database to get the uuid of a ringing call
 			call_hostname = "";
-			sql = "SELECT call_uuid AS uuid, hostname, ip_addr FROM channels ";
+			sql = "SELECT uuid, call_uuid, hostname, ip_addr FROM channels ";
 			sql = sql .. "WHERE callstate in ('RINGING', 'EARLY') ";
 			--sql = sql .. "AND direction = 'outbound' ";
 			sql = sql .. "AND (";
@@ -189,14 +197,16 @@
 				--for key, val in pairs(row) do
 				--	freeswitch.consoleLog("NOTICE", "row "..key.." "..val.."\n");
 				--end
-				uuid = row.uuid;
+				if row.uuid == row.call_uuid then
+					uuid = channel_variable(row.uuid, 'ent_originate_aleg_uuid') or row.uuid
+				else
+					uuid = row.call_uuid;
+				end
 				call_hostname = row.hostname;
 				ip_addr = row.ip_addr;
 			end);
 	end
 
---get the hostname
-	hostname = freeswitch.getGlobalVariable("hostname");
 	freeswitch.consoleLog("NOTICE", "Hostname:"..hostname.."  Call Hostname:"..call_hostname.."\n");
 
 --intercept a call that is ringing

--- a/resources/install/scripts/intercept_group.lua
+++ b/resources/install/scripts/intercept_group.lua
@@ -200,6 +200,7 @@
 				if row.uuid == row.call_uuid then
 					uuid = channel_variable(row.uuid, 'ent_originate_aleg_uuid') or
 							channel_variable(row.uuid, 'cc_member_session_uuid') or
+							channel_variable(row.uuid, 'fifo_bridge_uuid') or
 							row.uuid
 				else
 					uuid = row.call_uuid;

--- a/resources/install/scripts/resources/functions/channel_utils.lua
+++ b/resources/install/scripts/resources/functions/channel_utils.lua
@@ -1,0 +1,20 @@
+
+local api = api or freeswitch.API()
+
+function channel_variable(uuid, name)
+	local result = api:executeString("uuid_getvar " .. uuid .. " " .. name)
+
+	if result:sub(1, 4) == '-ERR' then return nil, result end
+	if result == '_undef_' then return false end
+
+	return result
+end
+
+function channel_evalute(uuid, cmd)
+	local result = api:executeString("eval uuid:" .. uuid .. " " .. cmd)
+
+	if result:sub(1, 4) == '-ERR' then return nil, result end
+	if result == '_undef_' then return false end
+
+	return result
+end


### PR DESCRIPTION
With enterprise call each outbound channel has its own call_uuid.
But we have to use `intercept` for call_uuid of inbound channel.

I see problen only with loopback. 
If outbound call make call to user via loopback but I think fusion does not do this.