### PR TITLE
Fix an issue when using KEY and only one domain

### DIFF
--- a/resources/check_auth.php
+++ b/resources/check_auth.php
@@ -226,7 +226,7 @@ require_once "resources/require.php";
 						//$sql .= "and username='".$username."' ";
 					}
 					//$sql .= "and domain_uuid='".$domain_uuid."' ";
-					if (($_SESSION["user"]["unique"]["text"] == "global") || (count($_SESSION["domains"]) == 1)){
+					if (($_SESSION["user"]["unique"]["text"] == "global") || (count($_SESSION["domains"]) <= 1)){
 						//unique username - global (example: email address)
 					}
 					else {

--- a/resources/check_auth.php
+++ b/resources/check_auth.php
@@ -22,6 +22,7 @@
 
 	Contributor(s):
 	Mark J Crane <markjcrane@fusionpbx.com>
+	Luis Daniel Lucio Quiroz <dlucio@okay.com.mx>
 */
 require_once "resources/require.php";
 
@@ -225,7 +226,7 @@ require_once "resources/require.php";
 						//$sql .= "and username='".$username."' ";
 					}
 					//$sql .= "and domain_uuid='".$domain_uuid."' ";
-					if ($_SESSION["user"]["unique"]["text"] == "global") {
+					if (($_SESSION["user"]["unique"]["text"] == "global") || (count($_SESSION["domains"]) == 1)){
 						//unique username - global (example: email address)
 					}
 					else {


### PR DESCRIPTION
When you only have one domain count($_SESSION["domains"]) == 1, condition if (count($_SESSION["domains"]) > 1), (line 57 aprox) never sets the domain_uuid variable.

Then the $prep_statement->bindParam(':domain_uuid', $domain_uuid); (line 239) will never substitute the string for a uuid, causing this to fail.