### PR TITLE
Fix small bugs and clear code in call_flow.

### DIFF
--- a/resources/install/scripts/resources/functions/presence_in.lua
+++ b/resources/install/scripts/resources/functions/presence_in.lua
@@ -1,0 +1,23 @@
+local function turn_lamp(on, user, uuid)
+	local event = freeswitch.Event("PRESENCE_IN");
+	event:addHeader("proto", "sip");
+	event:addHeader("event_type", "presence");
+	event:addHeader("alt_event_type", "dialog");
+	event:addHeader("Presence-Call-Direction", "outbound");
+	event:addHeader("from", user);
+	event:addHeader("login", user);
+	event:addHeader("unique-id", uuid);
+	event:addHeader("status", "Active (1 waiting)");
+	if on then
+		event:addHeader("answer-state", "confirmed");
+		event:addHeader("rpid", "unknown");
+		event:addHeader("event_count", "1");
+	else
+		event:addHeader("answer-state", "terminated");
+	end
+	event:fire();
+end
+
+return {
+	turn_lamp = turn_lamp;
+}


### PR DESCRIPTION
* Move code to turn on/off BLF to separate function.
```Lua
presence_in.turn_lamp( toggle == "false",
  call_flow_feature_code.."@"..domain_name,
  call_flow_uuid
);
```

<b>One note</b>
Turn on code define `event:addHeader("status", "Active (1 waiting)");`
Turn off code define `event:addHeader("state", "Active (1 waiting)");`

I leave only `event:addHeader("status", "Active (1 waiting)");` in both cases.
Tested on Grandstream GXP-2000

* Close temp file in call_flow_monitor because on Windows it prevent to remove it.
* Connect/release to database inside call_flow_monitor loop.
* Check successful connection to database in call_flow_monitor loop so monitor did not crash
if connection temporary lost.