### PR TITLE
Fix. Call intercept - a scenario where an outgoing call can be intercepted

### DIFF
--- a/resources/install/scripts/intercept_group.lua
+++ b/resources/install/scripts/intercept_group.lua
@@ -186,6 +186,7 @@
 			end
 			sql = sql .. ") ";
 			sql = sql .. "and call_uuid is not null ";
+			sql = sql .. "and direction = 'outbound' ";
 			--if (domain_count > 1) then
 			--	sql = sql .. "and context = '"..context.."' ";
 			--end


### PR DESCRIPTION
If Alice calls Bob's mobile and Bob returns a "183 Session progress" with SDP (for example if the mobile has no service) the call stays in EARLY callstate in the database.

If Charlie (from the same Call Group as Alice) dials "*8", the outgoing call from Alice gets chosen as an "interceptable" call and freeswitch bridges Alice and Charlie's legs, sending a "CANCEL - Reason: SIP;cause=200;text="Call completed elsewhere" to Bob's call leg.

This should fix it. We make sure that the direction of the call is outbound.