### PR TITLE
Fix. hungup_rx.lua works on Windows

### DIFF
--- a/resources/install/scripts/app/fax/resources/scripts/hangup_rx.lua
+++ b/resources/install/scripts/app/fax/resources/scripts/hangup_rx.lua
@@ -43,7 +43,7 @@
 
 	local IS_WINDOWS = (package.config:sub(1,1) == '\\')
 
-	local function Q(s)
+	local function enquote(s)
 		local q = IS_WINDOWS and '"' or "'"
 		if s:find('%s') or s:find(q, nil, true) then
 			s = q .. s:gsub(q, q..q) .. q
@@ -192,15 +192,15 @@
 
 --fax to email
 
-	-- cmd = "lua" .. " " .. Q(scripts_dir .. "/fax_to_email.lua") .. " ";
-	cmd = Q(php_dir.."/"..php_bin).." "..Q(document_root.."/secure/fax_to_email.php").." ";
-	cmd = cmd .. "email="..Q(fax_email).." ";
-	cmd = cmd .. "extension="..Q(fax_extension).." ";
-	cmd = cmd .. "name="..Q(fax_file).." "; 
-	cmd = cmd .. "messages=" .. Q("result:"..fax_result_text.." sender:"..fax_remote_station_id.." pages:"..fax_document_total_pages).." ";
-	cmd = cmd .. "domain="..Q(domain_name).." ";
-	cmd = cmd .. "caller_id_name=" .. Q(caller_id_name or '') .. " ";
-	cmd = cmd .. "caller_id_number=" .. Q(caller_id_number or '') .. " ";
+	-- cmd = "lua" .. " " .. enquote(scripts_dir .. "/fax_to_email.lua") .. " ";
+	cmd = enquote(php_dir.."/"..php_bin).." "..enquote(document_root.."/secure/fax_to_email.php").." ";
+	cmd = cmd .. "email="..enquote(fax_email).." ";
+	cmd = cmd .. "extension="..enquote(fax_extension).." ";
+	cmd = cmd .. "name="..enquote(fax_file).." "; 
+	cmd = cmd .. "messages=" .. enquote("result:"..fax_result_text.." sender:"..fax_remote_station_id.." pages:"..fax_document_total_pages).." ";
+	cmd = cmd .. "domain="..enquote(domain_name).." ";
+	cmd = cmd .. "caller_id_name=" .. enquote(caller_id_name or '') .. " ";
+	cmd = cmd .. "caller_id_number=" .. enquote(caller_id_number or '') .. " ";
 	if #fax_forward_number > 0 then
 		cmd = cmd .. "fax_relay=true ";
 	end

--- a/resources/install/scripts/app/fax/resources/scripts/hangup_rx.lua
+++ b/resources/install/scripts/app/fax/resources/scripts/hangup_rx.lua
@@ -45,7 +45,7 @@
 
 	local function Q(s)
 		local q = IS_WINDOWS and '"' or "'"
-		if s:find('%s') then
+		if s:find('%s') or s:find(q, nil, true) then
 			s = q .. s:gsub(q, q..q) .. q
 		end
 		return s
@@ -192,6 +192,7 @@
 
 --fax to email
 
+	-- cmd = "lua" .. " " .. Q(scripts_dir .. "/fax_to_email.lua") .. " ";
 	cmd = Q(php_dir.."/"..php_bin).." "..Q(document_root.."/secure/fax_to_email.php").." ";
 	cmd = cmd .. "email="..Q(fax_email).." ";
 	cmd = cmd .. "extension="..Q(fax_extension).." ";

--- a/resources/install/scripts/app/fax/resources/scripts/hangup_rx.lua
+++ b/resources/install/scripts/app/fax/resources/scripts/hangup_rx.lua
@@ -41,6 +41,16 @@
 --array count
 	require "resources.functions.count";
 
+	local IS_WINDOWS = (package.config:sub(1,1) == '\\')
+
+	local function Q(s)
+		local q = IS_WINDOWS and '"' or "'"
+		if s:find('%s') then
+			s = q .. s:gsub(q, q..q) .. q
+		end
+		return s
+	end
+
 -- set channel variables to lua variables
 	domain_uuid = env:getHeader("domain_uuid");
 	domain_name = env:getHeader("domain_name");
@@ -181,23 +191,16 @@
 	end
 
 --fax to email
-	cmd = "'"..php_dir.."/"..php_bin.."' '"..document_root.."/secure/fax_to_email.php' ";
-	cmd = cmd .. "email='"..fax_email.."' ";
-	cmd = cmd .. "extension="..fax_extension.." ";
-	cmd = cmd .. "name='"..fax_file.."' "; 
-	cmd = cmd .. "messages='result:"..fax_result_text.." sender:"..fax_remote_station_id.." pages:"..fax_document_total_pages.."' ";
-	cmd = cmd .. "domain="..domain_name.." ";
-	cmd = cmd .. "caller_id_name='";
-	if (caller_id_name ~= nil) then
-		cmd = cmd .. caller_id_name;
-	end
-	cmd = cmd .. "' ";
-	cmd = cmd .. "caller_id_number=";
-	if (caller_id_number ~= nil) then
-		cmd = cmd .. caller_id_number;
-	end
-	cmd = cmd .. " ";
-	if (string.len(fax_forward_number) > 0) then
+
+	cmd = Q(php_dir.."/"..php_bin).." "..Q(document_root.."/secure/fax_to_email.php").." ";
+	cmd = cmd .. "email="..Q(fax_email).." ";
+	cmd = cmd .. "extension="..Q(fax_extension).." ";
+	cmd = cmd .. "name="..Q(fax_file).." "; 
+	cmd = cmd .. "messages=" .. Q("result:"..fax_result_text.." sender:"..fax_remote_station_id.." pages:"..fax_document_total_pages).." ";
+	cmd = cmd .. "domain="..Q(domain_name).." ";
+	cmd = cmd .. "caller_id_name=" .. Q(caller_id_name or '') .. " ";
+	cmd = cmd .. "caller_id_number=" .. Q(caller_id_number or '') .. " ";
+	if #fax_forward_number > 0 then
 		cmd = cmd .. "fax_relay=true ";
 	end
 	freeswitch.consoleLog("notice", "[fax] command: " .. cmd .. "\n");


### PR DESCRIPTION
1. Command should use only double quotes.
2. Application should not be quoted (I am not sure may be it is bug in FS `system` command).

So I use double quote on Windows and single quote on other system.
Also I quote strings only if they contain spaces.
To escape quote in string i just double it.
`you got "some text"` become to `you got ""some text"""`