### PR TITLE
local_hostname needs to use hostname

### DIFF
--- a/resources/install/scripts/app/conference_center/index.lua
+++ b/resources/install/scripts/app/conference_center/index.lua
@@ -385,7 +385,7 @@
 			end
 
 		--check if someone has already joined the conference
-			local_hostname = trim(api:execute("switchname", ""));
+			local_hostname = trim(api:execute("hostname", ""));
 			freeswitch.consoleLog("notice", "[conference center] local_hostname is " .. local_hostname .. "\n");
 			sql = "SELECT hostname FROM channels WHERE application = 'conference' AND dest = '" .. destination_number .. "' AND cid_num <> '".. caller_id_number .."' LIMIT 1";
 			if (debug["sql"]) then


### PR DESCRIPTION
hostname and switchname are not always the same. hostname warrants the server name, switchname doesnt. This will fix conference when you have db backend, no loadbalancing enabled and HA environment (active - pasive).

nasty workaround is to add an entry of switchname in /etc/hosts