### PR TITLE
Fix. problem when same session can release task multiple times.

### DIFF
--- a/resources/install/scripts/fax_queue/exec.lua
+++ b/resources/install/scripts/fax_queue/exec.lua
@@ -132,6 +132,12 @@ local function check()
 end
 
 local function task()
+  local session_uuid = session:getVariable('uuid')
+
+  session:setVariable('fax_queue_task_session', session_uuid)
+
+  log.infof("SESSION UUID: %s", session_uuid)
+
   session:waitForAnswer(session)
 
   while not session:answered() do

--- a/resources/install/scripts/fax_queue/next.lua
+++ b/resources/install/scripts/fax_queue/next.lua
@@ -51,6 +51,9 @@ local function next_task()
 
   if not ok then
     Tasks.release_task(task)
+    if task.status ~= 0 then
+      Tasks.remove_task(task)
+    end
     log.noticef("Error execute task: %s", tostring(err))
   end
 

--- a/resources/install/scripts/fax_queue/next.lua
+++ b/resources/install/scripts/fax_queue/next.lua
@@ -41,6 +41,9 @@ local function next_task()
     local ok, status, info = esl:api(originate)
     if not ok then
       Tasks.wait_task(task, false, info)
+      if task.status ~= 0 then
+        Tasks.remove_task(task)
+      end
       log.noticef('Can not originate to `%s` cause: %s: %s ', task.uri, tostring(status), tostring(info))
     else
       log.noticef("originate successfuly: %s", tostring(info))
@@ -51,9 +54,6 @@ local function next_task()
 
   if not ok then
     Tasks.release_task(task)
-    if task.status ~= 0 then
-      Tasks.remove_task(task)
-    end
     log.noticef("Error execute task: %s", tostring(err))
   end
 

--- a/resources/install/scripts/fax_queue/retry.lua
+++ b/resources/install/scripts/fax_queue/retry.lua
@@ -10,7 +10,7 @@
 	local Tasks    = require "fax_queue.tasks"
 
 	local fax_task_uuid  = env:getHeader('fax_task_uuid')
-	local task       = Tasks.select_task(fax_task_uuid)
+	local task           = Tasks.select_task(fax_task_uuid)
 	if not task then
 		log.warningf("Can not find fax task: %q", tostring(fax_task_uuid))
 		return 
@@ -25,6 +25,7 @@
 
 -- Channel/FusionPBX variables
 	local uuid                           = env:getHeader("uuid")
+	local fax_queue_task_session         = env:getHeader('fax_queue_task_session')
 	local domain_uuid                    = env:getHeader("domain_uuid")                  or task.domain_uuid
 	local domain_name                    = env:getHeader("domain_name")                  or task.domain_name
 	local origination_caller_id_name     = env:getHeader("origination_caller_id_name")   or '000000000000000'
@@ -338,9 +339,15 @@
 			end
 		end
 
-		Tasks.wait_task(task, answered, hangup_cause_q850)
-		if task.status ~= 0 then
-			Tasks.remove_task(task)
+		-- if task use group call then retry.lua will be called multiple times
+		-- here we check eathre that channel which execute `exec.lua`
+		-- Note that if there no one execute `exec.lua` we do not need call this
+		-- becase it should deal in `next.lua`
+		if fax_queue_task_session == uuid then
+			Tasks.wait_task(task, answered, hangup_cause_q850)
+			if task.status ~= 0 then
+				Tasks.remove_task(task)
+			end
 		end
 	end
 

--- a/resources/install/scripts/fax_queue/retry.lua
+++ b/resources/install/scripts/fax_queue/retry.lua
@@ -77,6 +77,7 @@
 
 	log.noticef([[<<< CALL RESULT >>>
     uuid:                          = '%s'
+    task_session_uuid:             = '%s'
     answered:                      = '%s'
     fax_file:                      = '%s'
     wav_file:                      = '%s'
@@ -91,6 +92,7 @@
     fax_options                    = '%s'
 ]],
     tostring(uuid)                         ,
+    tostring(fax_queue_task_session)       ,
     tostring(answered)                     ,
     tostring(fax_file)                     ,
     tostring(wav_file)                     ,

--- a/resources/install/scripts/fax_queue/tasks.lua
+++ b/resources/install/scripts/fax_queue/tasks.lua
@@ -103,6 +103,14 @@ local remove_finished_tasks_sql = [[
   delete from v_fax_tasks where task_status > 3
 ]]
 
+local function serialize(task, header)
+  local str = header or ''
+  for k, v in pairs(task) do
+    str = str .. ('\n %q = %q'):format(tostring(k), tostring(v))
+  end
+  return str
+end
+
 local function get_db()
   if not db then
     db = assert(Database.new('system'))


### PR DESCRIPTION
It can be when originate has group dial-string. So it call `api_hangup_hook`
for each channel.
Now we release task in `retry.lua` only if originate success and this is same channel
which execute `exec.lua`.
If originate fail we release task in `next.lua`.
But we write log for each channel so we can have more log than expected.