### PR TITLE
freeswitch.email() function has change behaivour

### DIFF
--- a/resources/install/scripts/app/voicemail/resources/functions/send_email.lua
+++ b/resources/install/scripts/app/voicemail/resources/functions/send_email.lua
@@ -150,15 +150,15 @@
 				--send the email
 					file = voicemail_dir.."/"..id.."/msg_"..uuid.."."..vm_message_ext;
 					if (voicemail_file == "attach") then
-						freeswitch.email("",
-							"",
+						freeswitch.email(voicemail_mail_to,
+							voicemail_mail_to,
 							"To: "..voicemail_mail_to.."\nFrom: "..voicemail_mail_to.."\nX-Headers: "..headers.."\nSubject: "..subject,
 							body,
 							file
 							);
 					else
-						freeswitch.email("",
-							"",
+						freeswitch.email(voicemail_mail_to,
+							voicemail_mail_to,
 							"To: "..voicemail_mail_to.."\nFrom: "..voicemail_mail_to.."\nX-Headers: "..headers.."\nSubject: "..subject,
 							body
 							);


### PR DESCRIPTION
before 1.6.5, first two arguements could be "", and freeswitch would use system value. Since 1.6.5 they are mandatory, they must be any valid email regexp.  As the variable voicemail_mail_to has a valid one, we use it.