### PR TITLE
Add. `send_mail` wrapper function to freeswitch.email and v_mailto.php.

### DIFF
--- a/resources/install/scripts/app/voicemail/resources/functions/send_email.lua
+++ b/resources/install/scripts/app/voicemail/resources/functions/send_email.lua
@@ -23,6 +23,12 @@
 --	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 --	POSSIBILITY OF SUCH DAMAGE.
 
+	local send_mail = require 'resources.functions.send_mail'
+
+	local function T(str)
+		return text[str][default_language..'-'..default_dialect] or text[str]['en-us']
+	end
+
 --define a function to send email
 	function send_email(id, uuid)
 		--get voicemail message details
@@ -103,10 +109,12 @@
 					end
 
 				--prepare the headers
-					headers = '{"X-FusionPBX-Domain-UUID":"'..domain_uuid..'",';
-					headers = headers..'"X-FusionPBX-Domain-Name":"'..domain_name..'",';
-					headers = headers..'"X-FusionPBX-Call-UUID":"'..uuid..'",';
-					headers = headers..'"X-FusionPBX-Email-Type":"voicemail"}';
+					local headers = {
+						["X-FusionPBX-Domain-UUID"] = domain_uuid;
+						["X-FusionPBX-Domain-Name"] = domain_name;
+						["X-FusionPBX-Call-UUID"]   = uuid;
+						["X-FusionPBX-Email-Type"]  = 'voicemail';
+					}
 
 				--prepare the subject
 					local f = io.open(file_subject, "r");
@@ -134,11 +142,11 @@
 					body = body:gsub("${sip_to_user}", id);
 					body = body:gsub("${dialed_user}", id);
 					if (voicemail_file == "attach") then
-						body = body:gsub("${message}", text['label-attached'][default_language.."-"..default_dialect]);
+						body = body:gsub("${message}", T'label-attached');
 					elseif (voicemail_file == "link") then
-						body = body:gsub("${message}", "<a href='https://"..domain_name.."/app/voicemails/voicemail_messages.php?action=download&type=vm&t=bin&id="..id.."&voicemail_uuid="..db_voicemail_uuid.."&uuid="..uuid.."&src=email'>"..text['label-download'][default_language.."-"..default_dialect].."</a>");
+						body = body:gsub("${message}", "<a href='https://"..domain_name.."/app/voicemails/voicemail_messages.php?action=download&type=vm&t=bin&id="..id.."&voicemail_uuid="..db_voicemail_uuid.."&uuid="..uuid.."&src=email'>"..T'label-download'.."</a>");
 					else
-						body = body:gsub("${message}", "<a href='https://"..domain_name.."/app/voicemails/voicemail_messages.php?action=autoplay&id="..db_voicemail_uuid.."&uuid="..uuid.."'>"..text['label-listen'][default_language.."-"..default_dialect].."</a>");
+						body = body:gsub("${message}", "<a href='https://"..domain_name.."/app/voicemails/voicemail_messages.php?action=autoplay&id="..db_voicemail_uuid.."&uuid="..uuid.."'>"..T'label-listen'.."</a>");
 					end
 					body = body:gsub(" ", "&nbsp;");
 					body = body:gsub("%s+", "");
@@ -147,22 +155,15 @@
 					body = body:gsub("\n", "");
 					body = trim(body);
 
-				--send the email
+				--prepare file
 					file = voicemail_dir.."/"..id.."/msg_"..uuid.."."..vm_message_ext;
-					if (voicemail_file == "attach") then
-						freeswitch.email("",
-							"",
-							"To: "..voicemail_mail_to.."\nFrom: "..voicemail_mail_to.."\nX-Headers: "..headers.."\nSubject: "..subject,
-							body,
-							file
-							);
-					else
-						freeswitch.email("",
-							"",
-							"To: "..voicemail_mail_to.."\nFrom: "..voicemail_mail_to.."\nX-Headers: "..headers.."\nSubject: "..subject,
-							body
-							);
-					end
+
+				--send the email
+					send_mail(headers,
+						voicemail_mail_to,
+						{subject, body},
+						(voicemail_file == "attach") and file
+					);
 			end
 
 		--whether to keep the voicemail message and details local after email

--- a/resources/install/scripts/resources/functions/send_mail.lua
+++ b/resources/install/scripts/resources/functions/send_mail.lua
@@ -74,7 +74,7 @@ if freeswitch then
   function send_mail(headers, address, message, file)
     local xheaders = "{"
     for k,v in pairs(headers) do
-      xheaders = xheaders .. ("'%s':'%s',"):format(k, v)
+      xheaders = xheaders .. ('"%s":"%s",'):format(k, v)
     end
     xheaders = xheaders:sub(1,-2) .. '}'
 

--- a/resources/install/scripts/resources/functions/send_mail.lua
+++ b/resources/install/scripts/resources/functions/send_mail.lua
@@ -1,0 +1,107 @@
+
+local send_mail
+
+if not freeswitch then
+  local Settings = require "resources.functions.lazy_settings"
+  local Database = require "resources.functions.database"
+  local log      = require "resources.functions.log".sendmail
+  local sendmail = require "sendmail"
+  local uuid     = require "uuid"
+
+  function send_mail(headers, address, message, file)
+    local domain_uuid = headers["X-FusionPBX-Domain-UUID"]
+    local domain_name = headers["X-FusionPBX-Domain-Name"]
+    local email_type  = headers["X-FusionPBX-Email-Type"] or 'info'
+    local call_uuid   = headers["X-FusionPBX-Email-Type"]
+    local db          = dbh or Database.new('system')
+    local settings    = Settings.new(db, domain_name, domain_uuid)
+
+    local ssl = settings:get('email', 'smtp_secure', 'var');
+
+    local ok, err = sendmail{
+      server = {
+        address  = settings:get('email','smtp_host','var');
+        user     = settings:get('email','smtp_username','var');
+        password = settings:get('email','smtp_password','var');
+        ssl      = (ssl == 'true') and { verify = {"none"} };
+      },
+
+      from = {
+        title    = settings:get('email', 'smtp_from_name', 'var');
+        address  = settings:get('email', 'smtp_from', 'var');
+      },
+
+      to = {
+        address = address;
+      },
+
+      message = message;
+      file = file;
+    }
+
+    if not ok then
+      log.warningf("Mailer Error: %s", err)
+
+      local email_uuid = uuid.new()
+      local sql  = "insert into v_emails ( "
+      sql = sql .. "email_uuid, "
+      if call_uuid then sql = sql .. "call_uuid, " end
+      sql = sql .. "domain_uuid, "
+      sql = sql .. "sent_date, "
+      sql = sql .. "type, "
+      sql = sql .. "status, "
+      sql = sql .. "email "
+      sql = sql .. ") values ( "
+      sql = sql .. "'" .. email_uuid                         .. "', "
+      if call_uuid then sql = sql .. "'" .. call_uuid   .. "', " end
+      sql = sql .. "'" .. domain_uuid .. "', "
+      sql = sql .. "now(),"
+      sql = sql .. "'" .. email_type  .. "', "
+      sql = sql .. "'failed', "
+      sql = sql .. "'' "
+      sql = sql .. ") "
+
+      db:query(sql)
+
+      log.infof("Retained in v_emails as email_uuid = %s", email_uuid)
+    else
+      log.infof("Mail to %s sent!", address)
+    end
+  end
+end
+
+if freeswitch then
+  function send_mail(headers, address, message, file)
+    local xheaders = "{"
+    for k,v in pairs(headers) do
+      xheaders = xheaders .. ("'%s':'%s',"):format(k, v)
+    end
+    xheaders = xheaders:sub(1,-2) .. '}'
+
+    local subject = message[1]
+    local body    = message[2] or ''
+
+    local mail_headers =
+      "To: "        .. address  .. "\n" ..
+      "From: "      .. address  .. "\n" ..
+      "Subject: "   .. subject  .. "\n" ..
+      "X-Headers: " .. xheaders
+
+    if file then
+      freeswitch.email(address, address, mail_headers, body, file)
+    else
+      freeswitch.email(address, address, mail_headers, body, file)
+    end
+  end
+end
+
+return send_mail
+
+-- local headers = {
+--   ["X-FusionPBX-Domain-UUID"] = '2d171c4c-b237-49ca-9d76-9cffc1618fa7';
+--   ["X-FusionPBX-Domain-Name"] = 'domain.com';
+--   ["X-FusionPBX-Email-Type"]  = 'voicemail';
+-- }
+-- send_mail(headers, 'alexey@domain.com', {'hello', 'world'})
+
+


### PR DESCRIPTION
Also add implementation based on [sendmail](https://github.com/moteus/lua-sendmail) library.

Fix. Send voicemail when set unknown language/dialect.

I add `T` function.
This function allows change
```Lua
text['label-attached'][default_language.."-"..default_dialect] or text['label-attached']['en-us']
```
to
```Lua
T'label-attached'
```
So I think one letter function is very convinient.
But if not I will change it to other name e.g. 
```Lua
i18n('label-attached')
```