### PR TITLE
Fix. Make channel uuid optional in email.

### DIFF
--- a/secure/v_mailto.php
+++ b/secure/v_mailto.php
@@ -292,11 +292,14 @@
 		$mailer_error = $mail->ErrorInfo;
 		echo "Mailer Error: ".$mailer_error."\n\n";
 
+		$call_uuid = $headers["X-FusionPBX-Call-UUID"];
 		// log/store message in database for review
 		$email_uuid = uuid();
 		$sql = "insert into v_emails ( ";
 		$sql .= "email_uuid, ";
-		$sql .= "call_uuid, ";
+		if ($call_uuid) {
+			$sql .= "call_uuid, ";
+		}
 		$sql .= "domain_uuid, ";
 		$sql .= "sent_date, ";
 		$sql .= "type, ";
@@ -304,7 +307,9 @@
 		$sql .= "email ";
 		$sql .= ") values ( ";
 		$sql .= "'".$email_uuid."', ";
-		$sql .= "'".$headers["X-FusionPBX-Call-UUID"]."', ";
+		if ($call_uuid) {
+			$sql .= "'".$call_uuid."', ";
+		}
 		$sql .= "'".$headers["X-FusionPBX-Domain-UUID"]."', ";
 		$sql .= "now(),";
 		$sql .= "'".$headers["X-FusionPBX-Email-Type"]."', ";


### PR DESCRIPTION
This needs for example if fax server could not create outgoing channel.