### PR TITLE
Fix. Append PROJECT_PATH to DOCUMENT_ROOT

### DIFF
--- a/core/upgrade/index.php
+++ b/core/upgrade/index.php
@@ -53,7 +53,7 @@ if (sizeof($_POST) > 0) {
 
 	// run source update
 	if ($do["source"] && permission_exists("upgrade_source") && !is_dir("/usr/share/examples/fusionpbx")) {
-		chdir($_SERVER["DOCUMENT_ROOT"]);
+		chdir($_SERVER["DOCUMENT_ROOT"].PROJECT_PATH);
 		exec("git pull", $response_source_update);
 		$update_failed = true;
 		if (sizeof($response_source_update) > 0) {


### PR DESCRIPTION
To get the Advanced -> Update -> Source menu working:

chdir($_SERVER["DOCUMENT_ROOT"].PROJECT_PATH);

as:
$_SERVER["DOCUMENT_ROOT"] = /var/www
PROJECT_PATH = /fusionpbx
