### PR TITLE
XML Handler incorrectly handling 'date-time' time conditions

### DIFF
--- a/resources/install/scripts/app/xml_handler/resources/scripts/dialplan/dialplan.lua
+++ b/resources/install/scripts/app/xml_handler/resources/scripts/dialplan/dialplan.lua
@@ -187,6 +187,8 @@
 								condition_type = 'time';
 							elseif (dialplan_detail_type == "week") then 
 								condition_type = 'time';
+							elseif (dialplan_detail_type == "date-time") then 
+								condition_type = 'time';
 							else
 								condition_type = 'default';
 							end


### PR DESCRIPTION
This pull requests fixes XML Handler support for 'date-time' time condition. With this, date-time gets rendered as:

```
 <condition date-time="2015-12-15 15:00~2015-12-16 15:00">
```
 Without this, the time condition WOULD get redered as:
```
 <condition field="date-time" expression="2015-12-15 15:00~2015-12-16 15:00">
```
 which is incorrect and would always match false in FreeSWITCH.

 FreeSWITCH docs for this are here: https://freeswitch.org/confluence/display/FREESWITCH/Time+of+Day+and+Holiday+Routing#TimeofDayandHolidayRouting-Variables

 All other time condition variables documented seem to be included in FusionPBX'es XML Handler.