### PR TITLE
Change. Reuse same esl connection to send cache event and command.

### DIFF
--- a/resources/classes/cache.php
+++ b/resources/classes/cache.php
@@ -33,17 +33,23 @@ class cache {
 	 * @var string $value	string to be cached
 	 */
 	public function set($key, $value) {
-		//send a custom event
-			
-		//run the memcache
+		// connect to event socket
 			$fp = event_socket_create($_SESSION['event_socket_ip_address'], $_SESSION['event_socket_port'], $_SESSION['event_socket_password']);
-			if ($fp) {
-				$command = "memcache set ".$key." ".$value;
-				return event_socket_request($fp, 'api '.$command);
-			}
-			else {
+			if ($fp === false) {
 				return false;
 			}
+
+		//send a custom event
+
+		//run the memcache
+			$command = "memcache set ".$key." ".$value;
+			$result = event_socket_request($fp, 'api '.$command);
+
+		//close event socket
+			fclose($fp);
+
+		// return result
+			return $result;
 	}
 
 	/**
@@ -51,17 +57,23 @@ class cache {
 	 * @var string $key		cache id
 	 */
 	public function get($key) {
-		//send a custom event
-			
-		//run the memcache
+		// connect to event socket
 			$fp = event_socket_create($_SESSION['event_socket_ip_address'], $_SESSION['event_socket_port'], $_SESSION['event_socket_password']);
-			if ($fp) {
-				$command = "memcache get ".$key;
-				return event_socket_request($fp, 'api '.$command);
-			}
-			else {
+			if ($fp === false) {
 				return false;
 			}
+
+		//send a custom event
+
+		//run the memcache
+			$command = "memcache get ".$key;
+			$result = event_socket_request($fp, 'api '.$command);
+
+		//close event socket
+			fclose($fp);
+
+		// return result
+			return $result;
 	}
 
 	/**
@@ -69,52 +81,58 @@ class cache {
 	 * @var string $key		cache id
 	 */
 	public function delete($key) {
-		//send a custom event
+		// connect to event socket
 			$fp = event_socket_create($_SESSION['event_socket_ip_address'], $_SESSION['event_socket_port'], $_SESSION['event_socket_password']);
-			if ($fp) {
-				$event = "sendevent CUSTOM\n";
-				$event .= "Event-Name: MEMCACHE\n";
-				$event .= "Event-Subclass: delete\n";
-				$event .= "API-Command: memcache\n";
-				$event .= "API-Command-Argument: delete ".$key."\n";
-				echo event_socket_request($fp, $event);
-			}
-
-		//run the memcache
-			$fp = event_socket_create($_SESSION['event_socket_ip_address'], $_SESSION['event_socket_port'], $_SESSION['event_socket_password']);
-			if ($fp) {
-				$command = "memcache delete ".$key;
-				return event_socket_request($fp, 'api '.$command);
-			}
-			else {
+			if ($fp === false) {
 				return false;
 			}
+
+		//send a custom event
+			$event = "sendevent CUSTOM\n";
+			$event .= "Event-Name: MEMCACHE\n";
+			$event .= "Event-Subclass: delete\n";
+			$event .= "API-Command: memcache\n";
+			$event .= "API-Command-Argument: delete ".$key."\n";
+			event_socket_request($fp, $event);
+
+		//run the memcache
+			$command = "memcache delete ".$key;
+			$result = event_socket_request($fp, 'api '.$command);
+
+		//close event socket
+			fclose($fp);
+
+		// return result
+			return $result;
 	}
 
 	/**
 	 * Delete the entire cache
 	 */
 	public function flush() {
-		//send a custom event
+		// connect to event socket
 			$fp = event_socket_create($_SESSION['event_socket_ip_address'], $_SESSION['event_socket_port'], $_SESSION['event_socket_password']);
-			if ($fp) {
-				$event = "sendevent CUSTOM\n";
-				$event .= "Event-Name: MEMCACHE\n";
-				$event .= "Event-Subclass: flush\n";
-				$event .= "API-Command: memcache\n";
-				$event .= "API-Command-Argument: flush\n";
-				echo event_socket_request($fp, $event);
-			}
-
-		//run the memcache
-			$fp = event_socket_create($_SESSION['event_socket_ip_address'], $_SESSION['event_socket_port'], $_SESSION['event_socket_password']);
-			if ($fp) {
-				$command = "memcache flush";
-				return event_socket_request($fp, 'api '.$command);
-			}
-			else {
+			if ($fp === false) {
 				return false;
 			}
+
+		//send a custom event
+			$event = "sendevent CUSTOM\n";
+			$event .= "Event-Name: MEMCACHE\n";
+			$event .= "Event-Subclass: flush\n";
+			$event .= "API-Command: memcache\n";
+			$event .= "API-Command-Argument: flush\n";
+			event_socket_request($fp, $event);
+
+		//run the memcache
+			$command = "memcache flush";
+			$result = event_socket_request($fp, 'api '.$command);
+
+		//close event socket
+			fclose($fp);
+
+		// return result
+			return $result;
 	}
 }
 


### PR DESCRIPTION
Fix. Implicitly close esl connection after do cache command.