### PR TITLE
Update install_fusionpbx.php

### DIFF
--- a/core/install/resources/classes/install_fusionpbx.php
+++ b/core/install/resources/classes/install_fusionpbx.php
@@ -410,21 +410,21 @@ include "root.php";
 					$connect_string;
 					if (strlen($this->global_settings->db_host()) == 0 && strlen($this->global_settings->db_port()) == 0) {
 						//if both host and port are empty use the unix socket
-						$connect_string = "mysql:host=$this->global_settings->db_host();unix_socket=/var/run/mysqld/mysqld.sock;";
+						$connect_string = "mysql:host={$this->global_settings->db_host()};unix_socket=/var/run/mysqld/mysqld.sock;";
 					}
 					elseif (strlen($this->global_settings->db_port()) == 0) {
 						//leave out port if it is empty
-						$connect_string = "mysql:host=$this->global_settings->db_host();";
+						$connect_string = "mysql:host={$this->global_settings->db_host()};";
 					}
 					else {
-						$connect_string = "mysql:host=$this->global_settings->db_host();port=$this->global_settings->db_port();";
+						$connect_string = "mysql:host={$this->global_settings->db_host()};port={$this->global_settings->db_port()};";
 					}
 
 				//create the table, user and set the permissions only if the db_create_username was provided
-					if ($this->global_settings->db_create()) {
+					if ($this->global_settings->db_create_username()) {
 						$this->write_progress("\tCreating database");				
 						try {
-							$this->dbh = new PDO($connect_string, $this->global_settings->db_create_username(), db_create_password, array(PDO::MYSQL_ATTR_INIT_COMMAND => 'SET NAMES utf8'));
+							$this->dbh = new PDO($connect_string, $this->global_settings->db_create_username(), $this->global_settings->db_create_password(), array(PDO::MYSQL_ATTR_INIT_COMMAND => 'SET NAMES utf8'));
 							$this->dbh->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 							$this->dbh->setAttribute(PDO::ATTR_EMULATE_PREPARES, true);
 						}
@@ -441,7 +441,7 @@ include "root.php";
 
 						//create user and set the permissions
 							try {
-								$tmp_sql = "CREATE USER '".$this->global_settings->db_username()."'@'%' IDENTIFIED BY '".$this->global_settings->db_password()."'; ";
+								$tmp_sql = "GRANT SELECT ON ".$this->global_settings->db_name().".* TO '"$this->global_settings->db_username()."'@'%' IDENTIFIED BY '".$this->global_settings->db_password()."'; ";
 								$this->dbh->query($tmp_sql);
 							}
 							catch (PDOException $error) {
@@ -503,7 +503,7 @@ include "root.php";
 				$this->write_progress("\tInstalling data to database");
 				//select the database
 					try {
-						$this->dbh = new PDO($connect_string, $this->global_settings->db_username(), db_password, array(PDO::MYSQL_ATTR_INIT_COMMAND => 'SET NAMES utf8'));
+						$this->dbh = new PDO($connect_string, $this->global_settings->db_username(), $this->global_settings->db_password(), array(PDO::MYSQL_ATTR_INIT_COMMAND => 'SET NAMES utf8'));
 						$this->dbh->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 						$this->dbh->setAttribute(PDO::ATTR_EMULATE_PREPARES, true);
 					}

--- a/core/install/resources/classes/install_fusionpbx.php
+++ b/core/install/resources/classes/install_fusionpbx.php
@@ -441,7 +441,7 @@ include "root.php";
 
 						//create user and set the permissions
 							try {
-								$tmp_sql = "CREATE USER '".$this->global_settings->db_username()."'@'%' IDENTIFIED BY '".$this->global_settings->db_password()."'; ";
+								$tmp_sql = "GRANT SELECT ON ".$this->global_settings->db_name().".* TO '".$this->global_settings->db_username()."'@'%' IDENTIFIED BY '".$this->global_settings->db_password()."'; ";
 								$this->dbh->query($tmp_sql);
 							}
 							catch (PDOException $error) {

--- a/core/install/resources/classes/install_fusionpbx.php
+++ b/core/install/resources/classes/install_fusionpbx.php
@@ -441,7 +441,7 @@ include "root.php";
 
 						//create user and set the permissions
 							try {
-								$tmp_sql = "GRANT SELECT ON ".$this->global_settings->db_name().".* TO '"$this->global_settings->db_username()."'@'%' IDENTIFIED BY '".$this->global_settings->db_password()."'; ";
+								$tmp_sql = "CREATE USER '".$this->global_settings->db_username()."'@'%' IDENTIFIED BY '".$this->global_settings->db_password()."'; ";
 								$this->dbh->query($tmp_sql);
 							}
 							catch (PDOException $error) {


### PR DESCRIPTION
Fix several problems causing mysql create to fail.

-All these fixes were tested on CentOS v7 using PHP v5.4 and MariaDB v5.5

* Without brackets the variables strings are not returned.  

* db_create_password variable is incorrect so I changed it to $this->global_settings->db_create_password().

*  db_password variable is incorrect so I changed it to $this->global_settings->db_password().
  