### PR TITLE
simplified polycom rules

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -17,10 +17,6 @@ RewriteRule     ^(?:.*/)?provision/([A-Fa-f0-9]{12})(\.(xml|cfg))?$         app/
 #Polycom
 RewriteRule     ^(?:.*/)?provision/000000000000.cfg$                       app/provison/?mac=$1&file={$mac}.cfg [QSA]
 RewriteRule     ^(?:.*/)?provision/features.cfg$                           app/provision/?mac=$1&file=features.cfg [QSA]
-RewriteRule     ^(?:.*/)?provision/([A-Fa-f0-9]{12})-sip.cfg$              app/provision/?mac=$1&file=sip.cfg [QSA]
-RewriteRule     ^(?:.*/)?provision/([A-Fa-f0-9]{12})-phone.cfg$            app/provision/?mac=$1 [QSA]
-RewriteRule     ^(?:.*/)?provision/([A-Fa-f0-9]{12})-registration.cfg$     app/provision/?mac=$1&file={$mac}-registration.cfg [QSA]
-RewriteRule     ^(?:.*/)?provision/([A-Fa-f0-9]{12})-site.cfg$             app/provision/?mac=$1&file=site.cfg [QSA]
-RewriteRule     ^(?:.*/)?provision/([A-Fa-f0-9]{12})-web.cfg$              app/provision/?mac=$1&file=web.cfg [QSA]
+RewriteRule     ^(?:.*/)?provision/([A-Fa-f0-9]{12})-([a-zA-Z0-9-_.]+)$    app/provision/?mac=$1&file=$2 [QSA]
 
 Options -Indexes


### PR DESCRIPTION
simplified polycom rewrites to support ${mac}-any_filename.ext
the filename portion can only be alphanumeric and a - or _ or .