### PR TITLE
Update W52P Provisioning Template

### DIFF
--- a/resources/templates/provision/yealink/w52p/{$mac}.cfg
+++ b/resources/templates/provision/yealink/w52p/{$mac}.cfg
@@ -80,7 +80,7 @@ account.1.precondition =
 account.1.subscribe_register =
 
 #Enable or disable the phone to subscribe the message waiting indicator; 0-Disabled (default), 1-Enabled;
-account.1.subscribe_mwi = 
+account.1.subscribe_mwi = 1
 
 #Configure MWI subscribe expiry time (in seconds). It ranges from 0 to 84600, the default value is 3600.
 account.1.subscribe_mwi_expires = 


### PR DESCRIPTION
account.1.subscribe_mwi should be set to '1' as per Yealink documentation. Not setting this may cause MWI to not work on the W52P.