### PR TITLE
Fix. Break query loop accordin FS documentation

### DIFF
--- a/resources/install/scripts/resources/functions/database.lua
+++ b/resources/install/scripts/resources/functions/database.lua
@@ -77,6 +77,38 @@ local function new_database(backend)
 
     assert(db:connected())
 
+    do local x = 0
+    db:query("select 1 as v union all select 2 as v", function(row)
+      x = x + 1
+      return 1
+    end)
+    assert(x == 1, ("Got %d expected %d"):format(x, 1))
+    end
+
+    do local x = 0
+    db:query("select 1 as v union all select 2 as v", function(row)
+      x = x + 1
+      return 0
+    end)
+    assert(x == 2, ("Got %d expected %d"):format(x, 2))
+    end
+
+    do local x = 0
+    db:query("select 1 as v union all select 2 as v", function(row)
+      x = x + 1
+      return true
+    end)
+    assert(x == 2, ("Got %d expected %d"):format(x, 2))
+    end
+
+    do local x = 0
+    db:query("select 1 as v union all select 2 as v", function(row)
+      x = x + 1
+      return false
+    end)
+    assert(x == 2, ("Got %d expected %d"):format(x, 2))
+    end
+
     assert("1" == db:first_value("select 1 as v union all select 2 as v"))
 
     local t = assert(db:first_row("select '1' as v union all select '2' as v"))
@@ -99,6 +131,11 @@ local function new_database(backend)
 
     db:release()
     assert(not db:connected())
+
+    -- second close
+    db:release()
+    assert(not db:connected())
+
     log.info('self_test Database - pass')
   end
 

--- a/resources/install/scripts/resources/functions/database.lua
+++ b/resources/install/scripts/resources/functions/database.lua
@@ -88,6 +88,14 @@ local function new_database(backend)
     do local x = 0
     db:query("select 1 as v union all select 2 as v", function(row)
       x = x + 1
+      return -1
+    end)
+    assert(x == 1, ("Got %d expected %d"):format(x, 1))
+    end
+
+    do local x = 0
+    db:query("select 1 as v union all select 2 as v", function(row)
+      x = x + 1
       return 0
     end)
     assert(x == 2, ("Got %d expected %d"):format(x, 2))

--- a/resources/install/scripts/resources/functions/database.lua
+++ b/resources/install/scripts/resources/functions/database.lua
@@ -117,6 +117,14 @@ local function new_database(backend)
     assert(x == 2, ("Got %d expected %d"):format(x, 2))
     end
 
+    do local x = 0
+    db:query("select 1 as v union all select 2 as v", function(row)
+      x = x + 1
+      return "1"
+    end)
+    assert(x == 1, ("Got %d expected %d"):format(x, 2))
+    end
+
     assert("1" == db:first_value("select 1 as v union all select 2 as v"))
 
     local t = assert(db:first_row("select '1' as v union all select '2' as v"))

--- a/resources/install/scripts/resources/functions/database/luasql.lua
+++ b/resources/install/scripts/resources/functions/database/luasql.lua
@@ -54,7 +54,8 @@ function LuaSQLDatabase:query(sql, fn)
       local row, err = cur:fetch({}, "a")
       if not row then break end
       local ok, ret = pcall(fn, apply_names(row, colnames, ""))
-      if (not ok) or (type(ret) == 'number' and ret ~= 0) then
+      ret = tonumber(ret)
+      if (not ok) or (ret and ret ~= 0) then
         break
       end
     end

--- a/resources/install/scripts/resources/functions/database/luasql.lua
+++ b/resources/install/scripts/resources/functions/database/luasql.lua
@@ -54,7 +54,7 @@ function LuaSQLDatabase:query(sql, fn)
       local row, err = cur:fetch({}, "a")
       if not row then break end
       local ok, ret = pcall(fn, apply_names(row, colnames, ""))
-      if (not ok) or (type(ret) == 'number' and ret > 0) then
+      if (not ok) or (type(ret) == 'number' and ret ~= 0) then
         break
       end
     end

--- a/resources/install/scripts/resources/functions/database/odbc.lua
+++ b/resources/install/scripts/resources/functions/database/odbc.lua
@@ -38,7 +38,10 @@ function OdbcDatabase:query(sql, fn)
   self._rows_affected = nil
   if fn then
     return self._dbh:neach(sql, function(row)
-      return fn(remove_null(row, odbc.NULL, ""))
+      local n = fn(remove_null(row, odbc.NULL, ""))
+      if type(n) == 'number' and n ~= 0 then
+        return true
+      end
     end)
   end
   local ok, err = self._dbh:exec(sql)

--- a/resources/install/scripts/resources/functions/database/odbc.lua
+++ b/resources/install/scripts/resources/functions/database/odbc.lua
@@ -38,8 +38,8 @@ function OdbcDatabase:query(sql, fn)
   self._rows_affected = nil
   if fn then
     return self._dbh:neach(sql, function(row)
-      local n = fn(remove_null(row, odbc.NULL, ""))
-      if type(n) == 'number' and n ~= 0 then
+      local n = tonumber((fn(remove_null(row, odbc.NULL, ""))))
+      if n and n ~= 0 then
         return true
       end
     end)

--- a/resources/install/scripts/resources/functions/database/odbcpool.lua
+++ b/resources/install/scripts/resources/functions/database/odbcpool.lua
@@ -39,8 +39,8 @@ function OdbcPoolDatabase:query(sql, fn)
   if fn then
     ok, err = cli:acquire(self._timeout, function(dbh)
       local ok, err = dbh:neach(sql, function(row)
-        local n = fn(remove_null(row, odbc.NULL, ""))
-        if type(n) == 'number' and n ~= 0 then
+        local n = tonumber((fn(remove_null(row, odbc.NULL, ""))))
+        if n and n ~= 0 then
           return true
         end
       end)

--- a/resources/install/scripts/resources/functions/database/odbcpool.lua
+++ b/resources/install/scripts/resources/functions/database/odbcpool.lua
@@ -39,7 +39,10 @@ function OdbcPoolDatabase:query(sql, fn)
   if fn then
     ok, err = cli:acquire(self._timeout, function(dbh)
       local ok, err = dbh:neach(sql, function(row)
-        return fn(remove_null(row, odbc.NULL, ""))
+        local n = fn(remove_null(row, odbc.NULL, ""))
+        if type(n) == 'number' and n ~= 0 then
+          return true
+        end
       end)
       if err and not ok then
         log.errf("Can not execute sql: %s\n%s", tostring(err), sql)


### PR DESCRIPTION
From [FreeSWITCH documentation](https://freeswitch.org/confluence/display/FREESWITCH/Lua+with+Database#LuawithDatabase-freeswitch.Dbh) 

> If you (optionally) return a **number other than 0** from the callback-function, you'll break the loop.

Problem that FS also breaks loop if callback returns string which contain number
```Lua
dbh:query(sql, function()
  -- according doc it should not break loop
  --  but it do in current implementation.
  return "1"
end)
```