### PR TITLE
Fix. Use operator panel with short extension.

### DIFF
--- a/app/operator_panel/resources/functions/get_call_activity.php
+++ b/app/operator_panel/resources/functions/get_call_activity.php
@@ -166,9 +166,11 @@ function get_call_activity() {
 		}
 
 		//reindex array using extension instead of auto-incremented value
+		$result = array();
 		foreach ($array as $index => $subarray) {
+			$extension = $subarray['extension'];
 			foreach ($subarray as $field => $value) {
-				$array[$subarray['extension']][$field] = $array[$index][$field];
+				$result[$extension][$field] = $array[$index][$field];
 				unset($array[$index][$field]);
 			}
 			unset($array[$subarray['extension']]['extension']);
@@ -176,5 +178,5 @@ function get_call_activity() {
 		}
 
 	//return array
-		return $array;
+		return $result;
 }


### PR DESCRIPTION
Problem because if you have say 15 ext. and one of ext has say number `14`
and extension `14` has index 15 in array.
And php returns
```PHP
$a = array('14' => 'string', 14 => 'number');
print($a['14']); // number
``