### PR TITLE
WhitespaceClean-app/dialplan

### DIFF
--- a/app/dialplan/resources/classes/dialplan.php
+++ b/app/dialplan/resources/classes/dialplan.php
@@ -485,7 +485,7 @@ include "root.php";
 										$dialplan_detail_data = str_replace("\$1", $regex_match_1, $dialplan_detail_data);
 										$dialplan_detail_data = str_replace("\$2", $regex_match_2, $dialplan_detail_data);
 										$dialplan_detail_data = str_replace("\$3", $regex_match_3, $dialplan_detail_data);
-										$this->bridges = $dialplan_detail_data; 
+										$this->bridges = $dialplan_detail_data;
 									}
 							}
 						}

--- a/app/dialplan/resources/switch/conf/dialplan/310_att_xfer.xml
+++ b/app/dialplan/resources/switch/conf/dialplan/310_att_xfer.xml
@@ -1,4 +1,4 @@
-﻿<context name="{v_context}"> 
+﻿<context name="{v_context}">
 	<extension name="att_xfer" number="att_xfer" continue="false" app_uuid="7bd7a113-0afc-406a-b4a7-33077c22ac39">
 		<condition field="destination_number" expression="^att_xfer$">
 			<action application="read" data="2 6 'tone_stream://%(10000,0,350,440)' digits 30000 #"/>

--- a/app/dialplan/resources/switch/conf/dialplan/410_freeswitch_conference.xml
+++ b/app/dialplan/resources/switch/conf/dialplan/410_freeswitch_conference.xml
@@ -2,7 +2,7 @@
 	<extension name="freeswitch_conference" number="*9888" continue="false" app_uuid="8e3ad78e-4b48-4d36-af7e-4920a9757043" enabled="false">
 		<condition field="destination_number" expression="^\*9(888|8888|1616|3232)$">
 			<action application="export" data="hold_music=silence"/>
-			<!-- 
+			<!--
 				 This will take the SAS from the b-leg and send it to the display on the a-leg phone.
 				 Known working with Polycom and Snom maybe others.
 			-->

--- a/app/dialplan/resources/switch/conf/dialplan/430_directory.xml
+++ b/app/dialplan/resources/switch/conf/dialplan/430_directory.xml
@@ -1,7 +1,7 @@
 <context name="{v_context}">
 	<extension name="directory" number="*411" continue="false" app_uuid="a223dc70-28a1-4979-834e-8af813cd8ea6">
 		<condition field="destination_number" expression="^\*411$">
-			<action application="lua" data="directory.lua"/> 
+			<action application="lua" data="directory.lua"/>
 		</condition>
 	</extension>
 </context>

--- a/app/dialplan_inbound/app_defaults.php
+++ b/app/dialplan_inbound/app_defaults.php
@@ -60,7 +60,7 @@
 	if (count($_SESSION["domains"]) > 1) {
 		//make sure the public directory and xml file exist
 		if (strlen($_SESSION['switch']['dialplan']['dir']) > 0) {
-			if (!is_dir($_SESSION['switch']['dialplan']['dir'].'/public'.$_SESSION['domains'][$domain_uuid]['domain_name'])) { 
+			if (!is_dir($_SESSION['switch']['dialplan']['dir'].'/public'.$_SESSION['domains'][$domain_uuid]['domain_name'])) {
 				mkdir($_SESSION['switch']['dialplan']['dir'].'/public/'.$_SESSION['domains'][$domain_uuid]['domain_name'],0777,true);
 			}
 			$file = $_SESSION['switch']['dialplan']['dir']."/public/".$_SESSION['domains'][$domain_uuid]['domain_name'].".xml";


### PR DESCRIPTION
whitespace pass over files
for reference regex that was used s/[ \t]+(\r?\n)/\1/