### PR TITLE
WhitespaceClean-app/sip_profiles

### DIFF
--- a/app/sip_profiles/resources/xml/sip_profiles/default.xml
+++ b/app/sip_profiles/resources/xml/sip_profiles/default.xml
@@ -1,5 +1,5 @@
 <profile name="{v_sip_profile_name}">
-	<!-- http://wiki.freeswitch.org/wiki/Sofia_Configuration_Files --> 
+	<!-- http://wiki.freeswitch.org/wiki/Sofia_Configuration_Files -->
 	<!--aliases are other names that will work as a valid profile name for this profile-->
 	<aliases>
 	</aliases>

--- a/app/sip_profiles/resources/xml/sip_profiles/external-ipv6.xml
+++ b/app/sip_profiles/resources/xml/sip_profiles/external-ipv6.xml
@@ -1,8 +1,8 @@
 <profile name="{v_sip_profile_name}">
-	<!-- http://wiki.freeswitch.org/wiki/Sofia_Configuration_Files --> 
+	<!-- http://wiki.freeswitch.org/wiki/Sofia_Configuration_Files -->
 	<!--aliases are other names that will work as a valid profile name for this profile-->
 	<aliases>
-		<!-- 
+		<!--
 		<alias name="outbound"/>
 		<alias name="nat"/>
 		-->

--- a/app/sip_profiles/resources/xml/sip_profiles/external.xml
+++ b/app/sip_profiles/resources/xml/sip_profiles/external.xml
@@ -1,8 +1,8 @@
 <profile name="{v_sip_profile_name}">
-	<!-- http://wiki.freeswitch.org/wiki/Sofia_Configuration_Files --> 
+	<!-- http://wiki.freeswitch.org/wiki/Sofia_Configuration_Files -->
 	<!--aliases are other names that will work as a valid profile name for this profile-->
 	<aliases>
-		<!-- 
+		<!--
 		<alias name="outbound"/>
 		<alias name="nat"/>
 		-->

--- a/app/sip_profiles/resources/xml/sip_profiles/internal-ipv6.xml
+++ b/app/sip_profiles/resources/xml/sip_profiles/internal-ipv6.xml
@@ -1,5 +1,5 @@
 <profile name="{v_sip_profile_name}">
-	<!-- http://wiki.freeswitch.org/wiki/Sofia_Configuration_Files --> 
+	<!-- http://wiki.freeswitch.org/wiki/Sofia_Configuration_Files -->
 	<settings>
 {v_sip_profile_settings}
 	</settings>

--- a/app/sip_profiles/resources/xml/sip_profiles/internal.xml
+++ b/app/sip_profiles/resources/xml/sip_profiles/internal.xml
@@ -1,5 +1,5 @@
 <profile name="{v_sip_profile_name}">
-	<!-- http://wiki.freeswitch.org/wiki/Sofia_Configuration_Files --> 
+	<!-- http://wiki.freeswitch.org/wiki/Sofia_Configuration_Files -->
 	<!--aliases are other names that will work as a valid profile name for this profile-->
 	<aliases>
 		<!--
@@ -17,7 +17,7 @@
 		<!--<domain name="$${domain}" parse="true"/>-->
 		<!-- indicator to parse the directory for domains with parse="true" to get gateways and alias every domain to this profile -->
 		<!--<domain name="all" alias="true" parse="true"/>-->
-		<domain name="all" alias="true" parse="false"/> 
+		<domain name="all" alias="true" parse="false"/>
 	</domains>
 
 	<settings>


### PR DESCRIPTION
whitespace pass over files
for reference regex that was used s/[ \t]+(\r?\n)/\1/