### PR TITLE
WhitespaceClean-app/xml_cdr

### DIFF
--- a/app/xml_cdr/v_xml_cdr_import.php
+++ b/app/xml_cdr/v_xml_cdr_import.php
@@ -80,10 +80,10 @@
 			global $debug;
 
 		//fix the xml by escaping the contents of <sip_full_XXX>
-			$xml_string = preg_replace_callback("/<([^><]+)>(.*?[><].*?)<\/\g1>/", 
+			$xml_string = preg_replace_callback("/<([^><]+)>(.*?[><].*?)<\/\g1>/",
 				function ($matches) {
 					return '<' . $matches[1] . '>' .
-						str_replace(">", "&gt;", 
+						str_replace(">", "&gt;",
 							str_replace("<", "&lt;", $matches[2])
 						) .
 					'</' . $matches[1] . '>';

--- a/app/xml_cdr/xml_cdr_import_update.php
+++ b/app/xml_cdr/xml_cdr_import_update.php
@@ -82,7 +82,7 @@
 							$db->beginTransaction();
 						//reset the count
 							$x = 0;
-					}	
+					}
 				//parse the xml to get the call detail record info
 					try {
 						$xml = simplexml_load_string($xml_string);
@@ -101,14 +101,14 @@
 						echo $sql."\n";
 						$db->exec($sql);
 						$x++;
-					}				
+					}
 			}
 		//save the transaction
 			$db->commit();
 		//echo finished
 			echo "completed\n";
 	}
-	if ($xml_cdr_archive == "dir") { 
+	if ($xml_cdr_archive == "dir") {
 		$xml_cdr_list = glob($_SESSION['switch']['log']['dir']."/xml_cdr/archive/*/*/*/*.xml");
 		echo "count: ".count($xml_cdr_list)."\n";
 		//print_r($xml_cdr_list);

--- a/app/xml_cdr/xml_cdr_statistics_inc.php
+++ b/app/xml_cdr/xml_cdr_statistics_inc.php
@@ -125,7 +125,7 @@ else {
          } else {
              $mos_comparison = '';
         }
-		//$mos_comparison = check_str($_REQUEST["mos_comparison"]);		
+		//$mos_comparison = check_str($_REQUEST["mos_comparison"]);
 		$mos_score = check_str($_REQUEST["mos_score"]);
 	}
 


### PR DESCRIPTION
whitespace pass over files
for reference regex that was used s/[ \t]+(\r?\n)/\1/