### PR TITLE
WhitespaceClean-resources/templates/conf

### DIFF
--- a/resources/templates/conf/autoload_configs/cidlookup.conf.xml
+++ b/resources/templates/conf/autoload_configs/cidlookup.conf.xml
@@ -23,7 +23,7 @@ WHERE v_contact_phones.contact_uuid = v_contacts.contact_uuid AND (v_contact_pho
 LIMIT 1
       "/>
 
-    <!-- comment out citystate-sql to not setup a database (city/state) 
+    <!-- comment out citystate-sql to not setup a database (city/state)
          lookup -->
     <!--
     <param name="citystate-sql" value="

--- a/resources/templates/conf/autoload_configs/console.conf.xml
+++ b/resources/templates/conf/autoload_configs/console.conf.xml
@@ -2,8 +2,8 @@
   <!-- pick a file name, a function name or 'all' -->
   <!-- map as many as you need for specific debugging -->
   <mappings>
-    <!-- 
-      name can be a file name, function name or 'all' 
+    <!--
+      name can be a file name, function name or 'all'
       value is one or more of debug,info,notice,warning,err,crit,alert,all
       See examples below
 
@@ -15,11 +15,11 @@
       Example: the following turns on debugging for error and critical levels only
       <map name="all" value="err,crit"/>
 
-      NOTE: using map name="all" will override any other settings!  If you 
+      NOTE: using map name="all" will override any other settings!  If you
             want a more specific set of console messages then you will need
             to specify which files and/or functions you want to have debug
-            messages.  One option is to turn on just the more critical 
-            messages with map name="all", then specify the other types of 
+            messages.  One option is to turn on just the more critical
+            messages with map name="all", then specify the other types of
             console messages you want to see for various files and functions.
 
       Example: turn on ERROR, CRIT, ALERT for all modules, then specify other
@@ -31,12 +31,12 @@
         <map name="mod_sndfile.c" value="warning,info,debug"/>
      -->
     <map name="all" value="console,debug,info,notice,warning,err,crit,alert"/>
-    
+
     <!--
       You can use or modify this sample set of mappings.  It turns on higher
       level messages for all modules and then specifies extra lower level
       messages for OpenZAP, Sofia, and switch core messages.
-      
+
     <map name="all"                         value="warning,err,crit,alert"/>
     <map name="zap_analog.c"                value="all"/>
     <map name="zap_io.c"                    value="all"/>
@@ -44,8 +44,8 @@
     <map name="zap_zt.c"                    value="all"/>
     <map name="mod_openzap"                 value="all"/>
     <map name="sofia.c"                     value="notice"/>
-    <map name="switch_core_state_machine.c" value="all"/>      
-    
+    <map name="switch_core_state_machine.c" value="all"/>
+
     -->
   </mappings>
   <settings>

--- a/resources/templates/conf/autoload_configs/directory.conf.xml
+++ b/resources/templates/conf/autoload_configs/directory.conf.xml
@@ -18,4 +18,4 @@
       <param name="search-order" value="last_name"/>
     </profile>
   </profiles>
-</configuration> 
+</configuration>

--- a/resources/templates/conf/autoload_configs/easyroute.conf.xml
+++ b/resources/templates/conf/autoload_configs/easyroute.conf.xml
@@ -7,7 +7,7 @@
 
     <!-- Default Technology and profile -->
     <param name="default-techprofile" value="sofia/default"/>
-    
+
     <!-- IP or Hostname of Default Route -->
     <param name="default-gateway" value="192.168.66.6"/>
 
@@ -21,7 +21,7 @@
 	 call_limit varchar(16) - contains optional call limit
 	 tech_prefix varchar(128) - tech prefix used to build dial string (ex: sofia/default )
 	 acctcode varchar(128) - used to set channel variable acctcode for logging into the CDRs
-	 destination_number varchar(16) - Number returning for the query for building the dial string. (ex: 18005551212) 
+	 destination_number varchar(16) - Number returning for the query for building the dial string. (ex: 18005551212)
 	 See Documentation on the Wiki for further information -->
     <!-- <param name="custom-query" value="call  FS_GET_SIP_LOCATION(%s);"/> -->
   </settings>

--- a/resources/templates/conf/autoload_configs/erlang_event.conf.xml
+++ b/resources/templates/conf/autoload_configs/erlang_event.conf.xml
@@ -16,7 +16,7 @@
     <!-- in additon to cookie, optionally restrict by ACL -->
     <!--<param name="apply-inbound-acl" value="lan"/>-->
     <!-- alternative is "binary" -->
-    <!--<param name="encoding" value="string"/>--> 
+    <!--<param name="encoding" value="string"/>-->
     <!-- provide compatability with previous OTP release (use with care) -->
     <!--<param name="compat-rel" value="12"/> -->
   </settings>

--- a/resources/templates/conf/autoload_configs/freetdm.conf.xml
+++ b/resources/templates/conf/autoload_configs/freetdm.conf.xml
@@ -1,6 +1,6 @@
 <!-- Please refer to http://wiki.freeswitch.org/wiki/FreeTDM for further documentation  -->
 
-<!-- 
+<!--
 This is a sample FreeSWITCH XML configuration for FreeTDM
 Remember you still need to configure freetdm.conf (no XML extension) in $prefix/conf/
 directory of FreeSWITCH. The freetdm.conf (no XML extension) is a simple text file
@@ -8,11 +8,11 @@ definining the I/O interfaces (Sangoma, DAHDI etc). This file (freetdm.conf.xml)
 with the signaling protocols that you can run on top of your I/O interfaces.
 -->
 <configuration name="freetdm.conf" description="FreeTDM Configuration">
-	
+
 	<settings>
 		<param name="debug" value="0"/>
 		<!--<param name="hold-music" value="$${moh_uri}"/>-->
-		<!-- Analog global options (they apply to all spans) 
+		<!-- Analog global options (they apply to all spans)
 		     Remember you can only choose between either call-swap
 		     or 3-way, not both!
 		-->
@@ -65,7 +65,7 @@ with the signaling protocols that you can run on top of your I/O interfaces.
 			<!-- whether you want to enable callwaiting feature -->
 			<!--<param name="callwaiting" value="true"/>-->
 
-			<!-- whether you want to answer/hangup on polarity reverse for outgoing calls in FXO devices 
+			<!-- whether you want to answer/hangup on polarity reverse for outgoing calls in FXO devices
 			     and send polarity reverse on answer/hangup for incoming calls in FXS devices -->
 			<!--<param name="answer-polarity-reverse" value="false"/>-->
 			<!--<param name="hangup-polarity-reverse" value="false"/>-->
@@ -76,7 +76,7 @@ with the signaling protocols that you can run on top of your I/O interfaces.
 			-->
 
 			<!-- Retrieve caller id on polarity reverse -->
-			<!-- 
+			<!--
 			<param name="polarity-callerid" value="true"/>
 			-->
 
@@ -92,10 +92,10 @@ with the signaling protocols that you can run on top of your I/O interfaces.
 		</span>
 	</analog_spans>
 
-	<!-- 
-	
+	<!--
+
  	openr2 (MFC-R2 signaling) spans (ftmod_r2)
-	
+
 	In order to use this type of spans your FreeTDM must have been compiled with ftmod_r2 module.
 	The module is compiled if the openr2 library is present when running the ./configure script
 	in the FreeTDM source code
@@ -103,17 +103,17 @@ with the signaling protocols that you can run on top of your I/O interfaces.
 	MFC-R2 signaling has lots of variants from country to country and even sometimes
 	minor variants inside the same country. The only mandatory parameters here are:
 	variant, but typically you also want to set max_ani and max_dnis.
-	IT IS RECOMMENDED that you leave the default values (leaving them commented) for the 
-	other parameters unless you have problems or you have been instructed to change some 
-	parameter. OpenR2 library uses the 'variant' parameter to try to determine the 
-	best defaults for your country.  If you want to contribute your configs for a particular 
-	country send them to the e-mail of the primary OpenR2 developer that you can find in the 
+	IT IS RECOMMENDED that you leave the default values (leaving them commented) for the
+	other parameters unless you have problems or you have been instructed to change some
+	parameter. OpenR2 library uses the 'variant' parameter to try to determine the
+	best defaults for your country.  If you want to contribute your configs for a particular
+	country send them to the e-mail of the primary OpenR2 developer that you can find in the
 	AUTHORS file of the OpenR2 package, they will be added to the samples directory of openr2.
 
 	-->
 	<r2_spans>
 		<span name="wp1" cfgprofile="testr2">
-			
+
 			<!--
 			MFC/R2 variant. This depends on the OpenR2 supported variants
 			A list of values can be found by executing the openr2 command r2test -l
@@ -130,20 +130,20 @@ with the signaling protocols that you can run on top of your I/O interfaces.
 			<param name="dialplan" value="XML"/>
 			<param name="context" value="default"/>
 
-			<!-- 
+			<!--
 			Max amount of ANI (caller id digits) to ask for
-			<param name="max_ani" value="4"/> 
+			<param name="max_ani" value="4"/>
 			-->
-			<!-- 
-			Max amount of DNIS to ask for 
-			<param name="max_dnis" value="4"/> 
+			<!--
+			Max amount of DNIS to ask for
+			<param name="max_dnis" value="4"/>
 			-->
 
 			<!-- Do not set parameters below this line unless you desire to tweak it because is not working -->
-			
-			<!-- 
+
+			<!--
 			Whether or not to get the ANI before getting DNIS (only affects incoming calls)
-			Some telcos require ANI first some others do not care, if default go wrong on 
+			Some telcos require ANI first some others do not care, if default go wrong on
 			incoming calls, change this value
 			<param name="get_ani_first" value="yes"/>
 			-->
@@ -237,23 +237,23 @@ with the signaling protocols that you can run on top of your I/O interfaces.
 			WARNING: advanced users only! I really mean it
 			this parameter is commented by default because
 			YOU DON'T NEED IT UNLESS YOU REALLY GROK MFC/R2
-			READ COMMENTS on doc/r2proto.conf in openr2 package 
+			READ COMMENTS on doc/r2proto.conf in openr2 package
 			for more info
 			<param name="advanced_protocol_file" value="/usr/local/freeswitch/conf/r2proto.conf"/>
 			-->
 
 			<!-- USE THIS FOR DEBUGGING MFC-R2 PROTOCOL -->
-			<!-- 
+			<!--
 			Where to dump advanced call file protocol logs
 			<param name="logdir" value="$${base_dir}/log/mfcr2"/>
 			-->
 
-			<!-- 
+			<!--
 			MFC/R2 valid logging values are: all,error,warning,debug,notice,cas,mf,nothing
 			error,warning,debug and notice are self-descriptive
 			'cas' is for logging ABCD CAS tx and rx
 			'mf' is for logging of the Multi Frequency tones
-			You can mix up values, like: loglevel=error,debug,mf to log just error, debug and 
+			You can mix up values, like: loglevel=error,debug,mf to log just error, debug and
 			multi frequency messages
 			'all' is a special value to log all the activity
 			'nothing' is a clean-up value, in case you want to not log any activity for
@@ -265,7 +265,7 @@ with the signaling protocols that you can run on top of your I/O interfaces.
 			<param name="logging" value="debug,notice,warning,error,mf,cas"/>
 			-->
 
-			<!-- 
+			<!--
 			whether or not to drop protocol call files into 'logdir'
 			<param name="call_files" value="yes"/>
 			-->
@@ -284,7 +284,7 @@ with the signaling protocols that you can run on top of your I/O interfaces.
 	<!-- Sangoma ISDN PRI/BRI spans. Requires libsng_isdn to be installed -->
 	<sangoma_pri_spans>
 		<span name="wp1">
-			<!-- 
+			<!--
 				Switch emulation/Variant
 				Possible values are:
 					national
@@ -293,7 +293,7 @@ with the signaling protocols that you can run on top of your I/O interfaces.
 					qsig
 					euroisdn
 					ntt
-			
+
 			<param name="switchtype" value="national"/>
 			-->
 			<!--
@@ -301,7 +301,7 @@ with the signaling protocols that you can run on top of your I/O interfaces.
 				Possible values are:
 					net
 					cpe
-				
+
 				<param name="signalling" value="cpe"/>
 			-->
 			<!--
@@ -381,7 +381,7 @@ with the signaling protocols that you can run on top of your I/O interfaces.
 				Bearer Capability - User Layer 1
 				Set the Bearer Capability - User Layer 1 on outbound calls
 				Possible values are:
-				
+
 				V.110
 				ulaw
 				alaw
@@ -392,13 +392,13 @@ with the signaling protocols that you can run on top of your I/O interfaces.
 				Channel Restart Timeout
 				If we do not receive a RESTART message within this timeout on link
 				UP, we will send a channel restart.
-				
-				
+
+
 				<param name="channel-restart-timeout" value="20"/>
 			-->
 			<!--
 				Local Number (MSN)
-				On incoming calls, we will only respond to this call if 
+				On incoming calls, we will only respond to this call if
 				the Called Party Number matches this value.
 
 				Note: Up to 8 local numbers can be added per span.
@@ -452,7 +452,7 @@ with the signaling protocols that you can run on top of your I/O interfaces.
 				Force sending complete
 				Will add Sending Complete IE to outgoing SETUP message
 				By default, enabled on EuroISDN, disabled on US variants.
-				
+
 				<param name="force-sending-complete" value="yes/no"/>
 			-->
 			<!--
@@ -464,13 +464,13 @@ with the signaling protocols that you can run on top of your I/O interfaces.
 					on-proceed
 					on-progress
 					on-alert
-				
+
 				<param name="early-media-override" value="on-alert"/>
 			-->
 			<!--
 				Invert Channel ID Invert Bit
 
-				Invert the Channel ID Extend Bit 
+				Invert the Channel ID Extend Bit
 
 				<param name="chan-id-invert-extend-bit" value="yes/no"/>
 			-->
@@ -478,7 +478,7 @@ with the signaling protocols that you can run on top of your I/O interfaces.
 				CID Name transmit method
 
 				How to transmit Caller ID Name
-				
+
 				Possible values:
 				display-ie
 				user-user-ie
@@ -499,11 +499,11 @@ with the signaling protocols that you can run on top of your I/O interfaces.
 
 				<param name="cid-name-transmit-method" value="default"/>
 			-->
-			<!-- 
+			<!--
 				Q.931 Timers in seconds
-				
+
 				Override default Q.931 values
-				
+
 				timers:
 				timer-t301
 				timer-t302
@@ -526,9 +526,9 @@ with the signaling protocols that you can run on top of your I/O interfaces.
 				-->
 		</span>
 	</sangoma_pri_spans>
-	
 
-	<!-- 
+
+	<!--
 		PRI passive tapping spans. Requires patched version from libpri at http://svn.digium.com/svn/libpri/team/moy/tap-1.4
 		You must also configure FreeTDM with "-with-pritap" (see ./configure help for details)
 	-->
@@ -537,13 +537,13 @@ with the signaling protocols that you can run on top of your I/O interfaces.
 			<!-- The peer span name used to tap the link -->
 			<param name="peerspan" value="tapped2"/>
 
-			<!-- 
-				Whether to mix the audio from the peerspan with the audio from this span 
+			<!--
+				Whether to mix the audio from the peerspan with the audio from this span
 				This is most likely what you want (and therefore the default) so you can hear
 				the full conversation being tapped instead of just one side
 			-->
 			<!-- <param name="mixaudio" value="yes"/> -->
-			
+
 			<!-- switch parameters (required), where to send calls to -->
 			<param name="dialplan" value="XML"/>
 			<param name="context" value="default"/>

--- a/resources/templates/conf/autoload_configs/httapi.conf.xml
+++ b/resources/templates/conf/autoload_configs/httapi.conf.xml
@@ -29,20 +29,20 @@
 	<permission name="set-vars" value="false">
 	  <!-- default to "deny" or "allow" -->
 	  <!-- type attr can be "deny" or "allow" nothing defaults to opposite of the list default so allow in this case -->
-	  <!-- 
+	  <!--
 	  <variable-list default="deny">
 	    <variable name="caller_id_name"/>
-	    <variable name="hangup"/> 
+	    <variable name="hangup"/>
 	  </variable-list>
 	  -->
 	</permission>
 	<permission name="get-vars" value="false">
 	  <!-- default to "deny" or "allow" -->
 	  <!-- type attr can be "deny" or "allow" nothing defaults to opposite of the list default so allow in this case -->
-	  <!-- 
+	  <!--
 	  <variable-list default="deny">
 	    <variable name="caller_id_name"/>
-	    <variable name="hangup"/> 
+	    <variable name="hangup"/>
 	  </variable-list>
 	  -->
 	</permission>
@@ -58,15 +58,15 @@
 	<permission name="expand-vars-in-tag-body" value="false">
 	  <!-- default to "deny" or "allow" -->
 	  <!-- type attr can be "deny" or "allow" nothing defaults to opposite of the list default so allow in this case -->
-	  <!-- 
+	  <!--
 	  <variable-list default="deny">
 	    <variable name="caller_id_name"/>
-	    <variable name="hangup"/> 
+	    <variable name="hangup"/>
 	  </variable-list>
 
 	  <api-list default="deny">
 	    <api name="expr"/>
-	    <api name="lua"/> 
+	    <api name="lua"/>
 	  </api-list>
 	  -->
 	</permission>
@@ -79,11 +79,11 @@
 	<permission name="conference" value="true"/>
 	<permission name="conference-set-profile" value="false"/>
       </permissions>
-      
+
       <params>
 	<!-- default url can be overridden by app data -->
 	<param name="gateway-url" value="http://www.freeswitch.org/api/index.cgi" />
-	
+
 	<!-- set this to provide authentication credentials to the server -->
 	<!--<param name="gateway-credentials" value="muser:mypass"/>-->
 	<!--<param name="auth-scheme" value="basic"/>-->

--- a/resources/templates/conf/autoload_configs/lcr.conf.xml
+++ b/resources/templates/conf/autoload_configs/lcr.conf.xml
@@ -15,7 +15,7 @@
       <param name="id" value="2"/>
       <param name="order_by" value="reliability,quality"/>
     </profile>
-<!-- 
+<!--
   Some samples of how to do custom SQL:
 
     =============================================================

--- a/resources/templates/conf/autoload_configs/logfile.conf.xml
+++ b/resources/templates/conf/autoload_configs/logfile.conf.xml
@@ -18,7 +18,7 @@
 			</settings>
 			<mappings>
 				<!--
-				name can be a file name, function name or 'all' 
+				name can be a file name, function name or 'all'
 				value is one or more of debug,info,notice,warning,err,crit,alert,all
 				Please see comments in console.conf.xml for more information
 				-->

--- a/resources/templates/conf/autoload_configs/lua.conf.xml
+++ b/resources/templates/conf/autoload_configs/lua.conf.xml
@@ -1,14 +1,14 @@
 <configuration name="lua.conf" description="LUA Configuration">
   <settings>
 
-    <!-- 
+    <!--
     Specify local directories that will be searched for LUA modules
     These entries will be pre-pended to the LUA_CPATH environment variable
     -->
     <!-- <param name="module-directory" value="/usr/lib/lua/5.1/?.so"/> -->
     <!-- <param name="module-directory" value="/usr/local/lib/lua/5.1/?.so"/> -->
 
-    <!-- 
+    <!--
     Specify local directories that will be searched for LUA scripts
     These entries will be pre-pended to the LUA_PATH environment variable
     -->
@@ -21,7 +21,7 @@
     <!--
     The following options identifies a lua script that is launched
     at startup and may live forever in the background.
-    You can define multiple lines, one for each script you 
+    You can define multiple lines, one for each script you
     need to run.
     -->
 

--- a/resources/templates/conf/autoload_configs/modules.conf.xml
+++ b/resources/templates/conf/autoload_configs/modules.conf.xml
@@ -1,6 +1,6 @@
 <configuration name="modules.conf" description="Modules">
   <modules>
-    
+
     <!-- Loggers (I'd load these first) -->
     <load module="mod_console"/>
     <load module="mod_logfile"/>
@@ -113,7 +113,7 @@
     <!-- <load module="mod_cepstral"/> -->
     <!-- <load module="mod_tts_commandline"/> -->
     <!-- <load module="mod_rss"/> -->
-    
+
     <!-- Say -->
     <load module="mod_say_en"/>
     <!-- <load module="mod_say_ru"/> -->

--- a/resources/templates/conf/autoload_configs/mongo.conf.xml
+++ b/resources/templates/conf/autoload_configs/mongo.conf.xml
@@ -1,6 +1,6 @@
 <configuration name="mongo.conf">
   <settings>
-    <!-- 
+    <!--
       connection-string handles different ways to connect to mongo
       samples:
          server:port

--- a/resources/templates/conf/autoload_configs/perl.conf.xml
+++ b/resources/templates/conf/autoload_configs/perl.conf.xml
@@ -4,9 +4,9 @@
     <!--<param name="xml-handler-bindings" value="dialplan"/>-->
 
     <!--
-	The following options identifies a perl script that is launched	
+	The following options identifies a perl script that is launched
 	at startup and may live forever in the background.
-	You can define multiple lines, one for each script you 
+	You can define multiple lines, one for each script you
 	need to run.
     -->
     <!--param name="startup-script" value="startup_script_1.pl"/-->

--- a/resources/templates/conf/autoload_configs/portaudio.conf.xml
+++ b/resources/templates/conf/autoload_configs/portaudio.conf.xml
@@ -1,7 +1,7 @@
 <configuration name="portaudio.conf" description="Soundcard Endpoint">
   <settings>
-    <!-- indev, outdev, ringdev: 
-	 partial case sensitive string match on something in the name 
+    <!-- indev, outdev, ringdev:
+	 partial case sensitive string match on something in the name
 	 or the device number prefixed with # eg "#1" (or blank for default) -->
 
     <!-- device to use for input -->
@@ -33,7 +33,7 @@
     <param name="codec-ms" value="20"/>
   </settings>
 
-  <!-- 
+  <!--
 	mod_portaudio "streams"
 
 	The portaudio streams were introduced to support multiple devices and multiple channels in mod_portaudio.
@@ -41,8 +41,8 @@
 	want to use them at the same time, you can do it configuring streams and endpoints here.
 
 	A "stream" is just a logical container for some settings required by portaudio in order to stream audio and
-	define a friendly name for that configuration. Streams in itself do not do anything else than contain configs. 
-	Once you have your streams defined you can proceed to define "endpoints". Go to the "<endpoints>" section 
+	define a friendly name for that configuration. Streams in itself do not do anything else than contain configs.
+	Once you have your streams defined you can proceed to define "endpoints". Go to the "<endpoints>" section
 	for more information on endpoints.
 
 	You can use the command "pa shstreams" (portaudio shared streams) to show the configured streams.
@@ -56,16 +56,16 @@
 
 	<!-- This sample "usb1" configuration was tested with a USB Griffin iMic device -->
   	<stream name="usb1">
-		<!-- 
-			Which device to use for input in this stream 
-			The value for this parameter must be either in the form '#devno', 
+		<!--
+			Which device to use for input in this stream
+			The value for this parameter must be either in the form '#devno',
 			for example '#2' for device number 2, or 'device-name', like 'iMic USB audio system'
 			The output of command "pa devlist" will show you device names and numbers as enumerated
 			by portaudio.
 		-->
 		<param name="indev" value="#2" />
 
-		<!-- 
+		<!--
 			Same as the indev but for output. In this case the device is capable of input and output
 			Some devices are capable of input only or output only (see the default example)
 	       	-->
@@ -74,13 +74,13 @@
 		<!-- The sample rate to use for this stream -->
 		<param name="sample-rate" value="48000" />
 
-		<!-- 
+		<!--
 			Size of the packets in milliseconds. The smaller the number the less latency you'll have
-			The minimum value is 10ms 
+			The minimum value is 10ms
 		-->
 		<param name="codec-ms" value="10" />
 
-		<!-- 
+		<!--
 			How many channels to open for this stream.
 			If you're device is stereo, you can choose 2 here. However, bear in mind that then
 			your left and right channels will be separated and when creating endpoints you will have
@@ -106,7 +106,7 @@
   	</stream>
   </streams>
 
-  <!-- 
+  <!--
 	mod_portaudio "endpoints"
 
 	Endpoints is a way to define the input and output that a given portaudio channel will use.
@@ -138,23 +138,23 @@
   -->
   <endpoints>
 
-	<!-- 
-		An endpoint is a handle name to refer to a configuration that determines where to read media from 
-		and write media to. The endpoint can use any input/output stream combination for that purpose as 
+	<!--
+		An endpoint is a handle name to refer to a configuration that determines where to read media from
+		and write media to. The endpoint can use any input/output stream combination for that purpose as
 		long as the streams match the sampling rate and codec-ms (see <streams> XML tag).
 		You can also omit the instream or the outstream parameter (but obviously not both).
 	-->
 
-	<!-- 
+	<!--
 		Configuration for a "default" bidirectional endpoint that uses the default stream defined previously in
 		the <streams> section.
 	 -->
   	<endpoint name="default">
-		<!-- 
+		<!--
 			The instream, outstream is the name of the stream and channel to use. The stream
-			name is the same you configured in the <streams> section. This parameters follow 
+			name is the same you configured in the <streams> section. This parameters follow
 			the syntax <stream-name>:<channel index>. You can omit either the outstream
-			or the instream, but not both! The channel index is zero-based and must be consistent 
+			or the instream, but not both! The channel index is zero-based and must be consistent
 			with the number of channels available for that stream (as configured in the <stream> section).
 			You cannot use index 1 if you chose channels=1 in the stream configuration.
 		-->
@@ -162,50 +162,50 @@
 		<param name="outstream" value="default:0" />
 	</endpoint>
 
-	<!-- 
+	<!--
 		This endpoint uses the USB stream defined previously in the <streams> section and
-		is 'send-only' or 'output-only' and uses the channel index 0 (left channel in a stereo device) 
+		is 'send-only' or 'output-only' and uses the channel index 0 (left channel in a stereo device)
 	-->
   	<endpoint name="usb1out-left">
 		<param name="outstream" value="usb1:0" />
 	</endpoint>
 
-	<!-- 
+	<!--
 		This endpoint uses the USB stream defined previously in the <streams> section and
-		is 'send-only' or 'output-only' and uses the channel index 1 (right channel in a stereo device) 
+		is 'send-only' or 'output-only' and uses the channel index 1 (right channel in a stereo device)
 	-->
   	<endpoint name="usb1out-right">
 		<param name="outstream" value="usb1:1" />
 	</endpoint>
 
-	<!-- 
+	<!--
 		This endpoint uses the USB stream defined previously in the <streams> section and
-		is 'receive-only' or 'input-only' and uses the channel index 0 (left channel in a stereo device) 
+		is 'receive-only' or 'input-only' and uses the channel index 0 (left channel in a stereo device)
 	-->
   	<endpoint name="usb1in-left">
 		<param name="instream" value="usb1:0" />
 	</endpoint>
 
-	<!-- 
+	<!--
 		This endpoint uses the USB stream defined previously in the <streams> section and
-		is 'receive-only' or 'input-only' and uses the channel index 1 (right channel in a stereo device) 
+		is 'receive-only' or 'input-only' and uses the channel index 1 (right channel in a stereo device)
 	-->
   	<endpoint name="usb1in-right">
 		<param name="instream" value="usb1:1" />
 	</endpoint>
 
-	<!-- 
+	<!--
 		This endpoint uses the USB stream defined previously in the <streams> section and
-		is 'bidirectional' or 'send-receive' and uses the channel index 0 (left channel in a stereo device) 
+		is 'bidirectional' or 'send-receive' and uses the channel index 0 (left channel in a stereo device)
 	-->
   	<endpoint name="usb1-left">
 		<param name="instream" value="usb1:0" />
 		<param name="outstream" value="usb1:0" />
 	</endpoint>
 
-	<!-- 
+	<!--
 		This endpoint uses the USB stream defined previously in the <streams> section and
-		is 'bidirectional' or 'send-receive' and uses the channel index 1 (right channel in a stereo device) 
+		is 'bidirectional' or 'send-receive' and uses the channel index 1 (right channel in a stereo device)
 	-->
   	<endpoint name="usb1-right">
 		<param name="instream" value="usb1:1" />

--- a/resources/templates/conf/autoload_configs/python.conf.xml
+++ b/resources/templates/conf/autoload_configs/python.conf.xml
@@ -6,7 +6,7 @@
     <!--
 	The following options identifies a py module that is launched
 	at startup and may live forever in the background.
-	You can define multiple lines, one for each script you 
+	You can define multiple lines, one for each script you
 	need to run.
     -->
     <!--<param name="startup-script" value="startup_script_1"/>-->

--- a/resources/templates/conf/autoload_configs/sangoma_codec.conf.xml
+++ b/resources/templates/conf/autoload_configs/sangoma_codec.conf.xml
@@ -2,17 +2,17 @@
 
 	<settings>
 		<!--
-		Comma separated list of codecs to register with FreeSWITCH, 
+		Comma separated list of codecs to register with FreeSWITCH,
 		by default (if this parameter is not set) all available codecs are registered.
 		Valid codec values are: PCMU,PCMA,G729,G726-32,G722,GSM,G723,AMR,G7221,iLBC
 		If this parameter is not specified only G729 will be registered
 		<param name="register" value="all"/>
 		-->
 
-		<!-- 
+		<!--
 		List of codecs to not register with FreeSWITCH, by default this is empty,
-	        but you may want to not load PCMU and PCMA or may be others to not use your 
-	        resources in codecs that are done well and fast in software.	
+	        but you may want to not load PCMU and PCMA or may be others to not use your
+	        resources in codecs that are done well and fast in software.
 		<param name="noregister" value="PCMU,PCMA"/>
 		-->
 

--- a/resources/templates/conf/autoload_configs/spandsp.conf.xml
+++ b/resources/templates/conf/autoload_configs/spandsp.conf.xml
@@ -1,7 +1,7 @@
 <configuration name="spandsp.conf" description="SpanDSP config">
     <modem-settings>
 <!--
-    total-modems set to N will create that many soft-modems.  
+    total-modems set to N will create that many soft-modems.
     If you use them with Hylafax you need the following for each one numbered 0..N:
 
     1) A line like this in /etc/inittab:

--- a/resources/templates/conf/autoload_configs/switch.conf.xml
+++ b/resources/templates/conf/autoload_configs/switch.conf.xml
@@ -13,7 +13,7 @@
 		<key name="10" value="sofia profile internal siptrace on"/>
 		<key name="11" value="sofia profile internal siptrace off"/>
 		<key name="12" value="version"/>
-	</cli-keybindings> 
+	</cli-keybindings>
 
 	<default-ptimes>
 		<!-- Set this to override the 20ms assumption of various codecs in the sdp with no ptime defined -->
@@ -45,7 +45,7 @@
 
 		<!--
 		Max number of sessions to allow at any given time.
-		
+
 		NOTICE: If you're driving 28 T1's in a single box you should set this to 644*2 or 1288
 		this will ensure you're able to use the entire DS3 without a problem.  Otherwise you'll
 		be 144 channels short of always filling that DS3 up which can translate into waste.
@@ -64,24 +64,24 @@
 		<!-- Maximum SQL Buffer length must be greater than sql-buffer-len -->
 		<!-- <param name="max-sql-buffer-len" value="2m"/> -->
 
-		<!-- 
-		 The min-dtmf-duration specifies the minimum DTMF duration to use on 
+		<!--
+		 The min-dtmf-duration specifies the minimum DTMF duration to use on
 		 outgoing events. Events shorter than this will be increased in duration
-		 to match min_dtmf_duration. You cannot configure a dtmf duration on a 
+		 to match min_dtmf_duration. You cannot configure a dtmf duration on a
 		 profile that is less than this setting. You may increase this value,
-		 but cannot set it lower than 400. This value cannot exceed 
+		 but cannot set it lower than 400. This value cannot exceed
 		 max-dtmf-duration. -->
 		<param name="min-dtmf-duration" value="640"/>
 
-		<!-- 
+		<!--
 		 The max-dtmf-duration caps the playout of a DTMF event at the specified
 		 duration. Events exceeding this duration will be truncated to this
 		 duration. You cannot configure a duration on a profile that exceeds
-		 this setting. This setting can be lowered, but cannot exceed 192000. 
+		 this setting. This setting can be lowered, but cannot exceed 192000.
 		 This setting cannot be set lower than min_dtmf_duration. -->
 		<!-- <param name="max-dtmf-duration" value="192000"/> -->
 
-		<!-- 
+		<!--
 		 The default_dtmf_duration specifies the DTMF duration to use on
 		 originated DTMF events or on events that are received without a
 		 duration specified. This value can be increased or lowered. This
@@ -144,7 +144,7 @@
 		<param name="rtp-enable-zrtp" value="true"/>
 
 		<!-- <param name="core-db-dsn" value="$${dsn}" /> -->
-		<!-- 
+		<!--
 		 Allow to specify the sqlite db at a different location (In this example, move it to ramdrive for
 		 better performance on most linux distro (note, you loose the data if you reboot))
 		-->

--- a/resources/templates/conf/autoload_configs/tts_commandline.conf.xml
+++ b/resources/templates/conf/autoload_configs/tts_commandline.conf.xml
@@ -6,7 +6,7 @@
 	${rate}: sample rate (example: 8000)
 	${voice}: voice_name passed to TTS(quoted)
 	${file}: output file (quoted, including .wav extension)
-    
+
     Example commands can be found at:
     http://wiki.freeswitch.org/wiki/Mod_tts_commandline#Example_commands
 	-->

--- a/resources/templates/conf/autoload_configs/voicemail.conf.xml
+++ b/resources/templates/conf/autoload_configs/voicemail.conf.xml
@@ -67,4 +67,4 @@
       <!--<param name="record-copyright" value="Your Copyright"/>-->
     </profile>
   </profiles>
-</configuration> 
+</configuration>

--- a/resources/templates/conf/autoload_configs/voicemail_ivr.conf.xml
+++ b/resources/templates/conf/autoload_configs/voicemail_ivr.conf.xml
@@ -150,7 +150,7 @@
 				<key dtmf="4" action="rerecord" variable="VM-Key-ReRecord-File" />
 				<key dtmf="#" action="skip_instruction" />
 			</keys>
-			</menu>			
+			</menu>
 
 			<menu name="std_forward_ask_prepend">
 			<phrases>

--- a/resources/templates/conf/autoload_configs/xml_cdr.conf.xml
+++ b/resources/templates/conf/autoload_configs/xml_cdr.conf.xml
@@ -22,7 +22,7 @@
     <!-- optional: if not present we do log the b leg -->
     <!-- true or false if we should create a cdr for the b leg of a call-->
     <param name="log-b-leg" value="false"/>
-    
+
     <!-- optional: if not present, all filenames are the uuid of the call -->
     <!-- true or false if a leg files are prefixed "a_" -->
     <param name="prefix-a-leg" value="true"/>
@@ -30,15 +30,15 @@
     <!-- encode the post data may be 'true' for url encoding, 'false' for no encoding, 'base64' for base64 encoding or 'textxml' for text/xml -->
     <param name="encode" value="true"/>
 
-    <!-- optional: set to true to disable Expect: 100-continue lighttpd requires this setting --> 
+    <!-- optional: set to true to disable Expect: 100-continue lighttpd requires this setting -->
     <param name="disable-100-continue" value="true"/>
-    
+
     <!-- optional: full path to the error log dir for failed web posts if not specified its the same as log-dir -->
     <!-- either an absolute path, a relative path assuming ${prefix}/logs or a blank or omitted value will default to ${prefix}/logs/xml_cdr -->
     <!-- <param name="err-log-dir" value="/tmp"/> -->
 
     <!-- which auhtentification scheme to use. Supported values are: basic, digest, NTLM, GSS-NEGOTIATE or "any" for automatic detection -->
-    <!--<param name="auth-scheme" value="basic"/>--> 
+    <!--<param name="auth-scheme" value="basic"/>-->
 
     <!-- optional: this will enable the CA root certificate check by libcurl to
          verify that the certificate was issued by a major Certificate Authority.

--- a/resources/templates/conf/dialplan/default/00_ladspa.xml.noload
+++ b/resources/templates/conf/dialplan/default/00_ladspa.xml.noload
@@ -1,5 +1,5 @@
 <include>
-  
+
   <X-PRE-PROCESS cmd="set" data="AT_EPENT1=0 0 0 -1 -1 0 -1 0 -1 -1 0 -1"/>
   <X-PRE-PROCESS cmd="set" data="AT_EPENT2=1 1 1 -1 -1 1 -1 1 -1 -1 1 -1"/>
   <X-PRE-PROCESS cmd="set" data="AT_CPENT1=0 -1 -1 0 -1 0 0 0 -1 -1 0 -1"/>
@@ -8,9 +8,9 @@
   <X-PRE-PROCESS cmd="set" data="AT_CMAJ2=1 -1 1 1 -1 1 -1 1 1 -1 1 -1"/>
   <X-PRE-PROCESS cmd="set" data="AT_BBLUES=1 -1 1 -1 -1 1 -1 1 1 1 -1 -1"/>
   <X-PRE-PROCESS cmd="set" data="ATGPENT2=-1 1 -1 1 -1 1 -1 -1 1 -1 1 -1"/>
-  
-  <extension name="101"> 
-    <condition field="destination_number" expression="^101$"> 
+
+  <extension name="101">
+    <condition field="destination_number" expression="^101$">
       <!-- AUTOTALENT DEFAULTS -->
 
       <!--
@@ -65,13 +65,13 @@
 
 
       <action application="set"><![CDATA[ladspa_params=${AT_TUNE} ${AT_FIXED} ${AT_PULL} ${AT_EPENT2} ${AT_AMOUNT} ${AT_SMOOTH} ${AT_SHIFT} ${AT_OUTSCALE} ${AT_LFODEPTH} ${AT_LFORATE} ${AT_LFOSHAPE} ${AT_LFOSYMM} ${AT_LFOQUANT} ${AT_FCORR} ${AT_FWARP} ${AT_MIX}]]></action>
-      
+
       <action application="ladspa_run" data="r|autotalent||${ladspa_params}"/>
       <action application="ladspa_run" data="r|tap_chorusflanger||"/>
       <action application="ladspa_run" data="r|phasers_1217.so|autoPhaser|"/>
       <action application="bridge" data="sofia/internal/888@conference.freeswitch.org"/>
 
-      </condition> 
-  </extension> 
+      </condition>
+  </extension>
 
 </include>

--- a/resources/templates/conf/dialplan/default/01_Talking_Clock.xml.noload
+++ b/resources/templates/conf/dialplan/default/01_Talking_Clock.xml.noload
@@ -8,7 +8,7 @@
       <action application="hangup"/>
     </condition>
   </extension>
-  
+
   <extension name="Talking Clock Date" ><!--e.g. March 8, 2011-->
     <condition field="destination_number" expression="^9171$">
       <action application="answer"/>
@@ -18,7 +18,7 @@
       <action application="hangup"/>
     </condition>
   </extension>
-  
+
   <extension name="Talking Clock Date and Time" ><!--e.g. March 8, 2011
 						     10:56pm-->
     <condition field="destination_number" expression="^9172$">

--- a/resources/templates/conf/dialplan/features.xml.noload
+++ b/resources/templates/conf/dialplan/features.xml.noload
@@ -54,7 +54,7 @@
 	</extension>
 
 	<extension name="is_secure" continue="true">
-		<!-- Only Truly consider it secure if its TLS and SRTP --> 
+		<!-- Only Truly consider it secure if its TLS and SRTP -->
 		<condition field="${sip_via_protocol}" expression="tls"/>
 		<condition field="${sip_secure_media_confirmed}" expression="^true$">
 			<action application="sleep" data="1000"/>

--- a/resources/templates/conf/dialplan/public.xml.noload
+++ b/resources/templates/conf/dialplan/public.xml.noload
@@ -2,10 +2,10 @@
     NOTICE:
 
     This context is usually accessed via the external sip profile listening on port 5080.
-    
+
     It is recommended to have separate inbound and outbound contexts.  Not only for security
     but clearing up why you would need to do such a thing.  You don't want outside un-authenticated
-    callers hitting your default context which allows dialing calls thru your providers and results 
+    callers hitting your default context which allows dialing calls thru your providers and results
     in Toll Fraud.
 -->
 
@@ -22,8 +22,8 @@
 
 	<!--
 	Tag anything pass thru here as an outside_call so you can make sure not
-	to create any routing loops based on the conditions that it came from 
-	the outside of the switch.  
+	to create any routing loops based on the conditions that it came from
+	the outside of the switch.
 	-->
 	<extension name="outside_call" continue="true">
 		<condition>

--- a/resources/templates/conf/dialplan/public/00_inbound_did.xml.noload
+++ b/resources/templates/conf/dialplan/public/00_inbound_did.xml.noload
@@ -4,12 +4,12 @@
       <!--
 	  If you're hosting multiple domains you will want to set the
 	  target_domain on these calls so they hit the proper domain after you
-	  transfer the caller into the default context. 
-	  
+	  transfer the caller into the default context.
+
 	  $${domain} is the default domain set from vars.xml but you can set it
 	  to any domain you have setup in your user directory.
 
-      --> 
+      -->
       <action application="set" data="domain_name=$${domain}"/>
       <!-- This example maps the DID 5551212 to ring 1000 in the default context -->
       <action application="transfer" data="1000 XML default"/>

--- a/resources/templates/conf/directory/default.xml.noload
+++ b/resources/templates/conf/directory/default.xml.noload
@@ -1,9 +1,9 @@
 <!--
-    NOTICE NOTICE NOTICE NOTICE NOTICE NOTICE NOTICE NOTICE NOTICE NOTICE 
-    
+    NOTICE NOTICE NOTICE NOTICE NOTICE NOTICE NOTICE NOTICE NOTICE NOTICE
+
     FreeSWITCH works off the concept of users and domains just like email.
     You have users that are in domains for example 1000@domain.com.
-    
+
     When freeswitch gets a register packet it looks for the user in the directory
     based on the from or to domain in the packet depending on how your sofia profile
     is configured.  Out of the box the default domain will be the IP address of the
@@ -11,10 +11,10 @@
     CLI.  You will register your phones to the IP and not the hostname by default.
     If you wish to register using the domain please open vars.xml in the root conf
     directory and set the default domain to the hostname you desire.  Then you would
-    use the domain name in the client instead of the IP address to register 
+    use the domain name in the client instead of the IP address to register
     with FreeSWITCH.
-    
-    NOTICE NOTICE NOTICE NOTICE NOTICE NOTICE NOTICE NOTICE NOTICE NOTICE 
+
+    NOTICE NOTICE NOTICE NOTICE NOTICE NOTICE NOTICE NOTICE NOTICE NOTICE
 -->
 
 <include>
@@ -41,7 +41,7 @@
       <group name="sales">
 	<users>
 	  <!--
-	      type="pointer" is a pointer so you can have the 
+	      type="pointer" is a pointer so you can have the
 	      same user in multiple groups.  It basically means
 	      to keep searching for the user in the directory.
 	  -->

--- a/resources/templates/conf/directory/default/brian.xml.noload
+++ b/resources/templates/conf/directory/default/brian.xml.noload
@@ -1,7 +1,7 @@
 <include>
   <!--
-      ipauth if you have an cidr= in the user attributes ie cidr="1.2.3.4/32"  
-      see <node type="allow" domain="$${domain}"/> in default acl.conf.xml 
+      ipauth if you have an cidr= in the user attributes ie cidr="1.2.3.4/32"
+      see <node type="allow" domain="$${domain}"/> in default acl.conf.xml
   -->
   <user id="brian" cidr="192.0.2.0/24">
     <!-- Outbound Registrations Related to this user -->
@@ -16,7 +16,7 @@
       <!--/// domain to use in from: *optional* same as  realm, if blank ///-->
       <!--<param name="from-domain" value="asterlink.com"/>-->
       <!--/// account password *required* ///-->
-      <!--<param name="password" value="2007"/>--> 
+      <!--<param name="password" value="2007"/>-->
       <!--/// replace the INVITE from user with the channel's caller-id ///-->
       <!--<param name="caller-id-in-from" value="false"/>-->
       <!--/// extension for inbound calls: *optional* same as username, if blank ///-->
@@ -52,7 +52,7 @@
       <!--<param name="vm-email-all-messages" value="true"/>-->
       <!-- optionally use this instead if you want to store the hash of user:domain:pass-->
       <!--<param name="a1-hash" value="c6440e5de50b403206989679159de89a"/>-->
-      <!-- What this user is allowed to acces --> 
+      <!-- What this user is allowed to acces -->
       <!--<param name="http-allowed-api" value="jsapi,voicemail,status"/> -->
     </params>
     <variables>
@@ -74,7 +74,7 @@
       <!--<variable name="numbering_plan" value="US"/>-->
       <!--<variable name="default_area_code" value="434"/>-->
       <!--<variable name="default_gateway" value="asterlink.com"/>-->
-      <!--  
+      <!--
 	   NDLB-connectile-dysfunction - Rewrite contact ip and port
 	   NDLB-tls-connectile-dysfunction - Rewrite contact port only.
       -->

--- a/resources/templates/conf/directory/default/default.xml.noload
+++ b/resources/templates/conf/directory/default/default.xml.noload
@@ -6,8 +6,8 @@
 	Let it be known that this user can register without a password but since we do not assign
 	this user a user_context and we don't authenticate this user they will be put in context 'public'.
 
-	This isn't a security issue as the endpoint would be put into the same context 'public' as the 
-	sofia profile that starts on 5080 by default. If you're paranoid just remove this file and 
+	This isn't a security issue as the endpoint would be put into the same context 'public' as the
+	sofia profile that starts on 5080 by default. If you're paranoid just remove this file and
 	remove the external profile also.
 
     -->

--- a/resources/templates/conf/extensions.conf
+++ b/resources/templates/conf/extensions.conf
@@ -15,7 +15,7 @@ exten => ~^(18(0{2}|8{2}|7{2}|6{2})\d{7})$,n,bridge(${enum_auto_route})
 
 ; instead of exten, put anything about the call you would rather match on.
 ; either the names of a field in caller_profile or a string of variables to expand.
-caller_id_number => 2137991400,n,Goto(default|music) 
+caller_id_number => 2137991400,n,Goto(default|music)
 ${sip_from_user} => bill,n,Goto(default|music)
 
 

--- a/resources/templates/conf/freeswitch.xml
+++ b/resources/templates/conf/freeswitch.xml
@@ -1,24 +1,24 @@
 <?xml version="1.0"?>
 <!--
-    NOTICE NOTICE NOTICE NOTICE NOTICE NOTICE NOTICE NOTICE NOTICE NOTICE 
-    
-    This is the FreeSWITCH default config.  Everything you see before you now traverses 
+    NOTICE NOTICE NOTICE NOTICE NOTICE NOTICE NOTICE NOTICE NOTICE NOTICE
+
+    This is the FreeSWITCH default config.  Everything you see before you now traverses
     down into all the directories including files which include more files.  The default
     config comes out of the box already working in most situations as a PBX.  This will
     allow you to get started testing and playing with various things in FreeSWITCH.
-    
+
     Before you start to modify this default please visit this wiki page:
-    
+
     http://wiki.freeswitch.org/wiki/Getting_Started_Guide#Some_stuff_to_try_out.21
-    
+
     If all else fails you can read our FAQ located at:
-    
+
     http://wiki.freeswitch.org/wiki/FreeSwitch_FAQ
-    
-    NOTICE NOTICE NOTICE NOTICE NOTICE NOTICE NOTICE NOTICE NOTICE NOTICE 
+
+    NOTICE NOTICE NOTICE NOTICE NOTICE NOTICE NOTICE NOTICE NOTICE NOTICE
 -->
 <document type="freeswitch/xml">
-  <!--#comment 
+  <!--#comment
       All comments starting with #command will be preprocessed and never sent to the xml parser
       Valid instructions:
       #include ==> Include another file to this exact point
@@ -26,10 +26,10 @@
       #set     ==> Set a global variable (can be expanded during preprocessing with $$ variables)
                    (note the double $$ which denotes preprocessor variables)
       #comment ==> A general comment such as this
-      
+
       The preprocessor will compile the full xml document to ${prefix}/log/freeswitch.xml.fsxml
       Don't modify it while freeswitch is running cos it is mem mapped in most cases =D
-      
+
       The same can be achieved with the <X-PRE-PROCESS> tag where the attrs 'cmd' and 'data' are
       parsed in the same way.
   -->
@@ -41,7 +41,7 @@
   <section name="configuration" description="Various Configuration">
     <X-PRE-PROCESS cmd="include" data="autoload_configs/*.xml"/>
   </section>
-  
+
   <section name="dialplan" description="Regex/XML Dialplan">
     <X-PRE-PROCESS cmd="include" data="dialplan/*.xml"/>
   </section>

--- a/resources/templates/conf/freetdm.conf
+++ b/resources/templates/conf/freetdm.conf
@@ -6,7 +6,7 @@
 ; whether to launch a thread for CPU usage monitoring
 cpu_monitor => no
 
-; How often (in milliseconds) monitor CPU usage 
+; How often (in milliseconds) monitor CPU usage
 cpu_monitoring_interval => 1000
 
 ; At what CPU percentage raise a CPU alarm

--- a/resources/templates/conf/ivr_menus/demo_ivr.xml
+++ b/resources/templates/conf/ivr_menus/demo_ivr.xml
@@ -27,7 +27,7 @@
     <entry action="menu-sub" digits="6" param="demo_ivr_submenu"/>                  <!-- demo sub menu -->
     <!-- Using a regex in the digits tag lets you define a dial pattern for the caller
          You may define multiple regexes if you need a different pattern for some reason -->
-    <entry action="menu-exec-app" digits="/^(10[01][0-9])$/" param="transfer $1 XML features"/> 
+    <entry action="menu-exec-app" digits="/^(10[01][0-9])$/" param="transfer $1 XML features"/>
     <entry action="menu-top" digits="9"/>          <!-- Repeat this menu -->
   </menu>
 

--- a/resources/templates/conf/lang/en/ivr/sounds.xml
+++ b/resources/templates/conf/lang/en/ivr/sounds.xml
@@ -18,7 +18,7 @@
 			</match>
 		</input>
 	</macro>
-	
+
 	<macro name="has_left_conf">
 		<input pattern="^(\d+)$">
 			<match>
@@ -85,7 +85,7 @@
 				<action function="sleep" data="400"/>
 				<action function="say" data="$1" method="iterated" type="number"/>
 				<action function="sleep" data="400"/>
-				<action function="play-file" data="digits/2.wav"/>                                                                                                
+				<action function="play-file" data="digits/2.wav"/>
 				<action function="sleep" data="1000"/>
 				<action function="play-file" data="ivr/ivr-extension_number.wav"/>
 				<action function="sleep" data="400"/>

--- a/resources/templates/conf/lang/he/demo/demo-ivr.xml
+++ b/resources/templates/conf/lang/he/demo/demo-ivr.xml
@@ -67,7 +67,7 @@
 
   <!-- The following macro is the same as demo_ivr_main_menu except it is the "short" version -->
   <!-- The short version has all the options but not the initial greeting -->
-  <macro name="demo_ivr_main_menu_short" pause="100"> 
+  <macro name="demo_ivr_main_menu_short" pause="100">
     <input pattern="(.*)">
       <match>
         <!-- Menu option 1: Call FreeSWITCH conference-->

--- a/resources/templates/conf/lang/ru/demo/demo-ivr.xml
+++ b/resources/templates/conf/lang/ru/demo/demo-ivr.xml
@@ -66,7 +66,7 @@
 
   <!-- The following macro is the same as demo_ivr_main_menu except it is the "short" version -->
   <!-- The short version has all the options but not the initial greeting -->
-  <macro name="demo_ivr_main_menu_short" pause="250"> 
+  <macro name="demo_ivr_main_menu_short" pause="250">
     <input pattern="(.*)">
       <match>
         <!-- Menu option 1: Call FreeSWITCH conference-->
@@ -129,7 +129,7 @@
 
   <!-- The following macro is the same as demo_ivr_sub_menu except it is the "short" version -->
   <!-- The short version has all the options but not the initial greeting -->
-  <macro name="demo_ivr_sub_menu_short"> 
+  <macro name="demo_ivr_sub_menu_short">
     <input pattern="(.*)">
       <match>
         <!-- Menu option *: Return to top menu -->

--- a/resources/templates/conf/lang/ru/vm/sounds.xml
+++ b/resources/templates/conf/lang/ru/vm/sounds.xml
@@ -55,7 +55,7 @@
       <match>
 	<action function="play-file" data="voicemail/vm-you_have.wav"/>
 	<action function="say" data="$1" method="pronounced" type="MESSAGES"/>
-	<action function="play-file" data="voicemail/vm-$2.wav"/> 
+	<action function="play-file" data="voicemail/vm-$2.wav"/>
 	<action function="play-file" data="voicemail/vm-message.wav"/>
 <!--	<action function="play-file" data="voicemail/vm-in_folder.wav"/>-->
       </match>
@@ -65,16 +65,16 @@
       <match>
 	<action function="play-file" data="voicemail/vm-you_have.wav"/>
 	<action function="say" data="$1" method="pronounced" type="MESSAGES"/>
-	<action function="play-file" data="voicemail/vm-$2x.wav"/> 
+	<action function="play-file" data="voicemail/vm-$2x.wav"/>
 	<action function="play-file" data="voicemail/vm-messagex.wav"/>
 <!--	<action function="play-file" data="voicemail/vm-in_folder.wav"/>-->
       </match>
     </input>
-    <input pattern="^(\d+[0,2-9][2-4]|[2-9][2-4]|[2-4]):(.*)$"> 
+    <input pattern="^(\d+[0,2-9][2-4]|[2-9][2-4]|[2-4]):(.*)$">
       <match>
 	<action function="play-file" data="voicemail/vm-you_have.wav"/>
 	<action function="say" data="$1" method="pronounced" type="MESSAGES"/>
-	<action function="play-file" data="voicemail/vm-$2x.wav"/> 
+	<action function="play-file" data="voicemail/vm-$2x.wav"/>
 	<action function="play-file" data="voicemail/vm-messages.wav"/>
 	<action function="play-file" data="voicemail/vm-in_folder.wav"/>
       </match>
@@ -299,9 +299,9 @@
   <macro name="voicemail_say_message_number">
     <input pattern="^([a-z]+):(\d+)$">
       <match>
-	<action function="play-file" data="voicemail/vm-$1.wav"/> 
+	<action function="play-file" data="voicemail/vm-$1.wav"/>
 	<action function="play-file" data="voicemail/vm-message_number.wav"/>
-	<action function="say" data="$2" method="pronounced" type="items"/> 
+	<action function="say" data="$2" method="pronounced" type="items"/>
       </match>
     </input>
   </macro>
@@ -322,7 +322,7 @@
     </input>
   </macro>
   <!-- Note: Update this to marked-urgent,emailed and saved once new sound files are recorded -->
-  <macro name="voicemail_ack"> 
+  <macro name="voicemail_ack">
     <input pattern="^(too-small)$">
       <match>
 	<action function="play-file" data="voicemail/vm-too-small.wav"/>

--- a/resources/templates/conf/lang/ru/vm/tts.xml
+++ b/resources/templates/conf/lang/ru/vm/tts.xml
@@ -63,7 +63,7 @@
   <macro name="voicemail_menu">
     <input pattern="^([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*])$">
       <match>
-	<action function="speak-text" 
+	<action function="speak-text"
 		data="To listen to new messages, press $1, To listen to saved messages, press $2, For advanced options, press $3, to exit, press $4."/>
       </match>
     </input>
@@ -73,7 +73,7 @@
   <macro name="voicemail_config_menu">
     <input pattern="^([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*])$">
       <match>
-	<action function="speak-text" 
+	<action function="speak-text"
 		data="To record a greeting, press $1, To choose a greeting, press $2, To record your name, press $3, to change your password, press $5, to return to the main menu, press $5."/>
       </match>
     </input>
@@ -92,7 +92,7 @@
   <macro name="voicemail_record_file_check">
     <input pattern="^([0-9#*]):([0-9#*]):([0-9#*])$">
       <match>
-	<action function="speak-text" 
+	<action function="speak-text"
 		data="To listen to the recording, press $1, To save the recording, press $2, To re record, press $3."/>
       </match>
     </input>
@@ -101,7 +101,7 @@
   <macro name="voicemail_record_urgent_check">
     <input pattern="^([0-9#*]):([0-9#*])$">
       <match>
-	<action function="speak-text" 
+	<action function="speak-text"
 		data="To mark this message urgent, press $1, To continue, press $2."/>
       </match>
     </input>
@@ -134,7 +134,7 @@
   <macro name="voicemail_listen_file_check">
     <input pattern="^([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*])$">
       <match>
-	<action function="speak-text" 
+	<action function="speak-text"
 		data="To listen to the recording again, press $1, To save the recording, press $2,  To delete the recording, press $3, to forward the recording to your email, press $4, to call the caller now, press $5, To forward this message to another extension, press $6."/>
       </match>
     </input>

--- a/resources/templates/conf/notify-voicemail.tpl
+++ b/resources/templates/conf/notify-voicemail.tpl
@@ -5,7 +5,7 @@ Subject: Voicemail from "${voicemail_caller_id_name}" <${voicemail_caller_id_num
 X-Priority: ${voicemail_priority}
 X-Mailer: FreeSWITCH
 
-Content-Type: multipart/alternative; 
+Content-Type: multipart/alternative;
 	boundary="000XXX000"
 
 --000XXX000

--- a/resources/templates/conf/sip_profiles/external-ipv6.xml.noload
+++ b/resources/templates/conf/sip_profiles/external-ipv6.xml.noload
@@ -1,9 +1,9 @@
 <profile name="external-ipv6">
-	<!-- http://wiki.freeswitch.org/wiki/Sofia_Configuration_Files --> 
+	<!-- http://wiki.freeswitch.org/wiki/Sofia_Configuration_Files -->
 	<!-- This profile is only for outbound registrations to providers -->
 
 	<aliases>
-		<!-- 
+		<!--
 		<alias name="outbound"/>
 		<alias name="nat"/>
 		-->
@@ -19,7 +19,7 @@
 		<param name="user-agent-string" value="FreeSWITCH" enabled="true"/>
 		<param name="shutdown-on-fail" value="true" enabled="false"/>
 		<param name="sip-trace" value="no"/>
-		<param name="sip-capture" value="no"/>        
+		<param name="sip-capture" value="no"/>
 		<param name="rfc2833-pt" value="101"/>
 		<!-- RFC 5626 : Send reg-id and sip.instance -->
 		<param name="enable-rfc-5626" value="true" enabled="false"/>
@@ -38,9 +38,9 @@
 		<param name="local-network-acl" value="localnet.auto"/>
 		<param name="manage-presence" value="false"/>
 
-		<!-- used to share presence info across sofia profiles 
+		<!-- used to share presence info across sofia profiles
 		 manage-presence needs to be set to passive on this profile
-		 if you want it to behave as if it were the internal profile 
+		 if you want it to behave as if it were the internal profile
 		 for presence.
 		-->
 		<!-- Name of the db to use for this profile -->

--- a/resources/templates/conf/sip_profiles/external.xml.noload
+++ b/resources/templates/conf/sip_profiles/external.xml.noload
@@ -1,12 +1,12 @@
 <profile name="external">
-	<!-- http://wiki.freeswitch.org/wiki/Sofia_Configuration_Files --> 
+	<!-- http://wiki.freeswitch.org/wiki/Sofia_Configuration_Files -->
 	<!-- This profile is only for outbound registrations to providers -->
 	<gateways>
 		<X-PRE-PROCESS cmd="include" data="external/*.xml"/>
 	</gateways>
 
 	<aliases>
-		<!-- 
+		<!--
 		<alias name="outbound"/>
 		<alias name="nat"/>
 		-->
@@ -22,7 +22,7 @@
 		<param name="user-agent-string" value="FreeSWITCH" enabled="true"/>
 		<param name="shutdown-on-fail" value="true" enabled="false"/>
 		<param name="sip-trace" value="no"/>
-		<param name="sip-capture" value="no"/>        
+		<param name="sip-capture" value="no"/>
 		<param name="rfc2833-pt" value="101"/>
 		<!-- RFC 5626 : Send reg-id and sip.instance -->
 		<param name="enable-rfc-5626" value="true" enabled="false"/>
@@ -41,9 +41,9 @@
 		<param name="local-network-acl" value="localnet.auto"/>
 		<param name="manage-presence" value="false"/>
 
-		<!-- used to share presence info across sofia profiles 
+		<!-- used to share presence info across sofia profiles
 		 manage-presence needs to be set to passive on this profile
-		 if you want it to behave as if it were the internal profile 
+		 if you want it to behave as if it were the internal profile
 		 for presence.
 		-->
 		<!-- Name of the db to use for this profile -->

--- a/resources/templates/conf/sip_profiles/external/example.xml
+++ b/resources/templates/conf/sip_profiles/external/example.xml
@@ -9,7 +9,7 @@
   <!--/// domain to use in from: *optional* same as  realm, if blank ///-->
   <!--<param name="from-domain" value="asterlink.com"/>-->
   <!--/// account password *required* ///-->
-  <!--<param name="password" value="2007"/>--> 
+  <!--<param name="password" value="2007"/>-->
   <!--/// extension for inbound calls: *optional* same as username, if blank ///-->
   <!--<param name="extension" value="cluecon"/>-->
   <!--/// proxy host: *optional* same as realm, if blank ///-->

--- a/resources/templates/conf/sip_profiles/internal.xml.noload
+++ b/resources/templates/conf/sip_profiles/internal.xml.noload
@@ -24,7 +24,7 @@
 		<!--<domain name="$${domain}" parse="true"/>-->
 		<!-- indicator to parse the directory for domains with parse="true" to get gateways and alias every domain to this profile -->
 		<!--<domain name="all" alias="true" parse="true"/>-->
-		<domain name="all" alias="true" parse="false"/> 
+		<domain name="all" alias="true" parse="false"/>
 	</domains>
 
 	<settings>
@@ -34,7 +34,7 @@
 		-->
 		<param name="media-option" value="resume-media-on-hold" enabled="false"/>
 		<!--
-		This will allow a call after an attended transfer go back to 
+		This will allow a call after an attended transfer go back to
 		 bypass media after an attended transfer.
 		-->
 		<param name="media-option" value="bypass-media-after-att-xfer" enabled="false"/>
@@ -51,7 +51,7 @@
 		<!-- Don't be picky about negotiated DTMF just always offer 2833 and accept both 2833 and INFO -->
 		<param name="liberal-dtmf" value="true" enabled="false"/>
 
-		<!-- 
+		<!--
 			Sometimes, in extremely rare edge cases, the Sofia SIP stack may stop
 			responding. These options allow you to enable and control a watchdog
 			on the Sofia SIP stack so that if it stops responding for the
@@ -64,7 +64,7 @@
 			through the FreeSWITCH CLI either on an individual profile basis or
 			globally for all profiles. So, if you run in an HA environment with a
 			master and slave, you should use the CLI to make sure the watchdog is
-			only enabled on the master. 
+			only enabled on the master.
 			If such crash occurs, FreeSWITCH will dump core if allowed. The
 			stacktrace will include function watchdog_triggered_abort().
 		-->
@@ -111,7 +111,7 @@
 		<!-- Enable Compact SIP headers. -->
 		<param name="enable-compact-headers" value="true" enabled="false"/>
 		<!--
-		enable/disable session timers 
+		enable/disable session timers
 		-->
 		<param name="enable-timer" value="false" enabled="false"/>
 		<param name="minimum-session-expires" value="120" enabled="false"/>
@@ -192,7 +192,7 @@
 		<!-- TLS version ("sslv23" (default), "tlsv1"). NOTE: Phones may not work with TLSv1 -->
 		<param name="tls-version" value="$${sip_tls_version}"/>
 
-		<!-- turn on auto-flush during bridge (skip timer sleep when the socket already has data) 
+		<!-- turn on auto-flush during bridge (skip timer sleep when the socket already has data)
 		 (reduces delay on latent connections default true, must be disabled explicitly)-->
 		<param name="rtp-autoflush-during-bridge" value="false" enabled="false"/>
 
@@ -223,7 +223,7 @@
 
 		<!--TTL for nonce in sip auth-->
 		<param name="nonce-ttl" value="60"/>
-		<!--Uncomment if you want to force the outbound leg of a bridge to only offer the codec 
+		<!--Uncomment if you want to force the outbound leg of a bridge to only offer the codec
 		that the originator is using-->
 		<param name="disable-transcoding" value="true" enabled="false"/>
 		<!-- Handle 302 Redirect in the dialplan -->
@@ -285,7 +285,7 @@
 		<param name="disable-transfer" value="true" enabled="false"/>
 		<param name="disable-register" value="true" enabled="false"/>
 
-		<!-- 
+		<!--
 		enable-3pcc can be set to either 'true' or 'proxy', true accepts the call
 		right away, proxy waits until the call has been answered then sends accepts
 		-->
@@ -294,7 +294,7 @@
 		<!-- use at your own risk or if you know what this does.-->
 		<param name="NDLB-force-rport" value="safe" enabled="true"/>
 		<!--
-		Choose the realm challenge key. Default is auto_to if not set. 
+		Choose the realm challenge key. Default is auto_to if not set.
 
 		auto_from  - uses the from field as the value for the sip realm.
 		auto_to    - uses the to field as the value for the sip realm.
@@ -331,38 +331,38 @@
 		<param name="disable-srv" value="false" enabled="false"/>
 		<param name="disable-naptr" value="false" enabled="false"/>
 
-		<!-- The following can be used to fine-tune timers within sofia's transport layer 
+		<!-- The following can be used to fine-tune timers within sofia's transport layer
 			 Those settings are for advanced users and can safely be left as-is -->
 
 		<!-- Initial retransmission interval (in milliseconds).
-			Set the T1 retransmission interval used by the SIP transaction engine. 
+			Set the T1 retransmission interval used by the SIP transaction engine.
 			The T1 is the initial duration used by request retransmission timers A and E (UDP) as well as response retransmission timer G. 	 -->
 		<param name="timer-T1" value="500" enabled="false"/>
 
 		<!--  Transaction timeout (defaults to T1 * 64).
 			Set the T1x64 timeout value used by the SIP transaction engine.
-			The T1x64 is duration used for timers B, F, H, and J (UDP) by the SIP transaction engine. 
+			The T1x64 is duration used for timers B, F, H, and J (UDP) by the SIP transaction engine.
 			The timeout value T1x64 can be adjusted separately from the initial retransmission interval T1. -->
 		<param name="timer-T1X64" value="32000" enabled="false"/>
 
 		<!-- Maximum retransmission interval (in milliseconds).
-			Set the maximum retransmission interval used by the SIP transaction engine. 
-			The T2 is the maximum duration used for the timers E (UDP) and G by the SIP transaction engine. 
-			Note that the timer A is not capped by T2. Retransmission interval of INVITE requests grows exponentially 
+			Set the maximum retransmission interval used by the SIP transaction engine.
+			The T2 is the maximum duration used for the timers E (UDP) and G by the SIP transaction engine.
+			Note that the timer A is not capped by T2. Retransmission interval of INVITE requests grows exponentially
 			until the timer B fires.  -->
 		<param name="timer-T2" value="4000" enabled="false"/>
 
 		<!--
 			Transaction lifetime (in milliseconds).
-			Set the lifetime for completed transactions used by the SIP transaction engine. 
-			A completed transaction is kept around for the duration of T4 in order to catch late responses. 
+			Set the lifetime for completed transactions used by the SIP transaction engine.
+			A completed transaction is kept around for the duration of T4 in order to catch late responses.
 			The T4 is the maximum duration for the messages to stay in the network and the duration of SIP timer K. -->
 		<param name="timer-T4" value="4000" enabled="false"/>
 
 		<!-- Turn on a jitterbuffer for every call -->
 		<param name="auto-jitterbuffer-msec" value="60" enabled="false"/>
 
-		<!-- By default mod_sofia will ignore the codecs in the sdp for hold/unhold operations 
+		<!-- By default mod_sofia will ignore the codecs in the sdp for hold/unhold operations
 			Set this to true if you want to actually parse the sdp and re-negotiate the codec during hold/unhold.
 			It's probably not what you want so stick with the default unless you really need to change this.
 		-->

--- a/resources/templates/conf/sip_profiles/internal/example.xml
+++ b/resources/templates/conf/sip_profiles/internal/example.xml
@@ -9,7 +9,7 @@
   <!--/// domain to use in from: *optional* same as  realm, if blank ///-->
   <!--<param name="from-domain" value="asterlink.com"/>-->
   <!--/// account password *required* ///-->
-  <!--<param name="password" value="2007"/>--> 
+  <!--<param name="password" value="2007"/>-->
   <!--/// extension for inbound calls: *optional* same as username, if blank ///-->
   <!--<param name="extension" value="cluecon"/>-->
   <!--/// proxy host: *optional* same as realm, if blank ///-->

--- a/resources/templates/conf/vars.xml
+++ b/resources/templates/conf/vars.xml
@@ -1,6 +1,6 @@
 <include>
   <!-- Preprocessor Variables
-       These are introduced when configuration strings must be consistent across modules. 
+       These are introduced when configuration strings must be consistent across modules.
        NOTICE: YOU CAN NOT COMMENT OUT AN X-PRE-PROCESS line, Remove the line instead.
   -->
 
@@ -9,8 +9,8 @@
 
   <!--
       This setting is what sets the default domain FreeSWITCH will use if all else fails.
-      
-      FreeSWICH will default to $${local_ip_v4} unless changed.  Changing this setting does 
+
+      FreeSWICH will default to $${local_ip_v4} unless changed.  Changing this setting does
       affect the sip authentication.  Please review conf/directory/default.xml for more
       information on this topic.
   -->
@@ -21,18 +21,18 @@
 
   <!--
       Enable ZRTP globally you can override this on a per channel basis
-      
+
       http://wiki.freeswitch.org/wiki/ZRTP (on how to enable zrtp)
   -->
   <X-PRE-PROCESS cmd="set" data="zrtp_secure_media=true"/>
 
-  <!-- 
+  <!--
        Examples of codec options: (module must be compiled and loaded)
-       
+
        codecname[@8000h|16000h|32000h[@XXi]]
-       
+
        XX is the frame size must be multples allowed for the codec
-       FreeSWITCH can support 10-120ms on some codecs. 
+       FreeSWITCH can support 10-120ms on some codecs.
        We do not support exceeding the MTU of the RTP packet.
 
 
@@ -62,21 +62,21 @@
        AAL2-G726-40     - Same as G726-40 but using AAL2 packing. (multiples of 10)
        LPC              - LPC10 using 90ms ptime (only supports 90ms at this time in FreeSWITCH)
        L16              - L16 isn't recommended for VoIP but you can do it. L16 can exceed the MTU rather quickly.
-       
+
        These are the passthru audio codecs:
-       
+
        G729             - G729 in passthru mode. (mod_g729)
        G723             - G723.1 in passthru mode. (mod_g723_1)
        AMR              - AMR in passthru mode. (mod_amr)
-       
+
        These are the passthru video codecs: (mod_h26x)
-       
+
        H261             - H.261 Video
        H263             - H.263 Video
        H263-1998        - H.263-1998 Video
        H263-2000        - H.263-2000 Video
        H264             - H.264 Video
-       
+
        RTP Dynamic Payload Numbers currently used in FreeSWITCH and what for.
 
        96  - AMR
@@ -86,9 +86,9 @@
        100 -
        101 - telephone-event
        102 -
-       103 - 
-       104 - 
-       105 - 
+       103 -
+       104 -
+       105 -
        106 - BV16
        107 - G722.1 (16kHz)
        108 -
@@ -108,7 +108,7 @@
        122 - AAL2-G726-32 && G726-32
        123 - AAL2-G726-24 && G726-24
        124 - AAL2-G726-16 && G726-16
-       125 - 
+       125 -
        126 -
        127 - BV32
 
@@ -118,20 +118,20 @@
 
   <!--
       xmpp_client_profile and xmpp_server_profile
-      xmpp_client_profile can be any string. 
+      xmpp_client_profile can be any string.
       xmpp_server_profile is appended to "dingaling_" to form the database name
       containing the "subscriptions" table.
-      used by: dingaling.conf.xml enum.conf.xml 
-  --> 
+      used by: dingaling.conf.xml enum.conf.xml
+  -->
 
   <X-PRE-PROCESS cmd="set" data="xmpp_client_profile=xmppc"/>
   <X-PRE-PROCESS cmd="set" data="xmpp_server_profile=xmpps"/>
-  <!-- 
+  <!--
        THIS IS ONLY USED FOR DINGALING
 
        bind_server_ip
 
-       Can be an ip address, a dns name, or "auto". 
+       Can be an ip address, a dns name, or "auto".
        This determines an ip address available on this host to bind.
        If you are separating RTP and SIP traffic, you will want to have
        use different addresses where this variable appears.
@@ -140,7 +140,7 @@
   <X-PRE-PROCESS cmd="set" data="bind_server_ip=auto"/>
 
   <!-- NOTICE NOTICE NOTICE NOTICE NOTICE NOTICE NOTICE NOTICE NOTICE NOTICE NOTICE
-       
+
        If you're going to load test FreeSWITCH please input real IP addresses
        for external_rtp_ip and external_sip_ip
   -->
@@ -172,7 +172,7 @@
 
   <!-- unroll-loops
        Used to turn on sip loopback unrolling.
-  --> 
+  -->
   <X-PRE-PROCESS cmd="set" data="unroll_loops=true"/>
 
   <!-- outbound_caller_id and outbound_caller_name
@@ -226,7 +226,7 @@
   <!--
       Setting up your default sip provider is easy.
       Below are some values that should work in most cases.
-      
+
       These are for conf/directory/default/example.com.xml
   -->
   <X-PRE-PROCESS cmd="set" data="default_provider=example.com"/>

--- a/resources/templates/conf/voicemail.tpl
+++ b/resources/templates/conf/voicemail.tpl
@@ -5,7 +5,7 @@ Subject: Voicemail from "${voicemail_caller_id_name}" <${voicemail_caller_id_num
 X-Priority: ${voicemail_priority}
 X-Mailer: FreeSWITCH
 
-Content-Type: multipart/alternative; 
+Content-Type: multipart/alternative;
 	boundary="000XXX000"
 
 --000XXX000


### PR DESCRIPTION
whitespace pass over files
for reference regex that was used s/[ \t]+(\r?\n)/\1/