### PR TITLE
WhitespaceClean-resources/templates/smarty

### DIFF
--- a/resources/templates/engine/smarty/README
+++ b/resources/templates/engine/smarty/README
@@ -176,7 +176,7 @@ backward compatible with Smarty 2, except for the following items:
 
 
 There are many things that are new to Smarty 3. Here are the notable items:
-   
+
 LEXER/PARSER
 ============
 
@@ -197,8 +197,8 @@ is still supported for BC.
 Examples:
 {$x+$y}                           will output the sum of x and y.
 {$foo = strlen($bar)}             function in assignment
-{assign var=foo value= $x+$y}     in attributes 
-{$foo = myfunct( ($x+$y)*3 )}     as function parameter 
+{assign var=foo value= $x+$y}     in attributes
+{$foo = myfunct( ($x+$y)*3 )}     as function parameter
 {$foo[$x+3]}                      as array index
 
 Smarty tags can be used as values within other tags.
@@ -239,18 +239,18 @@ Examples:
 
 The original "dot" notation stays, and with improvements.
 Examples:
-{$foo.a.b.c}        =>  $foo['a']['b']['c'] 
+{$foo.a.b.c}        =>  $foo['a']['b']['c']
 {$foo.a.$b.c}       =>  $foo['a'][$b]['c']        with variable index
 {$foo.a.{$b+4}.c}   =>  $foo['a'][$b+4]['c']       with expression as index
 {$foo.a.{$b.c}}     =>  $foo['a'][$b['c']]         with nested index
 
-note that { and } are used to address ambiguties when nesting the dot syntax. 
+note that { and } are used to address ambiguties when nesting the dot syntax.
 
 Variable names themselves can be variable and contain expressions.
 Examples:
 $foo         normal variable
-$foo_{$bar}  variable name containing other variable 
-$foo_{$x+$y} variable name containing expressions 
+$foo_{$bar}  variable name containing other variable
+$foo_{$x+$y} variable name containing expressions
 $foo_{$bar}_buh_{$blar}  variable name with multiple segments
 {$foo_{$x}}  will output the variable $foo_1 if $x has a value of 1.
 
@@ -290,7 +290,7 @@ $var@last           true on last iteration
 
 The Smarty 2 {foreach} tag syntax is still supported.
 
-NOTE: {$bar[foo]} still indicates a variable inside of a {section} named foo. 
+NOTE: {$bar[foo]} still indicates a variable inside of a {section} named foo.
 If you want to access an array element with index foo, you must use quotes
 such as {$bar['foo']}, or use the dot syntax {$bar.foo}.
 
@@ -377,12 +377,12 @@ $smarty->display('string:This is my template, {$foo}!'); // php
 VARIABLE SCOPE / VARIABLE STORAGE
 =================================
 
-In Smarty 2, all assigned variables were stored within the Smarty object. 
-Therefore, all variables assigned in PHP were accessible by all subsequent 
+In Smarty 2, all assigned variables were stored within the Smarty object.
+Therefore, all variables assigned in PHP were accessible by all subsequent
 fetch and display template calls.
 
-In Smarty 3, we have the choice to assign variables to the main Smarty object, 
-to user-created data objects, and to user-created template objects. 
+In Smarty 3, we have the choice to assign variables to the main Smarty object,
+to user-created data objects, and to user-created template objects.
 These objects can be chained. The object at the end of a chain can access all
 variables belonging to that template and all variables within the parent objects.
 The Smarty object can only be the root of a chain, but a chain can be isolated
@@ -396,7 +396,7 @@ global variables.
 A Smarty data object can be created as follows:
 $data = $smarty->createData();    // create root data object
 $data->assign('foo','bar');       // assign variables as usual
-$data->config_load('my.conf');									 // load config file    
+$data->config_load('my.conf');									 // load config file
 
 $data= $smarty->createData($smarty);  // create data object having a parent link to
 the Smarty object
@@ -414,7 +414,7 @@ The first parameter can be a template name, a smarty object or a data object.
 Examples:
 $tpl = $smarty->createTemplate('mytpl.tpl'); // create template object not linked to any parent
 $tpl->assign('foo','bar');                   // directly assign variables
-$tpl->config_load('my.conf');									 // load config file    
+$tpl->config_load('my.conf');									 // load config file
 
 $tpl = $smarty->createTemplate('mytpl.tpl',$smarty);  // create template having a parent link to the Smarty object
 $tpl = $smarty->createTemplate('mytpl.tpl',$data);    // create template having a parent link to the $data object
@@ -424,31 +424,31 @@ If the $parent parameter is not specified in these method calls, the template ob
 is will link back to the Smarty object as it's parent.
 
 If a template is called by an {include...} tag from another template, the
-subtemplate links back to the calling template as it's parent. 
+subtemplate links back to the calling template as it's parent.
 
 All variables assigned locally or from a parent template are accessible. If the
 template creates or modifies a variable by using the {assign var=foo...} or
 {$foo=...} tags, these new values are only known locally (local scope). When the
 template exits, none of the new variables or modifications can be seen in the
-parent template(s). This is same behavior as in Smarty 2. 
+parent template(s). This is same behavior as in Smarty 2.
 
 With Smarty 3, we can assign variables with a scope attribute which allows the
 availablility of these new variables or modifications globally (ie in the parent
 templates.)
 
-Possible scopes are local, parent, root and global. 
+Possible scopes are local, parent, root and global.
 Examples:
 {assign var=foo value='bar'}       // no scope is specified, the default 'local'
 {$foo='bar'}                       // same, local scope
 {assign var=foo value='bar' scope='local'} // same, local scope
 
-{assign var=foo value='bar' scope='parent'} // Values will be available to the parent object 
+{assign var=foo value='bar' scope='parent'} // Values will be available to the parent object
 {$foo='bar' scope='parent'}                 // (normally the calling template)
 
-{assign var=foo value='bar' scope='root'}   // Values will be exported up to the root object, so they can 
+{assign var=foo value='bar' scope='root'}   // Values will be exported up to the root object, so they can
 {$foo='bar' scope='root'}                   // be seen from all templates using the same root.
 
-{assign var=foo value='bar' scope='global'} // Values will be exported to global variable storage, 
+{assign var=foo value='bar' scope='global'} // Values will be exported to global variable storage,
 {$foo='bar' scope='global'}                 // they are available to any and all templates.
 
 
@@ -460,7 +460,7 @@ included template.
 PLUGINS
 =======
 
-Smarty3 are following the same coding rules as in Smarty2. 
+Smarty3 are following the same coding rules as in Smarty2.
 The only difference is that the template object is passed as additional third parameter.
 
 smarty_plugintype_name (array $params, object $smarty, object $template)
@@ -472,7 +472,7 @@ TEMPLATE INHERITANCE:
 =====================
 
 With template inheritance you can define blocks, which are areas that can be
-overriden by child templates, so your templates could look like this: 
+overriden by child templates, so your templates could look like this:
 
 parent.tpl:
 <html>
@@ -490,14 +490,14 @@ parent.tpl:
 </html>
 
 child.tpl:
-{extends file='parent.tpl'} 
+{extends file='parent.tpl'}
 {block name='title'}
 Child title
 {/block}
 
 grandchild.tpl:
-{extends file='child.tpl'} 
-{block name='title'}Home - {$smarty.block.parent}{/block} 
+{extends file='child.tpl'}
+{block name='title'}Home - {$smarty.block.parent}{/block}
 {block name='page-title'}My home{/block}
 {block name='content'}
   {foreach $images as $img}
@@ -507,10 +507,10 @@ grandchild.tpl:
 
 We redefined all the blocks here, however in the title block we used {$smarty.block.parent},
 which tells Smarty to insert the default content from the parent template in its place.
-The content block was overriden to display the image files, and page-title has also be 
-overriden to display a completely different title. 
+The content block was overriden to display the image files, and page-title has also be
+overriden to display a completely different title.
 
-If we render grandchild.tpl we will get this: 
+If we render grandchild.tpl we will get this:
 <html>
   <head>
     <title>Home - Child title</title>
@@ -528,8 +528,8 @@ If we render grandchild.tpl we will get this:
 NOTE: In the child templates everything outside the {extends} or {block} tag sections
 is ignored.
 
-The inheritance tree can be as big as you want (meaning you can extend a file that 
-extends another one that extends another one and so on..), but be aware that all files 
+The inheritance tree can be as big as you want (meaning you can extend a file that
+extends another one that extends another one and so on..), but be aware that all files
 have to be checked for modifications at runtime so the more inheritance the more overhead you add.
 
 Instead of defining the parent/child relationships with the {extends} tag in the child template you
@@ -537,7 +537,7 @@ can use the resource as follow:
 
 $smarty->display('extends:parent.tpl|child.tpl|grandchild.tpl');
 
-Child {block} tags may optionally have a append or prepend attribute. In this case the parent block content 
+Child {block} tags may optionally have a append or prepend attribute. In this case the parent block content
 is appended or prepended to the child block content.
 
 {block name='title' append} My title {/block}

--- a/resources/templates/engine/smarty/debug.tpl
+++ b/resources/templates/engine/smarty/debug.tpl
@@ -33,12 +33,12 @@ h2 {
 }
 
 body {
-    background: black; 
+    background: black;
 }
 
 p, table, div {
     background: #f0ead8;
-} 
+}
 
 p {
     margin: 0;
@@ -106,7 +106,7 @@ td {
 
 <table id="table_assigned_vars">
     {foreach $assigned_vars as $vars}
-       <tr class="{if $vars@iteration % 2 eq 0}odd{else}even{/if}">   
+       <tr class="{if $vars@iteration % 2 eq 0}odd{else}even{/if}">
        <th>${$vars@key|escape:'html'}</th>
        <td>{$vars|debug_print_var nofilter}</td></tr>
     {/foreach}
@@ -116,7 +116,7 @@ td {
 
 <table id="table_config_vars">
     {foreach $config_vars as $vars}
-       <tr class="{if $vars@iteration % 2 eq 0}odd{else}even{/if}">   
+       <tr class="{if $vars@iteration % 2 eq 0}odd{else}even{/if}">
        <th>{$vars@key|escape:'html'}</th>
        <td>{$vars|debug_print_var nofilter}</td></tr>
     {/foreach}

--- a/resources/templates/engine/smarty/sysplugins/smarty_internal_compile_include.php
+++ b/resources/templates/engine/smarty/sysplugins/smarty_internal_compile_include.php
@@ -81,7 +81,7 @@ class Smarty_Internal_Compile_Include extends Smarty_Internal_CompileBase
                 $_parent_scope = Smarty::SCOPE_GLOBAL;
             }
         }
-        
+
         $_caching = Smarty::CACHING_OFF;
 
         // flag if included template code should be merged into caller

--- a/resources/templates/engine/smarty/sysplugins/smarty_internal_templatelexer.php
+++ b/resources/templates/engine/smarty/sysplugins/smarty_internal_templatelexer.php
@@ -2,10 +2,10 @@
 /**
 * Smarty Internal Plugin Templatelexer
 *
-* This is the lexer to break the template source into tokens 
+* This is the lexer to break the template source into tokens
 * @package Smarty
 * @subpackage Compiler
-* @author Uwe Tews 
+* @author Uwe Tews
 */
 /**
 * Smarty Internal Plugin Templatelexer
@@ -72,8 +72,8 @@ class Smarty_Internal_Templatelexer
     				'AS' => 'as',
     				'TO' => 'to',
     				);
-    				
-    				
+
+
     function __construct($data,$compiler)
     {
 //        $this->data = preg_replace("/(\r\n|\r|\n)/", "\n", $data);
@@ -82,10 +82,10 @@ class Smarty_Internal_Templatelexer
         $this->line = 1;
         $this->smarty = $compiler->smarty;
         $this->compiler = $compiler;
-        $this->ldel = preg_quote($this->smarty->left_delimiter,'/'); 
-        $this->ldel_length = strlen($this->smarty->left_delimiter); 
+        $this->ldel = preg_quote($this->smarty->left_delimiter,'/');
+        $this->ldel_length = strlen($this->smarty->left_delimiter);
         $this->rdel = preg_quote($this->smarty->right_delimiter,'/');
-        $this->rdel_length = strlen($this->smarty->right_delimiter); 
+        $this->rdel_length = strlen($this->smarty->right_delimiter);
         $this->smarty_token_names['LDEL'] =	$this->smarty->left_delimiter;
         $this->smarty_token_names['RDEL'] =	$this->smarty->right_delimiter;
         $this->mbstring_overload = ini_get('mbstring.func_overload') & 2;
@@ -668,7 +668,7 @@ class Smarty_Internal_Templatelexer
     function yy_r2_46($yy_subpatterns)
     {
 
-  $this->token = Smarty_Internal_Templateparser::TP_PTR; 
+  $this->token = Smarty_Internal_Templateparser::TP_PTR;
     }
     function yy_r2_47($yy_subpatterns)
     {
@@ -968,7 +968,7 @@ class Smarty_Internal_Templatelexer
     $to = $match[0][1];
   } else {
     $this->compiler->trigger_template_error ("missing or misspelled literal closing tag");
-  }  
+  }
   if ($this->mbstring_overload) {
     $this->value = mb_substr($this->data,$this->counter,$to-$this->counter,'latin1');
   } else {

--- a/resources/templates/engine/smarty/sysplugins/smarty_internal_templateparser.php
+++ b/resources/templates/engine/smarty/sysplugins/smarty_internal_templateparser.php
@@ -1203,34 +1203,34 @@ static public $yy_action = array(
     public $yystack = array();  /* The parser's stack */
 
     public $yyTokenName = array(
-  '$',             'VERT',          'COLON',         'RDEL',        
-  'COMMENT',       'PHPSTARTTAG',   'PHPENDTAG',     'ASPSTARTTAG', 
-  'ASPENDTAG',     'FAKEPHPSTARTTAG',  'XMLTAG',        'TEXT',        
+  '$',             'VERT',          'COLON',         'RDEL',
+  'COMMENT',       'PHPSTARTTAG',   'PHPENDTAG',     'ASPSTARTTAG',
+  'ASPENDTAG',     'FAKEPHPSTARTTAG',  'XMLTAG',        'TEXT',
   'STRIPON',       'STRIPOFF',      'BLOCKSOURCE',   'LITERALSTART',
-  'LITERALEND',    'LITERAL',       'LDEL',          'DOLLAR',      
-  'ID',            'EQUAL',         'PTR',           'LDELIF',      
-  'LDELFOR',       'SEMICOLON',     'INCDEC',        'TO',          
-  'STEP',          'LDELFOREACH',   'SPACE',         'AS',          
-  'APTR',          'LDELSETFILTER',  'SMARTYBLOCKCHILDPARENT',  'LDELSLASH',   
-  'ATTR',          'INTEGER',       'COMMA',         'OPENP',       
-  'CLOSEP',        'MATH',          'UNIMATH',       'ANDSYM',      
-  'ISIN',          'ISDIVBY',       'ISNOTDIVBY',    'ISEVEN',      
-  'ISNOTEVEN',     'ISEVENBY',      'ISNOTEVENBY',   'ISODD',       
-  'ISNOTODD',      'ISODDBY',       'ISNOTODDBY',    'INSTANCEOF',  
-  'QMARK',         'NOT',           'TYPECAST',      'HEX',         
-  'DOT',           'SINGLEQUOTESTRING',  'DOUBLECOLON',   'AT',          
-  'HATCH',         'OPENB',         'CLOSEB',        'EQUALS',      
+  'LITERALEND',    'LITERAL',       'LDEL',          'DOLLAR',
+  'ID',            'EQUAL',         'PTR',           'LDELIF',
+  'LDELFOR',       'SEMICOLON',     'INCDEC',        'TO',
+  'STEP',          'LDELFOREACH',   'SPACE',         'AS',
+  'APTR',          'LDELSETFILTER',  'SMARTYBLOCKCHILDPARENT',  'LDELSLASH',
+  'ATTR',          'INTEGER',       'COMMA',         'OPENP',
+  'CLOSEP',        'MATH',          'UNIMATH',       'ANDSYM',
+  'ISIN',          'ISDIVBY',       'ISNOTDIVBY',    'ISEVEN',
+  'ISNOTEVEN',     'ISEVENBY',      'ISNOTEVENBY',   'ISODD',
+  'ISNOTODD',      'ISODDBY',       'ISNOTODDBY',    'INSTANCEOF',
+  'QMARK',         'NOT',           'TYPECAST',      'HEX',
+  'DOT',           'SINGLEQUOTESTRING',  'DOUBLECOLON',   'AT',
+  'HATCH',         'OPENB',         'CLOSEB',        'EQUALS',
   'NOTEQUALS',     'GREATERTHAN',   'LESSTHAN',      'GREATEREQUAL',
-  'LESSEQUAL',     'IDENTITY',      'NONEIDENTITY',  'MOD',         
-  'LAND',          'LOR',           'LXOR',          'QUOTE',       
-  'BACKTICK',      'DOLLARID',      'error',         'start',       
-  'template',      'template_element',  'smartytag',     'literal',     
+  'LESSEQUAL',     'IDENTITY',      'NONEIDENTITY',  'MOD',
+  'LAND',          'LOR',           'LXOR',          'QUOTE',
+  'BACKTICK',      'DOLLARID',      'error',         'start',
+  'template',      'template_element',  'smartytag',     'literal',
   'literal_elements',  'literal_element',  'value',         'modifierlist',
-  'attributes',    'expr',          'varindexed',    'statement',   
-  'statements',    'optspace',      'varvar',        'foraction',   
-  'modparameters',  'attribute',     'ternary',       'array',       
-  'ifcond',        'lop',           'variable',      'function',    
-  'doublequoted_with_quotes',  'static_class_access',  'object',        'arrayindex',  
+  'attributes',    'expr',          'varindexed',    'statement',
+  'statements',    'optspace',      'varvar',        'foraction',
+  'modparameters',  'attribute',     'ternary',       'array',
+  'ifcond',        'lop',           'variable',      'function',
+  'doublequoted_with_quotes',  'static_class_access',  'object',        'arrayindex',
   'indexdef',      'varvarele',     'objectchain',   'objectelement',
   'method',        'params',        'modifier',      'modparameter',
   'arrayelements',  'arrayelement',  'doublequoted',  'doublequotedcontent',
@@ -2160,9 +2160,9 @@ static public $yy_action = array(
     if ($this->compiler->has_code) {
         $tmp =''; foreach ($this->compiler->prefix_code as $code) {$tmp.=$code;} $this->compiler->prefix_code=array();
         $this->_retvalue = new _smarty_tag($this, $this->compiler->processNocacheCode($tmp.$this->yystack[$this->yyidx + -1]->minor,true));
-    } else { 
+    } else {
         $this->_retvalue = null;
-    }  
+    }
     $this->compiler->has_variable_string = false;
     $this->block_nesting_level = count($this->compiler->_tag_stack);
     }
@@ -2196,11 +2196,11 @@ static public $yy_action = array(
 #line 162 "smarty_internal_templateparser.y"
     function yy_r8(){
     if ($this->is_xml) {
-        $this->compiler->tag_nocache = true; 
+        $this->compiler->tag_nocache = true;
         $this->is_xml = false;
-        $save = $this->template->has_nocache_code; 
+        $save = $this->template->has_nocache_code;
         $this->_retvalue = new _smarty_text($this, $this->compiler->processNocacheCode("<?php echo '?>';?>\n", $this->compiler, true));
-        $this->template->has_nocache_code = $save; 
+        $this->template->has_nocache_code = $save;
     } elseif ($this->php_handling == Smarty::PHP_PASSTHRU) {
         $this->_retvalue = new _smarty_text($this, '?<?php ?>>');
     } elseif ($this->php_handling == Smarty::PHP_QUOTE) {
@@ -2260,17 +2260,17 @@ static public $yy_action = array(
 #line 225 "smarty_internal_templateparser.y"
     function yy_r11(){
     if ($this->strip) {
-        $this->_retvalue = new _smarty_text($this, preg_replace('![\t ]*[\r\n]+[\t ]*!', '', self::escape_start_tag($this->yystack[$this->yyidx + 0]->minor))); 
+        $this->_retvalue = new _smarty_text($this, preg_replace('![\t ]*[\r\n]+[\t ]*!', '', self::escape_start_tag($this->yystack[$this->yyidx + 0]->minor)));
     } else {
-        $this->_retvalue = new _smarty_text($this, self::escape_start_tag($this->yystack[$this->yyidx + 0]->minor));  
+        $this->_retvalue = new _smarty_text($this, self::escape_start_tag($this->yystack[$this->yyidx + 0]->minor));
     }
     }
 #line 2264 "smarty_internal_templateparser.php"
 #line 234 "smarty_internal_templateparser.y"
     function yy_r12(){
     $this->compiler->tag_nocache = true;
-    $this->is_xml = true; 
-    $save = $this->template->has_nocache_code; 
+    $this->is_xml = true;
+    $save = $this->template->has_nocache_code;
     $this->_retvalue = new _smarty_text($this, $this->compiler->processNocacheCode("<?php echo '<?xml';?>", $this->compiler, true));
     $this->template->has_nocache_code = $save;
     }
@@ -2407,7 +2407,7 @@ static public $yy_action = array(
 #line 2403 "smarty_internal_templateparser.php"
 #line 386 "smarty_internal_templateparser.y"
     function yy_r42(){
-    $tag = trim(substr($this->yystack[$this->yyidx + -1]->minor,$this->lex->ldel_length)); 
+    $tag = trim(substr($this->yystack[$this->yyidx + -1]->minor,$this->lex->ldel_length));
     $this->_retvalue = $this->compiler->compileTag(($tag == 'else if')? 'elseif' : $tag,array(),array('if condition'=>$this->yystack[$this->yyidx + 0]->minor));
     }
 #line 2409 "smarty_internal_templateparser.php"
@@ -2677,7 +2677,7 @@ static public $yy_action = array(
             $this->_retvalue = $this->smarty->registered_classes[$this->yystack[$this->yyidx + -2]->minor].'::'.$this->yystack[$this->yyidx + 0]->minor;
         } else {
             $this->_retvalue = $this->yystack[$this->yyidx + -2]->minor.'::'.$this->yystack[$this->yyidx + 0]->minor;
-        } 
+        }
     } else {
         $this->compiler->trigger_template_error ("static class '".$this->yystack[$this->yyidx + -2]->minor."' is undefined or not allowed by security setting");
     }
@@ -2705,7 +2705,7 @@ static public $yy_action = array(
         $smarty_var = $this->compiler->compileTag('private_special_variable',array(),$this->yystack[$this->yyidx + 0]->minor['smarty_internal_index']);
         $this->_retvalue = $smarty_var;
     } else {
-        // used for array reset,next,prev,end,current 
+        // used for array reset,next,prev,end,current
         $this->last_variable = $this->yystack[$this->yyidx + 0]->minor['var'];
         $this->last_index = $this->yystack[$this->yyidx + 0]->minor['smarty_internal_index'];
         $this->_retvalue = $this->compileVariable($this->yystack[$this->yyidx + 0]->minor['var']).$this->yystack[$this->yyidx + 0]->minor['smarty_internal_index'];
@@ -3023,7 +3023,7 @@ static public $yy_action = array(
     }
 #line 3020 "smarty_internal_templateparser.php"
 #line 1196 "smarty_internal_templateparser.y"
-    function yy_r190(){ 
+    function yy_r190(){
     $this->_retvalue = '\''.$this->yystack[$this->yyidx + -2]->minor.'\'=>'.$this->yystack[$this->yyidx + 0]->minor;
     }
 #line 3025 "smarty_internal_templateparser.php"


### PR DESCRIPTION
whitespace pass over files
for reference regex that was used s/[ \t]+(\r?\n)/\1/