### PR TITLE
Add. `role` to be able select database backend in constructor.

### DIFF
--- a/resources/install/scripts/resources/functions/database/native.lua
+++ b/resources/install/scripts/resources/functions/database/native.lua
@@ -4,8 +4,10 @@
 
 local log = require "resources.functions.log".database
 
+assert(freeswitch, "Require FreeSWITCH environment")
+
 -----------------------------------------------------------
-local FsDatabase = {} if freeswitch then
+local FsDatabase = {} do
 
 require "resources.functions.file_exists"
 require "resources.functions.database_handle"


### PR DESCRIPTION
To configure use `database.backend` option
It can be a string value like `database.backend = 'native'`.
So it will always use same backend.
Or it can be a table value like
```Lua
database.backend = {
  main   = 'native';
  base64 = 'luasql';
}
```
Role `database.backend.main` is predefined and it equal to `native` if not set.
If there no role when Database class creates or role unknown role `main` is used
```Lua
dbh = Database.new('system') -- uses role `main`
dbh = Database.new('system', 'main') -- same as previews
dbh = Database.new('system', 'base64') -- uses role `base64`
dbh = Database.new('system', 'test')   -- uses role `main`
```