### PR TITLE
initialize call_context

### DIFF
--- a/resources/install/scripts/app/xml_handler/resources/scripts/dialplan/dialplan.lua
+++ b/resources/install/scripts/app/xml_handler/resources/scripts/dialplan/dialplan.lua
@@ -27,6 +27,11 @@
 	local cache = require"resources.functions.cache"
 	local log = require"resources.functions.log"["xml_handler"]
 
+-- needed for cli-command xml_locate dialplan
+        if not call_context then
+                call_context = freeswitch.getGlobalVariable("domain");
+        end
+
 --get the cache
 	XML_STRING, err = cache.get("dialplan:" .. call_context)
 


### PR DESCRIPTION
If you use 'xml_locate dialplan' from fs_cli, you get an error, to prevent this I intialized call_context with the value of the "domain"-variable