### PR TITLE
Fix. Use default value in function definition.

### DIFF
--- a/resources/classes/menu.php
+++ b/resources/classes/menu.php
@@ -384,7 +384,7 @@
 			} //end function
 
 		//create the menu array
-			public function menu_array($sql, $menu_item_level) {
+			public function menu_array($sql = '', $menu_item_level = 0) {
 
 				//get the database connnection
 					$db = $this->db;


### PR DESCRIPTION
On `themes/default/template.php` it called without args
```PHP
$menu_array = $menu->menu_array();
```

And it produce PHP warning.