### PR TITLE
Fix. warning about using NULL as first argument in `foreach`.

### DIFF
--- a/resources/classes/menu.php
+++ b/resources/classes/menu.php
@@ -390,7 +390,7 @@
 					$db = $this->db;
 
 				//database ojbect does not exist return immediately
-					if (!$db) { return; }
+					if (!$db) { return Array(); }
 
 				//if there are no groups then set the public group
 					if (!isset($_SESSION['groups'])) {
@@ -435,6 +435,7 @@
 
 				//save the menu into an array
 					$x = 0;
+					$a = Array();
 					foreach($result as $row) {
 						//add the row to the array
 							$a[$x] = $row;


### PR DESCRIPTION
Problem now in `tepmplate.php`
```PHP
$menu_array = $menu->menu_array();
...
foreach ($menu_array as $index_main => $menu_parent) {
```

It appear while install process because in this moment there not `$db`
and `$menu->menu_array()` returns nothing.

I fix it like `$menu->menu_array()` always returns array.

This problem also can be solved in `tepmplate.php` like
```PHP
if(is_array($menu_array)){
  foreach ($menu_array as $index_main => $menu_parent) {
...
```