### PR TITLE
Fix. Display language name on Install page.

### DIFF
--- a/resources/app_languages.php
+++ b/resources/app_languages.php
@@ -14,6 +14,20 @@ $text['language-name']['de-at'] = "Deutsch - Österreich";
 $text['language-name']['ar-eg'] = "العربية - مصر";
 $text['language-name']['ru-ru'] = 'Русский - Россия';
 
+//language for `Select Language` install page
+$text['language-en-us']['en-us'] = "English - United States";
+$text['language-es-cl']['en-us'] = "Español - Chile";
+$text['language-pt-pt']['en-us'] = "Português - Portugal";
+$text['language-fr-fr']['en-us'] = "Français - France";
+$text['language-nl-nl']['en-us'] = "Nederlands - De Nederland";
+$text['language-pt-br']['en-us'] = "Brasileiro - Português";
+$text['language-pl'   ]['en-us'] = "Polski - Polska";
+$text['language-sv-se']['en-us'] = "Svenska - Sverige";
+$text['language-uk'   ]['en-us'] = "Українська - Україна";
+$text['language-de-at']['en-us'] = "Deutsch - Österreich";
+$text['language-ar-eg']['en-us'] = "العربية - مصر";
+$text['language-ru-ru']['en-us'] = 'Русский - Россия';
+
 //message
 $text['message-update']['en-us'] = "Update Completed";
 $text['message-update']['es-cl'] = "Actualización Completada";


### PR DESCRIPTION
This is special case because all this names should be displayed
in same time on single page on different languages.
So not translate in strict way.
Before:
![screenshot_1](https://cloud.githubusercontent.com/assets/1804306/14134829/42608c40-f662-11e5-9eec-61d5ee19be47.png)
After:
![screenshot_2](https://cloud.githubusercontent.com/assets/1804306/14134830/42613b7c-f662-11e5-83d6-d67da66b2ffa.png)

