### PR TITLE
Update call_block index.lua script

### DIFF
--- a/resources/install/scripts/app/call_block/index.lua
+++ b/resources/install/scripts/app/call_block/index.lua
@@ -46,7 +46,7 @@ This method causes the script to get its manadatory arguments directly from the 
 
 -- Command line parameters
 	local params = {
-			cid_num = string.gsub(tostring(session:getVariable("caller_id_number")), "+", ""),
+			cid_num = string.match(tostring(session:getVariable("caller_id_number")), "%d+"),
 			cid_name = session:getVariable("caller_id_name"),
 			domain_name = session:getVariable("domain_name"),
 			userid = "", -- session:getVariable("id")


### PR DESCRIPTION
We've had instances where special characters (other than +) are used in the caller_id_number field which prevents these calls from being detected using the call_block feature. We've resolved this by updating fusionpbx/resources/install/scripts/app/call_block/index.lua line 49 to match only numbers rather than using a gsub replace.