### PR TITLE
E.164 format support - contact_phone_edit.php

### DIFF
--- a/app/contacts/contact_phone_edit.php
+++ b/app/contacts/contact_phone_edit.php
@@ -66,7 +66,7 @@ if (strlen($_GET["contact_uuid"]) > 0) {
 		$phone_description = check_str($_POST["phone_description"]);
 
 		//remove any phone number formatting
-		$phone_number = preg_replace('{\D}', '', $phone_number);
+		$phone_number = preg_replace('{(?!^\+)[\D]}', '', $phone_number);
 
 		//use custom label if set
 		$phone_label = ($phone_label_custom != '') ? $phone_label_custom : $phone_label;


### PR DESCRIPTION
The + prefix is being removed, this should be ignored for the very start of the string, resolution below.

Line 69.
Replace:
$phone_number = preg_replace('{\D}', '', $phone_number);
With:
$phone_number = preg_replace('{(?!^\+)[\D]}', '', $phone_number);