### PR TITLE
Fix. Do not populate invalid paths.

### DIFF
--- a/app/edit/filelist.php
+++ b/app/edit/filelist.php
@@ -45,7 +45,7 @@ else {
 		$htmlfilelist = '';
 		$dirlist = opendir($dir);
 		$dir_array = array();
-		while (false !== ($file = readdir($dirlist))) {
+		if($dirlist !== false) while (false !== ($file = readdir($dirlist))) {
 			if ($file != "." AND $file != ".."){
 				$newpath = $dir.'/'.$file;
 				$level = explode('/',$newpath);

--- a/app/edit/fileoptionslist.php
+++ b/app/edit/fileoptionslist.php
@@ -49,7 +49,7 @@ else {
 		$htmlfilelist = '';
 		$dirlist = opendir($dir);
 		$dir_array = array();
-		while (false !== ($file = readdir($dirlist))) {
+		if($dirlist !== false) while (false !== ($file = readdir($dirlist))) {
 			if ($file != "." AND $file != ".."){
 				$newpath = $dir.'/'.$file;
 				$level = explode('/',$newpath);


### PR DESCRIPTION
Problem when `opendir($dir)` returns `false` and then
while cycle adds many empty strings which produce in the end
```
/etc/freeswitch/tls
/etc/freeswitch/tls/
/etc/freeswitch/tls//
/etc/freeswitch/tls///
/etc/freeswitch/tls////
/etc/freeswitch/tls/////
/etc/freeswitch/tls//////
/etc/freeswitch/tls///////
```