### PR TITLE
Fix for [ERR] sofia_glue.c:329 Invalid tls-verify-policy value: none

### DIFF
--- a/resources/templates/conf/sip_profiles/external-ipv6.xml.noload
+++ b/resources/templates/conf/sip_profiles/external-ipv6.xml.noload
@@ -82,7 +82,7 @@
 		<param name="tls-verify-date" value="true"/>
 		<!-- TLS verify policy, when registering/inviting gateways with other servers (outbound) or handling inbound registration/invite requests how should we verify their certificate -->
 		<!-- set to 'in' to only verify incoming connections, 'out' to only verify outgoing connections, 'all' to verify all connections, also 'in_subjects', 'out_subjects' and 'all_subjects' for subject validation. Multiple policies can be split with a '|' pipe -->
-		<param name="tls-verify-policy" value="none"/>
+		<!--<param name="tls-verify-policy" value="all|subjects_all"/>-->
 		<!-- Certificate max verify depth to use for validating peer TLS certificates when the verify policy is not none -->
 		<param name="tls-verify-depth" value="2"/>
 		<!-- If the tls-verify-policy is set to subjects_all or subjects_in this sets which subjects are allowed, multiple subjects can be split with a '|' pipe -->

--- a/resources/templates/conf/sip_profiles/external.xml.noload
+++ b/resources/templates/conf/sip_profiles/external.xml.noload
@@ -86,7 +86,7 @@
 		<param name="tls-verify-date" value="true"/>
 		<!-- TLS verify policy, when registering/inviting gateways with other servers (outbound) or handling inbound registration/invite requests how should we verify their certificate -->
 		<!-- set to 'in' to only verify incoming connections, 'out' to only verify outgoing connections, 'all' to verify all connections, also 'in_subjects', 'out_subjects' and 'all_subjects' for subject validation. Multiple policies can be split with a '|' pipe -->
-		<param name="tls-verify-policy" value="none"/>
+		<!--<param name="tls-verify-policy" value="all|subjects_all"/>-->
 		<!-- Certificate max verify depth to use for validating peer TLS certificates when the verify policy is not none -->
 		<param name="tls-verify-depth" value="2"/>
 		<!-- If the tls-verify-policy is set to subjects_all or subjects_in this sets which subjects are allowed, multiple subjects can be split with a '|' pipe -->

--- a/resources/templates/conf/sip_profiles/internal-ipv6.xml.noload
+++ b/resources/templates/conf/sip_profiles/internal-ipv6.xml.noload
@@ -47,12 +47,25 @@
 
 		<!-- TLS: disabled by default, set to "true" to enable -->
 		<param name="tls" value="$${internal_ssl_enable}"/>
+		<!-- Set to true to not bind on the normal sip-port but only on the TLS port -->
+		<param name="tls-only" value="false"/>
 		<!-- additional bind parameters for TLS -->
 		<param name="tls-bind-params" value="transport=tls"/>
 		<!-- Port to listen on for TLS requests. (5061 will be used if unspecified) -->
 		<param name="tls-sip-port" value="$${internal_tls_port}"/>
 		<!-- Location of the agent.pem and cafile.pem ssl certificates (needed for TLS server) -->
 		<param name="tls-cert-dir" value="$${internal_ssl_dir}"/>
+		<!-- Optionally set the passphrase password used by openSSL to encrypt/decrypt TLS private key files -->
+		<param name="tls-passphrase" value=""/>
+		<!-- Verify the date on TLS certificates -->
+		<param name="tls-verify-date" value="true"/>
+		<!-- TLS verify policy, when registering/inviting gateways with other servers (outbound) or handling inbound registration/invite requests how should we verify their certificate -->
+		<!-- set to 'in' to only verify incoming connections, 'out' to only verify outgoing connections, 'all' to verify all connections, also 'in_subjects', 'out_subjects' and 'all_subjects' for subject validation. Multiple policies can be split with a '|' pipe -->
+		<!--<param name="tls-verify-policy" value="all|subjects_all"/>-->
+		<!-- Certificate max verify depth to use for validating peer TLS certificates when the verify policy is not none -->
+		<param name="tls-verify-depth" value="2"/>
+		<!-- If the tls-verify-policy is set to subjects_all or subjects_in this sets which subjects are allowed, multiple subjects can be split with a '|' pipe -->
+		<param name="tls-verify-in-subjects" value=""/>
 		<!-- TLS version ("sslv23" (default), "tlsv1"). NOTE: Phones may not work with TLSv1 -->
 		<param name="tls-version" value="$${sip_tls_version}"/>
 

--- a/resources/templates/conf/sip_profiles/internal.xml.noload
+++ b/resources/templates/conf/sip_profiles/internal.xml.noload
@@ -184,7 +184,7 @@
 		<param name="tls-verify-date" value="true"/>
 		<!-- TLS verify policy, when registering/inviting gateways with other servers (outbound) or handling inbound registration/invite requests how should we verify their certificate -->
 		<!-- set to 'in' to only verify incoming connections, 'out' to only verify outgoing connections, 'all' to verify all connections, also 'in_subjects', 'out_subjects' and 'all_subjects' for subject validation. Multiple policies can be split with a '|' pipe -->
-		<param name="tls-verify-policy" value="none"/>
+		<!--<param name="tls-verify-policy" value="all|subjects_all"/>-->
 		<!-- Certificate max verify depth to use for validating peer TLS certificates when the verify policy is not none -->
 		<param name="tls-verify-depth" value="2"/>
 		<!-- If the tls-verify-policy is set to subjects_all or subjects_in this sets which subjects are allowed, multiple subjects can be split with a '|' pipe -->


### PR DESCRIPTION
you cannot actually set it to none, you have to not set it to get that
value.
made ipv6 profile tls settings consistent with ipv4 profile