### PR TITLE
Fix. Use correct database for Call Center while FS load.

### DIFF
--- a/resources/install/scripts/app/xml_handler/resources/scripts/configuration/callcenter.conf.lua
+++ b/resources/install/scripts/app/xml_handler/resources/scripts/configuration/callcenter.conf.lua
@@ -46,8 +46,13 @@
 			assert(dbh:connected());
 
 		--get the variables
-			dsn = trim(api:execute("global_getvar", "dsn"));
-			dsn_callcenter = trim(api:execute("global_getvar", "dsn_callcenter"));
+			dsn = trim(api:execute("global_getvar", "dsn")) or '';
+			dsn_callcenter = trim(api:execute("global_getvar", "dsn_callcenter")) or '';
+
+			if dsn:find("INVALID COMMAND", nil, true) then
+				freeswitch.consoleLog('err', '[xml_handler] Can not correctly load mod_callcenter becase mod_commands not loaded\n')
+				dsn, dsn_callcenter = '', ''
+			end
 
 		--start the xml array
 			local xml = {}
@@ -56,14 +61,12 @@
 			table.insert(xml, [[    <section name="configuration">]]);
 			table.insert(xml, [[            <configuration name="callcenter.conf" description="Call Center">]]);
 			table.insert(xml, [[                    <settings>]]);
-			if (dsn_callcenter) then
+			if #dsn_callcenter > 0 then
 				table.insert(xml, [[                            <param name="odbc-dsn" value="]]..dsn_callcenter..[["/>]]);
-			else
-				if (string.len(dsn) > 0) then
-					table.insert(xml, [[                            <param name="odbc-dsn" value="]]..database["switch"]..[["/>]]);
-				end
+			elseif #dsn > 0 then
+				table.insert(xml, [[                            <param name="odbc-dsn" value="]]..database["switch"]..[["/>]]);
 			end
-			--table.insert(xml, [[                          <param name="dbname" value="/usr/local/freeswitch/db/call_center.db"/>]]);
+			-- table.insert(xml, [[                          <param name="dbname" value="]]..database_dir..[[/call_center.db"/>]]);
 			table.insert(xml, [[                    </settings>]]);
 
 		--write the queues

--- a/resources/switch.php
+++ b/resources/switch.php
@@ -391,7 +391,7 @@ function save_module_xml() {
 	$xml .= "<configuration name=\"modules.conf\" description=\"Modules\">\n";
 	$xml .= "	<modules>\n";
 
-	$sql = "select * from v_modules order by module_category = 'Languages' OR  module_category = 'Loggers' DESC, module_category ";
+	$sql = "select * from v_modules order by module_name='mod_commands' OR module_category = 'Languages' OR  module_category = 'Loggers' DESC, module_category ";
 	$prep_statement = $db->prepare(check_sql($sql));
 	$prep_statement->execute();
 	$prev_module_cat = '';


### PR DESCRIPTION
Problem that `mod_commands` may load after than `mod_callcenter` and there no function `global_getvar`
So current code just create database with name `INVALID COMMAND!.db`.