### PR TITLE
BugFix-Default-MOH

### DIFF
--- a/app/music_on_hold/app_defaults.php
+++ b/app/music_on_hold/app_defaults.php
@@ -1,0 +1,36 @@
+<?php
+/*
+	FusionPBX
+	Version: MPL 1.1
+
+	The contents of this file are subject to the Mozilla Public License Version
+	1.1 (the "License"); you may not use this file except in compliance with
+	the License. You may obtain a copy of the License at
+	http://www.mozilla.org/MPL/
+
+	Software distributed under the License is distributed on an "AS IS" basis,
+	WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License
+	for the specific language governing rights and limitations under the
+	License.
+
+	The Original Code is FusionPBX
+
+	The Initial Developer of the Original Code is
+	Mark J Crane <markjcrane@fusionpbx.com>
+	Portions created by the Initial Developer are Copyright (C) 2016
+	the Initial Developer. All Rights Reserved.
+
+	Contributor(s):
+	Mark J Crane <markjcrane@fusionpbx.com>
+	Matthew Vale <github@mafoo.org>
+*/
+
+	if ($domains_processed == 1) {
+
+		require_once "app/music_on_hold/resources/classes/switch_music_on_hold.php";
+		$moh = new switch_music_on_hold;
+		$moh->xml();
+		$moh->save();
+	}
+
+?>

--- a/app/music_on_hold/resources/classes/switch_music_on_hold.php
+++ b/app/music_on_hold/resources/classes/switch_music_on_hold.php
@@ -184,11 +184,16 @@ include "root.php";
 					$file_contents = file_get_contents("/usr/share/examples/fusionpbx/resources/templates/conf/autoload_configs/local_stream.conf.xml");
 				}
 				else {
-					$file_contents = file_get_contents($_SERVER["DOCUMENT_ROOT"].PROJECT_PATH."/resources/templates/conf/autoload_configs/local_stream.conf.xml");
+					$file_contents = file_get_contents($_SERVER["PROJECT_ROOT"]."/resources/templates/conf/autoload_configs/local_stream.conf.xml");
 				}
-
-			//replace the variable
-				$file_contents = str_replace("{v_moh_categories}", $this->xml, $file_contents);
+			//check where the default music is stored
+				$default_moh_prefix = 'music/default';
+				if(file_exists($_SESSION['switch']['sounds']['dir'].'/music/8000')) {
+					$default_moh_prefix = 'music';
+				}
+			//replace the variables
+				$file_contents = preg_replace("music\/default", $default_moh_prefix, $file_contents);
+				$file_contents = preg_replace("[\t ]*(?:<!--)?{v_moh_categories}(?:-->)?", $this->xml, $file_contents);
 
 			//write the XML config file
 				$fout = fopen($_SESSION['switch']['conf']['dir']."/autoload_configs/local_stream.conf.xml","w");
@@ -198,6 +203,7 @@ include "root.php";
 			//reload the XML
 				$this->reload();
 		}
+
 	}
 
 //build and save the XML

--- a/resources/templates/conf/autoload_configs/local_stream.conf.xml
+++ b/resources/templates/conf/autoload_configs/local_stream.conf.xml
@@ -14,7 +14,7 @@
 		<!--<param name="chime-max" value="500"/>-->
 	</directory>
 
-	<directory name="moh/8000" path="$${sounds_dir}/music/8000">
+	<directory name="moh/8000" path="$${sounds_dir}/music/default/8000">
 		<param name="rate" value="8000"/>
 		<param name="shuffle" value="true"/>
 		<param name="channels" value="1"/>
@@ -22,7 +22,7 @@
 		<param name="timer-name" value="soft"/>
 	</directory>
 
-	<directory name="moh/16000" path="$${sounds_dir}/music/16000">
+	<directory name="moh/16000" path="$${sounds_dir}/music/default/16000">
 		<param name="rate" value="16000"/>
 		<param name="shuffle" value="true"/>
 		<param name="channels" value="1"/>
@@ -30,7 +30,7 @@
 		<param name="timer-name" value="soft"/>
 	</directory>
 
-	<directory name="moh/32000" path="$${sounds_dir}/music/32000">
+	<directory name="moh/32000" path="$${sounds_dir}/music/default/32000">
 		<param name="rate" value="32000"/>
 		<param name="shuffle" value="true"/>
 		<param name="channels" value="1"/>
@@ -38,7 +38,7 @@
 		<param name="timer-name" value="soft"/>
 	</directory>
 
-	<directory name="moh/48000" path="$${sounds_dir}/music/48000">
+	<directory name="moh/48000" path="$${sounds_dir}/music/default/48000">
 		<param name="rate" value="48000"/>
 		<param name="shuffle" value="true"/>
 		<param name="channels" value="1"/>
@@ -46,5 +46,5 @@
 		<param name="timer-name" value="soft"/>
 	</directory>
 
-	{v_moh_categories}
+	<!--{v_moh_categories}-->
 </configuration>


### PR DESCRIPTION
Added basic searching for moh

added basic searching for the default moh directory
added app_defaults so moh is configured/repairable with app_defaults
changed to use PROJECT_ROOT
changed template replacement to be encased in comment so xml will
validate
changed to use preg_replace so leading spaces and tabs can be stripped
(to output clean xml)
local_stream_conf dos2unixed
made default search consistent (they should all be music/default or
music not a mixture)