### PR TITLE
BugFix-add missing default ringback to lua

### DIFF
--- a/resources/install/scripts/resources/functions/format_ringback.lua
+++ b/resources/install/scripts/resources/functions/format_ringback.lua
@@ -7,8 +7,13 @@
 			api = freeswitch.API();
 		--handle ringback
 			if (ringback == nil or ringback == "") then
-				--get the default ring back
+				--get the default hold_music
 					ringback = trim(api:execute("global_getvar", "hold_music"));
+			elseif (ringback == "default_ringback") then
+				--get the default ringback variable
+					ringback = trim(api:execute("global_getvar", "ringback"));
+				--convert to tone_stream
+					ringback = "tone_stream://" .. ringback .. ";loops=-1";
 			elseif (ringback:match("%${.*}")) then
 				--strip the ${ and }
 					ringback = ringback:gsub("%${", "");


### PR DESCRIPTION
add processing of when ringback is set to default_ringback and correctly
set it to the current value of the globalvar for ringback
- [ ] Tested on Debian 8.5 VM