### PR TITLE
Fix variable names and clean up duplicate time settings in yealink files

### DIFF
--- a/resources/templates/provision/yealink/cp860/y000000000037.cfg
+++ b/resources/templates/provision/yealink/cp860/y000000000037.cfg
@@ -1433,54 +1433,6 @@ gui_lang.url =
 gui_lang.delete =
 
 #######################################################################################
-##         	                   Time Settings                                         ##
-#######################################################################################
-
-#Configure the time zone and time zone name. The time zone ranges from -11 to +12, the default value is +8.
-#The default time zone name is China(Beijing).
-#local_time.time_zone = +8
-#local_time.time_zone_name = China(Beijing)
-local_time.time_zone = {$yealink_time_zone}
-local_time.time_zone_name = {$yealink_time_zone_name}
-
-#Configure the domain name or the IP address of the NTP server. The default value is cn.pool.ntp.org.
-local_time.ntp_server1 = {$ntp_server_1}
-local_time.ntp_server2 = {$ntp_server_2}
-
-#Configure the update interval (in seconds) when using the NTP server. The default value is 1000.
-local_time.interval =
-
-#Configure the daylight saving time feature; 0-Disabled, 1-Enabled, 2-Automatic (default);
-local_time.summer_time =
-
-#Configure the DST type when the DST feature is enabled; 0-By Date (default), 1-By Week;
-local_time.dst_time_type =
-
-#Configure the start time of DST. The default value is 1/1/0.
-#If the DST type is configured as By Date, the value format is Month/Day/Hour. For example, the value 5/20/10 means the start time is at 10:00 on May 20.
-#If the DST type is configured as By Week, the value format is Month/Day of Week/Day of Week Last in Month/Hour of Day.
-#For example, the value 1/4/2/5 means the start time is at 5 o'clock on Tuesday of the 4th week in January.
-local_time.start_time = {$yealink_time_zone_start_time}
-
-#Configure the end time of DST. The default value is 12/31/23. The value format is the same to the start time.
-local_time.end_time = {$yealink_time_zone_end_time}
-
-#Configure the offset time (in seconds). It ranges from -300 to 300, the default value is blank.
-local_time.offset_time = {$yealink_offset_time}
-
-#Configure the time format; 0-12 Hour, 1-24 Hour (default);
-local_time.time_format = {$yealink_time_format}
-
-#Configure the date format; 0-WWW MMM DD (default), 1-DD-MMM-YY, 2-YYYY-MM-DD, 3-DD/MM/YYYY, 4-MM/DD/YY, 5-DD MMM YYYY, 6-WWW DD MMM;
-local_time.date_format = {$yealink_date_format}
-
-#Enable or disable the DHCP Time; 0-Disabled (default), 1-Enabled;
-local_time.dhcp_time =
-
-#Enable or disable the manual time; 0-NTP time, 1-manual time. The default value is 0.
-local_time.manual_time_enable =
-
-#######################################################################################
 ##                                   Trusted Certificates                            ##
 #######################################################################################
 #Before using this parameter, you should store the desired certificate to the provisioning server.

--- a/resources/templates/provision/yealink/cp860/{$mac}.cfg
+++ b/resources/templates/provision/yealink/cp860/{$mac}.cfg
@@ -924,8 +924,8 @@ account.2.xsi.port =
 #Configure the time zone and time zone name. The time zone ranges from -11 to +12, the default value is +8.
 #local_time.time_zone = +8
 #local_time.time_zone_name = China(Beijing)
-local_time.time_zone = {$time_zone}
-local_time.time_zone_name = {$time_zone_name}
+local_time.time_zone = {$yealink_time_zone}
+local_time.time_zone_name = {$yealink_time_zone_name}
 
 
 #######################################################################################
@@ -1408,16 +1408,6 @@ account.3.xsi.password =
 account.3.xsi.host =
 account.3.xsi.server_type =
 account.3.xsi.port =
-
-
-#######################################################################################
-##                                 Time                                              ##
-#######################################################################################
-#Configure the time zone and time zone name. The time zone ranges from -11 to +12, the default value is +8.
-#local_time.time_zone = +8
-#local_time.time_zone_name = China(Beijing)
-local_time.time_zone =
-local_time.time_zone_name =
 
 
 #######################################################################################
@@ -1904,16 +1894,6 @@ account.4.xsi.port =
 
 
 #######################################################################################
-##                                 Time                                              ##
-#######################################################################################
-#Configure the time zone and time zone name. The time zone ranges from -11 to +12, the default value is +8.
-#local_time.time_zone = +8
-#local_time.time_zone_name = China(Beijing)
-local_time.time_zone =
-local_time.time_zone_name =
-
-
-#######################################################################################
 ##                                   NETWORK                                         ##
 #######################################################################################
 ##0-ipv4, 1-ipv6, 2-ipv4&ipv6
@@ -2395,16 +2375,6 @@ account.5.xsi.port =
 
 
 #######################################################################################
-##                                 Time                                              ##
-#######################################################################################
-#Configure the time zone and time zone name. The time zone ranges from -11 to +12, the default value is +8.
-#local_time.time_zone = +8
-#local_time.time_zone_name = China(Beijing)
-local_time.time_zone =
-local_time.time_zone_name =
-
-
-#######################################################################################
 ##                                   NETWORK                                         ##
 #######################################################################################
 ##0-ipv4, 1-ipv6, 2-ipv4&ipv6
@@ -2883,16 +2853,6 @@ account.6.xsi.password =
 account.6.xsi.host =
 account.6.xsi.server_type =
 account.6.xsi.port =
-
-
-#######################################################################################
-##                                 Time                                              ##
-#######################################################################################
-#Configure the time zone and time zone name. The time zone ranges from -11 to +12, the default value is +8.
-#local_time.time_zone = +8
-#local_time.time_zone_name = China(Beijing)
-local_time.time_zone =
-local_time.time_zone_name =
 
 
 #######################################################################################

--- a/resources/templates/provision/yealink/t21p/y000000000052.cfg
+++ b/resources/templates/provision/yealink/t21p/y000000000052.cfg
@@ -1394,54 +1394,6 @@ gui_lang.url =
 gui_lang.delete =
 
 #######################################################################################
-##         	                   Time Settings                                         ##
-#######################################################################################
-
-#Configure the time zone and time zone name. The time zone ranges from -11 to +12, the default value is +8.
-#The default time zone name is China(Beijing).
-#local_time.time_zone = +8
-#local_time.time_zone_name = China(Beijing)
-local_time.time_zone = {$yealink_time_zone}
-local_time.time_zone_name = {$yealink_time_zone_name}
-
-#Configure the domain name or the IP address of the NTP server. The default value is cn.pool.ntp.org.
-local_time.ntp_server1 = {$ntp_server_1}
-local_time.ntp_server2 = {$ntp_server_2}
-
-#Configure the update interval (in seconds) when using the NTP server. The default value is 1000.
-local_time.interval =
-
-#Configure the daylight saving time feature; 0-Disabled, 1-Enabled, 2-Automatic (default);
-local_time.summer_time =
-
-#Configure the DST type when the DST feature is enabled; 0-By Date (default), 1-By Week;
-local_time.dst_time_type =
-
-#Configure the start time of DST. The default value is 1/1/0.
-#If the DST type is configured as By Date, the value format is Month/Day/Hour. For example, the value 5/20/10 means the start time is at 10:00 on May 20.
-#If the DST type is configured as By Week, the value format is Month/Day of Week/Day of Week Last in Month/Hour of Day.
-#For example, the value 1/4/2/5 means the start time is at 5 o'clock on Tuesday of the 4th week in January.
-local_time.start_time = {$yealink_time_zone_start_time}
-
-#Configure the end time of DST. The default value is 12/31/23. The value format is the same to the start time.
-local_time.end_time = {$yealink_time_zone_end_time}
-
-#Configure the offset time (in seconds). It ranges from -300 to 300, the default value is blank.
-local_time.offset_time = {$yealink_offset_time}
-
-#Configure the time format; 0-12 Hour, 1-24 Hour (default);
-local_time.time_format = {$yealink_time_format}
-
-#Configure the date format; 0-WWW MMM DD (default), 1-DD-MMM-YY, 2-YYYY-MM-DD, 3-DD/MM/YYYY, 4-MM/DD/YY, 5-DD MMM YYYY, 6-WWW DD MMM;
-local_time.date_format = {$yealink_date_format}
-
-#Enable or disable the DHCP Time; 0-Disabled (default), 1-Enabled;
-local_time.dhcp_time =
-
-#Enable or disable the manual time; 0-NTP time, 1-manual time. The default value is 0.
-local_time.manual_time_enable =
-
-#######################################################################################
 ##                                   Trusted Certificates                            ##
 #######################################################################################
 #Before using this parameter, you should store the desired certificate to the provisioning server.

--- a/resources/templates/provision/yealink/t21p/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t21p/{$mac}.cfg
@@ -924,8 +924,8 @@ account.2.xsi.port =
 #Configure the time zone and time zone name. The time zone ranges from -11 to +12, the default value is +8.
 #local_time.time_zone = +8
 #local_time.time_zone_name = China(Beijing)
-local_time.time_zone = {$time_zone}
-local_time.time_zone_name = {$time_zone_name}
+local_time.time_zone = {$yealink_time_zone}
+local_time.time_zone_name = {$yealink_time_zone_name}
 
 
 #######################################################################################
@@ -1411,16 +1411,6 @@ account.3.xsi.port =
 
 
 #######################################################################################
-##                                 Time                                              ##
-#######################################################################################
-#Configure the time zone and time zone name. The time zone ranges from -11 to +12, the default value is +8.
-#local_time.time_zone = +8
-#local_time.time_zone_name = China(Beijing)
-local_time.time_zone =
-local_time.time_zone_name =
-
-
-#######################################################################################
 ##                                   NETWORK                                         ##
 #######################################################################################
 ##0-ipv4, 1-ipv6, 2-ipv4&ipv6
@@ -1900,16 +1890,6 @@ account.4.xsi.password =
 account.4.xsi.host =
 account.4.xsi.server_type =
 account.4.xsi.port =
-
-
-#######################################################################################
-##                                 Time                                              ##
-#######################################################################################
-#Configure the time zone and time zone name. The time zone ranges from -11 to +12, the default value is +8.
-#local_time.time_zone = +8
-#local_time.time_zone_name = China(Beijing)
-local_time.time_zone =
-local_time.time_zone_name =
 
 
 #######################################################################################
@@ -2394,16 +2374,6 @@ account.5.xsi.port =
 
 
 #######################################################################################
-##                                 Time                                              ##
-#######################################################################################
-#Configure the time zone and time zone name. The time zone ranges from -11 to +12, the default value is +8.
-#local_time.time_zone = +8
-#local_time.time_zone_name = China(Beijing)
-local_time.time_zone =
-local_time.time_zone_name =
-
-
-#######################################################################################
 ##                                   NETWORK                                         ##
 #######################################################################################
 ##0-ipv4, 1-ipv6, 2-ipv4&ipv6
@@ -2882,16 +2852,6 @@ account.6.xsi.password =
 account.6.xsi.host =
 account.6.xsi.server_type =
 account.6.xsi.port =
-
-
-#######################################################################################
-##                                 Time                                              ##
-#######################################################################################
-#Configure the time zone and time zone name. The time zone ranges from -11 to +12, the default value is +8.
-#local_time.time_zone = +8
-#local_time.time_zone_name = China(Beijing)
-local_time.time_zone =
-local_time.time_zone_name =
 
 
 #######################################################################################

--- a/resources/templates/provision/yealink/t23g/y000000000044.cfg
+++ b/resources/templates/provision/yealink/t23g/y000000000044.cfg
@@ -1394,54 +1394,6 @@ gui_lang.url =
 gui_lang.delete =
 
 #######################################################################################
-##         	                   Time Settings                                         ##
-#######################################################################################
-
-#Configure the time zone and time zone name. The time zone ranges from -11 to +12, the default value is +8.
-#The default time zone name is China(Beijing).
-#local_time.time_zone = +8
-#local_time.time_zone_name = China(Beijing)
-local_time.time_zone = {$yealink_time_zone}
-local_time.time_zone_name = {$yealink_time_zone_name}
-
-#Configure the domain name or the IP address of the NTP server. The default value is cn.pool.ntp.org.
-local_time.ntp_server1 = {$ntp_server_1}
-local_time.ntp_server2 = {$ntp_server_2}
-
-#Configure the update interval (in seconds) when using the NTP server. The default value is 1000.
-local_time.interval =
-
-#Configure the daylight saving time feature; 0-Disabled, 1-Enabled, 2-Automatic (default);
-local_time.summer_time =
-
-#Configure the DST type when the DST feature is enabled; 0-By Date (default), 1-By Week;
-local_time.dst_time_type =
-
-#Configure the start time of DST. The default value is 1/1/0.
-#If the DST type is configured as By Date, the value format is Month/Day/Hour. For example, the value 5/20/10 means the start time is at 10:00 on May 20.
-#If the DST type is configured as By Week, the value format is Month/Day of Week/Day of Week Last in Month/Hour of Day.
-#For example, the value 1/4/2/5 means the start time is at 5 o'clock on Tuesday of the 4th week in January.
-local_time.start_time = {$yealink_time_zone_start_time}
-
-#Configure the end time of DST. The default value is 12/31/23. The value format is the same to the start time.
-local_time.end_time = {$yealink_time_zone_end_time}
-
-#Configure the offset time (in seconds). It ranges from -300 to 300, the default value is blank.
-local_time.offset_time = {$yealink_offset_time}
-
-#Configure the time format; 0-12 Hour, 1-24 Hour (default);
-local_time.time_format = {$yealink_time_format}
-
-#Configure the date format; 0-WWW MMM DD (default), 1-DD-MMM-YY, 2-YYYY-MM-DD, 3-DD/MM/YYYY, 4-MM/DD/YY, 5-DD MMM YYYY, 6-WWW DD MMM;
-local_time.date_format = {$yealink_date_format}
-
-#Enable or disable the DHCP Time; 0-Disabled (default), 1-Enabled;
-local_time.dhcp_time =
-
-#Enable or disable the manual time; 0-NTP time, 1-manual time. The default value is 0.
-local_time.manual_time_enable =
-
-#######################################################################################
 ##                                   Trusted Certificates                            ##
 #######################################################################################
 #Before using this parameter, you should store the desired certificate to the provisioning server.

--- a/resources/templates/provision/yealink/t23g/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t23g/{$mac}.cfg
@@ -924,8 +924,8 @@ account.2.xsi.port =
 #Configure the time zone and time zone name. The time zone ranges from -11 to +12, the default value is +8.
 #local_time.time_zone = +8
 #local_time.time_zone_name = China(Beijing)
-local_time.time_zone = {$time_zone}
-local_time.time_zone_name = {$time_zone_name}
+local_time.time_zone = {$yealink_time_zone}
+local_time.time_zone_name = {$yealink_time_zone_name}
 
 
 #######################################################################################
@@ -1411,16 +1411,6 @@ account.3.xsi.port =
 
 
 #######################################################################################
-##                                 Time                                              ##
-#######################################################################################
-#Configure the time zone and time zone name. The time zone ranges from -11 to +12, the default value is +8.
-#local_time.time_zone = +8
-#local_time.time_zone_name = China(Beijing)
-local_time.time_zone =
-local_time.time_zone_name =
-
-
-#######################################################################################
 ##                                   NETWORK                                         ##
 #######################################################################################
 ##0-ipv4, 1-ipv6, 2-ipv4&ipv6
@@ -1900,16 +1890,6 @@ account.4.xsi.password =
 account.4.xsi.host =
 account.4.xsi.server_type =
 account.4.xsi.port =
-
-
-#######################################################################################
-##                                 Time                                              ##
-#######################################################################################
-#Configure the time zone and time zone name. The time zone ranges from -11 to +12, the default value is +8.
-#local_time.time_zone = +8
-#local_time.time_zone_name = China(Beijing)
-local_time.time_zone =
-local_time.time_zone_name =
 
 
 #######################################################################################
@@ -2394,16 +2374,6 @@ account.5.xsi.port =
 
 
 #######################################################################################
-##                                 Time                                              ##
-#######################################################################################
-#Configure the time zone and time zone name. The time zone ranges from -11 to +12, the default value is +8.
-#local_time.time_zone = +8
-#local_time.time_zone_name = China(Beijing)
-local_time.time_zone =
-local_time.time_zone_name =
-
-
-#######################################################################################
 ##                                   NETWORK                                         ##
 #######################################################################################
 ##0-ipv4, 1-ipv6, 2-ipv4&ipv6
@@ -2882,16 +2852,6 @@ account.6.xsi.password =
 account.6.xsi.host =
 account.6.xsi.server_type =
 account.6.xsi.port =
-
-
-#######################################################################################
-##                                 Time                                              ##
-#######################################################################################
-#Configure the time zone and time zone name. The time zone ranges from -11 to +12, the default value is +8.
-#local_time.time_zone = +8
-#local_time.time_zone_name = China(Beijing)
-local_time.time_zone =
-local_time.time_zone_name =
 
 
 #######################################################################################

--- a/resources/templates/provision/yealink/t23p/y000000000044.cfg
+++ b/resources/templates/provision/yealink/t23p/y000000000044.cfg
@@ -1394,54 +1394,6 @@ gui_lang.url =
 gui_lang.delete =
 
 #######################################################################################
-##         	                   Time Settings                                         ##
-#######################################################################################
-
-#Configure the time zone and time zone name. The time zone ranges from -11 to +12, the default value is +8.
-#The default time zone name is China(Beijing).
-#local_time.time_zone = +8
-#local_time.time_zone_name = China(Beijing)
-local_time.time_zone = {$yealink_time_zone}
-local_time.time_zone_name = {$yealink_time_zone_name}
-
-#Configure the domain name or the IP address of the NTP server. The default value is cn.pool.ntp.org.
-local_time.ntp_server1 = {$ntp_server_1}
-local_time.ntp_server2 = {$ntp_server_2}
-
-#Configure the update interval (in seconds) when using the NTP server. The default value is 1000.
-local_time.interval =
-
-#Configure the daylight saving time feature; 0-Disabled, 1-Enabled, 2-Automatic (default);
-local_time.summer_time =
-
-#Configure the DST type when the DST feature is enabled; 0-By Date (default), 1-By Week;
-local_time.dst_time_type =
-
-#Configure the start time of DST. The default value is 1/1/0.
-#If the DST type is configured as By Date, the value format is Month/Day/Hour. For example, the value 5/20/10 means the start time is at 10:00 on May 20.
-#If the DST type is configured as By Week, the value format is Month/Day of Week/Day of Week Last in Month/Hour of Day.
-#For example, the value 1/4/2/5 means the start time is at 5 o'clock on Tuesday of the 4th week in January.
-local_time.start_time = {$yealink_time_zone_start_time}
-
-#Configure the end time of DST. The default value is 12/31/23. The value format is the same to the start time.
-local_time.end_time = {$yealink_time_zone_end_time}
-
-#Configure the offset time (in seconds). It ranges from -300 to 300, the default value is blank.
-local_time.offset_time = {$yealink_offset_time}
-
-#Configure the time format; 0-12 Hour, 1-24 Hour (default);
-local_time.time_format = {$yealink_time_format}
-
-#Configure the date format; 0-WWW MMM DD (default), 1-DD-MMM-YY, 2-YYYY-MM-DD, 3-DD/MM/YYYY, 4-MM/DD/YY, 5-DD MMM YYYY, 6-WWW DD MMM;
-local_time.date_format = {$yealink_date_format}
-
-#Enable or disable the DHCP Time; 0-Disabled (default), 1-Enabled;
-local_time.dhcp_time =
-
-#Enable or disable the manual time; 0-NTP time, 1-manual time. The default value is 0.
-local_time.manual_time_enable =
-
-#######################################################################################
 ##                                   Trusted Certificates                            ##
 #######################################################################################
 #Before using this parameter, you should store the desired certificate to the provisioning server.

--- a/resources/templates/provision/yealink/t23p/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t23p/{$mac}.cfg
@@ -924,8 +924,8 @@ account.2.xsi.port =
 #Configure the time zone and time zone name. The time zone ranges from -11 to +12, the default value is +8.
 #local_time.time_zone = +8
 #local_time.time_zone_name = China(Beijing)
-local_time.time_zone = {$time_zone}
-local_time.time_zone_name = {$time_zone_name}
+local_time.time_zone = {$yealink_time_zone}
+local_time.time_zone_name = {$yealink_time_zone_name}
 
 
 #######################################################################################
@@ -1411,16 +1411,6 @@ account.3.xsi.port =
 
 
 #######################################################################################
-##                                 Time                                              ##
-#######################################################################################
-#Configure the time zone and time zone name. The time zone ranges from -11 to +12, the default value is +8.
-#local_time.time_zone = +8
-#local_time.time_zone_name = China(Beijing)
-local_time.time_zone =
-local_time.time_zone_name =
-
-
-#######################################################################################
 ##                                   NETWORK                                         ##
 #######################################################################################
 ##0-ipv4, 1-ipv6, 2-ipv4&ipv6
@@ -1900,16 +1890,6 @@ account.4.xsi.password =
 account.4.xsi.host =
 account.4.xsi.server_type =
 account.4.xsi.port =
-
-
-#######################################################################################
-##                                 Time                                              ##
-#######################################################################################
-#Configure the time zone and time zone name. The time zone ranges from -11 to +12, the default value is +8.
-#local_time.time_zone = +8
-#local_time.time_zone_name = China(Beijing)
-local_time.time_zone =
-local_time.time_zone_name =
 
 
 #######################################################################################
@@ -2394,16 +2374,6 @@ account.5.xsi.port =
 
 
 #######################################################################################
-##                                 Time                                              ##
-#######################################################################################
-#Configure the time zone and time zone name. The time zone ranges from -11 to +12, the default value is +8.
-#local_time.time_zone = +8
-#local_time.time_zone_name = China(Beijing)
-local_time.time_zone =
-local_time.time_zone_name =
-
-
-#######################################################################################
 ##                                   NETWORK                                         ##
 #######################################################################################
 ##0-ipv4, 1-ipv6, 2-ipv4&ipv6
@@ -2882,16 +2852,6 @@ account.6.xsi.password =
 account.6.xsi.host =
 account.6.xsi.server_type =
 account.6.xsi.port =
-
-
-#######################################################################################
-##                                 Time                                              ##
-#######################################################################################
-#Configure the time zone and time zone name. The time zone ranges from -11 to +12, the default value is +8.
-#local_time.time_zone = +8
-#local_time.time_zone_name = China(Beijing)
-local_time.time_zone =
-local_time.time_zone_name =
 
 
 #######################################################################################

--- a/resources/templates/provision/yealink/t27p/y000000000045.cfg
+++ b/resources/templates/provision/yealink/t27p/y000000000045.cfg
@@ -1394,54 +1394,6 @@ gui_lang.url =
 gui_lang.delete =
 
 #######################################################################################
-##         	                   Time Settings                                         ##
-#######################################################################################
-
-#Configure the time zone and time zone name. The time zone ranges from -11 to +12, the default value is +8.
-#The default time zone name is China(Beijing).
-#local_time.time_zone = +8
-#local_time.time_zone_name = China(Beijing)
-local_time.time_zone = {$yealink_time_zone}
-local_time.time_zone_name = {$yealink_time_zone_name}
-
-#Configure the domain name or the IP address of the NTP server. The default value is cn.pool.ntp.org.
-local_time.ntp_server1 = {$ntp_server_primary}
-local_time.ntp_server2 = {$ntp_server_secondary}
-
-#Configure the update interval (in seconds) when using the NTP server. The default value is 1000.
-local_time.interval =
-
-#Configure the daylight saving time feature; 0-Disabled, 1-Enabled, 2-Automatic (default);
-local_time.summer_time =
-
-#Configure the DST type when the DST feature is enabled; 0-By Date (default), 1-By Week;
-local_time.dst_time_type =
-
-#Configure the start time of DST. The default value is 1/1/0.
-#If the DST type is configured as By Date, the value format is Month/Day/Hour. For example, the value 5/20/10 means the start time is at 10:00 on May 20.
-#If the DST type is configured as By Week, the value format is Month/Day of Week/Day of Week Last in Month/Hour of Day.
-#For example, the value 1/4/2/5 means the start time is at 5 o'clock on Tuesday of the 4th week in January.
-local_time.start_time = {$yealink_time_zone_start_time}
-
-#Configure the end time of DST. The default value is 12/31/23. The value format is the same to the start time.
-local_time.end_time = {$yealink_time_zone_end_time}
-
-#Configure the offset time (in seconds). It ranges from -300 to 300, the default value is blank.
-local_time.offset_time = {$yealink_offset_time}
-
-#Configure the time format; 0-12 Hour, 1-24 Hour (default);
-local_time.time_format = {$yealink_time_format}
-
-#Configure the date format; 0-WWW MMM DD (default), 1-DD-MMM-YY, 2-YYYY-MM-DD, 3-DD/MM/YYYY, 4-MM/DD/YY, 5-DD MMM YYYY, 6-WWW DD MMM;
-local_time.date_format = {$yealink_date_format}
-
-#Enable or disable the DHCP Time; 0-Disabled (default), 1-Enabled;
-local_time.dhcp_time =
-
-#Enable or disable the manual time; 0-NTP time, 1-manual time. The default value is 0.
-local_time.manual_time_enable =
-
-#######################################################################################
 ##                                   Trusted Certificates                            ##
 #######################################################################################
 #Before using this parameter, you should store the desired certificate to the provisioning server.

--- a/resources/templates/provision/yealink/t27p/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t27p/{$mac}.cfg
@@ -924,8 +924,8 @@ account.2.xsi.port =
 #Configure the time zone and time zone name. The time zone ranges from -11 to +12, the default value is +8.
 #local_time.time_zone = +8
 #local_time.time_zone_name = China(Beijing)
-local_time.time_zone = {$time_zone}
-local_time.time_zone_name = {$time_zone_name}
+local_time.time_zone = {$yealink_time_zone}
+local_time.time_zone_name = {$yealink_time_zone_name}
 
 
 #######################################################################################
@@ -1411,16 +1411,6 @@ account.3.xsi.port =
 
 
 #######################################################################################
-##                                 Time                                              ##
-#######################################################################################
-#Configure the time zone and time zone name. The time zone ranges from -11 to +12, the default value is +8.
-#local_time.time_zone = +8
-#local_time.time_zone_name = China(Beijing)
-local_time.time_zone =
-local_time.time_zone_name =
-
-
-#######################################################################################
 ##                                   NETWORK                                         ##
 #######################################################################################
 ##0-ipv4, 1-ipv6, 2-ipv4&ipv6
@@ -1900,16 +1890,6 @@ account.4.xsi.password =
 account.4.xsi.host =
 account.4.xsi.server_type =
 account.4.xsi.port =
-
-
-#######################################################################################
-##                                 Time                                              ##
-#######################################################################################
-#Configure the time zone and time zone name. The time zone ranges from -11 to +12, the default value is +8.
-#local_time.time_zone = +8
-#local_time.time_zone_name = China(Beijing)
-local_time.time_zone =
-local_time.time_zone_name =
 
 
 #######################################################################################
@@ -2394,16 +2374,6 @@ account.5.xsi.port =
 
 
 #######################################################################################
-##                                 Time                                              ##
-#######################################################################################
-#Configure the time zone and time zone name. The time zone ranges from -11 to +12, the default value is +8.
-#local_time.time_zone = +8
-#local_time.time_zone_name = China(Beijing)
-local_time.time_zone =
-local_time.time_zone_name =
-
-
-#######################################################################################
 ##                                   NETWORK                                         ##
 #######################################################################################
 ##0-ipv4, 1-ipv6, 2-ipv4&ipv6
@@ -2882,16 +2852,6 @@ account.6.xsi.password =
 account.6.xsi.host =
 account.6.xsi.server_type =
 account.6.xsi.port =
-
-
-#######################################################################################
-##                                 Time                                              ##
-#######################################################################################
-#Configure the time zone and time zone name. The time zone ranges from -11 to +12, the default value is +8.
-#local_time.time_zone = +8
-#local_time.time_zone_name = China(Beijing)
-local_time.time_zone =
-local_time.time_zone_name =
 
 
 #######################################################################################

--- a/resources/templates/provision/yealink/t29g/y000000000046.cfg
+++ b/resources/templates/provision/yealink/t29g/y000000000046.cfg
@@ -1394,54 +1394,6 @@ gui_lang.url =
 gui_lang.delete =
 
 #######################################################################################
-##         	                   Time Settings                                         ##
-#######################################################################################
-
-#Configure the time zone and time zone name. The time zone ranges from -11 to +12, the default value is +8.
-#The default time zone name is China(Beijing).
-#local_time.time_zone = +8
-#local_time.time_zone_name = China(Beijing)
-local_time.time_zone = {$yealink_time_zone}
-local_time.time_zone_name = {$yealink_time_zone_name}
-
-#Configure the domain name or the IP address of the NTP server. The default value is cn.pool.ntp.org.
-local_time.ntp_server1 = {$ntp_server_1}
-local_time.ntp_server2 = {$ntp_server_2}
-
-#Configure the update interval (in seconds) when using the NTP server. The default value is 1000.
-local_time.interval =
-
-#Configure the daylight saving time feature; 0-Disabled, 1-Enabled, 2-Automatic (default);
-local_time.summer_time =
-
-#Configure the DST type when the DST feature is enabled; 0-By Date (default), 1-By Week;
-local_time.dst_time_type =
-
-#Configure the start time of DST. The default value is 1/1/0.
-#If the DST type is configured as By Date, the value format is Month/Day/Hour. For example, the value 5/20/10 means the start time is at 10:00 on May 20.
-#If the DST type is configured as By Week, the value format is Month/Day of Week/Day of Week Last in Month/Hour of Day.
-#For example, the value 1/4/2/5 means the start time is at 5 o'clock on Tuesday of the 4th week in January.
-local_time.start_time = {$yealink_time_zone_start_time}
-
-#Configure the end time of DST. The default value is 12/31/23. The value format is the same to the start time.
-local_time.end_time = {$yealink_time_zone_end_time}
-
-#Configure the offset time (in seconds). It ranges from -300 to 300, the default value is blank.
-local_time.offset_time = {$yealink_offset_time}
-
-#Configure the time format; 0-12 Hour, 1-24 Hour (default);
-local_time.time_format = {$yealink_time_format}
-
-#Configure the date format; 0-WWW MMM DD (default), 1-DD-MMM-YY, 2-YYYY-MM-DD, 3-DD/MM/YYYY, 4-MM/DD/YY, 5-DD MMM YYYY, 6-WWW DD MMM;
-local_time.date_format = {$yealink_date_format}
-
-#Enable or disable the DHCP Time; 0-Disabled (default), 1-Enabled;
-local_time.dhcp_time =
-
-#Enable or disable the manual time; 0-NTP time, 1-manual time. The default value is 0.
-local_time.manual_time_enable =
-
-#######################################################################################
 ##                                   Trusted Certificates                            ##
 #######################################################################################
 #Before using this parameter, you should store the desired certificate to the provisioning server.

--- a/resources/templates/provision/yealink/t29g/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t29g/{$mac}.cfg
@@ -924,8 +924,8 @@ account.2.xsi.port =
 #Configure the time zone and time zone name. The time zone ranges from -11 to +12, the default value is +8.
 #local_time.time_zone = +8
 #local_time.time_zone_name = China(Beijing)
-local_time.time_zone = {$time_zone}
-local_time.time_zone_name = {$time_zone_name}
+local_time.time_zone = {$yealink_time_zone}
+local_time.time_zone_name = {$yealink_time_zone_name}
 
 
 #######################################################################################
@@ -1411,16 +1411,6 @@ account.3.xsi.port =
 
 
 #######################################################################################
-##                                 Time                                              ##
-#######################################################################################
-#Configure the time zone and time zone name. The time zone ranges from -11 to +12, the default value is +8.
-#local_time.time_zone = +8
-#local_time.time_zone_name = China(Beijing)
-local_time.time_zone =
-local_time.time_zone_name =
-
-
-#######################################################################################
 ##                                   NETWORK                                         ##
 #######################################################################################
 ##0-ipv4, 1-ipv6, 2-ipv4&ipv6
@@ -1900,16 +1890,6 @@ account.4.xsi.password =
 account.4.xsi.host =
 account.4.xsi.server_type =
 account.4.xsi.port =
-
-
-#######################################################################################
-##                                 Time                                              ##
-#######################################################################################
-#Configure the time zone and time zone name. The time zone ranges from -11 to +12, the default value is +8.
-#local_time.time_zone = +8
-#local_time.time_zone_name = China(Beijing)
-local_time.time_zone =
-local_time.time_zone_name =
 
 
 #######################################################################################
@@ -2394,16 +2374,6 @@ account.5.xsi.port =
 
 
 #######################################################################################
-##                                 Time                                              ##
-#######################################################################################
-#Configure the time zone and time zone name. The time zone ranges from -11 to +12, the default value is +8.
-#local_time.time_zone = +8
-#local_time.time_zone_name = China(Beijing)
-local_time.time_zone =
-local_time.time_zone_name =
-
-
-#######################################################################################
 ##                                   NETWORK                                         ##
 #######################################################################################
 ##0-ipv4, 1-ipv6, 2-ipv4&ipv6
@@ -2882,16 +2852,6 @@ account.6.xsi.password =
 account.6.xsi.host =
 account.6.xsi.server_type =
 account.6.xsi.port =
-
-
-#######################################################################################
-##                                 Time                                              ##
-#######################################################################################
-#Configure the time zone and time zone name. The time zone ranges from -11 to +12, the default value is +8.
-#local_time.time_zone = +8
-#local_time.time_zone_name = China(Beijing)
-local_time.time_zone =
-local_time.time_zone_name =
 
 
 #######################################################################################

--- a/resources/templates/provision/yealink/t41p/y000000000036.cfg
+++ b/resources/templates/provision/yealink/t41p/y000000000036.cfg
@@ -1434,54 +1434,6 @@ gui_lang.url =
 gui_lang.delete =
 
 #######################################################################################
-##         	                   Time Settings                                         ##
-#######################################################################################
-
-#Configure the time zone and time zone name. The time zone ranges from -11 to +12, the default value is +8.
-#The default time zone name is China(Beijing).
-#local_time.time_zone = +8
-#local_time.time_zone_name = China(Beijing)
-local_time.time_zone = {$yealink_time_zone}
-local_time.time_zone_name = {$yealink_time_zone_name}
-
-#Configure the domain name or the IP address of the NTP server. The default value is cn.pool.ntp.org.
-local_time.ntp_server1 = {$ntp_server_1}
-local_time.ntp_server2 = {$ntp_server_2}
-
-#Configure the update interval (in seconds) when using the NTP server. The default value is 1000.
-local_time.interval =
-
-#Configure the daylight saving time feature; 0-Disabled, 1-Enabled, 2-Automatic (default);
-local_time.summer_time =
-
-#Configure the DST type when the DST feature is enabled; 0-By Date (default), 1-By Week;
-local_time.dst_time_type =
-
-#Configure the start time of DST. The default value is 1/1/0.
-#If the DST type is configured as By Date, the value format is Month/Day/Hour. For example, the value 5/20/10 means the start time is at 10:00 on May 20.
-#If the DST type is configured as By Week, the value format is Month/Day of Week/Day of Week Last in Month/Hour of Day.
-#For example, the value 1/4/2/5 means the start time is at 5 o'clock on Tuesday of the 4th week in January.
-local_time.start_time = {$yealink_time_zone_start_time}
-
-#Configure the end time of DST. The default value is 12/31/23. The value format is the same to the start time.
-local_time.end_time = {$yealink_time_zone_end_time}
-
-#Configure the offset time (in seconds). It ranges from -300 to 300, the default value is blank.
-local_time.offset_time = {$yealink_offset_time}
-
-#Configure the time format; 0-12 Hour, 1-24 Hour (default);
-local_time.time_format = {$yealink_time_format}
-
-#Configure the date format; 0-WWW MMM DD (default), 1-DD-MMM-YY, 2-YYYY-MM-DD, 3-DD/MM/YYYY, 4-MM/DD/YY, 5-DD MMM YYYY, 6-WWW DD MMM;
-local_time.date_format = {$yealink_date_format}
-
-#Enable or disable the DHCP Time; 0-Disabled (default), 1-Enabled;
-local_time.dhcp_time =
-
-#Enable or disable the manual time; 0-NTP time, 1-manual time. The default value is 0.
-local_time.manual_time_enable =
-
-#######################################################################################
 ##                                   Trusted Certificates                            ##
 #######################################################################################
 #Before using this parameter, you should store the desired certificate to the provisioning server.

--- a/resources/templates/provision/yealink/t41p/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t41p/{$mac}.cfg
@@ -924,8 +924,8 @@ account.2.xsi.port =
 #Configure the time zone and time zone name. The time zone ranges from -11 to +12, the default value is +8.
 #local_time.time_zone = +8
 #local_time.time_zone_name = China(Beijing)
-local_time.time_zone = {$time_zone}
-local_time.time_zone_name = {$time_zone_name}
+local_time.time_zone = {$yealink_time_zone}
+local_time.time_zone_name = {$yealink_time_zone_name}
 
 
 #######################################################################################
@@ -1411,16 +1411,6 @@ account.3.xsi.port =
 
 
 #######################################################################################
-##                                 Time                                              ##
-#######################################################################################
-#Configure the time zone and time zone name. The time zone ranges from -11 to +12, the default value is +8.
-#local_time.time_zone = +8
-#local_time.time_zone_name = China(Beijing)
-local_time.time_zone =
-local_time.time_zone_name =
-
-
-#######################################################################################
 ##                                   NETWORK                                         ##
 #######################################################################################
 ##0-ipv4, 1-ipv6, 2-ipv4&ipv6
@@ -1900,16 +1890,6 @@ account.4.xsi.password =
 account.4.xsi.host =
 account.4.xsi.server_type =
 account.4.xsi.port =
-
-
-#######################################################################################
-##                                 Time                                              ##
-#######################################################################################
-#Configure the time zone and time zone name. The time zone ranges from -11 to +12, the default value is +8.
-#local_time.time_zone = +8
-#local_time.time_zone_name = China(Beijing)
-local_time.time_zone =
-local_time.time_zone_name =
 
 
 #######################################################################################
@@ -2394,16 +2374,6 @@ account.5.xsi.port =
 
 
 #######################################################################################
-##                                 Time                                              ##
-#######################################################################################
-#Configure the time zone and time zone name. The time zone ranges from -11 to +12, the default value is +8.
-#local_time.time_zone = +8
-#local_time.time_zone_name = China(Beijing)
-local_time.time_zone =
-local_time.time_zone_name =
-
-
-#######################################################################################
 ##                                   NETWORK                                         ##
 #######################################################################################
 ##0-ipv4, 1-ipv6, 2-ipv4&ipv6
@@ -2882,16 +2852,6 @@ account.6.xsi.password =
 account.6.xsi.host =
 account.6.xsi.server_type =
 account.6.xsi.port =
-
-
-#######################################################################################
-##                                 Time                                              ##
-#######################################################################################
-#Configure the time zone and time zone name. The time zone ranges from -11 to +12, the default value is +8.
-#local_time.time_zone = +8
-#local_time.time_zone_name = China(Beijing)
-local_time.time_zone =
-local_time.time_zone_name =
 
 
 #######################################################################################

--- a/resources/templates/provision/yealink/t42g/y000000000029.cfg
+++ b/resources/templates/provision/yealink/t42g/y000000000029.cfg
@@ -1446,54 +1446,6 @@ gui_lang.url =
 gui_lang.delete =
 
 #######################################################################################
-##         	                   Time Settings                                         ##
-#######################################################################################
-
-#Configure the time zone and time zone name. The time zone ranges from -11 to +12, the default value is +8.
-#The default time zone name is China(Beijing).
-#local_time.time_zone = +8
-#local_time.time_zone_name = China(Beijing)
-local_time.time_zone = {$yealink_time_zone}
-local_time.time_zone_name = {$yealink_time_zone_name}
-
-#Configure the domain name or the IP address of the NTP server. The default value is cn.pool.ntp.org.
-local_time.ntp_server1 = {$ntp_server_primary}
-local_time.ntp_server2 = {$ntp_server_secondary}
-
-#Configure the update interval (in seconds) when using the NTP server. The default value is 1000.
-local_time.interval =
-
-#Configure the daylight saving time feature; 0-Disabled, 1-Enabled, 2-Automatic (default);
-local_time.summer_time =
-
-#Configure the DST type when the DST feature is enabled; 0-By Date (default), 1-By Week;
-local_time.dst_time_type =
-
-#Configure the start time of DST. The default value is 1/1/0.
-#If the DST type is configured as By Date, the value format is Month/Day/Hour. For example, the value 5/20/10 means the start time is at 10:00 on May 20.
-#If the DST type is configured as By Week, the value format is Month/Day of Week/Day of Week Last in Month/Hour of Day.
-#For example, the value 1/4/2/5 means the start time is at 5 o'clock on Tuesday of the 4th week in January.
-local_time.start_time = {$yealink_time_zone_start_time}
-
-#Configure the end time of DST. The default value is 12/31/23. The value format is the same to the start time.
-local_time.end_time = {$yealink_time_zone_end_time}
-
-#Configure the offset time (in seconds). It ranges from -300 to 300, the default value is blank.
-local_time.offset_time = {$yealink_offset_time}
-
-#Configure the time format; 0-12 Hour, 1-24 Hour (default);
-local_time.time_format = {$yealink_time_format}
-
-#Configure the date format; 0-WWW MMM DD (default), 1-DD-MMM-YY, 2-YYYY-MM-DD, 3-DD/MM/YYYY, 4-MM/DD/YY, 5-DD MMM YYYY, 6-WWW DD MMM;
-local_time.date_format = {$yealink_date_format}
-
-#Enable or disable the DHCP Time; 0-Disabled (default), 1-Enabled;
-local_time.dhcp_time =
-
-#Enable or disable the manual time; 0-NTP time, 1-manual time. The default value is 0.
-local_time.manual_time_enable =
-
-#######################################################################################
 ##                                   Trusted Certificates                            ##
 #######################################################################################
 #Before using this parameter, you should store the desired certificate to the provisioning server.

--- a/resources/templates/provision/yealink/t42g/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t42g/{$mac}.cfg
@@ -924,8 +924,8 @@ account.2.xsi.port =
 #Configure the time zone and time zone name. The time zone ranges from -11 to +12, the default value is +8.
 #local_time.time_zone = +8
 #local_time.time_zone_name = China(Beijing)
-local_time.time_zone = {$time_zone}
-local_time.time_zone_name = {$time_zone_name}
+local_time.time_zone = {$yealink_time_zone}
+local_time.time_zone_name = {$yealink_time_zone_name}
 
 
 #######################################################################################
@@ -1411,16 +1411,6 @@ account.3.xsi.port =
 
 
 #######################################################################################
-##                                 Time                                              ##
-#######################################################################################
-#Configure the time zone and time zone name. The time zone ranges from -11 to +12, the default value is +8.
-#local_time.time_zone = +8
-#local_time.time_zone_name = China(Beijing)
-local_time.time_zone =
-local_time.time_zone_name =
-
-
-#######################################################################################
 ##                                   NETWORK                                         ##
 #######################################################################################
 ##0-ipv4, 1-ipv6, 2-ipv4&ipv6
@@ -1900,16 +1890,6 @@ account.4.xsi.password =
 account.4.xsi.host =
 account.4.xsi.server_type =
 account.4.xsi.port =
-
-
-#######################################################################################
-##                                 Time                                              ##
-#######################################################################################
-#Configure the time zone and time zone name. The time zone ranges from -11 to +12, the default value is +8.
-#local_time.time_zone = +8
-#local_time.time_zone_name = China(Beijing)
-local_time.time_zone =
-local_time.time_zone_name =
 
 
 #######################################################################################
@@ -2394,16 +2374,6 @@ account.5.xsi.port =
 
 
 #######################################################################################
-##                                 Time                                              ##
-#######################################################################################
-#Configure the time zone and time zone name. The time zone ranges from -11 to +12, the default value is +8.
-#local_time.time_zone = +8
-#local_time.time_zone_name = China(Beijing)
-local_time.time_zone =
-local_time.time_zone_name =
-
-
-#######################################################################################
 ##                                   NETWORK                                         ##
 #######################################################################################
 ##0-ipv4, 1-ipv6, 2-ipv4&ipv6
@@ -2882,16 +2852,6 @@ account.6.xsi.password =
 account.6.xsi.host =
 account.6.xsi.server_type =
 account.6.xsi.port =
-
-
-#######################################################################################
-##                                 Time                                              ##
-#######################################################################################
-#Configure the time zone and time zone name. The time zone ranges from -11 to +12, the default value is +8.
-#local_time.time_zone = +8
-#local_time.time_zone_name = China(Beijing)
-local_time.time_zone =
-local_time.time_zone_name =
 
 
 #######################################################################################

--- a/resources/templates/provision/yealink/t46g/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t46g/{$mac}.cfg
@@ -940,8 +940,8 @@ account.2.xsi.port =
 #Configure the time zone and time zone name. The time zone ranges from -11 to +12, the default value is +8.
 #local_time.time_zone = +8
 #local_time.time_zone_name = China(Beijing)
-local_time.time_zone = {$time_zone}
-local_time.time_zone_name = {$time_zone_name}
+local_time.time_zone = {$yealink_time_zone}
+local_time.time_zone_name = {$yealink_time_zone_name}
 
 
 #######################################################################################
@@ -1427,16 +1427,6 @@ account.3.xsi.port =
 
 
 #######################################################################################
-##                                 Time                                              ##
-#######################################################################################
-#Configure the time zone and time zone name. The time zone ranges from -11 to +12, the default value is +8.
-#local_time.time_zone = +8
-#local_time.time_zone_name = China(Beijing)
-local_time.time_zone =
-local_time.time_zone_name =
-
-
-#######################################################################################
 ##                                   NETWORK                                         ##
 #######################################################################################
 ##0-ipv4, 1-ipv6, 2-ipv4&ipv6
@@ -1916,16 +1906,6 @@ account.4.xsi.password =
 account.4.xsi.host =
 account.4.xsi.server_type =
 account.4.xsi.port =
-
-
-#######################################################################################
-##                                 Time                                              ##
-#######################################################################################
-#Configure the time zone and time zone name. The time zone ranges from -11 to +12, the default value is +8.
-#local_time.time_zone = +8
-#local_time.time_zone_name = China(Beijing)
-local_time.time_zone =
-local_time.time_zone_name =
 
 
 #######################################################################################
@@ -2410,16 +2390,6 @@ account.5.xsi.port =
 
 
 #######################################################################################
-##                                 Time                                              ##
-#######################################################################################
-#Configure the time zone and time zone name. The time zone ranges from -11 to +12, the default value is +8.
-#local_time.time_zone = +8
-#local_time.time_zone_name = China(Beijing)
-local_time.time_zone = {$time_zone}
-local_time.time_zone_name = {$time_zone_name}
-
-
-#######################################################################################
 ##                                   NETWORK                                         ##
 #######################################################################################
 ##0-ipv4, 1-ipv6, 2-ipv4&ipv6
@@ -2898,16 +2868,6 @@ account.6.xsi.password =
 account.6.xsi.host =
 account.6.xsi.server_type =
 account.6.xsi.port =
-
-
-#######################################################################################
-##                                 Time                                              ##
-#######################################################################################
-#Configure the time zone and time zone name. The time zone ranges from -11 to +12, the default value is +8.
-#local_time.time_zone = +8
-#local_time.time_zone_name = China(Beijing)
-local_time.time_zone =
-local_time.time_zone_name =
 
 
 #######################################################################################

--- a/resources/templates/provision/yealink/t48g/y000000000035.cfg
+++ b/resources/templates/provision/yealink/t48g/y000000000035.cfg
@@ -430,45 +430,6 @@ lang.wui =
 lang.gui = English
 
 #######################################################################################
-##                                   Time                                            ##
-#######################################################################################
-#Configure the domain name or the IP address of the NTP server. The default value is cn.pool.ntp.org.
-local_time.ntp_server1 = {$ntp_server_primary}
-local_time.ntp_server2 = {$ntp_server_secondary}
-
-#Configure the update interval (in seconds) when using the NTP server. The default value is 1000.
-local_time.interval =
-
-#Configure the daylight saving time feature; 0-Disabled, 1-Enabled, 2-Automatic (default);
-local_time.summer_time =
-
-#Configure the DST type when the DST feature is enabled; 0-By Date (default), 1-By Week;
-local_time.dst_time_type =
-
-#Configure the start time of DST. The default value is 1/1/0.
-#If the DST type is configured as By Date, the value format is Month/Day/Hour. For example, the value 5/20/10 means the start time is at 10:00 on May 20.
-#If the DST type is configured as By Week, the value format is Month/Day of Week/Day of Week Last in Month/Hour of Day.
-#For example, the value 1/4/2/5 means the start time is at 5 o'clock on Tuesday of the 4th week in January.
-local_time.start_time =
-
-#Configure the end time of DST. The default value is 12/31/23. The value format is the same to the start time.
-local_time.end_time =
-
-#Configure the offset time (in seconds). It ranges from -300 to 300, the default value is 60.
-local_time.offset_time =
-
-#Configure the time format; 0-12 Hour, 1-24 Hour (default);
-local_time.time_format =
-
-#Configure the date format; 0-WWW MMM DD (default), 1-DD-MMM-YY, 2-YYYY-MM-DD, 3-DD/MM/YYYY, 4-MM/DD/YY, 5-DD MMM YYYY, 6-WWW DD MMM;
-local_time.date_format =
-
-#Enable or disable the DHCP Time; 0-Disabled (default), 1-Enabled;
-local_time.dhcp_time =
-
-local_time.manual_time_enable = 0
-
-#######################################################################################
 ##                                   Auto Redial                                     ##
 #######################################################################################
 #Enable or disable the auto redial feature; 0-Disabled (default), 1-Enabled;

--- a/resources/templates/provision/yealink/t48g/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t48g/{$mac}.cfg
@@ -924,8 +924,8 @@ account.2.xsi.port =
 #Configure the time zone and time zone name. The time zone ranges from -11 to +12, the default value is +8.
 #local_time.time_zone = +8
 #local_time.time_zone_name = China(Beijing)
-local_time.time_zone = {$time_zone}
-local_time.time_zone_name = {$time_zone_name}
+local_time.time_zone = {$yealink_time_zone}
+local_time.time_zone_name = {$yealink_time_zone_name}
 
 
 #######################################################################################
@@ -1411,16 +1411,6 @@ account.3.xsi.port =
 
 
 #######################################################################################
-##                                 Time                                              ##
-#######################################################################################
-#Configure the time zone and time zone name. The time zone ranges from -11 to +12, the default value is +8.
-#local_time.time_zone = +8
-#local_time.time_zone_name = China(Beijing)
-local_time.time_zone =
-local_time.time_zone_name =
-
-
-#######################################################################################
 ##                                   NETWORK                                         ##
 #######################################################################################
 ##0-ipv4，1-ipv6,2-ipv4&ipv6
@@ -1899,16 +1889,6 @@ account.4.xsi.password =
 account.4.xsi.host =
 account.4.xsi.server_type =
 account.4.xsi.port =
-
-
-#######################################################################################
-##                                 Time                                              ##
-#######################################################################################
-#Configure the time zone and time zone name. The time zone ranges from -11 to +12, the default value is +8.
-#local_time.time_zone = +8
-#local_time.time_zone_name = China(Beijing)
-local_time.time_zone =
-local_time.time_zone_name =
 
 
 #######################################################################################
@@ -2393,16 +2373,6 @@ account.5.xsi.port =
 
 
 #######################################################################################
-##                                 Time                                              ##
-#######################################################################################
-#Configure the time zone and time zone name. The time zone ranges from -11 to +12, the default value is +8.
-#local_time.time_zone = +8
-#local_time.time_zone_name = China(Beijing)
-local_time.time_zone =
-local_time.time_zone_name =
-
-
-#######################################################################################
 ##                                   NETWORK                                         ##
 #######################################################################################
 ##0-ipv4，1-ipv6,2-ipv4&ipv6
@@ -2881,16 +2851,6 @@ account.6.xsi.password =
 account.6.xsi.host =
 account.6.xsi.server_type =
 account.6.xsi.port =
-
-
-#######################################################################################
-##                                 Time                                              ##
-#######################################################################################
-#Configure the time zone and time zone name. The time zone ranges from -11 to +12, the default value is +8.
-#local_time.time_zone = +8
-#local_time.time_zone_name = China(Beijing)
-local_time.time_zone =
-local_time.time_zone_name =
 
 
 #######################################################################################

--- a/resources/templates/provision/yealink/t49g/y000000000051.cfg
+++ b/resources/templates/provision/yealink/t49g/y000000000051.cfg
@@ -1446,54 +1446,6 @@ gui_lang.url =
 gui_lang.delete =
 
 #######################################################################################
-##         	                   Time Settings                                         ##
-#######################################################################################
-
-#Configure the time zone and time zone name. The time zone ranges from -11 to +12, the default value is +8.
-#The default time zone name is China(Beijing).
-#local_time.time_zone = +8
-#local_time.time_zone_name = China(Beijing)
-local_time.time_zone = {$yealink_time_zone}
-local_time.time_zone_name = {$yealink_time_zone_name}
-
-#Configure the domain name or the IP address of the NTP server. The default value is cn.pool.ntp.org.
-local_time.ntp_server1 = {$ntp_server_1}
-local_time.ntp_server2 = {$ntp_server_2}
-
-#Configure the update interval (in seconds) when using the NTP server. The default value is 1000.
-local_time.interval =
-
-#Configure the daylight saving time feature; 0-Disabled, 1-Enabled, 2-Automatic (default);
-local_time.summer_time =
-
-#Configure the DST type when the DST feature is enabled; 0-By Date (default), 1-By Week;
-local_time.dst_time_type =
-
-#Configure the start time of DST. The default value is 1/1/0.
-#If the DST type is configured as By Date, the value format is Month/Day/Hour. For example, the value 5/20/10 means the start time is at 10:00 on May 20.
-#If the DST type is configured as By Week, the value format is Month/Day of Week/Day of Week Last in Month/Hour of Day.
-#For example, the value 1/4/2/5 means the start time is at 5 o'clock on Tuesday of the 4th week in January.
-local_time.start_time = {$yealink_time_zone_start_time}
-
-#Configure the end time of DST. The default value is 12/31/23. The value format is the same to the start time.
-local_time.end_time = {$yealink_time_zone_end_time}
-
-#Configure the offset time (in seconds). It ranges from -300 to 300, the default value is blank.
-local_time.offset_time = {$yealink_offset_time}
-
-#Configure the time format; 0-12 Hour, 1-24 Hour (default);
-local_time.time_format = {$yealink_time_format}
-
-#Configure the date format; 0-WWW MMM DD (default), 1-DD-MMM-YY, 2-YYYY-MM-DD, 3-DD/MM/YYYY, 4-MM/DD/YY, 5-DD MMM YYYY, 6-WWW DD MMM;
-local_time.date_format = {$yealink_date_format}
-
-#Enable or disable the DHCP Time; 0-Disabled (default), 1-Enabled;
-local_time.dhcp_time =
-
-#Enable or disable the manual time; 0-NTP time, 1-manual time. The default value is 0.
-local_time.manual_time_enable =
-
-#######################################################################################
 ##                                   Trusted Certificates                            ##
 #######################################################################################
 #Before using this parameter, you should store the desired certificate to the provisioning server.

--- a/resources/templates/provision/yealink/t49g/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t49g/{$mac}.cfg
@@ -924,8 +924,8 @@ account.2.xsi.port =
 #Configure the time zone and time zone name. The time zone ranges from -11 to +12, the default value is +8.
 #local_time.time_zone = +8
 #local_time.time_zone_name = China(Beijing)
-local_time.time_zone = {$time_zone}
-local_time.time_zone_name = {$time_zone_name}
+local_time.time_zone = {$yealink_time_zone}
+local_time.time_zone_name = {$yealink_time_zone_name}
 
 
 #######################################################################################
@@ -1411,16 +1411,6 @@ account.3.xsi.port =
 
 
 #######################################################################################
-##                                 Time                                              ##
-#######################################################################################
-#Configure the time zone and time zone name. The time zone ranges from -11 to +12, the default value is +8.
-#local_time.time_zone = +8
-#local_time.time_zone_name = China(Beijing)
-local_time.time_zone =
-local_time.time_zone_name =
-
-
-#######################################################################################
 ##                                   NETWORK                                         ##
 #######################################################################################
 ##0-ipv4，1-ipv6,2-ipv4&ipv6
@@ -1900,16 +1890,6 @@ account.4.xsi.password =
 account.4.xsi.host =
 account.4.xsi.server_type =
 account.4.xsi.port =
-
-
-#######################################################################################
-##                                 Time                                              ##
-#######################################################################################
-#Configure the time zone and time zone name. The time zone ranges from -11 to +12, the default value is +8.
-#local_time.time_zone = +8
-#local_time.time_zone_name = China(Beijing)
-local_time.time_zone =
-local_time.time_zone_name =
 
 
 #######################################################################################
@@ -2394,16 +2374,6 @@ account.5.xsi.port =
 
 
 #######################################################################################
-##                                 Time                                              ##
-#######################################################################################
-#Configure the time zone and time zone name. The time zone ranges from -11 to +12, the default value is +8.
-#local_time.time_zone = +8
-#local_time.time_zone_name = China(Beijing)
-local_time.time_zone =
-local_time.time_zone_name =
-
-
-#######################################################################################
 ##                                   NETWORK                                         ##
 #######################################################################################
 ##0-ipv4，1-ipv6,2-ipv4&ipv6
@@ -2882,16 +2852,6 @@ account.6.xsi.password =
 account.6.xsi.host =
 account.6.xsi.server_type =
 account.6.xsi.port =
-
-
-#######################################################################################
-##                                 Time                                              ##
-#######################################################################################
-#Configure the time zone and time zone name. The time zone ranges from -11 to +12, the default value is +8.
-#local_time.time_zone = +8
-#local_time.time_zone_name = China(Beijing)
-local_time.time_zone =
-local_time.time_zone_name =
 
 
 #######################################################################################


### PR DESCRIPTION
Fix the variable names to be consistent across all yealink provision
files. Also remove all the duplicate/redundant time settings from the
files.