### PR TITLE
Add. Handler for SUBSCRIBE method for call flow application.

### DIFF
--- a/app/call_flows/call_flow_edit.php
+++ b/app/call_flows/call_flow_edit.php
@@ -230,7 +230,7 @@ if (count($_POST) > 0 && strlen($_POST["persistformvar"]) == 0) {
 					$dialplan->dialplan_uuid = $dialplan_uuid;
 					$dialplan->dialplan_detail_tag = 'condition'; //condition, action, antiaction
 					$dialplan->dialplan_detail_type = 'destination_number';
-					$dialplan->dialplan_detail_data = '^'.str_replace('*', '\*', $call_flow_feature_code).'$';
+					$dialplan->dialplan_detail_data = '^'.str_replace('+', '\+', str_replace('*', '\*', $call_flow_feature_code)).'$';
 					$dialplan->dialplan_detail_break = 'on-true';
 					//$dialplan->dialplan_detail_inline = '';
 					$dialplan->dialplan_detail_group = '1';
@@ -287,7 +287,7 @@ if (count($_POST) > 0 && strlen($_POST["persistformvar"]) == 0) {
 					$dialplan->dialplan_uuid = $dialplan_uuid;
 					$dialplan->dialplan_detail_tag = 'condition'; //condition, action, antiaction
 					$dialplan->dialplan_detail_type = 'destination_number';
-					$dialplan->dialplan_detail_data = '^'.str_replace('*', '\*', $call_flow_extension).'$';
+					$dialplan->dialplan_detail_data = '^'.str_replace('+', '\+', str_replace('*', '\*', $call_flow_extension)).'$';
 					//$dialplan->dialplan_detail_break = '';
 					//$dialplan->dialplan_detail_inline = '';
 					$dialplan->dialplan_detail_group = '2';

--- a/resources/install/scripts/call_flow_subscribe.lua
+++ b/resources/install/scripts/call_flow_subscribe.lua
@@ -1,0 +1,109 @@
+require "resources.functions.config"
+require "resources.functions.split"
+
+local log         = require "resources.functions.log".call_flow_subscribe
+local file        = require "resources.functions.file"
+local presence_in = require "resources.functions.presence_in"
+local Database    = require "resources.functions.database"
+
+local unpack = unpack or table.unpack
+
+local ievents = function(events, ...)
+	local n, a = select("#", ...), {...}
+	return function()
+		local block, timeout = unpack(a, 1, n)
+		if timeout and (timeout == 0) then
+			block, timeout = 0, 0
+		end
+		local event = events:pop(block, timeout or 0)
+		return not event, event
+	end
+end
+
+local find_call_flow_sql = [[select t1.call_flow_uuid, t1.call_flow_status
+from v_call_flows t1 inner join v_domains t2 on t1.domain_uuid = t2.domain_uuid
+where t2.domain_name = '%s' and t1.call_flow_feature_code = '%s'
+]]
+
+local function find_call_flow(user)
+	local ext, domain_name = split_first(user, '@', true)
+	if not domain_name then return end
+	local sql = string.format(find_call_flow_sql, domain_name, ext)
+	local dbh = Database.new('system')
+	if not dbh then return end
+	local row = dbh:first_row(sql)
+	dbh:release()
+	if not row then return end
+	return row.call_flow_uuid, row.call_flow_status
+end
+
+local IntervalTimer = {} do
+IntervalTimer.__index = IntervalTimer
+
+function IntervalTimer.new(interval)
+	local o = setmetatable({}, IntervalTimer)
+	o._interval = interval
+	return o
+end
+
+function IntervalTimer:rest()
+	local d = self._interval - os.difftime(os.time(), self._begin)
+	if d < 0 then d = 0 end
+	return d
+end
+
+function IntervalTimer:start()
+	self._begin = os.time()
+	return self
+end
+
+function IntervalTimer:stop()
+	self._begin = nil
+	return self
+end
+
+end
+
+local events = freeswitch.EventConsumer("PRESENCE_PROBE");
+local api = freeswitch.API();
+
+local pid_file = scripts_dir .. "/run/call_flow_subscribe.tmp";
+
+file.write(pid_file, "remove this file to stop the script")
+
+log.notice("start call_flow_subscribe");
+
+local timer = IntervalTimer.new(60):start()
+
+for timeout, event in ievents(events, 1, timer:rest() * 1000) do
+	if timeout or timer:rest() == 0 then
+		if not file.exists(pid_file) then break end
+		timer:start()
+	end
+
+	if event then
+		-- log.notice("event:" .. event:serialize("xml"));
+		if event:getHeader('Event-Calling-Function') == 'sofia_presence_handle_sip_i_subscribe' then
+			local from, to = event:getHeader('from'), event:getHeader('to')
+			if to and string.find(to, '^flow%+') then
+				local expires = event:getHeader('expires')
+				expires = expires and tonumber(expires)
+				if expires and expires > 0 then
+					local call_flow_uuid, call_flow_status = find_call_flow(to)
+					if call_flow_uuid then
+						log.debugf("Find call flow: %s", to)
+						presence_in.turn_lamp(call_flow_status == "false", to, call_flow_uuid);
+					else
+						log.warningf("Can not find call flow: %s", to)
+					end
+				else
+					log.debugf("%s UNSUBSCRIBE from %s", from, to)
+				end
+			end
+		end
+	end
+end
+
+file.remove(pid_file)
+
+log.notice("stop call_flow_subscribe")

--- a/resources/install/scripts/call_flow_subscribe.lua
+++ b/resources/install/scripts/call_flow_subscribe.lua
@@ -29,9 +29,9 @@ where t2.domain_name = '%s' and t1.call_flow_feature_code = '%s'
 local function find_call_flow(user)
 	local ext, domain_name = split_first(user, '@', true)
 	if not domain_name then return end
-	local sql = string.format(find_call_flow_sql, domain_name, ext)
 	local dbh = Database.new('system')
 	if not dbh then return end
+	local sql = string.format(find_call_flow_sql, dbh:escape(domain_name), dbh:escape(ext))
 	local row = dbh:first_row(sql)
 	dbh:release()
 	if not row then return end

--- a/resources/install/scripts/resources/functions/database.lua
+++ b/resources/install/scripts/resources/functions/database.lua
@@ -77,6 +77,14 @@ local function new_database(backend, backend_name)
     return result
   end
 
+  function Database:escape(str)
+    return (string.gsub(str, "'", "''"))
+  end
+
+  function Database:quote(str)
+    return "'" .. self:escape(str) .. "'"
+  end
+
   function Database.__self_test__(...)
     log.info('self_test Database - ' ..  Database._backend_name)
     local db = Database.new(...)
@@ -151,6 +159,16 @@ local function new_database(backend, backend_name)
     local a = assert(db:first_value("select NULL as a"))
     assert(a == "")
 
+    -- escape
+    local values = {"hello';select 'world", "hello'"}
+    for _, value in ipairs(values) do
+      local a = assert(db:first_value(
+        string.format("select '%s' as a", db:escape(value))
+      ))
+      assert(a == value)
+    end
+
+    -- close
     db:release()
     assert(not db:connected())
 

--- a/resources/install/scripts/resources/functions/presence_in.lua
+++ b/resources/install/scripts/resources/functions/presence_in.lua
@@ -1,17 +1,17 @@
 require "resources.functions.split"
 
 local function turn_lamp(on, user, uuid)
-	local userid, domain = split_first(user, "@", true)
-	local proto
+	local userid, domain, proto = split_first(user, "@", true)
+	proto, userid = split_first(userid, "+", true)
 	if userid then
-		proto, userid = split_first(userid, "+", true)
-		if userid then
-			user = userid  .. "@" .. domain
-		end
+		user = userid  .. "@" .. domain
+	else
+		proto = "sip"
 	end
 
+
 	local event = freeswitch.Event("PRESENCE_IN");
-	event:addHeader("proto", proto or "sip");
+	event:addHeader("proto", proto);
 	event:addHeader("event_type", "presence");
 	event:addHeader("alt_event_type", "dialog");
 	event:addHeader("Presence-Call-Direction", "outbound");

--- a/resources/install/scripts/resources/functions/presence_in.lua
+++ b/resources/install/scripts/resources/functions/presence_in.lua
@@ -1,6 +1,17 @@
+require "resources.functions.split"
+
 local function turn_lamp(on, user, uuid)
+	local userid, domain = split_first(user, "@", true)
+	local proto
+	if userid then
+		proto, userid = split_first(userid, "+", true)
+		if userid then
+			user = userid  .. "@" .. domain
+		end
+	end
+
 	local event = freeswitch.Event("PRESENCE_IN");
-	event:addHeader("proto", "sip");
+	event:addHeader("proto", proto or "sip");
 	event:addHeader("event_type", "presence");
 	event:addHeader("alt_event_type", "dialog");
 	event:addHeader("Presence-Call-Direction", "outbound");


### PR DESCRIPTION
Usage:
1. Run form fs_cli `luarun call_flow_subscribe.lua`
2. Create new call flow extension and set feature code to `flow+<EXTENSION>`(e.g. `flow+401`).
3. Set on the phone BLF key to `flow+401`

This code based on `mod_valet_parking`.

Notes.
Because of prefix `flow+` in subscribe FS does not response by self to such subscribe with notify so it should not reset blf on phone. So old way with `call_flow_monitor.lua` script also should works except when phone turn on BLF lamp will not be in any state and will be turn off. This lamp will be set to appropriate state only when state of call flow will be changed or when `call_flow_monitor` send current state.
`call_flow_subscribe.lua` send call flow state each time FS receive SUBSCRIBE with `flow+`.

PS. There bug in Fusion. When you create extensiont like `flow+401` fusion generate incorrect regexp like `^flow+401$`. I have no time to fix it today so I can do it tomorrow