### PR TITLE
Clear memcache when toggling on/off dialplans

### DIFF
--- a/app/dialplan/dialplans.php
+++ b/app/dialplan/dialplans.php
@@ -49,6 +49,13 @@ else {
 		unset($sql);
 		$_SESSION["message"] = $text['message-update'];
 	}
+	
+//delete the dialplan context from memcache
+	$fp = event_socket_create($_SESSION['event_socket_ip_address'], $_SESSION['event_socket_port'], $_SESSION['event_socket_password']);
+	if ($fp) {
+		$switch_cmd = "memcache delete dialplan:".$_SESSION["context"];
+		$switch_result = event_socket_request($fp, 'api '.$switch_cmd);
+	}
 
 //set the http values as php variables
 	$search = check_str($_REQUEST["search"]);


### PR DESCRIPTION
When clicking True/False link from the dialplan list (like outbound routes for example), the change isn't effective until the cache expires and leads to confusion.

Full editing the dialplan entry  via dialplan_detail_edit.php does this right and clears the cache, I took the code from there.