### PR TITLE
Enhance Voicemail Emails

### DIFF
--- a/core/default_settings/app_defaults.php
+++ b/core/default_settings/app_defaults.php
@@ -364,6 +364,13 @@ if ($domains_processed == 1) {
 		$array[$x]['default_setting_value'] = '90';
 		$array[$x]['default_setting_enabled'] = 'true';
 		$array[$x]['default_setting_description'] = 'Maximum length of a voicemail greeting (in seconds).';
+		$x++;
+		$array[$x]['default_setting_category'] = 'voicemail';
+		$array[$x]['default_setting_subcategory'] = 'display_domain_name';
+		$array[$x]['default_setting_name'] = 'boolean';
+		$array[$x]['default_setting_value'] = 'true';
+		$array[$x]['default_setting_enabled'] = 'false';
+		$array[$x]['default_setting_description'] = 'Enable display of @domain_name after voicemail_id when rendering emails.';
 
 	//get an array of the default settings
 		$sql = "select * from v_default_settings ";

--- a/resources/install/scripts/app/voicemail/resources/functions/send_email.lua
+++ b/resources/install/scripts/app/voicemail/resources/functions/send_email.lua
@@ -23,10 +23,16 @@
 --	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 --	POSSIBILITY OF SUCH DAMAGE.
 
+--load libraries
 	local send_mail = require 'resources.functions.send_mail'
+	local Database = require "resources.functions.database"
+	local Settings = require "resources.functions.lazy_settings"
 
 --define a function to send email
 	function send_email(id, uuid)
+		local db = dbh or Database.new('system')
+		local settings = Settings.new(db, domain_name, domain_uuid)
+
 		--get voicemail message details
 			sql = [[SELECT * FROM v_voicemails
 				WHERE domain_uuid = ']] .. domain_uuid ..[['
@@ -41,6 +47,7 @@
 				voicemail_mail_to = row["voicemail_mail_to"];
 				voicemail_file = row["voicemail_file"];
 				voicemail_local_after_email = row["voicemail_local_after_email"];
+				voicemail_description = row["voicemail_description"];
 			end);
 
 		--set default values
@@ -113,6 +120,16 @@
 						["X-FusionPBX-Email-Type"]  = 'voicemail';
 					}
 
+				--prepare the voicemail_name_formatted
+					voicemail_name_formatted = id;
+					local display_domain_name = settings:get('voicemail', 'display_domain_name', 'boolean');
+
+					if (display_domain_name == 'true') then
+						voicemail_name_formatted = id.."@"..domain_name;
+					end
+					if (voicemail_description ~= nil and voicemail_description ~= "" and voicemail_description ~= id) then
+						voicemail_name_formatted = voicemail_name_formatted.." ("..voicemail_description..")";
+					end
 				--prepare the subject
 					local f = io.open(file_subject, "r");
 					local subject = f:read("*all");
@@ -121,7 +138,10 @@
 					subject = subject:gsub("${caller_id_number}", caller_id_number);
 					subject = subject:gsub("${message_date}", message_date);
 					subject = subject:gsub("${message_duration}", message_length_formatted);
-					subject = subject:gsub("${account}", id);
+					subject = subject:gsub("${account}", voicemail_name_formatted);
+					subject = subject:gsub("${voicemail_id}", id);
+					subject = subject:gsub("${voicemail_description}", voicemail_description);
+					subject = subject:gsub("${voicemail_name_formatted}", voicemail_name_formatted);
 					subject = subject:gsub("${domain_name}", domain_name);
 					subject = trim(subject);
 					subject = '=?utf-8?B?'..base64.encode(subject)..'?=';
@@ -134,7 +154,10 @@
 					body = body:gsub("${caller_id_number}", caller_id_number);
 					body = body:gsub("${message_date}", message_date);
 					body = body:gsub("${message_duration}", message_length_formatted);
-					body = body:gsub("${account}", id);
+					body = body:gsub("${account}", voicemail_name_formatted);
+					body = body:gsub("${voicemail_id}", id);
+					body = body:gsub("${voicemail_description}", voicemail_description);
+					body = body:gsub("${voicemail_name_formatted}", voicemail_name_formatted);
 					body = body:gsub("${domain_name}", domain_name);
 					body = body:gsub("${sip_to_user}", id);
 					body = body:gsub("${dialed_user}", id);

--- a/resources/install/scripts/app/voicemail/resources/templates/de/at/email_body.tpl
+++ b/resources/install/scripts/app/voicemail/resources/templates/de/at/email_body.tpl
@@ -17,16 +17,16 @@
 							<strong>Nebenstelle</strong>
 						</td>
 						<td style="color: #666; font-family: Arial; font-size: 12px; padding-bottom: 11px;">
-							${account}
+							${voicemail_name_formatted}
 						</td>
 					</tr>
 					<tr>
 						<td style="color: #333; font-family: Arial; font-size: 12px; padding-bottom: 11px;" width="20%">
-						<strong>Anrufer</strong>
-					</td>
+							<strong>Anrufer</strong>
+						</td>
 						<td style="color: #666; font-family: Arial; font-size: 12px; padding-bottom: 11px;" width="80%">
-						${caller_id_number}
-					</td>
+							${caller_id_number}
+						</td>
 					</tr>
 					<!--
 					<tr>

--- a/resources/install/scripts/app/voicemail/resources/templates/de/de/email_body.tpl
+++ b/resources/install/scripts/app/voicemail/resources/templates/de/de/email_body.tpl
@@ -17,7 +17,7 @@
 							<strong>Nebenstelle</strong>
 						</td>
 						<td style="color: #666; font-family: Arial; font-size: 12px; padding-bottom: 11px;">
-							${account}
+							${voicemail_name_formatted}
 						</td>
 					</tr>
 					<tr>

--- a/resources/install/scripts/app/voicemail/resources/templates/en/gb/email_body.tpl
+++ b/resources/install/scripts/app/voicemail/resources/templates/en/gb/email_body.tpl
@@ -1,61 +1,61 @@
 <html>
-<table width="400" border="0" cellspacing="0" cellpadding="0" align="center"
-style="border: 1px solid #cbcfd5;-moz-border-radius: 4px;
--webkit-border-radius: 4px; border-radius: 4px;">
-<tr>
-<td valign="middle" align="center" bgcolor="#e5e9f0" style="background-color: #e5e9f0;
-color: #000; font-family: Arial; font-size: 14px; padding: 7px;-moz-border-radius: 4px;
--webkit-border-radius: 4px; border-radius: 4px;">
-<strong>New Voicemail</strong>
-</td>
-</tr>
-<tr>
-<td valign="top" style="padding: 15px;">
-<table width="100%" border="0" cellspacing="0" cellpadding="0">
-<tr>
-<td style="color: #333; font-family: Arial; font-size: 12px; padding-bottom: 11px;">
-<strong>To</strong>
-</td>
-<td style="color: #666; font-family: Arial; font-size: 12px; padding-bottom: 11px;">
-${account}@${domain_name}
-</td>
-</tr>
-<tr>
-<td style="color: #333; font-family: Arial; font-size: 12px; padding-bottom: 11px;" width="20%">
-<strong>From</strong>
-</td>
-<td style="color: #666; font-family: Arial; font-size: 12px; padding-bottom: 11px;" width="80%">
-${caller_id_number}
-</td>
-</tr>
-<!--
-<tr>
-<td style="color: #333; font-family: Arial; font-size: 12px; padding-bottom: 11px;">
-<strong>Received</strong>
-</td>
-<td style="color: #666; font-family: Arial; font-size: 12px; padding-bottom: 11px;">
-${message_date}
-</td>
-</tr>
--->
-<tr>
-<td style="color: #333; font-family: Arial; font-size: 12px; padding-bottom: 11px;">
-<strong>Message</strong>
-</td>
-<td style="color: #666; font-family: Arial; font-size: 12px; padding-bottom: 11px;">
-${message}
-</td>
-</tr>
-<tr>
-<td style="color: #333; font-family: Arial; font-size: 12px; padding-bottom: 11px;">
-<strong>Length</strong>
-</td>
-<td style="color: #666; font-family: Arial; font-size: 12px; padding-bottom: 11px;">
-${message_duration}
-</td>
-</tr>
-</table>
-</td>
-</tr>
-</table>
+	<table width="400" border="0" cellspacing="0" cellpadding="0" align="center"
+	style="border: 1px solid #cbcfd5;-moz-border-radius: 4px;
+	-webkit-border-radius: 4px; border-radius: 4px;">
+		<tr>
+			<td valign="middle" align="center" bgcolor="#e5e9f0" style="background-color: #e5e9f0;
+			color: #000; font-family: Arial; font-size: 14px; padding: 7px;-moz-border-radius: 4px;
+			-webkit-border-radius: 4px; border-radius: 4px;">
+				<strong>New Voicemail</strong>
+			</td>
+		</tr>
+		<tr>
+			<td valign="top" style="padding: 15px;">
+				<table width="100%" border="0" cellspacing="0" cellpadding="0">
+					<tr>
+						<td style="color: #333; font-family: Arial; font-size: 12px; padding-bottom: 11px;">
+							<strong>To</strong>
+						</td>
+						<td style="color: #666; font-family: Arial; font-size: 12px; padding-bottom: 11px;">
+							${voicemail_name_formatted}
+						</td>
+					</tr>
+					<tr>
+						<td style="color: #333; font-family: Arial; font-size: 12px; padding-bottom: 11px;" width="20%">
+							<strong>From</strong>
+						</td>
+						<td style="color: #666; font-family: Arial; font-size: 12px; padding-bottom: 11px;" width="80%">
+							${caller_id_number}
+						</td>
+					</tr>
+					<!--
+					<tr>
+						<td style="color: #333; font-family: Arial; font-size: 12px; padding-bottom: 11px;">
+							<strong>Received</strong>
+						</td>
+						<td style="color: #666; font-family: Arial; font-size: 12px; padding-bottom: 11px;">
+							${message_date}
+						</td>
+					</tr>
+					-->
+					<tr>
+						<td style="color: #333; font-family: Arial; font-size: 12px; padding-bottom: 11px;">
+							<strong>Message</strong>
+						</td>
+						<td style="color: #666; font-family: Arial; font-size: 12px; padding-bottom: 11px;">
+							${message}
+						</td>
+					</tr>
+					<tr>
+						<td style="color: #333; font-family: Arial; font-size: 12px; padding-bottom: 11px;">
+							<strong>Length</strong>
+						</td>
+						<td style="color: #666; font-family: Arial; font-size: 12px; padding-bottom: 11px;">
+							${message_duration}
+						</td>
+					</tr>
+				</table>
+			</td>
+		</tr>
+	</table>
 </html>

--- a/resources/install/scripts/app/voicemail/resources/templates/en/us/email_body.tpl
+++ b/resources/install/scripts/app/voicemail/resources/templates/en/us/email_body.tpl
@@ -6,7 +6,7 @@
 			<td valign="middle" align="center" bgcolor="#e5e9f0" style="background-color: #e5e9f0;
 			color: #000; font-family: Arial; font-size: 14px; padding: 7px;-moz-border-radius: 4px;
 			-webkit-border-radius: 4px; border-radius: 4px;">
-			<strong>New Voicemail</strong>
+				<strong>New Voicemail</strong>
 			</td>
 		</tr>
 		<tr>
@@ -17,7 +17,7 @@
 							<strong>To</strong>
 						</td>
 						<td style="color: #666; font-family: Arial; font-size: 12px; padding-bottom: 11px;">
-							${account}
+							${voicemail_name_formatted}
 						</td>
 					</tr>
 					<tr>


### PR DESCRIPTION
* Renamed template variable account to voicemail_id and adjusted all templates
* Added ${voicemail_description}
* Added ${voicemail_name_formatted} (will render the voicemail identifier in accordance with  Default/Domain Settings > Voicemail > display_domain_name)
* Updated templates to be consistent spacing
* Updated templates to include use of ${voicemail_name_formatted}
* Changed ${account} to be voicemail_name_formatted instead of id