### PR TITLE
Fix. Lua can not generate non CUSTOM event with subclass.

### DIFF
--- a/resources/install/scripts/resources/functions/cache.lua
+++ b/resources/install/scripts/resources/functions/cache.lua
@@ -21,7 +21,7 @@ if not api then
 end
 
 local function send_event(action, key)
-  local event = freeswitch.Event("MEMCACHE", action);
+  local event = freeswitch.Event("MEMCACHE");
   event:addHeader("API-Command", "memcache");
   event:addHeader("API-Command-Argument", action .. " " .. key);
   event:fire()


### PR DESCRIPTION
There 2 way.
First one generate `MEMCACHE` event without subclass
Second generate `CUSTOM` event with subclass e.g. `fusion::memcache`