### PR TITLE
Add silence_stream to default voicemail message

### DIFF
--- a/resources/install/scripts/app/voicemail/resources/functions/play_greeting.lua
+++ b/resources/install/scripts/app/voicemail/resources/functions/play_greeting.lua
@@ -83,6 +83,7 @@
 							session:execute("playback","silence_stream://200");
 					else
 						--default greeting
+						session:execute("playback","silence_stream://200");
 						dtmf_digits = macro(session, "person_not_available_record_message", 1, 200);
 					end
 			end


### PR DESCRIPTION
This corrects the issue in #1760, where the default voicemail message was not being played and instead skipped directly to recording (start recording tone).