### PR TITLE
Fix. Properly stop (e.g. remove pid file) event consumer loop in case of error

### DIFF
--- a/resources/install/scripts/resources/functions/event_consumer.lua
+++ b/resources/install/scripts/resources/functions/event_consumer.lua
@@ -501,7 +501,7 @@ function EventConsumer:bind(event_name, cb)
 	end
 end
 
-function EventConsumer:run()
+function EventConsumer:_run()
 	self._running = true
 
 	-- set some huge default interval
@@ -538,6 +538,18 @@ function EventConsumer:run()
 	end
 
 	self._running = false
+end
+
+function EventConsumer:run()
+	local ok, err = xpcall(function()
+		self:_run()
+	end, debug.traceback)
+
+	if not ok then
+		-- ensure we stop loop and remove pid file
+		self:stop()
+		error(err)
+	end
 end
 
 function EventConsumer:stop()


### PR DESCRIPTION
It may be need if using Fusion `Services` app.
Then if there error in such service and `pid` file remain exists then there
no way to restart such service from Web UI.