### PR TITLE
Missing .wav file extension in wakeup.xml

### DIFF
--- a/resources/templates/conf/lang/en/ivr/wakeup.xml
+++ b/resources/templates/conf/lang/en/ivr/wakeup.xml
@@ -69,7 +69,7 @@
 			<match>
 				<!-- To accept press 1 to cancel press 2 -->
 				<action function="execute" data="sleep(750)"/>
-				<action function="play-file" data="ivr/ivr-to_accept_press"/>
+				<action function="play-file" data="ivr/ivr-to_accept_press.wav"/>
 				<action function="play-file" data="digits/1.wav"/>
 				<action function="play-file" data="ivr/ivr-to_reject.wav"/>
 				<action function="play-file" data="voicemail/vm-press.wav"/>

--- a/resources/templates/conf/lang/en/wakeup/sounds.xml
+++ b/resources/templates/conf/lang/en/wakeup/sounds.xml
@@ -52,7 +52,7 @@
 			<match>
 				<!-- To accept press 1 to cancel press 2 -->
 				<action function="execute" data="sleep(750)"/>
-				<action function="play-file" data="ivr/ivr-to_accept_press"/>
+				<action function="play-file" data="ivr/ivr-to_accept_press.wav"/>
 				<action function="play-file" data="digits/1.wav"/>
 				<action function="play-file" data="ivr/ivr-to_reject.wav"/>
 				<action function="play-file" data="voicemail/vm-press.wav"/>


### PR DESCRIPTION
The missing ".wav" extension makes Freeswitch looking for .PCMU file, which does not exist. The call hangs up without setting the wakeup.