### PR TITLE
Add. Access list of IP an extension can register from.

### DIFF
--- a/app/extensions/app_config.php
+++ b/app/extensions/app_config.php
@@ -309,6 +309,10 @@
 		$apps[$x]['db'][$y]['fields'][$z]['type'] = "text";
 		$apps[$x]['db'][$y]['fields'][$z]['description']['en-us'] = "";
 		$z++;
+		$apps[$x]['db'][$y]['fields'][$z]['name'] = "access_acl";
+		$apps[$x]['db'][$y]['fields'][$z]['type'] = "text";
+		$apps[$x]['db'][$y]['fields'][$z]['description']['en-us'] = "";
+		$z++;
 		$apps[$x]['db'][$y]['fields'][$z]['name'] = "cidr";
 		$apps[$x]['db'][$y]['fields'][$z]['type'] = "text";
 		$apps[$x]['db'][$y]['fields'][$z]['description']['en-us'] = "";
@@ -413,7 +417,6 @@
 		$apps[$x]['db'][$y]['fields'][$z]['type']['sqlite'] = "text";
 		$apps[$x]['db'][$y]['fields'][$z]['type']['mysql'] = "char(36)";
 		$apps[$x]['db'][$y]['fields'][$z]['description']['en-us'] = "";
-
 
 
 		$y = 1; //table array index

--- a/app/extensions/app_languages.php
+++ b/app/extensions/app_languages.php
@@ -897,6 +897,19 @@ $text['label-auth_acl']['ro'] = "ACL autentificare";
 $text['label-auth_acl']['ar-eg'] = "";
 $text['label-auth_acl']['he'] = "";
 
+$text['label-access_acl']['en-us'] = "Access ACL";
+$text['label-access_acl']['es-cl'] = "";
+$text['label-access_acl']['pt-pt'] = "";
+$text['label-access_acl']['fr-fr'] = "";
+$text['label-access_acl']['pt-br'] = "";
+$text['label-access_acl']['pl'] = "";
+$text['label-access_acl']['uk'] = "";
+$text['label-access_acl']['sv-se'] = "";
+$text['label-access_acl']['de-at'] = "";
+$text['label-access_acl']['ro'] = "";
+$text['label-access_acl']['ar-eg'] = "";
+$text['label-access_acl']['he'] = "";
+
 $text['label-accountcode']['en-us'] = "Account Code";
 $text['label-accountcode']['es-cl'] = "Código de Cuenta";
 $text['label-accountcode']['pt-pt'] = "Código de Conta";
@@ -1533,6 +1546,19 @@ $text['description-auth_acl']['de-at'] = "Geben Sie die Auth ACL hier an.";
 $text['description-auth_acl']['ro'] = "Introduceți ACL-ul pentru autentificare aici.";
 $text['description-auth_acl']['ar-eg'] = "";
 $text['description-auth_acl']['he'] = "";
+
+$text['description-access_acl']['en-us'] = "Enter the Access ACL here.";
+$text['description-access_acl']['es-cl'] = "";
+$text['description-access_acl']['pt-pt'] = "";
+$text['description-access_acl']['fr-fr'] = "";
+$text['description-access_acl']['pt-br'] = "";
+$text['description-access_acl']['pl'] = "";
+$text['description-access_acl']['uk'] = "";
+$text['description-access_acl']['sv-se'] = "";
+$text['description-access_acl']['de-at'] = "";
+$text['description-access_acl']['ro'] = "";
+$text['description-access_acl']['ar-eg'] = "";
+$text['description-access_acl']['he'] = "";
 
 $text['description-accountcode']['en-us'] = "Enter the account code here.";
 $text['description-accountcode']['es-cl'] = "Ingrese el código de cuenta aquí.";

--- a/app/extensions/extension_edit.php
+++ b/app/extensions/extension_edit.php
@@ -129,6 +129,7 @@ else {
 			$user_record = check_str($_POST["user_record"]);
 			$hold_music = check_str($_POST["hold_music"]);
 			$auth_acl = check_str($_POST["auth_acl"]);
+			$access_acl = check_str($_POST["access_acl"]);
 			$cidr = check_str($_POST["cidr"]);
 			$sip_force_contact = check_str($_POST["sip_force_contact"]);
 			$sip_force_expires = check_str($_POST["sip_force_expires"]);
@@ -451,6 +452,7 @@ if (count($_POST) > 0 && strlen($_POST["persistformvar"]) == 0) {
 							$sql .= "user_record, ";
 							$sql .= "hold_music, ";
 							$sql .= "auth_acl, ";
+							$sql .= "access_acl, ";
 							$sql .= "cidr, ";
 							$sql .= "sip_force_contact, ";
 							if (strlen($sip_force_expires) > 0) {
@@ -513,6 +515,7 @@ if (count($_POST) > 0 && strlen($_POST["persistformvar"]) == 0) {
 							$sql .= "'$user_record', ";
 							$sql .= "'$hold_music', ";
 							$sql .= "'$auth_acl', ";
+							$sql .= "'$access_acl', ";
 							$sql .= "'$cidr', ";
 							$sql .= "'$sip_force_contact', ";
 							if (strlen($sip_force_expires) > 0) {
@@ -667,6 +670,7 @@ if (count($_POST) > 0 && strlen($_POST["persistformvar"]) == 0) {
 					$sql .= "user_record = '$user_record', ";
 					$sql .= "hold_music = '$hold_music', ";
 					$sql .= "auth_acl = '$auth_acl', ";
+					$sql .= "access_acl = '$access_acl', ";
 					$sql .= "cidr = '$cidr', ";
 					$sql .= "sip_force_contact = '$sip_force_contact', ";
 					if (strlen($sip_force_expires) == 0) {
@@ -857,6 +861,7 @@ if (count($_POST) > 0 && strlen($_POST["persistformvar"]) == 0) {
 			$user_record = $row["user_record"];
 			$hold_music = $row["hold_music"];
 			$auth_acl = $row["auth_acl"];
+			$access_acl = $row["access_acl"];
 			$cidr = $row["cidr"];
 			$sip_force_contact = $row["sip_force_contact"];
 			$sip_force_expires = $row["sip_force_expires"];
@@ -1837,6 +1842,17 @@ if (count($_POST) > 0 && strlen($_POST["persistformvar"]) == 0) {
 	echo "   <input class='formfld' type='text' name='auth_acl' maxlength='255' value=\"$auth_acl\">\n";
 	echo "   <br />\n";
 	echo $text['description-auth_acl']."\n";
+	echo "</td>\n";
+	echo "</tr>\n";
+
+	echo "<tr>\n";
+	echo "<td width=\"30%\" class='vncell' valign='top' align='left' nowrap='nowrap'>\n";
+	echo "    ".$text['label-access_acl']."\n";
+	echo "</td>\n";
+	echo "<td width=\"70%\" class='vtable' align='left'>\n";
+	echo "   <input class='formfld' type='text' name='access_acl' maxlength='255' value=\"$access_acl\">\n";
+	echo "   <br />\n";
+	echo $text['description-access_acl']."\n";
 	echo "</td>\n";
 	echo "</tr>\n";
 


### PR DESCRIPTION
Notes.
1. When use fs_path=true also need create ACL with name `fs_path` and add to it all FS (https://github.com/fusionpbx/fusionpbx/compare/master...moteus:extension_access_acl?expand=1#diff-7ea5ac35f2e54352f73910f11d0c0a24R561)
2. This PR adds one more requiest to `user_data` when used data from cache (https://github.com/fusionpbx/fusionpbx/compare/master...moteus:extension_access_acl?expand=1#diff-7ea5ac35f2e54352f73910f11d0c0a24R551)