### PR TITLE
Change. Use `service::control` event to control services

### DIFF
--- a/resources/install/scripts/app/voicemail/resources/scripts/mwi_subscribe.lua
+++ b/resources/install/scripts/app/voicemail/resources/scripts/mwi_subscribe.lua
@@ -8,7 +8,7 @@ local cache         = require "resources.functions.cache"
 local mwi_notify    = require "app.voicemail.resources.functions.mwi_notify"
 
 local service_name = "mwi"
-local pid_file = scripts_dir .. "/run/mwi_subscribe.tmp"
+local pid_file = scripts_dir .. "/run/" .. service_name .. ".tmp"
 
 local vm_message_count do
 
@@ -93,7 +93,9 @@ events:bind("SHUTDOWN", function(self, name, event)
 end)
 
 -- Control commands from FusionPBX
-events:bind("CUSTOM::fusion::service::" .. service_name, function(self, name, event)
+events:bind("CUSTOM::fusion::service::control", function(self, name, event)
+	if service_name ~= event:getHeader('service-name') then return end
+
 	local command = event:getHeader('service-command')
 	if command == "stop" then
 		log.notice("get stop command")

--- a/resources/install/scripts/call_flow_subscribe.lua
+++ b/resources/install/scripts/call_flow_subscribe.lua
@@ -28,7 +28,7 @@ end
 end
 
 local service_name = "flow"
-local pid_file = scripts_dir .. "/run/call_flow_subscribe.tmp"
+local pid_file = scripts_dir .. "/run/" .. service_name .. ".tmp"
 
 local events = EventConsumer.new(pid_file)
 
@@ -39,7 +39,9 @@ events:bind("SHUTDOWN", function(self, name, event)
 end)
 
 -- Control commands from FusionPBX
-events:bind("CUSTOM::fusion::service::" .. service_name, function(self, name, event)
+events:bind("CUSTOM::fusion::service::control", function(self, name, event)
+	if service_name ~= event:getHeader('service-name') then return end
+
 	local command = event:getHeader('service-command')
 	if command == "stop" then
 		log.notice("get stop command")

--- a/resources/install/scripts/call_flow_subscribe.lua
+++ b/resources/install/scripts/call_flow_subscribe.lua
@@ -27,7 +27,7 @@ end
 
 end
 
-local service_name = "flow"
+local service_name = "call_flow"
 local pid_file = scripts_dir .. "/run/" .. service_name .. ".tmp"
 
 local events = EventConsumer.new(pid_file)

--- a/resources/install/scripts/resources/startup/odbc_pool.lua
+++ b/resources/install/scripts/resources/startup/odbc_pool.lua
@@ -69,12 +69,14 @@ events:bind("SHUTDOWN", function(self, name, event)
 end)
 
 -- Control commands from FusionPBX
-events:bind("CUSTOM::fusion::service::" .. service_name, function(self, name, event)
+events:bind("CUSTOM::fusion::service::control", function(self, name, event)
+  if service_name ~= event:getHeader('service-name') then return end
+
   local command = event:getHeader('service-command')
   if command == "stop" then
     log.notice("get stop command")
     return self:stop()
-   end
+  end
 
   log.warningf('Unknown service command: %s', command or '<NONE>')
 end)

--- a/resources/install/scripts/service
+++ b/resources/install/scripts/service
@@ -5,10 +5,69 @@
 --  # stop `mwi_subscribe` monitor
 --  fs_cli -x "lua service mwi stop"
 
+require "resources.functions.config"
+
+local log  = require "resources.functions.log".service
+local file = require "resources.functions.file"
+
 local destination = assert(argv[1], "No service name")
 local command     = assert(argv[2], "No command")
 
-local event = freeswitch.Event("CUSTOM", "fusion::service::"  .. destination);
-event:addHeader('service-command', command)
+local function service_status(name)
+	local pid_file = scripts_dir .. "/run/" .. name .. ".tmp"
+	return not not file.exists(pid_file)
+end
 
-event:fire()
+local function send_control(name, cmd)
+	local event = freeswitch.Event("CUSTOM", "fusion::service::control")
+	event:addHeader('service-name', name)
+	event:addHeader('service-command', cmd)
+	event:fire()
+end
+
+local known_commands = {}
+
+known_commands.status = function()
+	log.noticef( 'service %s: %s', destination,
+		service_status(destination) and 'RUNNING' or 'STOPPED'
+	)
+end;
+
+known_commands.start = function()
+	if service_status(destination) then
+		log.warningf('service %s already started', destination)
+		return
+	end
+
+	--! @todo implemnt start command
+	log.err('Not implemted yet')
+end;
+
+known_commands.restart = function()
+	if not service_status(destination) then
+		log.warningf('service %s not started', destination)
+		return
+	end
+
+	--! @todo implemnt start command
+	log.err('Not implemted yet')
+end;
+
+known_commands.stop = function()
+	if not service_status(destination) then
+		log.warningf('service %s not started', destination)
+		return
+	end
+
+	log.noticef('stopping service: %s', destination)
+	send_control(destination, 'stop')
+end;
+
+-- try handle known commands
+local cmd = known_commands[command]
+if cmd then return cmd() end
+
+log.warningf('send raw command `%s` to service %s', command, destination)
+
+-- forward command to service itself
+send_control(destination, command)


### PR DESCRIPTION
This is more FS way. E.g. sofia sends `sofia::register` event
and add all information to headers. So now `service` script
emit `fusion::service::control` event and each service responsible
for test its own name. This also allows add in future evnets to
e.g. monitor service status like `fusion::service::satus` so it
will be possible write service which will be restart services.