### PR TITLE
Enhance-Add message stack

### DIFF
--- a/resources/functions.php
+++ b/resources/functions.php
@@ -1923,4 +1923,10 @@ function number_pad($number,$n) {
 			return false;
 	}
 
+	if (!function_exists('add_message')) {
+		function add_message($message, $mood, $delay) {
+			$_SESSION["messages"][] = array(message=> $message, mood=>$mood, delay=>$delay);
+		}
+	}
+
 ?>

--- a/themes/default/css.php
+++ b/themes/default/css.php
@@ -1336,57 +1336,40 @@ $default_login = ($_REQUEST['login'] == 'default') ? true : false;
 	#message_container {
 		z-index: 99998;
 		position: absolute;
-		top: -80px;
+		top: 0;
 		left: 0;
 		right: 0;
-		filter: alpha(opacity=0);
-		opacity: 0;
-		-moz-opacity:0;
-		-khtml-opacity: 0;
-		padding: 15px 0;
+		padding: 0;
 	}
 
-	#message_text {
+	.message_text {
 		z-index: 99999;
-		position: absolute;
-		top: -80px;
-		left: 0;
-		right: 0;
-		filter: alpha(opacity=0);
-		opacity: 0;
-		-moz-opacity:0;
-		-khtml-opacity: 0;
 		margin: 0 auto;
-		vertical-align: middle;
-		padding: 15px 0;
+		padding: 0.5em 0;
 		text-align: center;
 		font-family: arial, san-serif;
 		font-size: 10pt;
+		display: block;
+		border-bottom: solid 1px;
 	}
-
-	.message_container_mood_default {
-		background: <?php echo $_SESSION['theme']['message_default_background_color']['text']; ?>;
-		}
-
-	.message_container_mood_negative {
-		background: <?php echo $_SESSION['theme']['message_negative_background_color']['text']; ?>;
-		}
-
-	.message_container_mood_alert {
-		background: <?php echo $_SESSION['theme']['message_alert_background_color']['text']; ?>;
-		}
 
 	.message_text_mood_default {
 		color: <?php echo $_SESSION['theme']['message_default_color']['text']; ?>;
-		}
+		background: <?php echo $_SESSION['theme']['message_default_background_color']['text']; ?>;
+		border-bottom-color: <?php echo $_SESSION['theme']['message_default_color']['text']; ?>;
+	}
 
 	.message_text_mood_negative {
 		color: <?php echo $_SESSION['theme']['message_negative_color']['text']; ?>;
-		}
+		background: <?php echo $_SESSION['theme']['message_negative_background_color']['text']; ?>;
+		border-bottom-color: <?php echo $_SESSION['theme']['message_negative_color']['text']; ?>;
+	}
 
 	.message_text_mood_alert {
 		color: <?php echo $_SESSION['theme']['message_alert_color']['text']; ?>;
-		}
+		background: <?php echo $_SESSION['theme']['message_alert_background_color']['text']; ?>;
+		border-bottom-color: <?php echo $_SESSION['theme']['message_alert_color']['text']; ?>;
+	}
 
 /* OPERATOR PANEL ****************************************************************/
 

--- a/themes/default/template.php
+++ b/themes/default/template.php
@@ -68,19 +68,22 @@
 		function display_message(msg, mood, delay) {
 			var mood = (typeof mood !== 'undefined') ? mood : 'default';
 			var delay = (typeof delay !== 'undefined') ? delay : <?php echo (1000 * (float) $_SESSION['theme']['message_delay']['text']); ?>;
-			if (msg != '') {
-				var inner_width = $(window).width();
+			if (msg !== '') {
+				//var inner_width = $(window).width();
 				// add class by mood
-				$("#message_container").addClass('message_container_mood_'+mood);
-				$("#message_text").addClass('message_text_mood_'+mood);
-				// output message
-				$("#message_text").html(msg);
-				$("#message_container").css({height: $("#message_text").css("height")});
-				$("#message_container").css({width: inner_width});
-				$("#message_text").show().animate({top: '+=80'}, 500).animate({opacity: 1}, 'fast').delay(delay).animate({top: '-=80'}, 1000).animate({opacity: 0});
-				$("#message_container").show().animate({top: '+=80'}, 500).animate({opacity: <?php echo $_SESSION['theme']['message_opacity']['text']; ?>}, "fast").delay(delay).animate({top: '-=80'}, 1000).animate({opacity: 0}, function() {
-					$("#message_container").removeClass('message_container_mood_'+mood);
-				});
+				var message_text = $(document.createElement('div'));
+				message_text.addClass('message_text message_text_mood_'+mood);
+				message_text.html(msg);
+				//message_text.css({width: inner_width, height: 0});
+				//message_text.show();
+				message_text.click(function() {
+					var object = $(this);
+					object.clearQueue().finish();
+					object.css({height: '3em'})
+					object.animate({height: '0', 'font-size': '0', 'border-bottom-width': '0'}, 1000).animate({opacity: 0});
+				} );
+				$("#message_container").append(message_text);
+				message_text.animate({height: '3em'}, 500).animate({opacity: 1}, 'fast').delay(delay).animate({height: '0', 'font-size': '0', 'border-bottom-width': '0'}, 1000).animate({opacity: 0});
 			}
 		}
 
@@ -100,6 +103,21 @@
 				}
 				echo "); ";
 				unset($_SESSION['message'], $_SESSION['message_mood'], $_SESSION['message_delay']);
+			}
+			if(count($_SESSION['messages']) > 0 ){
+				foreach ($_SESSION['messages'] as $message) {
+					$message_text = addslashes($message['message']);
+					$message_mood = $message['mood'];
+					$message_delay = $message['delay'];
+
+					echo "display_message('".$message_text."'";
+					echo ($message_mood != '') ? ", '".$message_mood."'" : ", 'default'";
+					if ($message_delay != '') {
+						echo ", '".$message_delay."'";
+					}
+					echo "); ";
+				}
+				unset($_SESSION['messages']);
 			}
 			?>
 
@@ -291,7 +309,7 @@
 </head>
 
 <?php
-//add multi-lingual support
+//add multilingual support
 	$language = new text;
 	$text = $language->get(null,'themes/default');
 ?>
@@ -299,7 +317,6 @@
 <body onload="<?php echo $onload;?>">
 
 	<div id='message_container' class='message_container_mood_default'></div>
-	<div id='message_text' class='message_container_text_default'></div>
 
 	<?php
 	//logged in show the domains block


### PR DESCRIPTION
Support legacy $_SESSION['message_*']
Use new $_SESSION['messages'] array
New function add_message($message, $mood, $delay) to simplify adding messages
- [x] Tested on CentOS 7 Host firefox client

I think the functional code is complete, all that is left is cosmetic tweaks as required and testing on other platforms
