### PR TITLE
Time of day routing convertion fixed.

### DIFF
--- a/app/time_conditions/time_condition_edit.php
+++ b/app/time_conditions/time_condition_edit.php
@@ -271,10 +271,10 @@
 					if ($cond_var == 'time-of-day') {
 						$cond_var = 'minute-of-day';
 						$array_cond_start = explode(':', $cond_start);
-						$cond_start = ($array_cond_start[0] * 60) + $array_cond_start[1];
+						$cond_start = ($array_cond_start[0] * 60) + $array_cond_start[1] + 1;
 						if ($cond_stop != '') {
 							$array_cond_stop = explode(':', $cond_stop);
-							$cond_stop = ($array_cond_stop[0] * 60) + $array_cond_stop[1];
+							$cond_stop = ($array_cond_stop[0] * 60) + $array_cond_stop[1] + 1;
 						}
 					}
 
@@ -903,6 +903,8 @@ if ($action == 'update') {
 				//convert minute-of-day to time-of-day values
 				if ($cond_var == 'minute-of-day') {
 					$cond_var = 'time-of-day';
+					--$cond_val_start;
+					--$cond_val_stop;
 					$cond_val_start = number_pad(floor($cond_val_start / 60),2).":".number_pad(fmod($cond_val_start, 60),2);
 					if ($cond_val_stop != '') {
 						$cond_val_stop = number_pad(floor($cond_val_stop / 60),2).":".number_pad(fmod($cond_val_stop, 60),2);


### PR DESCRIPTION
This is a minor bug which is fixed with a few minor adjustments.

Valid values for 'minute-of-day' in FreeSWITCH are 1-1440, the page is currently converting 'time-of-day' to 'minute-of-day' as 0-1439, the fix will correct the values to 1-1440.

Sources:
https://wiki.freeswitch.org/wiki/Time_of_Day_Routing