### PR TITLE
Update to time_condition_edit.php

### DIFF
--- a/app/time_conditions/time_condition_edit.php
+++ b/app/time_conditions/time_condition_edit.php
@@ -709,6 +709,9 @@
 								sel_stop.options[sel_stop.options.length] = new Option(((h != 0) ? ((h >= 12) ? ((h == 12) ? h : (h - 12)) + ':' + pad(m, 2) + ' PM' : h + ':' + pad(m, 2) + ' AM') : '12:' + pad(m, 2) + ' AM'), pad(h, 2)  + ':' + pad(m, 2));
 							}
 						}
+						h = 23;
+						m = 59;
+						sel_stop.options[sel_stop.options.length] = new Option(((h != 0) ? ((h >= 12) ? ((h == 12) ? h : (h - 12)) + ':' + pad(m, 2) + ' PM' : h + ':' + pad(m, 2) + ' AM') : '12:' + pad(m, 2) + ' AM'), pad(h, 2)  + ':' + pad(m, 2));
 						break;
 
 				}


### PR DESCRIPTION
When using 'time-of-day' it's not currently possible to specify a range which will finish at the end of the day.

This is a minor adjustment to allow a range which finishes at the end of the day 23:59 to be specified.