### PR TITLE
BugFix-Support spaces in streamfile.lua

### DIFF
--- a/resources/install/scripts/streamfile.lua
+++ b/resources/install/scripts/streamfile.lua
@@ -1,6 +1,7 @@
 --get the argv values
 	script_name = argv[0];
-	file_name = argv[1];
+	file_name = table.concat(argv, " ");
+	freeswitch.consoleLog("notice", "[streamfile] file_name: " .. file_name .. "\n");
 
 --include config.lua
 	require "resources.functions.config";


### PR DESCRIPTION
use table.concat as a workaround to spaces in filesames
alternative is adjust all destiantions to quote filenames, but would
require app_defaults catch to fix all exisiting written destinations.