### PR TITLE
Add one touch voice mail access to messages key

### DIFF
--- a/resources/templates/provision/polycom/5.x/{$mac}.cfg
+++ b/resources/templates/provision/polycom/5.x/{$mac}.cfg
@@ -124,6 +124,12 @@
 		{if $headset_mode != ''}up.handsfreeMode="1"
 		up.headsetMode="{$headset_mode}"{/if}
 		{if $analog_headset_option != ''}up.analogHeadsetOption="{$analog_headset_option}"{/if}
+		{if isset($polycom_onetouchvoicemail)}
+			up.oneTouchVoiceMail="{$polycom_onetouchvoicemail}"
+			{else}
+			up.oneTouchVoiceMail="0"
+		{/if}
+
 	/>
 	<SOFT_KEYS
 		softkey.1.label="VMTransfer"


### PR DESCRIPTION
I have been assigning a button on the Polycom VVX phones to allow users to access their voice mail from the phone easier that simply is a speed dial to *97 with a button label "My VoiceMail".  Why?  Because by default when a user presses the dedicated messages key (that has the picture of an envelope) the user is shown a screen titled "Messages".  There they press 1 or Select soft key to choose "Message Center".  Then a screen shows a summary count urgent, new and saved messages totals and the user can then press the Connect soft key to connect them to *97 to be prompted for their password.  This shortens up the process by 2 key presses and is more simple for the user.

I found an option to change the messages key so it does not display the summary and just dials the voice mail server access number.

This is from the admin guide for 5.3.0 software:

up.oneTouchVoiceMail
default is 0
If 1, the phone dials voicemail services directly (if available on the call server) without displaying the voicemail  summary. If 0, the phone displays a summary page with message counts. The user must press the Connect soft key to dial the voicemail server

To change the messages key to have one touch access to voice mail do this:
In FusionPBX web GUI, click Advanced, Default Settings add a new entry:
Category=provision
Subcategory=polycom_onetouchvoicemail
Type=text
Value=1
Enabled=True
Description=If 1, the phone dials voicemail services directly (if available on the call server) without displaying the voicemail  summary. If 0, the phone displays a summary page with message counts. The user must press the Connect soft  key to dial the voicemail

Then go to Status, Registrations and find the phone(s) you want to update and click "Provision"