### PR TITLE
Corrects some cases where dialplan conditions were not fully handled

### DIFF
--- a/resources/install/scripts/app/xml_handler/resources/scripts/dialplan/dialplan.lua
+++ b/resources/install/scripts/app/xml_handler/resources/scripts/dialplan/dialplan.lua
@@ -235,19 +235,19 @@
 							end
 
 						--condition tag but leave off the ending
-						if (condition_type == "default") then
-							condition = [[				<condition field="]] .. dialplan_detail_type .. [[" expression="]] .. dialplan_detail_data .. [["]] .. condition_break;
-						elseif (condition_type == "time") then
-							if (condition_attribute) then
-								condition_attribute = condition_attribute .. dialplan_detail_type .. [[="]] .. dialplan_detail_data .. [[" ]];
+							if (condition_type == "default") then
+								condition = [[				<condition field="]] .. dialplan_detail_type .. [[" expression="]] .. dialplan_detail_data .. [["]] .. condition_break;
+							elseif (condition_type == "time") then
+								if (condition_attribute) then
+									condition_attribute = condition_attribute .. dialplan_detail_type .. [[="]] .. dialplan_detail_data .. [[" ]];
+								else
+									condition_attribute = dialplan_detail_type .. [[="]] .. dialplan_detail_data .. [[" ]];
+								end
+								condition = ""; --prevents a duplicate time condition
 							else
-								condition_attribute = dialplan_detail_type .. [[="]] .. dialplan_detail_data .. [[" ]];
+								condition = [[				<condition field="]] .. dialplan_detail_type .. [[" expression="]] .. dialplan_detail_data .. [["]] ..  condition_break;
 							end
-							condition = ""; --prevents a duplicate time condition
-						else
-							condition = [[				<condition field="]] .. dialplan_detail_type .. [[" expression="]] .. dialplan_detail_data .. [["]] ..  condition_break;
-						end
-						condition_tag_status = "open";
+							condition_tag_status = "open";
 					end
 					if (dialplan_detail_tag == "action" or dialplan_detail_tag == "anti-action") then
 						if (condition_tag_status == "open") then

--- a/resources/install/scripts/app/xml_handler/resources/scripts/dialplan/dialplan.lua
+++ b/resources/install/scripts/app/xml_handler/resources/scripts/dialplan/dialplan.lua
@@ -223,7 +223,6 @@
 								condition_tag_status = "closed";
 								condition_type = "";
 								condition_attribute = "";
-								condition_expression = "";
 							end
 						end
 
@@ -236,7 +235,6 @@
 							else
 								condition_attribute = dialplan_detail_type .. [[="]] .. dialplan_detail_data .. [[" ]];
 							end
-							condition_expression = "";
 							condition = ""; --prevents a duplicate time condition
 						else
 							condition = [[				<condition field="]] .. dialplan_detail_type .. [[" expression="]] .. dialplan_detail_data .. [["]] ..  condition_break;

--- a/resources/install/scripts/app/xml_handler/resources/scripts/dialplan/dialplan.lua
+++ b/resources/install/scripts/app/xml_handler/resources/scripts/dialplan/dialplan.lua
@@ -83,9 +83,6 @@
 		--set defaults
 			previous_dialplan_uuid = "";
 			previous_dialplan_detail_group = "";
-			previous_dialplan_detail_tag = "";
-			previous_dialplan_detail_type = "";
-			previous_dialplan_detail_data = "";
 			dialplan_tag_status = "closed";
 			condition_tag_status = "closed";
 
@@ -290,9 +287,6 @@
 				--save the previous values
 					previous_dialplan_uuid = dialplan_uuid;
 					previous_dialplan_detail_group = dialplan_detail_group;
-					previous_dialplan_detail_tag = dialplan_detail_tag;
-					previous_dialplan_detail_type = dialplan_detail_type;
-					previous_dialplan_detail_data = dialplan_detail_data;
 
 				--increment the x
 					x = x + 1;

--- a/resources/install/scripts/app/xml_handler/resources/scripts/dialplan/dialplan.lua
+++ b/resources/install/scripts/app/xml_handler/resources/scripts/dialplan/dialplan.lua
@@ -148,18 +148,20 @@
 					end
 
 				--close the tags
-					if (condition_tag_status ~= "closed") then
+					if (dialplan_tag_status ~= "closed") then
 						if ((previous_dialplan_uuid ~= dialplan_uuid) or (previous_dialplan_detail_group ~= dialplan_detail_group)) then
-							if (condition_attribute and (string.len(condition_attribute) > 0)) then
-								table.insert(xml, [[				<condition ]] .. condition_attribute .. condition_break .. [[/>]]);
-								condition_attribute = "";
-							elseif (condition and (string.len(condition) > 0)) then
-								table.insert(xml, condition .. [[/>]]);
-								condition = "";
-							elseif (condition_tag_status ~= "closed") then
-								table.insert(xml, [[				</condition>]]);
+							if (condition_tag_status ~= "closed") then
+								if (condition_attribute and (string.len(condition_attribute) > 0)) then
+									table.insert(xml, [[				<condition ]] .. condition_attribute .. condition_break .. [[/>]]);
+									condition_attribute = "";
+								elseif (condition and (string.len(condition) > 0)) then
+									table.insert(xml, condition .. [[/>]]);
+									condition = "";
+								elseif (condition_tag_status ~= "closed") then
+									table.insert(xml, [[				</condition>]]);
+								end
+								condition_tag_status = "closed";
 							end
-							condition_tag_status = "closed";
 						end
 						if (previous_dialplan_uuid ~= dialplan_uuid) then
 							table.insert(xml, [[			</extension>]]);


### PR DESCRIPTION
In trying to write a dialplan I ran into some cases where the XML was not correct.  Since a dialplan condition statement could be in one of three states: (1) already output to XML opening a
<condition ...> block, (2) currently saved in var condition, or (3) one or more time conditions saved
in var condition_attribute, the main change is to check/handle all three possible cases at those
places where conditions are finalized.

If a dialplan group only consisted of a condition, then the output XML would become just
a </condition> entry without any opening <condition ...> entry.

If a time-based condition was following by a non time condition, the time condition would be
completely lost.

If a time-based condition, in a new dialplan group follows an action statement, the time condition
would get treated as a non-time condition (i.e. condition_type was being cleared).

If a dialplan was entered (incorrectly) without any condition statement, and only action statements,
the XML <extension> would not get closed at the start of a new dialplan uuid, and thus the erroneous
dialplan uuid and the following uuid would be merged into a single extension.
