### PR TITLE
use extension rather than username

### DIFF
--- a/resources/install/scripts/app/xml_handler/resources/scripts/directory/directory.lua
+++ b/resources/install/scripts/app/xml_handler/resources/scripts/directory/directory.lua
@@ -257,7 +257,7 @@
 									--set a default dial string
 										if (dial_string == null) then
 											local username = (#number_alias > 0) and number_alias or extension
-											dial_string = "{sip_invite_domain=" .. domain_name .. ",presence_id=" .. user .. "@" .. domain_name .. "}${sofia_contact(" .. username .. "@" .. domain_name .. ")}";
+											dial_string = "{sip_invite_domain=" .. domain_name .. ",presence_id=" .. user .. "@" .. domain_name .. "}${sofia_contact(" .. extension .. "@" .. domain_name .. ")}";
 										end
 									--set the an alternative dial string if the hostnames don't match
 										if (load_balancing) then


### PR DESCRIPTION
username is set to alias if it exists, otherwise it falls back to the extension value.
sofia_contact does not work with aliases. since we have the extension value already filled, it is safe to use it