### PR TITLE
$fax_number variable is undefined

### DIFF
--- a/app/fax/resources/classes/fax.php
+++ b/app/fax/resources/classes/fax.php
@@ -158,10 +158,10 @@
 					$dialplan["dialplan_details"][$y]["dialplan_detail_tag"] = "action";
 					$dialplan["dialplan_details"][$y]["dialplan_detail_type"] = "rxfax";
 					if (count($_SESSION["domains"]) > 1) {
-						$dialplan["dialplan_details"][$y]["dialplan_detail_data"] = $_SESSION['switch']['storage']['dir'].'/fax/'.$_SESSION['domain_name'].'/'.$fax_extension.'/inbox/'.$forward_prefix.'${last_fax}.tif';
+						$dialplan["dialplan_details"][$y]["dialplan_detail_data"] = $_SESSION['switch']['storage']['dir'].'/fax/'.$_SESSION['domain_name'].'/${destination_number}/inbox/'.$forward_prefix.'${last_fax}.tif';
 					}
 					else {
-						$dialplan["dialplan_details"][$y]["dialplan_detail_data"] = $_SESSION['switch']['storage']['dir'].'/fax/'.$fax_extension.'/inbox/'.$forward_prefix.'${last_fax}.tif';
+						$dialplan["dialplan_details"][$y]["dialplan_detail_data"] = $_SESSION['switch']['storage']['dir'].'/fax/${destination_number}/inbox/'.$forward_prefix.'${last_fax}.tif';
 					}
 					$dialplan["dialplan_details"][$y]["dialplan_detail_group"] = "1";
 					$dialplan["dialplan_details"][$y]["dialplan_detail_order"] = $y * 10;


### PR DESCRIPTION
$fax_number variable is not defined, instead of this, it is safe to use ${destination_number}. Freeswitch will do the smart substitution.

The lack of this variable breaks the incoming rxfax command, as the complete path to store TIF files does not exist.