### PR TITLE
export domain_name to fix load balancing

### DIFF
--- a/app/dialplan/resources/switch/conf/dialplan/999_local_extension.xml
+++ b/app/dialplan/resources/switch/conf/dialplan/999_local_extension.xml
@@ -20,6 +20,7 @@
 			<!--<action application="export" data="nolocal:sip_secure_media=${user_data(${dialed_extension}@${domain_name} var sip_secure_media)}"/>-->
 			<action application="hash" data="insert/${domain_name}-last_dial/${called_party_call_group}/${uuid}"/>
 			<action application="set" data="api_hangup_hook=lua app.lua hangup"/>
+			<action application="export" data="domain_name=${context}"/>
 			<!-- standard method -->
 			<action application="bridge" data="user/${destination_number}@${domain_name}"/>
 			<!-- sofia contact -->


### PR DESCRIPTION
This is for 4.0

When using balancing, and getting an INVITE from a peer PBX, the domain is lost and we get public context. This breaks the load balancing.
I have found that we need to export domain_name variable in order to let the LUA XML Handler to create the correct SQL query (which it uses the variable domain_name) to find where an endpoint is registered. This change is harmless for non-loadbalanced deployments.