### PR TITLE
Fix e-mail attachment handling / conversion & allow local emails to be valid

### DIFF
--- a/app/fax/fax_send.php
+++ b/app/fax/fax_send.php
@@ -354,7 +354,9 @@ function fax_split_dtmf(&$fax_number, &$fax_dtmf){
 				//convert uploaded file to pdf, if necessary
 				if ($fax_file_extension != "pdf" && $fax_file_extension != "tif") {
 					chdir($dir_fax_temp);
-					exec("libreoffice --headless --convert-to pdf --outdir ".$dir_fax_temp." ".$dir_fax_temp.'/'.$fax_name.'.'.$fax_file_extension);
+					$attachment_file_name = $_files['name'][$index];
+					exec("libreoffice --headless --convert-to pdf --outdir ".$dir_fax_temp." ".$dir_fax_temp.'/'.escapeshellarg($attachment_file_name));
+					unset($attachment_file_name);
 					@unlink($dir_fax_temp.'/'.$fax_name.'.'.$fax_file_extension);
 				}
 

--- a/app/fax/fax_send.php
+++ b/app/fax/fax_send.php
@@ -346,6 +346,11 @@ function fax_split_dtmf(&$fax_number, &$fax_dtmf){
 				$fax_name = str_replace("+", "_", $fax_name);
 				$fax_name = str_replace("=", "_", $fax_name);
 
+
+				$attachment_file_name = $_files['name'][$index];
+				rename($dir_fax_temp.'/'.$attachment_file_name, $dir_fax_temp.'/'.$fax_name.'.'.$fax_file_extension);
+				unset($attachment_file_name);
+
 				if (!$included) {
 					//move uploaded file
 					move_uploaded_file($_files['tmp_name'][$index], $dir_fax_temp.'/'.$fax_name.'.'.$fax_file_extension);

--- a/app/fax/fax_send.php
+++ b/app/fax/fax_send.php
@@ -359,9 +359,7 @@ function fax_split_dtmf(&$fax_number, &$fax_dtmf){
 				//convert uploaded file to pdf, if necessary
 				if ($fax_file_extension != "pdf" && $fax_file_extension != "tif") {
 					chdir($dir_fax_temp);
-					$attachment_file_name = $_files['name'][$index];
-					exec("libreoffice --headless --convert-to pdf --outdir ".$dir_fax_temp." ".$dir_fax_temp.'/'.escapeshellarg($attachment_file_name));
-					unset($attachment_file_name);
+					exec("libreoffice --headless --convert-to pdf --outdir ".$dir_fax_temp." ".$dir_fax_temp.'/'.$fax_name.'.'.$fax_file_extension);
 					@unlink($dir_fax_temp.'/'.$fax_name.'.'.$fax_file_extension);
 				}
 

--- a/resources/functions.php
+++ b/resources/functions.php
@@ -1101,7 +1101,7 @@ function number_pad($number,$n) {
 // validate email address syntax
 	if(!function_exists('valid_email')) {
 		function valid_email($email) {
-			$regex = '/^[A-z0-9][\w.-]*@[A-z0-9][\w\-\.]+\.[A-z0-9]{2,6}$/';
+			$regex = '/^[A-z0-9][\w.-]*@[A-z0-9][\w\-\.]+(\.[A-z0-9]{2,6})?$/';
 			if ($email != "" && preg_match($regex, $email) == 1) {
 				return true; // email address has valid syntax
 			}


### PR DESCRIPTION
- Since $fax_name is modified the code didn't work properly, as the filenames didn't change.
The whole code works now fine, when renaming the attachment file to $fax_name.
- local email addresses where not valid, since the valid_email checker required a domain with 2-6 characters. 
