### PR TITLE
Update macro.lua to fix reading voicemail extension number

### DIFF
--- a/resources/install/scripts/app/voicemail/resources/functions/macro.lua
+++ b/resources/install/scripts/app/voicemail/resources/functions/macro.lua
@@ -39,12 +39,13 @@
 				end
 			--the person at extension 101 is not available record your message at the tone press any key or stop talking to end the recording
 				if (name == "person_not_available_record_message") then
+					local voicemail_greet_id
 					table.insert(actions, {app="streamFile",data="voicemail/vm-person.wav"});
 					--pronounce the voicemail_id
 					if (session:getVariable("voicemail_alternate_greet_id")) then
-						local voicemail_greet_id = session:getVariable("voicemail_alternate_greet_id");
+						voicemail_greet_id = session:getVariable("voicemail_alternate_greet_id");
 					else
-						local voicemail_greet_id = voicemail_id;
+						voicemail_greet_id = voicemail_id;
 					end
 					table.insert(actions, {app="say.number.iterated",data=voicemail_greet_id});
 					table.insert(actions, {app="streamFile",data="voicemail/vm-not_available.wav"});


### PR DESCRIPTION
Expected result: The person at extension XXX is unavailable ...
Actual result: The person at is unavailable... 
i.e. it doesn't say the extension number.

bug: trying to access local variable voicemail_greet_id outside it's scope...so it doesn't exist and you get this in the logs:

2016-09-18 12:32:54.615249 [ERR] switch_cpp.cpp:977 Error! invalid args. 

Fix moves local variable creation outside the inner "if" so it's available for the later table.insert