### PR TITLE
Look further for domain_name

### DIFF
--- a/resources/install/scripts/app/xml_handler/index.lua
+++ b/resources/install/scripts/app/xml_handler/index.lua
@@ -82,6 +82,9 @@
 	if (domain_name == nil) then
 		domain_name = params:getHeader("variable_domain_name");
 	end
+        if (domain_name == nil) then
+                domain_name = params:getHeader("variable_sip_from_host");
+        end
 	purpose   = params:getHeader("purpose");
 	profile   = params:getHeader("profile");
 	key    = params:getHeader("key");


### PR DESCRIPTION
When using load balancing, and a ring group is involved the domain_name, variable_domain_name, nor the sip_from_host are filled. Instead, there is a variable called variable_sip_from_host which it has the correct value.

This fix fixes this, avoiding a NIL in the domain_name variable, therefore domain_uuid empty