### PR TITLE
fix fax multiple files.

### DIFF
--- a/app/fax/fax_emails.php
+++ b/app/fax/fax_emails.php
@@ -172,9 +172,7 @@ if (sizeof($result) != 0) {
 
 				//check sender
 				$sender_authorized = false;
-				foreach ($authorized_senders as $authorized_sender) {
-					if (substr_count($metadata[0]['from'], $authorized_sender) > 0) { $sender_authorized = true; }
-				}
+				if (in_array($metadata[0]['from'],$authorized_senders)) { $sender_authorized = true; }
 
 				if ($sender_authorized) {
 
@@ -218,7 +216,7 @@ if (sizeof($result) != 0) {
 					}
 
 					foreach($message['messages'] as &$msg){
-						if(($msg['size'] > 0) && ($msg['type'] == 'text/plain')) {
+						if(($msg['size'] > 0)) {
 							$fax_message = $msg['data'];
 							break;
 						}
@@ -226,6 +224,7 @@ if (sizeof($result) != 0) {
 
 					if ($fax_message != '') {
 						$fax_message = strip_tags($fax_message);
+						$fax_message = str_replace("&nbsp;", "\r\n", $fax_message);
 						$fax_message = str_replace("\r\n\r\n", "\r\n", $fax_message);
 					}
 
@@ -244,17 +243,18 @@ if (sizeof($result) != 0) {
 							//block unauthorized files
 								if (!$fax_allowed_extension['.' . $fax_file_extension]) { continue; } 
 							//support only attachments
-								if($attachment['disposition'] != 'attachment'){ continue; } 
+								//if($attachment['disposition'] != 'attachment'){ continue; } 
 
 							//store attachment in local fax temp folder
-								$local_filepath = $fax_dir.'/'.$fax_extension.'/temp/'.$attachment['name'];
+								$uuid_filename = uuid();
+								$local_filepath = $fax_dir.'/'.$fax_extension.'/temp/'.$uuid_filename."-".$attachment['name'];
 								file_put_contents($local_filepath, $attachment['data']);
 
 							//load files array with attachments
 								$emailed_files['error'][] = 0;
 								$emailed_files['size'][] = $attachment['size'];
-								$emailed_files['tmp_name'][] = $attachment['name'];
-								$emailed_files['name'][] = $attachment['name'];
+								$emailed_files['tmp_name'][] = $uuid_filename."-".$attachment['name'];
+								$emailed_files['name'][] = $uuid_filename."-".$attachment['name'];
 						}
 					}
 

--- a/app/fax/fax_send.php
+++ b/app/fax/fax_send.php
@@ -313,6 +313,7 @@ function fax_split_dtmf(&$fax_number, &$fax_dtmf){
 		// process uploaded or emailed files (if any)
 		$fax_page_count = 0;
 		$_files = (!$included) ? $_FILES['fax_files'] : $emailed_files;
+		unset($tif_files);
 		foreach ($_files['tmp_name'] as $index => $fax_tmp_name) {
 			$uploaded_file = (!$included) ? is_uploaded_file($fax_tmp_name) : true;
 			if ( $uploaded_file && $_files['error'][$index] == 0 && $_files['size'][$index] > 0 ) {


### PR DESCRIPTION
Added some changes from ICR regarding the text/plain emails, added a
uuid to the file name when getting saved to the FS in the event that
multiple emails come in with the same exact file name and also reset
the tif_files in fax_send as it was just adding to the end of the array
and creating bad tiffcp commands.