### PR TITLE
Add the capability to have extension and DID with same number

### DIFF
--- a/app/dialplan_outbound/dialplan_outbound_add.php
+++ b/app/dialplan_outbound/dialplan_outbound_add.php
@@ -378,6 +378,13 @@ else {
 						unset($sql);
 
 					$dialplan_detail_tag = 'condition'; //condition, action, antiaction
+					$dialplan_detail_type = '${user_exists}';
+					$dialplan_detail_data = 'false';
+					$dialplan_detail_order = '004';
+					$dialplan_detail_group = '0';
+					dialplan_detail_add($_SESSION['domain_uuid'], $dialplan_uuid, $dialplan_detail_tag, $dialplan_detail_order, $dialplan_detail_group, $dialplan_detail_type, $dialplan_detail_data);
+
+					$dialplan_detail_tag = 'condition'; //condition, action, antiaction
 					$dialplan_detail_type = 'destination_number';
 					$dialplan_detail_data = $dialplan_expression;
 					$dialplan_detail_order = '005';


### PR DESCRIPTION
Usually, there is a dial plan clash when you have a DID and an extension the same number (10+ digits longer). Adding this condition will force user verification, as it is supposed when you use an outgoing route, the user is not local.

Some internal (999) extension work must be done, I will post that shortly for 4.0. It seems 4.2 doesn't need this as it checks for user existance regarding extension name.