### PR TITLE
faxing smtp_port fix + smtp certificate override

### DIFF
--- a/core/default_settings/app_defaults.php
+++ b/core/default_settings/app_defaults.php
@@ -170,11 +170,11 @@ if ($domains_processed == 1) {
 		$array[$x]['default_setting_description'] = '';
 		$x++;
 		$array[$x]['default_setting_category'] = 'email';
-		$array[$x]['default_setting_subcategory'] = 'smtp_ignore_bad_certificate';
+		$array[$x]['default_setting_subcategory'] = 'smtp_validate_certificate';
 		$array[$x]['default_setting_name'] = 'bolean';
-		$array[$x]['default_setting_value'] = 'false';
+		$array[$x]['default_setting_value'] = 'true';
 		$array[$x]['default_setting_enabled'] = 'true';
-		$array[$x]['default_setting_description'] = 'set to true to ignore SSL certificate warnings e.g. for self-signed certificates';
+		$array[$x]['default_setting_description'] = 'set to false to ignore SSL certificate warnings e.g. for self-signed certificates';
 		$x++;	
 		$array[$x]['default_setting_category'] = 'login';
 		$array[$x]['default_setting_subcategory'] = 'password_reset_key';

--- a/core/default_settings/app_defaults.php
+++ b/core/default_settings/app_defaults.php
@@ -169,6 +169,13 @@ if ($domains_processed == 1) {
 		$array[$x]['default_setting_enabled'] = 'true';
 		$array[$x]['default_setting_description'] = '';
 		$x++;
+		$array[$x]['default_setting_category'] = 'email';
+		$array[$x]['default_setting_subcategory'] = 'smtp_ignore_bad_certificate';
+		$array[$x]['default_setting_name'] = 'bolean';
+		$array[$x]['default_setting_value'] = 'false';
+		$array[$x]['default_setting_enabled'] = 'true';
+		$array[$x]['default_setting_description'] = 'set to true to ignore SSL certificate warnings e.g. for self-signed certificates';
+		$x++;	
 		$array[$x]['default_setting_category'] = 'login';
 		$array[$x]['default_setting_subcategory'] = 'password_reset_key';
 		$array[$x]['default_setting_name'] = 'text';

--- a/secure/fax_to_email.php
+++ b/secure/fax_to_email.php
@@ -515,6 +515,29 @@ if(!function_exists('fax_split_dtmf')) {
 		//prepare the mail object
 			$mail = new PHPMailer();
 			$mail->IsSMTP(); // set mailer to use SMTP
+		
+		//use settings for smtp port override if present
+			if (isset($_SESSION['email']['smtp_port'])) {
+				$mail->Port = (int)$_SESSION['email']['smtp_port']['numeric'];
+			} else {
+				$mail->Port = 0;
+			}
+
+		//optional ignore bad certificates
+			if (isset($_SESSION['email']['smtp_ignore_bad_certificate'])) {
+				if ($_SESSION['email']['smtp_ignore_bad_certificate']['boolean'] == "true") {
+
+					// this works around TLS certificate problems e.g. self-signed certificates
+					$mail->SMTPOptions = array(
+						'ssl' => array(
+						'verify_peer' => false,
+						'verify_peer_name' => false,
+						'allow_self_signed' => true
+						)
+					);
+				}
+			}
+		
 
 			if ($_SESSION['email']['smtp_auth']['var'] == "true") {
 				$mail->SMTPAuth = $_SESSION['email']['smtp_auth']['var']; // turn on/off SMTP authentication

--- a/secure/fax_to_email.php
+++ b/secure/fax_to_email.php
@@ -523,9 +523,9 @@ if(!function_exists('fax_split_dtmf')) {
 				$mail->Port = 0;
 			}
 
-		//optional ignore bad certificates
-			if (isset($_SESSION['email']['smtp_ignore_bad_certificate'])) {
-				if ($_SESSION['email']['smtp_ignore_bad_certificate']['boolean'] == "true") {
+		//optionally skip certificate validation
+			if (isset($_SESSION['email']['smtp_validate_certificate'])) {
+				if ($_SESSION['email']['smtp_validate_certificate']['boolean'] == "false") {
 
 					// this works around TLS certificate problems e.g. self-signed certificates
 					$mail->SMTPOptions = array(

--- a/secure/v_mailto.php
+++ b/secure/v_mailto.php
@@ -189,6 +189,22 @@
 			default: $mail->IsSMTP(); break;
 		}
 	} else $mail->IsSMTP();
+
+// optional bypass TLS certificate check e.g. for self-signed certificates
+        if (isset($_SESSION['email']['smtp_ignore_bad_certificate'])) {
+                if ($_SESSION['email']['smtp_ignore_bad_certificate']['boolean'] == "true") {
+
+                        // this is needed to work around TLS certificate problems
+                        $mail->SMTPOptions = array(
+                                'ssl' => array(
+                                'verify_peer' => false,
+                                'verify_peer_name' => false,
+                                'allow_self_signed' => true
+                                )
+                        );
+                }
+        }
+
 	$mail->SMTPAuth = $smtp['auth'];
 	$mail->Host = $smtp['host'];
 	if ($smtp['port']!=0) $mail->Port=$smtp['port'];

--- a/secure/v_mailto.php
+++ b/secure/v_mailto.php
@@ -190,11 +190,11 @@
 		}
 	} else $mail->IsSMTP();
 
-// optional bypass TLS certificate check e.g. for self-signed certificates
-        if (isset($_SESSION['email']['smtp_ignore_bad_certificate'])) {
-                if ($_SESSION['email']['smtp_ignore_bad_certificate']['boolean'] == "true") {
+// optional bypass TLS certificate validation
+        if (isset($_SESSION['email']['smtp_validate_certificate'])) {
+                if ($_SESSION['email']['smtp_validate_certificate']['boolean'] == "false") {
 
-                        // this is needed to work around TLS certificate problems
+                        // this is needed to work around TLS certificate problems e.g. self-signed certificates
                         $mail->SMTPOptions = array(
                                 'ssl' => array(
                                 'verify_peer' => false,


### PR DESCRIPTION
smtp_ignore_bad_certificate is added to default settings.  Default is false.

If set to true then will add flags for PHPMailer to ignore certificate checks.  This lets you use self-signed certificates.

Note: you have a similar override as an option for imap on the fax server advanced options.  This patch does something the equivalent on the SMTP side for sending fax and voicemail to email.

This patch lets you use self-signed certs on recent php/phpmailer combinations.  

This patch lets fax-to-email work with non-standard smtp ports by adding similar logic from voicemail-to-email (v_mailto.php).
