### PR TITLE
#1987 combined fix for Master

### DIFF
--- a/app/fax/app_config.php
+++ b/app/fax/app_config.php
@@ -507,7 +507,9 @@
 		$apps[$x]['db'][$y]['fields'][$z]['description']['en-us'] = "";
 		$z++;
 		$apps[$x]['db'][$y]['fields'][$z]['name'] = "fax_date";
-		$apps[$x]['db'][$y]['fields'][$z]['type'] = "date";
+		$apps[$x]['db'][$y]['fields'][$z]['type']['pgsql'] = "timestamp";
+		$apps[$x]['db'][$y]['fields'][$z]['type']['sqlite'] = "date";
+		$apps[$x]['db'][$y]['fields'][$z]['type']['mysql'] = "timestamp";
 		$apps[$x]['db'][$y]['fields'][$z]['description']['en-us'] = "";
 		$z++;
 		$apps[$x]['db'][$y]['fields'][$z]['name'] = "fax_epoch";

--- a/app/fax/app_defaults.php
+++ b/app/fax/app_defaults.php
@@ -139,7 +139,7 @@ if ($domains_processed == 1) {
 		$x++;
 
 	//get an array of the default settings
-		$sql = "select * from v_default_settings ";
+		$sql = "select * from v_default_settings where default_setting_category = 'fax'";
 		$prep_statement = $db->prepare($sql);
 		$prep_statement->execute();
 		$default_settings = $prep_statement->fetchAll(PDO::FETCH_NAMED);

--- a/app/fax/fax_log_view.php
+++ b/app/fax/fax_log_view.php
@@ -11,10 +11,8 @@ else {
 }
 
 //add multi-lingual support
-	require_once "app_languages.php";
-	foreach($text as $key => $value) {
-		$text[$key] = $value[$_SESSION['domain']['language']['code']];
-	}
+	$language = new text;
+	$text = $language->get();
 
 //pre-populate the form
 	if (isset($_REQUEST["id"]) && isset($_REQUEST["fax_uuid"])) {


### PR DESCRIPTION
app/fax/app_defaults.php:
+ fix: duplicate check only within same default_setting_category.  This fixes the bug where "keep_local" for fax wasn't being created because there was a "keep_local" for voicemail.  Without this fix you will get a lua error due to the field not being set and nothing shows up in the sent faxes log.

fax/fax_log_view.php:
+ fix: back button text is missing.  Copied correct localized text code from another fax page that worked.

app/fax/app_config.php
+ fix: date field is now timestamp for postgres+mysql.  This fixes the listing only showing the date, not the time as well.

Note: app->defaults doesn't change field types.  Existing installs will have to manually update the field type e.g. for postgres:

sudo -sHu postgres
\d fusionpbx
alter table v_fax_logs alter column fax_date type timestamp without time zone;
\q