### PR TITLE
Update sip.trust_ctrl for yealink firmware version 80

### DIFF
--- a/resources/templates/provision/yealink/cp860/y000000000037.cfg
+++ b/resources/templates/provision/yealink/cp860/y000000000037.cfg
@@ -679,6 +679,7 @@ features.call_completion_enable =
 
 #Enable or disable the phone to dial the IP address directly; 0-Disabled, 1-Enabled (default);
 features.direct_ip_call_enable = 0
+sip.trust_ctrl=1
 
 #Configure the power Indicator LED to turn on or turn off; 0-On (default), 1-Off;
 features.power_led_on = 1

--- a/resources/templates/provision/yealink/t20p/y000000000007.cfg
+++ b/resources/templates/provision/yealink/t20p/y000000000007.cfg
@@ -1072,6 +1072,7 @@ features.relog_offtime =
 #Enable or disable the phone to dial the IP address directly; 0-Disabled, 1-Enabled (default);
 #Require reboot;
 features.direct_ip_call_enable = 0
+sip.trust_ctrl=1
 
 #Specify the ring device when the phone is in the Headset mode; 0-use Speaker (default), 1-use Headset;
 features.ringer_device.is_use_headset =

--- a/resources/templates/provision/yealink/t21p/y000000000052.cfg
+++ b/resources/templates/provision/yealink/t21p/y000000000052.cfg
@@ -639,6 +639,7 @@ features.call_completion_enable =
 
 #Enable or disable the phone to dial the IP address directly; 0-Disabled, 1-Enabled (default);
 features.direct_ip_call_enable = 0
+sip.trust_ctrl=1
 
 #Configure the power Indicator LED to turn on or turn off; 0-On (default), 1-Off;
 features.power_led_on = 1

--- a/resources/templates/provision/yealink/t22p/y000000000005.cfg
+++ b/resources/templates/provision/yealink/t22p/y000000000005.cfg
@@ -1072,6 +1072,7 @@ features.relog_offtime =
 #Enable or disable the phone to dial the IP address directly; 0-Disabled, 1-Enabled (default);
 #Require reboot;
 features.direct_ip_call_enable = 0
+sip.trust_ctrl=1
 
 #Specify the ring device when the phone is in the Headset mode; 0-use Speaker (default), 1-use Headset;
 features.ringer_device.is_use_headset =

--- a/resources/templates/provision/yealink/t23g/y000000000044.cfg
+++ b/resources/templates/provision/yealink/t23g/y000000000044.cfg
@@ -639,6 +639,7 @@ features.call_completion_enable =
 
 #Enable or disable the phone to dial the IP address directly; 0-Disabled, 1-Enabled (default);
 features.direct_ip_call_enable = 0
+sip.trust_ctrl=1
 
 #Configure the power Indicator LED to turn on or turn off; 0-On (default), 1-Off;
 features.power_led_on = 1

--- a/resources/templates/provision/yealink/t23p/y000000000044.cfg
+++ b/resources/templates/provision/yealink/t23p/y000000000044.cfg
@@ -639,6 +639,7 @@ features.call_completion_enable =
 
 #Enable or disable the phone to dial the IP address directly; 0-Disabled, 1-Enabled (default);
 features.direct_ip_call_enable = 0
+sip.trust_ctrl=1
 
 #Configure the power Indicator LED to turn on or turn off; 0-On (default), 1-Off;
 features.power_led_on = 1

--- a/resources/templates/provision/yealink/t26p/y000000000004.cfg
+++ b/resources/templates/provision/yealink/t26p/y000000000004.cfg
@@ -1072,6 +1072,7 @@ features.relog_offtime =
 #Enable or disable the phone to dial the IP address directly; 0-Disabled, 1-Enabled (default);
 #Require reboot;
 features.direct_ip_call_enable = 0
+sip.trust_ctrl=1
 
 #Specify the ring device when the phone is in the Headset mode; 0-use Speaker (default), 1-use Headset;
 features.ringer_device.is_use_headset =

--- a/resources/templates/provision/yealink/t27p/y000000000045.cfg
+++ b/resources/templates/provision/yealink/t27p/y000000000045.cfg
@@ -639,6 +639,7 @@ features.call_completion_enable =
 
 #Enable or disable the phone to dial the IP address directly; 0-Disabled, 1-Enabled (default);
 features.direct_ip_call_enable = 0
+sip.trust_ctrl=1
 
 #Configure the power Indicator LED to turn on or turn off; 0-On (default), 1-Off;
 features.power_led_on = 1

--- a/resources/templates/provision/yealink/t28p/y000000000000.cfg
+++ b/resources/templates/provision/yealink/t28p/y000000000000.cfg
@@ -1072,6 +1072,7 @@ features.relog_offtime =
 #Enable or disable the phone to dial the IP address directly; 0-Disabled, 1-Enabled (default);
 #Require reboot;
 features.direct_ip_call_enable = 0
+sip.trust_ctrl=1
 
 #Specify the ring device when the phone is in the Headset mode; 0-use Speaker (default), 1-use Headset;
 features.ringer_device.is_use_headset =

--- a/resources/templates/provision/yealink/t29g/y000000000046.cfg
+++ b/resources/templates/provision/yealink/t29g/y000000000046.cfg
@@ -639,6 +639,7 @@ features.call_completion_enable =
 
 #Enable or disable the phone to dial the IP address directly; 0-Disabled, 1-Enabled (default);
 features.direct_ip_call_enable = 0
+sip.trust_ctrl=1
 
 #Configure the power Indicator LED to turn on or turn off; 0-On (default), 1-Off;
 features.power_led_on = 1

--- a/resources/templates/provision/yealink/t32g/y000000000032.cfg
+++ b/resources/templates/provision/yealink/t32g/y000000000032.cfg
@@ -1072,6 +1072,7 @@ features.relog_offtime =
 #Enable or disable the phone to dial the IP address directly; 0-Disabled, 1-Enabled (default);
 #Require reboot;
 features.direct_ip_call_enable = 0
+sip.trust_ctrl=1
 
 #Specify the ring device when the phone is in the Headset mode; 0-use Speaker (default), 1-use Headset;
 features.ringer_device.is_use_headset =

--- a/resources/templates/provision/yealink/t38g/y000000000038.cfg
+++ b/resources/templates/provision/yealink/t38g/y000000000038.cfg
@@ -1072,6 +1072,7 @@ features.relog_offtime =
 #Enable or disable the phone to dial the IP address directly; 0-Disabled, 1-Enabled (default);
 #Require reboot;
 features.direct_ip_call_enable = 0
+sip.trust_ctrl=1
 
 #Specify the ring device when the phone is in the Headset mode; 0-use Speaker (default), 1-use Headset;
 features.ringer_device.is_use_headset =

--- a/resources/templates/provision/yealink/t40p/y000000000054.cfg
+++ b/resources/templates/provision/yealink/t40p/y000000000054.cfg
@@ -639,6 +639,7 @@ features.call_completion_enable =
 
 #Enable or disable the phone to dial the IP address directly; 0-Disabled, 1-Enabled (default);
 features.direct_ip_call_enable = 0
+sip.trust_ctrl=1
 
 #Configure the power Indicator LED to turn on or turn off; 0-On (default), 1-Off;
 features.power_led_on = 1

--- a/resources/templates/provision/yealink/t41p/y000000000036.cfg
+++ b/resources/templates/provision/yealink/t41p/y000000000036.cfg
@@ -639,6 +639,7 @@ features.call_completion_enable =
 
 #Enable or disable the phone to dial the IP address directly; 0-Disabled, 1-Enabled (default);
 features.direct_ip_call_enable = 0
+sip.trust_ctrl=1
 
 #Configure the power Indicator LED to turn on or turn off; 0-On (default), 1-Off;
 features.power_led_on = 1

--- a/resources/templates/provision/yealink/t42g/y000000000029.cfg
+++ b/resources/templates/provision/yealink/t42g/y000000000029.cfg
@@ -639,6 +639,7 @@ features.call_completion_enable =
 
 #Enable or disable the phone to dial the IP address directly; 0-Disabled, 1-Enabled (default);
 features.direct_ip_call_enable = 0
+sip.trust_ctrl=1
 
 #Configure the power Indicator LED to turn on or turn off; 0-On (default), 1-Off;
 features.power_led_on = 1

--- a/resources/templates/provision/yealink/t46g/y000000000028.cfg
+++ b/resources/templates/provision/yealink/t46g/y000000000028.cfg
@@ -639,6 +639,7 @@ features.call_completion_enable =
 
 #Enable or disable the phone to dial the IP address directly; 0-Disabled, 1-Enabled (default);
 features.direct_ip_call_enable = 0
+sip.trust_ctrl=1
 
 #Configure the power Indicator LED to turn on or turn off; 0-On (default), 1-Off;
 features.power_led_on = 1

--- a/resources/templates/provision/yealink/t48g/y000000000035.cfg
+++ b/resources/templates/provision/yealink/t48g/y000000000035.cfg
@@ -639,6 +639,7 @@ features.call_completion_enable =
 
 #Enable or disable the phone to dial the IP address directly; 0-Disabled, 1-Enabled (default);
 features.direct_ip_call_enable = 0
+sip.trust_ctrl=1
 
 #Configure the power Indicator LED to turn on or turn off; 0-On (default), 1-Off;
 features.power_led_on = 1

--- a/resources/templates/provision/yealink/t49g/y000000000051.cfg
+++ b/resources/templates/provision/yealink/t49g/y000000000051.cfg
@@ -639,6 +639,7 @@ features.call_completion_enable =
 
 #Enable or disable the phone to dial the IP address directly; 0-Disabled, 1-Enabled (default);
 features.direct_ip_call_enable = 0
+sip.trust_ctrl=1
 
 #Configure the power Indicator LED to turn on or turn off; 0-On (default), 1-Off;
 features.power_led_on = 1

--- a/resources/templates/provision/yealink/vp530/y000000000023.cfg
+++ b/resources/templates/provision/yealink/vp530/y000000000023.cfg
@@ -938,6 +938,7 @@ features.relog_offtime = 5
 #Enable or disable the phone to dial the IP address directly; 0-Disabled, 1-Enabled (default);
 #Require reboot;
 features.direct_ip_call_enable = 0
+sip.trust_ctrl=1
 
 #Specify the ring device when the phone is in the Headset mode; 0-use Speaker (default), 1-use Headset;
 features.ringer_device.is_use_headset = 0

--- a/resources/templates/provision/yealink/w52p/y000000000025.cfg
+++ b/resources/templates/provision/yealink/w52p/y000000000025.cfg
@@ -314,6 +314,7 @@ call_waiting.tone =
 
 #Enable or disable the phone to dial the IP address directly; 0-Disabled, 1-Enabled (default);
 features.direct_ip_call_enable = 0
+sip.trust_ctrl=1
 
 #Enable or disable the phone to save the call history; 0-Disabled, 1-Enabled (default);
 features.save_call_history =


### PR DESCRIPTION
In version 80 of the yealink firmware the trust_ctl changed from
account.X.sip_trust_ctrl=1  to sip.trust_ctrl=1. Making this change in
the provisioning files.