### PR TITLE
Fix Voicemail for E-164 Caller ID

### DIFF
--- a/resources/install/scripts/app/voicemail/index.lua
+++ b/resources/install/scripts/app/voicemail/index.lua
@@ -69,6 +69,9 @@
 			destination_number = session:getVariable("destination_number");
 			caller_id_name = session:getVariable("caller_id_name");
 			caller_id_number = session:getVariable("caller_id_number");
+			if (string.sub(caller_id_number, 1, 1) == "/") then
+				caller_id_number = string.sub(caller_id_number, 2, -1);
+			end
 			voicemail_greeting_number = session:getVariable("voicemail_greeting_number");
 			skip_instructions = session:getVariable("skip_instructions");
 			skip_greeting = session:getVariable("skip_greeting");


### PR DESCRIPTION
When saving Voicemail messages where the Caller ID number uses E-164 format these may include a '/' prefix used to escape '+'. This causes the '/' to be saved with the number which prevents the call from being returned.

The above fixes the issue by removing '/' prefix from the start of the Caller ID number before saving the Voicemail message.