### PR TITLE
Add. Support number_alias field as presence id in follow me/call forward

### DIFF
--- a/app/calls/resources/classes/call_forward.php
+++ b/app/calls/resources/classes/call_forward.php
@@ -68,8 +68,7 @@ include "root.php";
 
 			//set the dial string
 				if ($this->forward_all_enabled == "true") {
-					$dial_string = "{presence_id=".$this->forward_all_destination."@".$_SESSION['domain_name'];
-					$dial_string .= ",instant_ringback=true";
+					$dial_string = "{instant_ringback=true";
 					$dial_string .= ",domain_uuid=".$_SESSION['domain_uuid'];
 					$dial_string .= ",sip_invite_domain=".$_SESSION['domain_name'];
 					$dial_string .= ",domain_name=".$_SESSION['domain_name'];
@@ -121,11 +120,20 @@ include "root.php";
 						}
 					}
 
-					$dial_string .= "}";
 					if (extension_exists($this->forward_all_destination)) {
+						// For support load_balance we need set `dialed_extension`
+						$dial_string .= ",dialed_extension=".$this->forward_all_destination;
+						// we do not need here presence_id because user dial-string already has one
+						$dial_string .= "}";
 						$dial_string .= "user/".$this->forward_all_destination."@".$_SESSION['domain_name'];
 					}
 					else {
+						// setting here presence_id equal extension not dialed number allows work BLF and intercept.
+						$presence_id = extension_presence_id($this->extension, $this->number_alias);
+						// $presence_id = $this->forward_all_destination;
+						$dial_string .= ",presence_id=".$presence_id."@".$_SESSION['domain_name'];
+						$dial_string .= "}";
+
 						if ($_SESSION['domain']['bridge']['text'] == "outbound" || $_SESSION['domain']['bridge']['text'] == "bridge") {
 							$bridge = outbound_route_to_bridge ($_SESSION['domain_uuid'], $this->forward_all_destination);
 							$dial_string .= $bridge[0];

--- a/app/calls/resources/classes/follow_me.php
+++ b/app/calls/resources/classes/follow_me.php
@@ -43,6 +43,7 @@ include "root.php";
 		public $outbound_caller_id_name;
 		public $outbound_caller_id_number;
 		private $extension;
+		private $number_alias;
 		private $toll_allow;
 
 		public $destination_data_1;
@@ -248,6 +249,7 @@ include "root.php";
 					$this->extension = $row["extension"];
 					$this->accountcode = $row["accountcode"];
 					$this->toll_allow = $row["toll_allow"];
+					$this->number_alias = $row["number_alias"];
 					$this->outbound_caller_id_name = $row["outbound_caller_id_name"];
 					$this->outbound_caller_id_number = $row["outbound_caller_id_number"];
 				}
@@ -347,12 +349,15 @@ include "root.php";
 					if ($x > 0) {
 						$dial_string .= ",";
 					}
-					if (extension_exists($row["follow_me_destination"])) {
+					if (($presence_id = extension_presence_id($row["follow_me_destination"])) !== false) {
 						//set the dial string
+						// using here `sofia_contact` instead of `user/` allows add registered device
+						// so you can make follow me for extension `100` like `100` and avoid recusion
+						// but it ignores DND/CallForwad settings
 						if (strlen($_SESSION['domain']['dial_string']['text']) == 0) {
 							$dial_string .= "[";
 							$dial_string .= "outbound_caller_id_number=$dial_string_caller_id_number,";
-							$dial_string .= "presence_id=".$row["follow_me_destination"]."@".$_SESSION['domain_name'].",";
+							$dial_string .= "presence_id=".$presence_id."@".$_SESSION['domain_name'].',';
 							if ($row["follow_me_prompt"] == "1") {
 								$dial_string .= "group_confirm_key=exec,group_confirm_file=lua confirm.lua,confirm=true,";
 							}
@@ -374,6 +379,7 @@ include "root.php";
 						}
 					}
 					else {
+						$presence_id = extension_presence_id($this->extension, $this->number_alias);
 						$dial_string .= "[";
 						if ($_SESSION['cdr']['follow_me_fix']['boolean'] == "true"){
 							$dial_string .= "outbound_caller_id_name=".$this->outbound_caller_id_name;
@@ -384,7 +390,7 @@ include "root.php";
 						else{
 							$dial_string .= "outbound_caller_id_number=$dial_string_caller_id_number";
 						}
-						$dial_string .= ",presence_id=".$this->extension."@".$_SESSION['domain_name'];
+						$dial_string .= ",presence_id=".$presence_id."@".$_SESSION['domain_name'];
 						if ($row["follow_me_prompt"] == "1") {
 							$dial_string .= ",group_confirm_key=exec,group_confirm_file=lua confirm.lua,confirm=true,";
 						}

--- a/resources/install/scripts/app/xml_handler/resources/scripts/directory/action/reverse-auth-lookup.lua
+++ b/resources/install/scripts/app/xml_handler/resources/scripts/directory/action/reverse-auth-lookup.lua
@@ -83,7 +83,7 @@
 		table.insert(xml, [[<document type="freeswitch/xml">]]);
 		table.insert(xml, [[	<section name="directory">]]);
 		table.insert(xml, [[		<domain name="]] .. domain_name .. [[" alias="true">]]);
-		table.insert(xml, [[			<user id="]] .. extension .. [[">]]);
+		table.insert(xml, [[			<user id="]] .. extension .. [["]] .. number_alias .. [[>]]);
 		table.insert(xml, [[				<params>]]);
 		table.insert(xml, [[					<param name="reverse-auth-user" value="]] .. extension .. [["/>]]);
 		table.insert(xml, [[					<param name="reverse-auth-pass" value="]] .. password .. [["/>]]);

--- a/resources/install/scripts/app/xml_handler/resources/scripts/directory/directory.lua
+++ b/resources/install/scripts/app/xml_handler/resources/scripts/directory/directory.lua
@@ -607,7 +607,7 @@
 							dbh:release();
 
 						--set the cache
-							local key = "directory:" .. (DIAL_STRING_BASED_ON_USERID and sip_from_number or sip_from_user) .. "@" .. domain_name
+							local key = "directory:" .. sip_from_number .. "@" .. domain_name
 							if debug['cache'] then
 								freeswitch.consoleLog("notice", "[xml_handler-directory][memcache] set key: " .. key .. "\n")
 							end

--- a/resources/install/scripts/call_forward.lua
+++ b/resources/install/scripts/call_forward.lua
@@ -37,25 +37,13 @@
 --include config.lua
 	require "resources.functions.config";
 
---include config.lua
-	require "resources.functions.settings";
-
 	require "resources.functions.channel_utils";
 
 	local log = require "resources.functions.log".call_forward
 	local cache = require "resources.functions.cache"
 	local Database = require "resources.functions.database"
+	local Settings = require "resources.functions.lazy_settings"
 	local route_to_bridge = require "resources.functions.route_to_bridge"
-
-	local function opt(t, ...)
-		if select('#', ...) == 0 then
-			return t
-		end
-		if type(t) ~= 'table' then
-			return nil
-		end
-		return opt(t[...], select(2, ...))
-	end
 
 	local function empty(t)
 		return (not t) or (#t == 0)
@@ -86,7 +74,7 @@
 	session:sleep(1000);
 
 --connect to the database
-	dbh = Database.new('system');
+	local dbh = Database.new('system');
 
 --request id is true
 	if (request_id == "true") then
@@ -220,54 +208,47 @@
 			destination_number_alias = row.number_alias or '';
 		end);
 
-		local presence_id
-		if destination_extension then
-			if (#destination_number_alias > 0) and (opt(settings(domain_uuid), 'provision', 'number_as_presence_id', 'boolean') == 'true') then
-				presence_id = destination_number_alias
-			else
-				presence_id = destination_extension
-			end
-		elseif extension then
-			-- setting here presence_id equal extension not dialed number allows work BLF and intercept.
-			-- $presence_id = extension_presence_id($this->extension, $this->number_alias);
-			if (#number_alias > 0) and (opt(settings(domain_uuid), 'provision', 'number_as_presence_id', 'boolean') == 'true') then
-				presence_id = number_alias
-			else
-				presence_id = extension
-			end
-		else
-			presence_id = forward_all_destination
-		end
-
-		--set the dial_string
-		dial_string = "{presence_id="..presence_id.."@"..domain_name;
-		dial_string = dial_string .. ",instant_ringback=true";
-		dial_string = dial_string .. ",domain_uuid="..domain_uuid;
-		dial_string = dial_string .. ",sip_invite_domain="..domain_name;
-		dial_string = dial_string .. ",domain_name="..domain_name;
-		dial_string = dial_string .. ",domain="..domain_name;
-		dial_string = dial_string .. ",toll_allow='"..toll_allow.."'";
-		dial_string = dial_string .. ",sip_h_Diversion=<sip:"..extension.."@"..domain_name..">;reason=unconditional";
-		if (accountcode ~= nil) then
-			dial_string = dial_string .. ",accountcode="..accountcode;
-		end
-		dial_string = dial_string .. forward_caller_id
-		dial_string = dial_string .. "}";
-
 		if (destination_user ~= nil) then
 			cmd = "user_exists id ".. destination_user .." "..domain_name;
 		else
 			cmd = "user_exists id ".. forward_all_destination .." "..domain_name;
 		end
-		user_exists = trim(api:executeString(cmd));
-		if (user_exists == "true") then
-			if (destination_user ~= nil) then
-				dial_string = dial_string .. "user/"..destination_user.."@"..domain_name;
-			else
-				dial_string = dial_string .. "user/"..forward_all_destination.."@"..domain_name;
-			end
+		local user_exists = trim(api:executeString(cmd));
+
+		--set the dial_string
+		dial_string = "{instant_ringback=true";
+		dial_string = dial_string .. ",domain_uuid="..domain_uuid;
+		dial_string = dial_string .. ",sip_invite_domain="..domain_name;
+		dial_string = dial_string .. ",domain_name="..domain_name;
+		dial_string = dial_string .. ",domain="..domain_name;
+		dial_string = dial_string .. ",extension_uuid="..extension_uuid;
+		dial_string = dial_string .. ",toll_allow='"..toll_allow.."'";
+		dial_string = dial_string .. ",sip_h_Diversion=<sip:"..extension.."@"..domain_name..">;reason=unconditional";
+		if (not accountcode) or (#accountcode == 0) then
+			dial_string = dial_string .. ",sip_h_X-accountcode=${accountcode}";
 		else
-			local mode = opt(settings(domain_uuid), 'domain', 'bridge', 'text')
+			dial_string = dial_string .. ",sip_h_X-accountcode="..accountcode;
+			dial_string = dial_string .. ",accountcode="..accountcode;
+		end
+		dial_string = dial_string .. forward_caller_id
+
+		if (user_exists == "true") then
+			-- we do not need here presence_id because user dial-string already has one
+			dial_string = dial_string .. ",dialed_extension=" .. forward_all_destination
+			dial_string = dial_string .. "}"
+			dial_string = dial_string .. "user/"..forward_all_destination.."@"..domain_name;
+		else
+			-- setting here presence_id equal extension not dialed number allows work BLF and intercept.
+			local settings, presence_id = Settings.new(dbh, domain_name, domain_uuid)
+			if (#number_alias > 0) and (settings:get('provision', 'number_as_presence_id', 'text') == 'true') then
+				presence_id = number_alias
+			else
+				presence_id = extension
+			end
+
+			dial_string = dial_string .. ",presence_id="..presence_id.."@"..domain_name;
+			dial_string = dial_string .. "}";
+			local mode = settings:get('domain', 'bridge', 'text')
 			if mode == "outbound" or mode == "bridge" then
 				local bridge = route_to_bridge(dbh, domain_uuid, {
 					destination_number = forward_all_destination;

--- a/resources/switch.php
+++ b/resources/switch.php
@@ -531,7 +531,7 @@ function extension_exists($extension) {
 	$database->connect();
 	$db = $database->db;
 
-	$sql = "select * from v_extensions ";
+	$sql = "select 1 from v_extensions ";
 	$sql .= "where domain_uuid = '$domain_uuid' ";
 	$sql .= "and (extension = '$extension' ";
 	$sql .= "or number_alias = '$extension') ";
@@ -543,6 +543,42 @@ function extension_exists($extension) {
 	else {
 		return false;
 	}
+}
+
+function extension_presence_id($extension, $number_alias = false) {
+	global $domain_uuid;
+
+	//get the database connection
+	require_once "resources/classes/database.php";
+	$database = new database;
+	$database->connect();
+	$db = $database->db;
+
+	if ($number_alias === false) {
+		$sql = "select extension, number_alias from v_extensions ";
+		$sql .= "where domain_uuid = '$domain_uuid' ";
+		$sql .= "and (extension = '$extension' ";
+		$sql .= "or number_alias = '$extension') ";
+		$sql .= "and enabled = 'true' ";
+
+		$result = $db->query($sql)->fetchAll(PDO::FETCH_ASSOC);
+		if (count($result) == 0) {
+			return false;
+		}
+
+		foreach ($result as &$row) {
+			$extension = $row['extension'];
+			$number_alias = $row['number_alias'];
+			break;
+		}
+	}
+
+	if(strlen($number_alias) > 0) {
+		if($_SESSION['provision']['number_as_presence_id']['text'] === 'true') {
+			return $number_alias;
+		}
+	}
+	return $extension;
 }
 
 function get_recording_filename($id) {


### PR DESCRIPTION
* About calculate presence_id.

If some extension make CF/Follow me to another extension then presence id for such cannel set to
number of new extension. (e.g. ext 101 make forwad to 102. then presence_is is 102).

If some extension make CF/Follow me to some external number then presence id for such cannel set to
number of origin extension. (e.g. ext 101 make forwad to +0123456. then presence_is is 101).

* `reverse-auth-lookup.lua`
We have to set number-alias here because if we make call with setted `fs_path`  and use number-alias for this then without this record FS can not find auth info.

* `directory.lua`
If ext has number alias then we should set info in memcache for both ext id and number alias in any case.

