### PR TITLE
Import Destinations

### DIFF
--- a/app/destinations/app_config.php
+++ b/app/destinations/app_config.php
@@ -61,8 +61,10 @@
 		$apps[$x]['permissions'][$y]['name'] = 'destination_all';
 		$apps[$x]['permissions'][$y]['groups'][] = 'superadmin';
 		$y++;
-
-
+		$apps[$x]['permissions'][$y]['name'] = 'destination_import';
+		$apps[$x]['permissions'][$y]['groups'][] = 'superadmin';
+		$y++;
+		
 	//schema details
 		$y = 0; //table array index
 		$z = 0; //field array index

--- a/app/destinations/app_languages.php
+++ b/app/destinations/app_languages.php
@@ -1,4 +1,222 @@
 <?php
+$text['label-import_file_upload']['en-us'] = "File to Upload";
+$text['label-import_file_upload']['es-cl'] = "Archivo a subir";
+$text['label-import_file_upload']['pt-pt'] = "Ficheiro para submeter";
+$text['label-import_file_upload']['fr-fr'] = "Fichier à télécharger";
+$text['label-import_file_upload']['pt-br'] = "Importar arquivo";
+$text['label-import_file_upload']['pl'] = "Plik do wysłania";
+$text['label-import_file_upload']['uk'] = "Файл для завантаження";
+$text['label-import_file_upload']['sv-se'] = "Fil att ladda upp";
+$text['label-import_file_upload']['de-at'] = "Datei zum hochladen";
+$text['label-import_file_upload']['he'] = "";
+
+$text['description-csv_header_destination_type']['en-us'] = "destination_type (Type: inbound/outbound),";
+$text['description-csv_header_destination_type']['es-cl'] = "destination_type (Type: inbound/outbound),";
+$text['description-csv_header_destination_type']['pt-pt'] = "destination_type (Type: inbound/outbound),";
+$text['description-csv_header_destination_type']['fr-fr'] = "destination_type (Type: inbound/outbound),";
+$text['description-csv_header_destination_type']['pt-br'] = "destination_type (Type: inbound/outbound),";
+$text['description-csv_header_destination_type']['pl'] = "destination_type (Type: inbound/outbound),";
+$text['description-csv_header_destination_type']['uk'] = "destination_type (Type: inbound/outbound),";
+$text['description-csv_header_destination_type']['sv-se'] = "destination_type (Type: inbound/outbound),";
+$text['description-csv_header_destination_type']['he'] = "destination_type (Type: inbound/outbound),";
+
+$text['description-csv_header_destination_number']['en-us'] = "destination_number (Destination Number),";
+$text['description-csv_header_destination_number']['es-cl'] = "destination_number (Destination Number),";
+$text['description-csv_header_destination_number']['pt-pt'] = "destination_number (Destination Number),";
+$text['description-csv_header_destination_number']['fr-fr'] = "destination_number (Destination Number),";
+$text['description-csv_header_destination_number']['pt-br'] = "destination_number (Destination Number),";
+$text['description-csv_header_destination_number']['pl'] = "destination_number (Destination Number),";
+$text['description-csv_header_destination_number']['uk'] = "destination_number (Destination Number),";
+$text['description-csv_header_destination_number']['sv-se'] = "destination_number (Destination Number),";
+$text['description-csv_header_destination_number']['he'] = "destination_number (Destination Number),";
+
+$text['description-csv_header_destination_caller_id_name']['en-us'] = "destination_caller_id_name (Set the caller ID name. default = blank),";
+$text['description-csv_header_destination_caller_id_name']['es-cl'] = "destination_caller_id_name (Set the caller ID name. default = blank),,";
+$text['description-csv_header_destination_caller_id_name']['pt-pt'] = "destination_caller_id_name (Set the caller ID name. default = blank),,";
+$text['description-csv_header_destination_caller_id_name']['fr-fr'] = "destination_caller_id_name (Set the caller ID name. default = blank),";
+$text['description-csv_header_destination_caller_id_name']['pt-br'] = "destination_caller_id_name (Set the caller ID name. default = blank),";
+$text['description-csv_header_destination_caller_id_name']['pl'] = "destination_caller_id_name (Set the caller ID name. default = blank),";
+$text['description-csv_header_destination_caller_id_name']['uk'] = "destination_caller_id_name (Set the caller ID name. default = blank),";
+$text['description-csv_header_destination_caller_id_name']['sv-se'] = "destination_caller_id_name (Set the caller ID name. default = blank),";
+$text['description-csv_header_destination_caller_id_name']['de-at'] = "destination_caller_id_name (Set the caller ID name. default = blank),";
+$text['description-csv_header_destination_caller_id_name']['he'] = "destination_caller_id_name (Set the caller ID name. default = blank),";
+
+$text['description-csv_header_destination_caller_id_number']['en-us'] = "destination_caller_id_number (Set the caller ID number. default = blank),";
+$text['description-csv_header_destination_caller_id_number']['es-cl'] = "destination_caller_id_number (Set the caller ID number. default = blank),";
+$text['description-csv_header_destination_caller_id_number']['pt-pt'] = "destination_caller_id_number (Set the caller ID number. default = blank),";
+$text['description-csv_header_destination_caller_id_number']['fr-fr'] = "destination_caller_id_number (Set the caller ID number. default = blank),";
+$text['description-csv_header_destination_caller_id_number']['pt-br'] = "destination_caller_id_number (Set the caller ID number. default = blank),";
+$text['description-csv_header_destination_caller_id_number']['pl'] = "destination_caller_id_number (Set the caller ID number. default = blank),";
+$text['description-csv_header_destination_caller_id_number']['uk'] = "destination_caller_id_number (Set the caller ID number. default = blank),";
+$text['description-csv_header_destination_caller_id_number']['sv-se'] = "destination_caller_id_number (Set the caller ID number. default = blank),";
+$text['description-csv_header_destination_caller_id_number']['de-at'] = "destination_caller_id_number (Set the caller ID number. default = blank),";
+$text['description-csv_header_destination_caller_id_number']['he'] = "destination_caller_id_number (Set the caller ID number. default = blank),";
+
+$text['description-csv_header_destination_cid_name_prefix']['en-us'] = "destination_cid_name_prefix (Set a prefix on the caller ID name. default = blank),";
+$text['description-csv_header_destination_cid_name_prefix']['es-cl'] = "destination_cid_name_prefix (Set a prefix on the caller ID name. default = blank),";
+$text['description-csv_header_destination_cid_name_prefix']['pt-pt'] = "destination_cid_name_prefix (Set a prefix on the caller ID name. default = blank),";
+$text['description-csv_header_destination_cid_name_prefix']['fr-fr'] = "destination_cid_name_prefix (Set a prefix on the caller ID name. default = blank),";
+$text['description-csv_header_destination_cid_name_prefix']['pt-br'] = "destination_cid_name_prefix (Set a prefix on the caller ID name. default = blank),";
+$text['description-csv_header_destination_cid_name_prefix']['pl'] = "destination_cid_name_prefix (Set a prefix on the caller ID name. default = blank),";
+$text['description-csv_header_destination_cid_name_prefix']['uk'] = "destination_cid_name_prefix (Set a prefix on the caller ID name. default = blank),";
+$text['description-csv_header_destination_cid_name_prefix']['sv-se'] = "destination_cid_name_prefix (Set a prefix on the caller ID name. default = blank),";
+$text['description-csv_header_destination_cid_name_prefix']['de-at'] = "destination_cid_name_prefix (Set a prefix on the caller ID name. default = blank),";
+$text['description-csv_header_destination_cid_name_prefix']['he'] = "destination_cid_name_prefix (Set a prefix on the caller ID name. default = blank),";
+
+$text['description-csv_header_destination_context']['en-us'] = "destination_context (Context: default = public),";
+$text['description-csv_header_destination_context']['es-cl'] = "destination_context (Context: default = public),";
+$text['description-csv_header_destination_context']['pt-pt'] = "destination_context (Context: default = public),";
+$text['description-csv_header_destination_context']['fr-fr'] = "destination_context (Context: default = public),";
+$text['description-csv_header_destination_context']['pt-br'] = "destination_context (Context: default = public),";
+$text['description-csv_header_destination_context']['pl'] = "destination_context (Context: default = public),";
+$text['description-csv_header_destination_context']['uk'] = "destination_context (Context: default = public),";
+$text['description-csv_header_destination_context']['sv-se'] = "destination_context (Context: default = public),";
+$text['description-csv_header_destination_context']['de-at'] = "destination_context (Context: default = public),";
+$text['description-csv_header_destination_context']['he'] = "destination_context (Context: default = public),";
+
+$text['description-csv_header_destination_app']['en-us'] = "destination_app (Destination app: default = blank),";
+$text['description-csv_header_destination_app']['es-cl'] = "destination_app (Destination app: default = blank),";
+$text['description-csv_header_destination_app']['pt-pt'] = "destination_app (Destination app: default = blank),";
+$text['description-csv_header_destination_app']['fr-fr'] = "destination_app (Destination app: default = blank),";
+$text['description-csv_header_destination_app']['pt-br'] = "destination_app (Destination app: default = blank),";
+$text['description-csv_header_destination_app']['pl'] = "destination_app (Destination app: default = blank),";
+$text['description-csv_header_destination_app']['uk'] = "destination_app (Destination app: default = blank),";
+$text['description-csv_header_destination_app']['sv-se'] = "destination_app (Destination app: default = blank),";
+$text['description-csv_header_destination_app']['de-at'] = "destination_app (Destination app: default = blank),";
+$text['description-csv_header_destination_app']['he'] = "destination_app (Destination app: default = blank),";
+
+$text['description-csv_header_destination_data']['en-us'] = "destination_data (Destination data: default = blank),";
+$text['description-csv_header_destination_data']['es-cl'] = "destination_data (Destination data: default = blank),";
+$text['description-csv_header_destination_data']['pt-pt'] = "destination_data (Destination data: default = blank),";
+$text['description-csv_header_destination_data']['fr-fr'] = "destination_data (Destination data: default = blank),";
+$text['description-csv_header_destination_data']['pt-br'] = "destination_data (Destination data: default = blank),";
+$text['description-csv_header_destination_data']['pl'] = "destination_data (Destination data: default = blank),";
+$text['description-csv_header_destination_data']['uk'] = "destination_data (Destination data: default = blank),";
+$text['description-csv_header_destination_data']['sv-se'] = "destination_data (Destination data: default = blank),";
+$text['description-csv_header_destination_data']['de-at'] = "destination_data (Destination data: default = blank),";
+$text['description-csv_header_destination_data']['he'] = "destination_data (Destination data: default = blank),";
+
+$text['description-csv_header_destination_enabled']['en-us'] = "destination_enabled (true/false),";
+$text['description-csv_header_destination_enabled']['es-cl'] = "destination_enabled (true/false),";
+$text['description-csv_header_destination_enabled']['pt-pt'] = "destination_enabled (true/false),";
+$text['description-csv_header_destination_enabled']['fr-fr'] = "destination_enabled (true/false),";
+$text['description-csv_header_destination_enabled']['pt-br'] = "destination_enabled (true/false),";
+$text['description-csv_header_destination_enabled']['pl'] = "destination_enabled (true/false),";
+$text['description-csv_header_destination_enabled']['uk'] = "destination_enabled (true/false),";
+$text['description-csv_header_destination_enabled']['sv-se'] = "destination_enabled (true/false),";
+$text['description-csv_header_destination_enabled']['de-at'] = "destination_enabled (true/false),";
+$text['description-csv_header_destination_enabled']['he'] = "destination_enabled (true/false),";
+
+$text['description-csv_header_destination_description']['en-us'] = "destination_description (Description),";
+$text['description-csv_header_destination_description']['es-cl'] = "destination_description (Description),";
+$text['description-csv_header_destination_description']['pt-pt'] = "destination_description (Description),";
+$text['description-csv_header_destination_description']['fr-fr'] = "destination_description (Description),";
+$text['description-csv_header_destination_description']['pt-br'] = "destination_description (Description),";
+$text['description-csv_header_destination_description']['pl'] = "destination_description (Description),";
+$text['description-csv_header_destination_description']['uk'] = "destination_description (Description),";
+$text['description-csv_header_destination_description']['sv-se'] = "destination_description (Description),";
+$text['description-csv_header_destination_description']['de-at'] = "destination_description (Description),";
+$text['description-csv_header_destination_description']['he'] = "destination_description (Description),";
+
+$text['description-csv_header_destination_accountcode']['en-us'] = "destination_accountcode (Acountcode),";
+$text['description-csv_header_destination_accountcode']['es-cl'] = "destination_accountcode (Acountcode),";
+$text['description-csv_header_destination_accountcode']['pt-pt'] = "destination_accountcode (Acountcode),";
+$text['description-csv_header_destination_accountcode']['fr-fr'] = "destination_accountcode (Acountcode),";
+$text['description-csv_header_destination_accountcode']['pt-br'] = "destination_accountcode (Acountcode),";
+$text['description-csv_header_destination_accountcode']['pl'] = "destination_accountcode (Acountcode),";
+$text['description-csv_header_destination_accountcode']['uk'] = "destination_accountcode (Acountcode),";
+$text['description-csv_header_destination_accountcode']['sv-se'] = "destination_accountcode (Acountcode),";
+$text['description-csv_header_destination_accountcode']['de-at'] = "destination_accountcode (Acountcode),";
+$text['description-csv_header_destination_accountcode']['he'] = "destination_accountcode (Acountcode),";
+
+$text['description-csv_header_destination_action']['en-us'] = "destination_action (Transfer Action: example: '1000' will transfer to extension 1000)";
+$text['description-csv_header_destination_action']['es-cl'] = "destination_action (Transfer Action: example: '1000' will transfer to extension 1000)";
+$text['description-csv_header_destination_action']['pt-pt'] = "destination_action (Transfer Action: example: '1000' will transfer to extension 1000)";
+$text['description-csv_header_destination_action']['fr-fr'] = "destination_action (Transfer Action: example: '1000' will transfer to extension 1000)";
+$text['description-csv_header_destination_action']['pt-br'] = "destination_action (Transfer Action: example: '1000' will transfer to extension 1000)";
+$text['description-csv_header_destination_action']['pl'] = "destination_action (Transfer Action: example: '1000' will transfer to extension 1000)";
+$text['description-csv_header_destination_action']['uk'] = "destination_action (Transfer Action: example: '1000' will transfer to extension 1000)";
+$text['description-csv_header_destination_action']['sv-se'] = "destination_action (Transfer Action: example: '1000' will transfer to extension 1000)";
+$text['description-csv_header_destination_action']['de-at'] = "destination_action (Transfer Action: example: '1000' will transfer to extension 1000)";
+$text['description-csv_header_destination_action']['he'] = "destination_action (Transfer Action: example: '1000' will transfer to extension 1000)";
+
+$text['header-destinations_import']['en-us'] = "Import Destinations";
+$text['header-destinations_import']['es-cl'] = "Import Destinations";
+$text['header-destinations_import']['pt-pt'] = "Import Destinations";
+$text['header-destinations_import']['fr-fr'] = "Import Destinations";
+$text['header-destinations_import']['pt-br'] = "Import Destinations";
+$text['header-destinations_import']['pl'] = "Import Destinations";
+$text['header-destinations_import']['uk'] = "Import Destinations";
+$text['header-destinations_import']['sv-se'] = "Import Destinations";
+$text['header-destinations_import']['de-at'] = "Import Destinations";
+$text['header-destinations_import']['he'] = "Import Destinations";
+
+$text['description-destinations_import']['en-us'] = "Import extensions from a CSV file. Use the following headers:";
+$text['description-destinations_import']['es-cl'] = "Import extensions from a CSV file. Use the following headers:";
+$text['description-destinations_import']['pt-pt'] = "Import extensions from a CSV file. Use the following headers:";
+$text['description-destinations_import']['fr-fr'] = "Import extensions from a CSV file. Use the following headers:";
+$text['description-destinations_import']['pt-br'] = "Import extensions from a CSV file. Use the following headers:";
+$text['description-destinations_import']['pl'] = "Import extensions from a CSV file. Use the following headers:";
+$text['description-destinations_import']['uk'] = "Import extensions from a CSV file. Use the following headers:";
+$text['description-destinations_import']['sv-se'] = "Import extensions from a CSV file. Use the following headers:";
+$text['description-destinations_import']['de-at'] = "Import extensions from a CSV file. Use the following headers:";
+$text['description-destinations_import']['he'] = "Import extensions from a CSV file. Use the following headers:";
+
+$text['button-submit']['en-us'] = "Submit";
+$text['button-submit']['es-cl'] = "Submit";
+$text['button-submit']['pt-pt'] = "Submit";
+$text['button-submit']['fr-fr'] = "Submit";
+$text['button-submit']['pt-br'] = "Submit";
+$text['button-submit']['pl'] = "Submit";
+$text['button-submit']['uk'] = "Submit";
+$text['button-submit']['sv-se'] = "Submit";
+$text['button-submit']['de-at'] = "Submit";
+$text['button-submit']['he'] = "Submit";
+
+
+$text['header-destination_import_success']['en-us'] = "Import Complete";
+$text['header-destination_import_success']['es-cl'] = "Import Complete";
+$text['header-destination_import_success']['pt-pt'] = "Import Complete";
+$text['header-destination_import_success']['fr-fr'] = "Import Complete";
+$text['header-destination_import_success']['pt-br'] = "Import Complete";
+$text['header-destination_import_success']['pl'] = "Import Complete";
+$text['header-destination_import_success']['uk'] = "Import Complete";
+$text['header-destination_import_success']['sv-se'] = "Import Complete";
+$text['header-destination_import_success']['de-at'] = "Import Complete";
+$text['header-destination_import_success']['he'] = "Import Complete";
+
+$text['message-errors']['en-us'] = "The following errors occured. Please correct the CSV and upload again.";
+$text['message-errors']['es-cl'] = "The following errors occured. Please correct the CSV and upload again.";
+$text['message-errors']['pt-pt'] = "The following errors occured. Please correct the CSV and upload again.";
+$text['message-errors']['fr-fr'] = "The following errors occured. Please correct the CSV and upload again.";
+$text['message-errors']['pt-br'] = "The following errors occured. Please correct the CSV and upload again.";
+$text['message-errors']['pl'] = "The following errors occured. Please correct the CSV and upload again.";
+$text['message-errors']['uk'] = "The following errors occured. Please correct the CSV and upload again.";
+$text['message-errors']['sv-se'] = "The following errors occured. Please correct the CSV and upload again.";
+$text['message-errors']['de-at'] = "The following errors occured. Please correct the CSV and upload again.";
+$text['message-errors']['he'] = "The following errors occured. Please correct the CSV and upload again.";
+
+$text['message-input']['en-us'] = "The following was received from the CSV. Please review and click Submit to continue.";
+$text['message-input']['es-cl'] = "The following was received from the CSV. Please review and click Submit to continue.";
+$text['message-input']['pt-pt'] = "The following was received from the CSV. Please review and click Submit to continue.";
+$text['message-input']['fr-fr'] = "The following was received from the CSV. Please review and click Submit to continue.";
+$text['message-input']['pt-br'] = "The following was received from the CSV. Please review and click Submit to continue.";
+$text['message-input']['pl'] = "The following was received from the CSV. Please review and click Submit to continue.";
+$text['message-input']['uk'] = "The following was received from the CSV. Please review and click Submit to continue.";
+$text['message-input']['sv-se'] = "The following was received from the CSV. Please review and click Submit to continue.";
+$text['message-input']['de-at'] = "The following was received from the CSV. Please review and click Submit to continue.";
+$text['message-input']['he'] = "The following was received from the CSV. Please review and click Submit to continue.";
+
+$text['message-input_sucess']['en-us'] = "The following was successfully imported into the system.";
+$text['message-input_sucess']['es-cl'] = "The following was successfully imported into the system.";
+$text['message-input_sucess']['pt-pt'] = "The following was successfully imported into the system.";
+$text['message-input_sucess']['fr-fr'] = "The following was successfully imported into the system.";
+$text['message-input_sucess']['pt-br'] = "The following was successfully imported into the system.";
+$text['message-input_sucess']['pl'] = "The following was successfully imported into the system.";
+$text['message-input_sucess']['uk'] = "The following was successfully imported into the system.";
+$text['message-input_sucess']['sv-se'] = "The following was successfully imported into the system.";
+$text['message-input_sucess']['de-at'] = "The following was successfully imported into the system.";
+$text['message-input_sucess']['he'] = "The following was successfully imported into the system.";
 
 $text['title-destinations']['en-us'] = "Destinations";
 $text['title-destinations']['es-cl'] = "Destinos";
@@ -601,5 +819,17 @@ $text['billing-warning']['de-at'] = "Wenn Sie die Fusionpbx Abrechnung verwenden
 $text['billing-warning']['fa'] = "";
 $text['billing-warning']['ar-eg'] = "";
 $text['billing-warning']['he'] = "";
+
+$text['button-import']['en-us'] = "Import";
+$text['button-import']['en-us'] = "Import";
+$text['button-import']['es-cl'] = "Importar";
+$text['button-import']['pt-pt'] = "Importat";
+$text['button-import']['fr-fr'] = "Importer";
+$text['button-import']['pt-br'] = "Importar";
+$text['button-import']['pl'] = "Importuj";
+$text['button-import']['uk'] = "";
+$text['button-import']['sv-se'] = "Importera";
+$text['button-import']['de-at'] = "Importieren";
+$text['button-import']['he'] = "";
 
 ?>

--- a/app/destinations/destination_import.php
+++ b/app/destinations/destination_import.php
@@ -1,0 +1,302 @@
+<?php
+/*
+ FusionPBX
+ Version: MPL 1.1
+
+ The contents of this file are subject to the Mozilla Public License Version
+ 1.1 (the "License"); you may not use this file except in compliance with
+ the License. You may obtain a copy of the License at
+ http://www.mozilla.org/MPL/
+
+ Software distributed under the License is distributed on an "AS IS" basis,
+ WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License
+ for the specific language governing rights and limitations under the
+ License.
+
+ The Original Code is FusionPBX
+
+ The Initial Developer of the Original Code is
+ Mark J Crane <markjcrane@fusionpbx.com>
+ Portions created by the Initial Developer are Copyright (C) 2008-2012
+ the Initial Developer. All Rights Reserved.
+
+ Contributor(s):
+	KonradSC <konrd@yahoo.com>
+ */
+
+//includes
+	require_once "root.php";
+	require_once "resources/require.php";
+
+//include the class
+//	require_once "app/wizard/resources/classes/wizard.php";
+
+//check permissions
+	require_once "resources/check_auth.php";
+	if (permission_exists('destination_import')) {
+		//access granted
+	}
+	else {
+		echo "access denied";
+		exit;
+	}
+
+//add multi-lingual support
+	$language = new text;
+	$text = $language->get();
+
+//built in str_getcsv requires PHP 5.3 or higher, this function can be used to reproduct the functionality but requirs PHP 5.1.0 or higher
+	if(!function_exists('str_getcsv')) {
+		function str_getcsv($input, $delimiter = ",", $enclosure = '"', $escape = "\\") {
+			$fp = fopen("php://memory", 'r+');
+			fputs($fp, $input);
+			rewind($fp);
+			$data = fgetcsv($fp, null, $delimiter, $enclosure); // $escape only got added in 5.3.0
+			fclose($fp);
+			return $data;
+		}
+	}
+
+//set the max php execution time
+	ini_set(max_execution_time,7200);
+
+//get the http get values and set them as php variables
+	$order_by = check_str($_GET["order_by"]);
+	$order = check_str($_GET["order"]);
+	$delimiter = check_str($_GET["data_delimiter"]);
+	$enclosure = check_str($_GET["data_enclosure"]);
+
+//upload the user csv
+	if (($_POST['submit'] == "Upload") && is_uploaded_file($_FILES['ulfile']['tmp_name'])) {
+		$start_page = 1;
+
+		//copy the csv file
+			if (check_str($_POST['type']) == 'csv') {
+				$file_name = $_FILES['ulfile']['name'];
+				move_uploaded_file($_FILES['ulfile']['tmp_name'], $_SESSION['server']['temp']['dir'].'/'.$_FILES['ulfile']['name']);
+				$save_msg = "Uploaded file to ".$_SESSION['server']['temp']['dir']."/". htmlentities($_FILES['ulfile']['name']);
+				//system('chmod -R 744 '.$_SESSION['server']['temp']['dir'].'*');
+				unset($_POST['txtCommand']);
+			}
+		//get the contents of the csv file	
+			$handle = @fopen($_SESSION['server']['temp']['dir']."/". $_FILES['ulfile']['name'], "r");
+			if ($handle) {
+				//read the csv file into an array
+				$csv = array();
+				$header = null;
+				$x = 0;
+				while(($row = fgetcsv($handle)) !== false){
+				    if($header === null){
+				        $header = $row;
+				        continue;
+				    }
+				
+				    $newRow = array();
+				    for($i = 0; $i<count($row); $i++){
+				        $newRow[line] = $x + 1;
+				        $newRow[$header[$i]] = $row[$i];
+				    }
+				
+				    $csv[] = $newRow;
+				    $x++;
+				}
+			}
+				
+			if (!feof($handle)) {
+				echo "Error: Unable to open the file.\n";
+			}
+			fclose($handle);
+				
+			//loop through the array and check for errors	
+			$error_flag = 0;
+			$error_table = array();
+			foreach ($csv as $key => $csv_row) {
+				$destination_type = $csv_row['destination_type'];
+				$destination_number = $csv_row['destination_number'];
+				$destination_caller_id_name = $csv_row['destination_caller_id_name'];
+				$destination_caller_id_number = $csv_row['destination_caller_id_number'];
+				$destination_cid_name_prefix = $csv_row['destination_cid_name_prefix'];
+				$destination_context = $csv_row['destination_context'];
+				$destination_app = $csv_row['destination_app'];
+				$destination_data = $csv_row['destination_data'];
+				$destination_enablede = $csv_row['destination_enabled'];
+				$destination_description = $csv_row['destination_description'];
+				$destination_accountcode = $csv_row['destination_accountcode'];
+				$destination_action = $csv_row['destination_action'];
+				$line_number = $csv_row['line'];
+
+				
+				
+				//check for duplicate destination_number in csv
+				$u = 0;
+				foreach ($csv as $key => $csv_item)
+        			if (isset($csv_item['destination_number']) && $csv_item['destination_number'] == $destination_number) {
+            			$u++;
+        			}
+        		if($u > 1) {
+    				$error_line = "Line " . $line_number . ": " . $destination_number . " is a duplicate destination_number in the csv file";
+					$error_flag++;
+					array_push($error_table, $error_line);	
+        		}
+				
+				//check duplicate destination_number in database
+				$database = new database;
+				$database->table = "v_destinations";
+				$where[0]['name'] = 'domain_uuid';
+				$where[0]['operator'] = '=';
+				$where[0]['value'] = $_SESSION["domain_uuid"];
+				$where[1]['name'] = 'destination_number';
+				$where[1]['operator'] = '=';
+				$where[1]['value'] = "$destination_number";
+				$database->where = $where;
+				$result = $database->count();
+				if ($result > 0) {
+					$error_line = "Line " . $line_number . ": " . $destination_number . " is a duplicate destination_number";
+					$error_flag++;
+					array_push($error_table, $error_line);
+				}
+				unset($database,$result,$where);
+			}
+		
+		if($error_flag > 1) {		
+		//show the header
+			require_once "resources/header.php";
+			echo "<table width='100%' border='0' cellpadding='0' cellspacing='0'>\n";
+			echo "<tr>\n";
+			echo "<td align='left' width='30%' nowrap='nowrap'><b>".$text['header-destinations_import']."</b></td>\n";
+			echo "<td width='70%' align='right'>\n";
+			echo "	<input type='button' class='btn' name='' alt='".$text['button-back']."' onclick=\"window.location='destination_import.php?".$_GET["query_string"]."'\" value='".$text['button-back']."'>\n";
+			echo "</td>\n";
+			echo "</tr>\n";
+			echo "<tr>\n";
+			echo "<td align='left' colspan='2'>\n";
+			echo "	".$text['message-errors']."<br /><br />\n";
+			echo "</td>\n";
+			echo "</tr>\n";
+			echo "</table>\n";
+	
+		//show the error results
+			echo "<table width='100%'  border='0' cellpadding='0' cellspacing='0' width='100%'>\n";
+			echo "<tr>\n";
+			echo "	<th>".$error_flag." ".$text['label-error_import']."</th>\n";
+			echo "</tr>\n";
+			foreach($error_table as $row) {
+				echo "<tr>\n";
+				echo "	<td style='text-align:left' class='vncell' valign='top' align='left'>\n";
+				echo 		$row ."&nbsp;\n";
+				echo "	</td>\n";
+				echo "</tr>\n";
+			}
+			echo "</table>\n";
+			require_once "resources/footer.php";
+		//end the script
+			//break;
+		}		
+		else {
+			//show the header
+				require_once "resources/header.php";
+				echo "<table width='100%' border='0' cellpadding='0' cellspacing='0'>\n";
+				echo "<tr>\n";
+				echo "<td align='left' width='30%' nowrap='nowrap'><b>".$text['header-destinations_import']."</b></td>\n";
+				echo "<td width='70%' align='right'>\n";
+				echo "	<input type='button' class='btn' name='' alt='".$text['button-back']."' onclick=\"window.location='destination_import.php?".$_GET["query_string"]."'\" value='".$text['button-back']."'>\n";
+				echo "	<input type='button' class='btn' name='' alt='".$text['button-submit']."' value='".$text['button-submit']."' onclick=\"window.location='destination_import_add.php?import_file=".$file_name."';\">\n";
+				echo "</td>\n";
+				echo "</tr>\n";
+				echo "<tr>\n";
+				echo "<td align='left' colspan='2'>\n";
+				echo "	".$text['message-input']."<br /><br />\n";
+				echo "</td>\n";
+				echo "</tr>\n";
+				echo "</table>\n";
+	
+			//show the valid input results
+				echo "<table width='100%'  border='0' cellpadding='0' cellspacing='0' width='100%'>\n";
+				echo "<tr>\n";
+				//$first_row = array();
+				$first_row = $csv[0];
+				foreach ($first_row as $key =>$row) {
+					echo "	<th>".$key."</th>\n";
+				}
+				echo "</tr>\n";
+				
+				foreach ($csv as $key => $csv_row) {
+					echo "<tr>\n";
+					
+					foreach ($csv_row as $csv_item){
+						echo "	<td style='text-align:left' class='vncell' valign='top' align='right'>\n";
+						echo 		$csv_item ."&nbsp;\n";
+						echo "	</td>\n";
+					}
+					//echo "	</td>\n";
+					echo "</tr>\n";
+				}
+				echo "</table>\n";
+				//echo "<table width='100%'  border='0' cellpadding='0' cellspacing='0' width='100%'>\n";
+				require_once "resources/footer.php";
+		}
+	}	 
+
+//begin the Start Page content
+	if($start_page == 0) {
+		require_once "resources/header.php";
+		echo "<table width='100%' border='0' cellpadding='0' cellspacing='0'>\n";
+		echo "	<tr>\n";
+		echo "	<td valign='top' align='left' width='30%' nowrap='nowrap'>\n";
+		echo "		<b>".$text['header-destinations_import']."</b><br />\n";
+		echo "		".$text['description-destinations_import']."<br />\n";
+		echo "		<br />\n";
+		//echo "		".$text['description-csv_headers']."<br />\n";
+		echo "		".$text['description-csv_header_destination_type']."<br />\n";
+		echo "		".$text['description-csv_header_destination_number']."<br />\n";
+		echo "		".$text['description-csv_header_destination_caller_id_name']."<br />\n";
+		echo "		".$text['description-csv_header_destination_caller_id_number']."<br />\n";
+		echo "		".$text['description-csv_header_destination_cid_name_prefix']."<br />\n";
+		echo "		".$text['description-csv_header_destination_context']."<br />\n";
+		echo "		".$text['description-csv_header_destination_app']."<br />\n";
+		echo "		".$text['description-csv_header_destination_data']."<br />\n";
+		echo "		".$text['description-csv_header_destination_enabled']."<br />\n";
+		echo "		".$text['description-csv_header_destination_description']."<br />\n";
+		echo "		".$text['description-csv_header_destination_accountcode']."<br />\n";
+		echo "		".$text['description-csv_header_destination_action']."<br />\n";
+		echo "	</td>\n";
+		echo "	<td valign='top' width='70%' align='right'>\n";
+		echo "	<input type='button' class='btn' name='' alt='".$text['button-back']."' onclick=\"javascript:history.back();\" value='".$text['button-back']."'>\n";
+		echo "	</td>\n";
+		echo "	</tr>\n";
+		echo "</table>";
+
+		echo "<br />\n";
+
+		echo "<form action='' method='POST' enctype='multipart/form-data' name='frmUpload' onSubmit=''>\n";
+		echo "	<table border='0' cellpadding='0' cellspacing='0' width='100%'>\n";
+
+		
+
+		echo "<tr>\n";
+		echo "<td class='vncell' valign='top' align='left' width='10%' nowrap='nowrap'>\n";
+		echo "			".$text['label-import_file_upload']."\n";
+		echo "</td>\n";
+		echo "<td class='vtable' align='left'>\n";
+		echo "			<input name='ulfile' type='file' class='formfld fileinput' id='ulfile'>\n";
+		echo "<br />\n";
+		echo "</td>\n";
+		echo "</tr>\n";
+
+		echo "	<tr>\n";
+		echo "		<td valign='bottom'>\n";
+		echo "		</td>\n";
+		echo "		<td valign='bottom' align='right' nowrap>\n";
+		echo "			<input name='type' type='hidden' value='csv'>\n";
+		echo "			<br />\n";
+		echo "			<input name='submit' type='submit' class='btn' id='upload' value=\"".$text['button-upload']."\">\n";
+		echo "		</td>\n";
+		echo "	</tr>\n";
+		echo "	</table>\n";
+		echo "<br><br>";
+		echo "</form>";
+
+	//include the footer
+		require_once "resources/footer.php";
+	}
+?>

--- a/app/destinations/destination_import_add.php
+++ b/app/destinations/destination_import_add.php
@@ -1,0 +1,289 @@
+<?php
+/*
+ FusionPBX
+ Version: MPL 1.1
+
+ The contents of this file are subject to the Mozilla Public License Version
+ 1.1 (the "License"); you may not use this file except in compliance with
+ the License. You may obtain a copy of the License at
+ http://www.mozilla.org/MPL/
+
+ Software distributed under the License is distributed on an "AS IS" basis,
+ WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License
+ for the specific language governing rights and limitations under the
+ License.
+
+ The Original Code is FusionPBX
+
+ The Initial Developer of the Original Code is
+ Mark J Crane <markjcrane@fusionpbx.com>
+ Portions created by the Initial Developer are Copyright (C) 2008-2012
+ the Initial Developer. All Rights Reserved.
+
+ Contributor(s):
+ KonradSC <konrd@yahoo.com>
+ */
+
+//includes
+	require_once "root.php";
+	require_once "resources/require.php";
+
+//include the device class//
+//	require_once "app/wizard/resources/classes/wizard.php";
+
+//check permissions
+	require_once "resources/check_auth.php";
+	if (permission_exists('destination_import') && $_GET['import_file'] != '') {
+		//access granted
+	}
+	else {
+		echo "access denied";
+		exit;
+	}
+
+//add multi-lingual support
+	$language = new text;
+	$text = $language->get();
+
+//built in str_getcsv requires PHP 5.3 or higher, this function can be used to reproduct the functionality but requirs PHP 5.1.0 or higher
+	if(!function_exists('str_getcsv')) {
+		function str_getcsv($input, $delimiter = ",", $enclosure = '"', $escape = "\\") {
+			$fp = fopen("php://memory", 'r+');
+			fputs($fp, $input);
+			rewind($fp);
+			$data = fgetcsv($fp, null, $delimiter, $enclosure); // $escape only got added in 5.3.0
+			fclose($fp);
+			return $data;
+		}
+	}
+
+//set the max php execution time
+	ini_set(max_execution_time,7200);
+
+	$file = check_str($_GET["import_file"]);
+	
+//get the contents of the csv file	
+	$handle = @fopen($_SESSION['server']['temp']['dir']."/". $file, "r");
+	if ($handle) {
+		//read the csv file into an array
+		$csv = array();
+		$header = null;
+		$x = 0;
+		echo "file is open";
+		while(($row = fgetcsv($handle)) !== false){
+		    if($header === null){
+		        $header = $row;
+		        continue;
+		    }
+		
+		    $newRow = array();
+		    for($i = 0; $i<count($row); $i++){
+		        $newRow[$header[$i]] = $row[$i];
+		        //$newRow[Line] = $x + 1;
+		    }
+		
+		    $csv[] = $newRow;
+		    $x++;
+		}
+	}
+					
+	if (!feof($handle)) {
+		echo "Error: Unable to open the file.\n";
+	}
+	fclose($handle);
+
+//add the dialplan permission
+	$p = new permissions;
+	$p->add("dialplan_add", 'temp');
+	$p->add("dialplan_detail_add", 'temp');
+	$p->add("dialplan_edit", 'temp');
+	$p->add("dialplan_detail_edit", 'temp');
+	
+	//cycle through the rows
+	foreach ($csv as $key => $csv_row) {
+		//set the variables
+			$destination_type = $csv_row['destination_type'];
+			$destination_number = $_SESSION["destination"]["destination_prefix"]["text"].$csv_row['destination_number'];
+			$destination_number_regex = string_to_regex($destination_number);
+			$destination_caller_id_name = $csv_row['destination_caller_id_name'];
+			$destination_caller_id_number = $csv_row['destination_caller_id_number'];
+			$destination_cid_name_prefix = $csv_row['destination_cid_name_prefix'];
+			$destination_context = $csv_row['destination_context'];
+			$destination_app = $csv_row['destination_app'];
+			$destination_data = $csv_row['destination_data'];
+			$destination_enabled = strtolower($csv_row['destination_enabled']);
+			$destination_description = $csv_row['destination_description'];
+			$destination_accountcode = $csv_row['destination_accountcode'];
+			$destination_action = $csv_row['destination_action'];
+			$destination_uuid = uuid();
+			$dialplan_uuid = uuid();
+			$domain_name = $_SESSION['domain_name'];
+			$domain_uuid = $_SESSION['domain_uuid'];
+			$line_number = $csv_row['line'];
+	
+
+
+
+		
+		//build the array
+			$i=0;
+			//v_destinations
+				$array["destinations"][$i]["destination_uuid"] = $destination_uuid;
+				$array["destinations"][$i]["domain_uuid"] = $domain_uuid;
+				$array["destinations"][$i]["destination_type"] = $destination_type;
+				$array["destinations"][$i]["destination_number"] = $destination_number;
+				$array["destinations"][$i]["destination_caller_id_name"] = $destination_caller_id_name;
+				$array["destinations"][$i]["destination_cid_name_prefix"] = $destination_cid_name_prefix;
+				$array["destinations"][$i]["destination_caller_id_number"] = $destination_caller_id_number;
+				$array["destinations"][$i]["destination_context"] = $destination_context;
+				$array["destinations"][$i]["destination_app"] = $destination_app;
+				$array["destinations"][$i]["destination_data"] = $destination_data;
+				$array["destinations"][$i]["destination_enabled"] = $destination_enabled;
+				$array["destinations"][$i]["destination_description"] = $destination_description;
+				$array["destinations"][$i]["destination_accountcode"] = $destination_accountcode;
+				$array["destinations"][$i]["dialplan_uuid"] = $dialplan_uuid;
+				$array["destinations"][$y]["destination_number_regex"] = $destination_number_regex;
+				
+				
+
+			//build the dialplan array
+				$array["dialplans"][$y]["app_uuid"] = "c03b422e-13a8-bd1b-e42b-b6b9b4d27ce4";
+				$array["dialplans"][$y]["dialplan_uuid"] = $dialplan_uuid;
+				$array["dialplans"][$y]["domain_uuid"] = $domain_uuid;
+				$array["dialplans"][$y]["dialplan_name"] = format_phone($destination_number);
+				$array["dialplans"][$y]["dialplan_number"] = $destination_number;
+				$array["dialplans"][$y]["dialplan_context"] = $destination_context;
+				$array["dialplans"][$y]["dialplan_continue"] = "false";
+				$array["dialplans"][$y]["dialplan_order"] = "100";
+				$array["dialplans"][$y]["dialplan_enabled"] = $destination_enabled;
+				$array["dialplans"][$y]["dialplan_description"] = $destination_description;
+
+				$dialplan_detail_order = 10;
+	
+			//increment the dialplan detail order
+				$dialplan_detail_order = $dialplan_detail_order + 10;
+	
+			//build the condition	
+				$dialplan_detail_uuid = uuid();
+				$array["dialplan_details"][$y]["dialplan_detail_uuid"] = $dialplan_detail_uuid;
+				$array["dialplan_details"][$y]["domain_uuid"] = $domain_uuid;
+				$array["dialplan_details"][$y]["dialplan_uuid"] = $dialplan_uuid;
+				$array["dialplan_details"][$y]["dialplan_detail_tag"] = "condition";
+				$array["dialplan_details"][$y]["dialplan_detail_type"] = "destination_number";
+				$array["dialplan_details"][$y]["dialplan_detail_data"] = $destination_number_regex;
+				$array["dialplan_details"][$y]["dialplan_detail_order"] = $dialplan_detail_order;
+				$dialplan_detail_order = $dialplan_detail_order + 10;				
+				$y++;
+			
+			//set the caller id name prefix
+				if (strlen($destination_cid_name_prefix) > 0) {
+					$dialplan_detail_uuid = uuid();
+					$array["dialplan_details"][$y]["dialplan_detail_uuid"] = $dialplan_detail_uuid;
+					$array["dialplan_details"][$y]["domain_uuid"] = $domain_uuid;
+					$array["dialplan_details"][$y]["dialplan_uuid"] = $dialplan_uuid;
+					$array["dialplan_details"][$y]["dialplan_detail_tag"] = "action";
+					$array["dialplan_details"][$y]["dialplan_detail_type"] = "set";
+					$array["dialplan_details"][$y]["dialplan_detail_data"] = "effective_caller_id_name=".$destination_cid_name_prefix."#\${caller_id_name}";
+					$array["dialplan_details"][$y]["dialplan_detail_order"] = $dialplan_detail_order;
+					$y++;
+	
+					//increment the dialplan detail order
+					$dialplan_detail_order = $dialplan_detail_order + 10;
+				}
+		
+			//set the call accountcode
+				if (strlen($destination_accountcode) > 0) {
+					$dialplan_detail_uuid = uuid();
+					$array["dialplan_details"][$y]["dialplan_detail_uuid"] = $dialplan_detail_uuid;
+					$array["dialplan_details"][$y]["domain_uuid"] = $domain_uuid;
+					$array["dialplan_details"][$y]["dialplan_uuid"] = $dialplan_uuid;
+					$array["dialplan_details"][$y]["dialplan_detail_tag"] = "action";
+					$array["dialplan_details"][$y]["dialplan_detail_type"] = "set";
+					$array["dialplan_details"][$y]["dialplan_detail_data"] = "accountcode=".$destination_accountcode;
+					$array["dialplan_details"][$y]["dialplan_detail_order"] = $dialplan_detail_order;
+					$y++;
+	
+					//increment the dialplan detail order
+					$dialplan_detail_order = $dialplan_detail_order + 10;
+				}
+			
+			//build the transfer action
+				$dialplan_detail_uuid = uuid();
+				$array["dialplan_details"][$y]["dialplan_detail_uuid"] = $dialplan_detail_uuid;
+				$array["dialplan_details"][$y]["domain_uuid"] = $domain_uuid;
+				$array["dialplan_details"][$y]["dialplan_uuid"] = $dialplan_uuid;
+				$array["dialplan_details"][$y]["dialplan_detail_tag"] = "action";
+				$array["dialplan_details"][$y]["dialplan_detail_type"] = "transfer";
+				$array["dialplan_details"][$y]["dialplan_detail_data"] = $destination_action. " XML " . $domain_name;
+				$array["dialplan_details"][$y]["dialplan_detail_order"] = $dialplan_detail_order;
+			
+
+			//save to the datbase
+				$database = new database;
+				$database->app_name = 'destinations';
+				$database->app_uuid = null;
+				$database->save($array);
+				$message = $database->message;
+				//echo "<pre>".print_r($message, true)."<pre>\n";
+				//exit;
+			unset($database,$array,$i);
+	
+		//end of loop for one line of csv
+	}
+
+//remove the temporary permission
+	$p->delete("dialplan_add", 'temp');
+	$p->delete("dialplan_detail_add", 'temp');
+	$p->delete("dialplan_edit", 'temp');
+	$p->delete("dialplan_detail_edit", 'temp');
+
+//synchronize the xml config
+	save_dialplan_xml();
+
+//clear the cache
+	$cache = new cache;
+	$cache->delete("dialplan:".$destination_context);
+
+
+//show the header
+	require_once "resources/header.php";
+	echo "<table width='100%' border='0' cellpadding='0' cellspacing='0'>\n";
+	echo "<tr>\n";
+	echo "<td align='left' width='30%' nowrap='nowrap'><b>".$text['header-destination_import_success']."</b></td>\n";
+	echo "<td width='70%' align='right'>\n";
+	echo "	<input type='button' class='btn' name='' alt='".$text['button-back']."' onclick=\"window.location='destination_import.php?".$_GET["query_string"]."'\" value='".$text['button-back']."'>\n";
+	echo "</td>\n";
+	echo "</tr>\n";
+	echo "<tr>\n";
+	echo "<td align='left' colspan='2'>\n";
+	echo "	".$text['message-input_sucess']."<br /><br />\n";
+	echo "</td>\n";
+	echo "</tr>\n";
+	echo "</table>\n";
+
+//show the valid input results
+	echo "<table width='100%'  border='0' cellpadding='0' cellspacing='0' width='100%'>\n";
+	echo "<tr>\n";
+	//$first_row = array();
+	$first_row = $csv[0];
+	foreach ($first_row as $key =>$row) {
+		echo "	<th>".$key."</th>\n";
+	}
+	echo "</tr>\n";
+	
+	foreach ($csv as $key => $csv_row) {
+		echo "<tr>\n";
+		
+		foreach ($csv_row as $csv_item){
+			echo "	<td style='text-align:left' class='vncell' valign='top' align='right'>\n";
+			echo 		$csv_item ."&nbsp;\n";
+			echo "	</td>\n";
+		}
+		//echo "	</td>\n";
+		echo "</tr>\n";
+	}
+	echo "</table>\n";
+	unset($csv);
+	require_once "resources/footer.php";
+
+?>

--- a/app/destinations/destination_import_add.php
+++ b/app/destinations/destination_import_add.php
@@ -17,7 +17,7 @@
 
  The Initial Developer of the Original Code is
  Mark J Crane <markjcrane@fusionpbx.com>
- Portions created by the Initial Developer are Copyright (C) 2008-2012
+ Portions created by the Initial Developer are Copyright (C) 2008-2016
  the Initial Developer. All Rights Reserved.
 
  Contributor(s):
@@ -60,8 +60,9 @@
 //set the max php execution time
 	ini_set(max_execution_time,7200);
 
+//get the file
 	$file = check_str($_GET["import_file"]);
-	
+
 //get the contents of the csv file	
 	$handle = @fopen($_SESSION['server']['temp']['dir']."/". $file, "r");
 	if ($handle) {
@@ -75,18 +76,18 @@
 		        $header = $row;
 		        continue;
 		    }
-		
+
 		    $newRow = array();
 		    for($i = 0; $i<count($row); $i++){
 		        $newRow[$header[$i]] = $row[$i];
 		        //$newRow[Line] = $x + 1;
 		    }
-		
+
 		    $csv[] = $newRow;
 		    $x++;
 		}
 	}
-					
+
 	if (!feof($handle)) {
 		echo "Error: Unable to open the file.\n";
 	}
@@ -98,7 +99,7 @@
 	$p->add("dialplan_detail_add", 'temp');
 	$p->add("dialplan_edit", 'temp');
 	$p->add("dialplan_detail_edit", 'temp');
-	
+
 	//cycle through the rows
 	foreach ($csv as $key => $csv_row) {
 		//set the variables
@@ -120,14 +121,12 @@
 			$domain_name = $_SESSION['domain_name'];
 			$domain_uuid = $_SESSION['domain_uuid'];
 			$line_number = $csv_row['line'];
-	
 
-
-
-		
 		//build the array
-			$i=0;
-			//v_destinations
+			//set the array id
+				$i = 0;
+
+			//build the destinations array
 				$array["destinations"][$i]["destination_uuid"] = $destination_uuid;
 				$array["destinations"][$i]["domain_uuid"] = $domain_uuid;
 				$array["destinations"][$i]["destination_type"] = $destination_type;
@@ -143,8 +142,6 @@
 				$array["destinations"][$i]["destination_accountcode"] = $destination_accountcode;
 				$array["destinations"][$i]["dialplan_uuid"] = $dialplan_uuid;
 				$array["destinations"][$y]["destination_number_regex"] = $destination_number_regex;
-				
-				
 
 			//build the dialplan array
 				$array["dialplans"][$y]["app_uuid"] = "c03b422e-13a8-bd1b-e42b-b6b9b4d27ce4";
@@ -158,11 +155,9 @@
 				$array["dialplans"][$y]["dialplan_enabled"] = $destination_enabled;
 				$array["dialplans"][$y]["dialplan_description"] = $destination_description;
 
-				$dialplan_detail_order = 10;
-	
 			//increment the dialplan detail order
-				$dialplan_detail_order = $dialplan_detail_order + 10;
-	
+				$dialplan_detail_order = $dialplan_detail_order = 10;
+
 			//build the condition	
 				$dialplan_detail_uuid = uuid();
 				$array["dialplan_details"][$y]["dialplan_detail_uuid"] = $dialplan_detail_uuid;
@@ -171,10 +166,12 @@
 				$array["dialplan_details"][$y]["dialplan_detail_tag"] = "condition";
 				$array["dialplan_details"][$y]["dialplan_detail_type"] = "destination_number";
 				$array["dialplan_details"][$y]["dialplan_detail_data"] = $destination_number_regex;
-				$array["dialplan_details"][$y]["dialplan_detail_order"] = $dialplan_detail_order;
-				$dialplan_detail_order = $dialplan_detail_order + 10;				
+				$array["dialplan_details"][$y]["dialplan_detail_order"] = $dialplan_detail_order;				
 				$y++;
-			
+
+			//increment the dialplan detail order
+				$dialplan_detail_order = $dialplan_detail_order = 10;
+
 			//set the caller id name prefix
 				if (strlen($destination_cid_name_prefix) > 0) {
 					$dialplan_detail_uuid = uuid();
@@ -186,11 +183,11 @@
 					$array["dialplan_details"][$y]["dialplan_detail_data"] = "effective_caller_id_name=".$destination_cid_name_prefix."#\${caller_id_name}";
 					$array["dialplan_details"][$y]["dialplan_detail_order"] = $dialplan_detail_order;
 					$y++;
-	
+
 					//increment the dialplan detail order
-					$dialplan_detail_order = $dialplan_detail_order + 10;
+					$dialplan_detail_order = $dialplan_detail_order = 10;
 				}
-		
+
 			//set the call accountcode
 				if (strlen($destination_accountcode) > 0) {
 					$dialplan_detail_uuid = uuid();
@@ -202,11 +199,11 @@
 					$array["dialplan_details"][$y]["dialplan_detail_data"] = "accountcode=".$destination_accountcode;
 					$array["dialplan_details"][$y]["dialplan_detail_order"] = $dialplan_detail_order;
 					$y++;
-	
+
 					//increment the dialplan detail order
 					$dialplan_detail_order = $dialplan_detail_order + 10;
 				}
-			
+
 			//build the transfer action
 				$dialplan_detail_uuid = uuid();
 				$array["dialplan_details"][$y]["dialplan_detail_uuid"] = $dialplan_detail_uuid;
@@ -216,7 +213,6 @@
 				$array["dialplan_details"][$y]["dialplan_detail_type"] = "transfer";
 				$array["dialplan_details"][$y]["dialplan_detail_data"] = $destination_action. " XML " . $domain_name;
 				$array["dialplan_details"][$y]["dialplan_detail_order"] = $dialplan_detail_order;
-			
 
 			//save to the datbase
 				$database = new database;
@@ -225,11 +221,9 @@
 				$database->save($array);
 				$message = $database->message;
 				//echo "<pre>".print_r($message, true)."<pre>\n";
-				//exit;
-			unset($database,$array,$i);
-	
-		//end of loop for one line of csv
-	}
+				unset($database,$array,$i);
+
+	} //end of loop for one line of csv
 
 //remove the temporary permission
 	$p->delete("dialplan_add", 'temp');
@@ -243,7 +237,6 @@
 //clear the cache
 	$cache = new cache;
 	$cache->delete("dialplan:".$destination_context);
-
 
 //show the header
 	require_once "resources/header.php";
@@ -270,10 +263,9 @@
 		echo "	<th>".$key."</th>\n";
 	}
 	echo "</tr>\n";
-	
+
 	foreach ($csv as $key => $csv_row) {
 		echo "<tr>\n";
-		
 		foreach ($csv_row as $csv_item){
 			echo "	<td style='text-align:left' class='vncell' valign='top' align='right'>\n";
 			echo 		$csv_item ."&nbsp;\n";

--- a/app/destinations/destinations.php
+++ b/app/destinations/destinations.php
@@ -134,6 +134,9 @@ else {
 	echo "		<td width='50%' align='left' nowrap='nowrap' valign='top'><b>".$text['header-destinations']." (".$num_rows.")</b></td>\n";
 	echo "			<form method='get' action=''>\n";
 	echo "			<td width='50%' align='right'>\n";
+	if (permission_exists('destination_import')){
+		echo "			<input type='button' class='btn' alt='".$text['button-import']."' onclick=\"window.location='destination_import.php'\" value='".$text['button-import']."'>\n";
+	}
 	if (permission_exists('destination_all')) {
 		if ($_GET['showall'] == 'true') {
 			echo "		<input type='hidden' name='showall' value='true'>";


### PR DESCRIPTION
Adds the ability for superusers to import destinations using CSV files. CSV headers match the database fields. The destination_action header will be used for a transfer step in the dialplan. So if the user specifies 1000 in the destination_action then "1000 XML xyz.domain.com" will be specified in the Transfer step. 

The new database function is used so transactions show up in transaction log correctly. 

One other thing is the ability to add prefixes to the destination number on the CSV. MS Excel doesn't play with plus symbols and CSV's very well. So a user can specify a $_SESSION["destination"]["destination_prefix"]["text"] and this value will be prefixed to the import destination_number. So 18005551212 would become +18005551212. I also considered adding this as a form field on the web page when specifying the csv file. 