### PR TITLE
[master] fix bug #2017 ring groups broken until re-save

### DIFF
--- a/app/ring_groups/ring_group_edit.php
+++ b/app/ring_groups/ring_group_edit.php
@@ -159,7 +159,8 @@
 
 		//get the ring group uuid
 			if (!isset($ring_group_uuid)) {
-				$ring_group_uuid = is_uuid($_REQUEST["ring_group_uuid"]);
+				$ring_group_uuid = uuid();
+				$_POST["ring_group_uuid"] = $ring_group_uuid;
 			}
 
 		//check for all required data
@@ -292,12 +293,6 @@
 					$dialplan["dialplan_enabled"] = "true";
 					$dialplan["dialplan_description"] = $ring_group_description;
 					$dialplan["app_uuid"] = "1d61fb65-1eec-bc73-a6ee-a6203b4fe6f2";
-
-				//add the ring_group_uuid
-					if (strlen($_POST["ring_group_uuid"]) == 0) {
-						$ring_group_uuid = uuid();
-						$_POST["ring_group_uuid"] = $ring_group_uuid;
-					}
 
 				//prepare the array
 					$array['ring_groups'][] = $_POST;


### PR DESCRIPTION
test case:
Create a new ring group with one extension.
Immediately dial the ring group number.

expected result:
Phone rings.  No errors in log.

actual result:
Call terminates and log has "0" as ring_group_uuid and a sql error.
Note: editing and re-saving the ring group works around the problem

The Problem:
Line 162: non-existent variable...being checked is returned as false  = 0

Line 278: Xml gets generated with bogus zero...

Line 298: Generate a new uuid...but too late.  We already generated the xml dial plan which will be invalid until we edit and resave this ring group.

fix:
Generate uuid before generating xml