### PR TITLE
[4.2] fix orphan v_ring_group_users after deleting ring group

### DIFF
--- a/app/ring_groups/ring_group_delete.php
+++ b/app/ring_groups/ring_group_delete.php
@@ -72,6 +72,13 @@ else {
 			$sql .= "and ring_group_uuid = '".$id."' ";
 			$db->exec(check_sql($sql));
 			unset($sql);
+			
+		//delete the ring group users
+			$sql = "delete from v_ring_group_users ";
+			$sql .= "where domain_uuid = '".$_SESSION['domain_uuid']."' ";
+			$sql .= "and ring_group_uuid = '".$id."' ";
+			$db->exec(check_sql($sql));
+			unset($sql);			
 
 		//delete the dialplan details
 			$sql = "delete from v_dialplan_details ";


### PR DESCRIPTION
Same as pr #2110 except for 4.2 branch

steps to test:
create a ring group with one extension and one user. This will add one user to v_ring_group_users table. Delete the ring group.

expected result:
ring group and all it's components are deleted

actual result
v_ring_group_user entry for this ring group is not deleted.

This fix: deletes v_ring_group_user when ring group is deleted.