### PR TITLE
additional error handling for backup/restore

### DIFF
--- a/app/backup/app_languages.php
+++ b/app/backup/app_languages.php
@@ -50,6 +50,16 @@ $text['message-restore_failed_format']['sv-se'] = "Återställning Misslyckades 
 $text['message-restore_failed_format']['uk'] = "Помилка відновлення: хибний формат файлу";
 $text['message-restore_failed_format']['de-at'] = "Wiederherstellung fehlgeschlagen - Ungültiges Dateiformat";
 
+$text['message-restore_failed_extract']['en-us'] = "Restore Failed - Extraction Error";
+$text['message-restore_failed_extract']['es-cl'] = "Restaurar Error - Error de extracción";
+$text['message-restore_failed_extract']['pt-pt'] = "Falha na restauração - Falha na extração";
+$text['message-restore_failed_extract']['fr-fr'] = "Échec de la restauration - Échec de l'extraction";
+$text['message-restore_failed_extract']['pt-br'] = "Falha na restauração - Falha na extração";
+$text['message-restore_failed_extract']['pl'] = "Przywracanie  nie powiodło się - Ekstrakcja zawiodły";
+$text['message-restore_failed_extract']['sv-se'] = "Återställning Misslyckades - extraktion misslyckades";
+$text['message-restore_failed_extract']['uk'] = "Помилка відновлення: Помилка при вилученні";
+$text['message-restore_failed_extract']['de-at'] = "Wiederherstellung fehlgeschlagen - Die Extraktion ist fehlgeschlagen";
+
 $text['message-restore_completed']['en-us'] = "Restore Completed";
 $text['message-restore_completed']['es-cl'] = "Restaurar Completado";
 $text['message-restore_completed']['pt-pt'] = "Concluída a Restauração";

--- a/app/backup/index.php
+++ b/app/backup/index.php
@@ -58,7 +58,9 @@ else {
 				if (isset($_SESSION['backup']['path'])) foreach ($_SESSION['backup']['path'] as $value) {
 					$cmd .= $value.' ';
 				}
-				exec($cmd);
+				$cmd .= " 2>&1";
+				exec($cmd, $response, $restore_errlevel);
+				$response_txt = "<br>" . implode("<br>", $response);
 
 			//download the file
 				session_cache_limiter('public');
@@ -79,7 +81,8 @@ else {
 				}
 				else {
 					//set response message
-					$_SESSION["message"] = $text['message-backup_failed_format'];
+					$_SESSION["message"] = $text['message-backup_failed_format'] . $response_txt;
+					$_SESSION['message_mood'] = 'negative';
 					header("Location: ".$_SERVER['PHP_SELF']);
 					exit;
 				}
@@ -87,6 +90,7 @@ else {
 			else {
 				//set response message
 				$_SESSION["message"] = $text['message-backup_failed_paths'];
+				$_SESSION['message_mood'] = 'negative';
 				header("Location: ".$_SERVER['PHP_SELF']);
 				exit;
 			}
@@ -123,20 +127,31 @@ else {
 			if (!$valid_format) {
 				@unlink($backup_path.'/'.$backup_file);
 				$_SESSION["message"] = $text['message-restore_failed_format'];
+				$_SESSION['message_mood'] = 'negative';
 				header("Location: ".$_SERVER['PHP_SELF']);
 				exit;
 			}
 			else {
-				exec($cmd);
-				//set response message
-				$_SESSION["message"] = $text['message-restore_completed'];
-				header("Location: ".$_SERVER['PHP_SELF']);
-				exit;
+				$cmd .= ' 2>&1';
+				exec($cmd, $response, $restore_errlevel);
+				$response_txt = "<br>" . implode("<br>", $response);
+				if ($restore_errlevel == 0) {
+					//set response message
+					$_SESSION["message"] = $text['message-restore_completed'];
+					header("Location: ".$_SERVER['PHP_SELF']);
+					exit;
+				} else {
+					$_SESSION["message"] = $text['message-restore_failed_extract'] . $response_txt;
+					$_SESSION['message_mood'] = 'negative';
+					header("Location: ".$_SERVER['PHP_SELF']);
+					exit;
+				}
 			}
 		}
 		else {
 			//set response message
 			$_SESSION["message"] = $text['message-restore_failed_upload'];
+			$_SESSION['message_mood'] = 'negative';
 			header("Location: ".$_SERVER['PHP_SELF']);
 			exit;
 		}


### PR DESCRIPTION
prerequisite:
- add at least one backup path to the Advanced->defaults
- do NOT install rar archive/de-archive programs

test case #1
- go to backup screen and download backups as rar

test case #2
- go to backup screen and upload a RAR file

expected result:
- get a sign that an error occurs

actual result:
- not clear if it failed, or why

fix:
added error message.  And you will get the top-bar warning in red on error instead of in green.

note: cut-pasted from google translate for "extraction failed" part of message-restore_failed_extract

Thank you @markjcrane 