### PR TITLE
Voicemail to sms notification

### DIFF
--- a/app/voicemails/app_config.php
+++ b/app/voicemails/app_config.php
@@ -64,6 +64,8 @@
 		$apps[$x]['permissions'][$y]['groups'][] = "admin";
 		$apps[$x]['permissions'][$y]['groups'][] = "user";
 		$y++;
+		$apps[$x]['permissions'][$y]['name'] = "voicemail_sms_edit";
+		$y++;
 
 	//schema details
 		$y = 0; //table array index
@@ -102,6 +104,10 @@
 		$apps[$x]['db'][$y]['fields'][$z]['name'] = "voicemail_mail_to";
 		$apps[$x]['db'][$y]['fields'][$z]['type'] = "text";
 		$apps[$x]['db'][$y]['fields'][$z]['description']['en-us'] = "Enter the email address to send voicemail to.";
+		$z++;
+		$apps[$x]['db'][$y]['fields'][$z]['name'] = "voicemail_sms_to";
+		$apps[$x]['db'][$y]['fields'][$z]['type'] = "text";
+		$apps[$x]['db'][$y]['fields'][$z]['description']['en-us'] = "Enter the sms did to send voicemail to.";
 		$z++;
 		$apps[$x]['db'][$y]['fields'][$z]['name'] = "voicemail_attach_file";
 		$apps[$x]['db'][$y]['fields'][$z]['type'] = "text";

--- a/app/voicemails/app_languages.php
+++ b/app/voicemails/app_languages.php
@@ -146,6 +146,17 @@ $text['label-voicemail_alternate_greet_id']['uk'] = "";
 $text['label-voicemail_alternate_greet_id']['de-at'] = "";
 $text['label-voicemail_alternate_greet_id']['he'] = "";
 
+$text['label-voicemail_sms_to']['en-us'] = "SMS To";
+$text['label-voicemail_sms_to']['es-cl'] = "SMS a";
+$text['label-voicemail_sms_to']['pt-pt'] = "";
+$text['label-voicemail_sms_to']['fr-fr'] = "SMS à";
+$text['label-voicemail_sms_to']['pt-br'] = "SMS para";
+$text['label-voicemail_sms_to']['pl'] = "SMS do";
+$text['label-voicemail_sms_to']['sv-se'] = "";
+$text['label-voicemail_sms_to']['uk'] = "SMS-повідомлення на";
+$text['label-voicemail_sms_to']['de-at'] = "SMS an";
+$text['label-voicemail_sms_to']['he'] = "";
+
 $text['label-voicemail_mail_to']['en-us'] = "Mail To";
 $text['label-voicemail_mail_to']['es-cl'] = "Correo a";
 $text['label-voicemail_mail_to']['pt-pt'] = "Email Para";
@@ -499,6 +510,17 @@ $text['description-voicemail_password']['sv-se'] = "Ange lösenordet.";
 $text['description-voicemail_password']['uk'] = "Введіть пароль";
 $text['description-voicemail_password']['de-at'] = "Geben Sie das numerische Mailbox Passwort an.";
 $text['description-voicemail_password']['he'] = "";
+
+$text['description-voicemail_sms_to']['en-us'] = "Enter the SMS Number to send voicemail notification to. ";
+$text['description-voicemail_sms_to']['es-cl'] = "Introduzca el número de SMS para enviar notificación de correo de voz.";
+$text['description-voicemail_sms_to']['pt-pt'] = "Digite o número de SMS para enviar notificação de correio de voz para.";
+$text['description-voicemail_sms_to']['fr-fr'] = "Entrez le numéro de SMS pour envoyer une notification de messagerie vocale à.";
+$text['description-voicemail_sms_to']['pt-br'] = "";
+$text['description-voicemail_sms_to']['pl'] = "Wprowadź numer SMS do wysyłania powiadomienia poczty głosowej.";
+$text['description-voicemail_sms_to']['sv-se'] = "Ange numret SMS för att skicka röstmeddelanden anmälan till.";
+$text['description-voicemail_sms_to']['uk'] = "Введіть номер SMS відправити повідомлення голосової пошти.";
+$text['description-voicemail_sms_to']['de-at'] = "Geben Sie die SMS-Nummer um Voicemail Benachrichtigung zu senden.";
+$text['description-voicemail_sms_to']['he'] = "הזן את מספר ה-SMS לשלוח הודעת תא קולי.";
 
 $text['description-voicemail_message']['en-us'] = "A list of recorded voice messages which shows when the message was created, caller ID information, length, file size and download or delete the message.";
 $text['description-voicemail_message']['es-cl'] = "Un listado de grabaciones de mensajes de voz que muestran la fecha de creación, información del Caller ID, duración, tamaño del archivo y permite descargar o eliminar el archivo";

--- a/app/voicemails/voicemail_edit.php
+++ b/app/voicemails/voicemail_edit.php
@@ -58,6 +58,7 @@ else {
 			$voicemail_options = $_POST["voicemail_options"];
 			$voicemail_alternate_greet_id = check_str($_POST["voicemail_alternate_greet_id"]);
 			$voicemail_mail_to = check_str($_POST["voicemail_mail_to"]);
+			$voicemail_sms_to = check_str($_POST["voicemail_sms_to"]);
 			$voicemail_file = check_str($_POST["voicemail_file"]);
 			$voicemail_local_after_email = check_str($_POST["voicemail_local_after_email"]);
 			$voicemail_enabled = check_str($_POST["voicemail_enabled"]);
@@ -145,6 +146,7 @@ if (count($_POST) > 0 && strlen($_POST["persistformvar"]) == 0) {
 				$sql .= "greeting_id, ";
 				$sql .= "voicemail_alternate_greet_id, ";
 				$sql .= "voicemail_mail_to, ";
+				$sql .= "voicemail_sms_to, ";
 				$sql .= "voicemail_file, ";
 				$sql .= "voicemail_local_after_email, ";
 				$sql .= "voicemail_enabled, ";
@@ -159,6 +161,7 @@ if (count($_POST) > 0 && strlen($_POST["persistformvar"]) == 0) {
 				$sql .= (($greeting_id != '') ? "'".$greeting_id."'" : 'null').", ";
 				$sql .= (($voicemail_alternate_greet_id != '') ? "'".$voicemail_alternate_greet_id."'" : 'null').", ";
 				$sql .= "'".$voicemail_mail_to."', ";
+				$sql .= "'".$voicemail_sms_to."', ";
 				$sql .= "'".$voicemail_file."', ";
 				$sql .= "'".$voicemail_local_after_email."', ";
 				$sql .= "'".$voicemail_enabled."', ";
@@ -177,6 +180,7 @@ if (count($_POST) > 0 && strlen($_POST["persistformvar"]) == 0) {
 				$sql .= "greeting_id = ".(($greeting_id != '') ? "'".$greeting_id."'" : 'null').", ";
 				$sql .= "voicemail_alternate_greet_id = ".(($voicemail_alternate_greet_id != '') ? "'".$voicemail_alternate_greet_id."'" : 'null').", ";
 				$sql .= "voicemail_mail_to = '".$voicemail_mail_to."', ";
+				$sql .= "voicemail_sms_to = '".$voicemail_sms_to."', ";
 				$sql .= "voicemail_file = '".$voicemail_file."', ";
 				$sql .= "voicemail_local_after_email = '".$voicemail_local_after_email."', ";
 				$sql .= "voicemail_enabled = '".$voicemail_enabled."', ";
@@ -262,6 +266,7 @@ if (count($_POST) > 0 && strlen($_POST["persistformvar"]) == 0) {
 			$greeting_id = $row["greeting_id"];
 			$voicemail_alternate_greet_id = $row["voicemail_alternate_greet_id"];
 			$voicemail_mail_to = $row["voicemail_mail_to"];
+			$voicemail_sms_to = $row["voicemail_sms_to"];
 			$voicemail_file = $row["voicemail_file"];
 			$voicemail_local_after_email = $row["voicemail_local_after_email"];
 			$voicemail_enabled = $row["voicemail_enabled"];
@@ -473,6 +478,18 @@ if (count($_POST) > 0 && strlen($_POST["persistformvar"]) == 0) {
 	echo $text['description-voicemail_mail_to']."\n";
 	echo "</td>\n";
 	echo "</tr>\n";
+	if(permission_exists('voicemail_sms_edit')) {
+		echo "<tr>\n";
+		echo "<td class='vncell' valign='top' align='left' nowrap='nowrap'>\n";
+		echo "	".$text['label-voicemail_sms_to']."\n";
+		echo "</td>\n";
+		echo "<td class='vtable' align='left'>\n";
+		echo "	<input class='formfld' type='text' name='voicemail_sms_to' maxlength='255' value=\"$voicemail_sms_to\">\n";
+		echo "<br />\n";
+		echo $text['description-voicemail_sms_to']."\n";
+		echo "</td>\n";
+		echo "</tr>\n";
+	}
 
 	echo "<tr>\n";
 	echo "<td class='vncell' valign='top' align='left' nowrap='nowrap'>\n";

--- a/resources/install/scripts/app/voicemail/index.lua
+++ b/resources/install/scripts/app/voicemail/index.lua
@@ -158,6 +158,19 @@
 					end
 				end
 			end
+
+			if (settings['voicemail']['voicemail_to_sms'] ~= nil) then
+				if (settings['voicemail']['voicemail_to_sms']['boolean'] ~= nil) then
+					voicemail_to_sms = settings['voicemail']['voicemail_to_sms']['boolean'];
+				else
+					voicemail_to_sms = false;
+				end
+			end
+			if (settings['voicemail']['voicemail_to_sms'] ~= nil) then
+				if (settings['voicemail']['voicemail_to_sms_did']['text'] ~= nil) then
+					voicemail_to_sms_did = settings['voicemail']['voicemail_to_sms_did']['text'];
+				end
+			end
 			if (not temp_dir) or (#temp_dir == 0) then
 				if (settings['server'] ~= nil) then
 					if (settings['server']['temp'] ~= nil) then
@@ -241,6 +254,7 @@
 	require "app.voicemail.resources.functions.listen_to_recording";
 	require "app.voicemail.resources.functions.message_waiting";
 	require "app.voicemail.resources.functions.send_email";
+	require "app.voicemail.resources.functions.send_sms";
 	require "app.voicemail.resources.functions.delete_recording";
 	require "app.voicemail.resources.functions.message_saved";
 	require "app.voicemail.resources.functions.return_call";
@@ -509,6 +523,9 @@
 						--send the email with the voicemail recording attached
 							if (tonumber(message_length) > 2) then
 								send_email(voicemail_id_copy, voicemail_message_uuid);
+								if (voicemail_to_sms) then
+									send_sms(voicemail_id_copy, voicemail_message_uuid);
+								end
 							end
 					end --for
 

--- a/resources/install/scripts/app/voicemail/resources/functions/send_sms.lua
+++ b/resources/install/scripts/app/voicemail/resources/functions/send_sms.lua
@@ -1,0 +1,99 @@
+--	Part of FusionPBX
+--	Copyright (C) 2013 Mark J Crane <markjcrane@fusionpbx.com>
+--	All rights reserved.
+--
+--	Redistribution and use in source and binary forms, with or without
+--	modification, are permitted provided that the following conditions are met:
+--
+--	1. Redistributions of source code must retain the above copyright notice,
+--	  this list of conditions and the following disclaimer.
+--
+--	2. Redistributions in binary form must reproduce the above copyright
+--	  notice, this list of conditions and the following disclaimer in the
+--	  documentation and/or other materials provided with the distribution.
+--
+--	THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+--	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+--	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+--	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+--	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+--	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+--	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+--	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+--	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+--	POSSIBILITY OF SUCH DAMAGE.
+
+--define a function to send sms
+	function send_sms(id, uuid)
+		debug["info"] = true;
+		api = freeswitch.API();
+
+		--get voicemail message details
+			sql = [[SELECT * FROM v_voicemails
+				WHERE domain_uuid = ']] .. domain_uuid ..[['
+				AND voicemail_id = ']] .. id ..[[']]
+			if (debug["sql"]) then
+				freeswitch.consoleLog("notice", "[voicemail] SQL: " .. sql .. "\n");
+			end
+			status = dbh:query(sql, function(row)
+				db_voicemail_uuid = string.lower(row["voicemail_uuid"]);
+				voicemail_sms_to = row["voicemail_sms_to"];
+				voicemail_file = row["voicemail_file"];
+			end);
+
+		--get the sms_body template
+			if (settings['voicemail']['voicemail_sms_body'] ~= nil) then
+				if (settings['voicemail']['voicemail_sms_body']['text'] ~= nil) then
+					sms_body = settings['voicemail']['voicemail_sms_body']['text'];
+				end
+			else
+				sms_body = 'You have a new voicemail from: ${caller_id_name} - ${caller_id_number} length ${message_length_formatted}';
+			end
+
+
+		--require the sms address to send to
+			if (string.len(voicemail_sms_to) > 2) then
+				--include languages file
+					local Text = require "resources.functions.text"
+					local text = Text.new("app.voicemail.app_languages")
+
+				--get voicemail message details
+					sql = [[SELECT * FROM v_voicemail_messages
+						WHERE domain_uuid = ']] .. domain_uuid ..[['
+						AND voicemail_message_uuid = ']] .. uuid ..[[']]
+					if (debug["sql"]) then
+						freeswitch.consoleLog("notice", "[voicemail] SQL: " .. sql .. "\n");
+					end
+					status = dbh:query(sql, function(row)
+						--get the values from the database
+							--uuid = row["voicemail_message_uuid"];
+							created_epoch = row["created_epoch"];
+							caller_id_name = row["caller_id_name"];
+							caller_id_number = row["caller_id_number"];
+							message_length = row["message_length"];
+					end);
+
+				--format the message length and date
+					message_length_formatted = format_seconds(message_length);
+					if (debug["info"]) then
+						freeswitch.consoleLog("notice", "[voicemail] message length: " .. message_length .. "\n");
+						freeswitch.consoleLog("notice", "[voicemail] domain_name: " .. domain_name .. "\n");
+					end
+					local message_date = os.date("%A, %d %b %Y %I:%M %p", created_epoch)
+
+					sms_body = sms_body:gsub("${caller_id_name}", caller_id_name);
+					sms_body = sms_body:gsub("${caller_id_number}", caller_id_number);
+					sms_body = sms_body:gsub("${message_date}", message_date);
+					sms_body = sms_body:gsub("${message_duration}", message_length_formatted);
+					sms_body = sms_body:gsub("${account}", id);
+					sms_body = sms_body:gsub("${domain_name}", domain_name);
+					sms_body = sms_body:gsub("${sip_to_user}", id);
+					sms_body = sms_body:gsub("${dialed_user}", id);
+
+--					sms_body = "hello";
+					cmd = "luarun app.lua sms outbound " .. voicemail_sms_to .. "@" .. domain_name .. " " .. voicemail_to_sms_did .. " '" .. sms_body .. "'";
+					api:executeString(cmd);
+
+			end
+
+	end


### PR DESCRIPTION
Requires that you have fusionpbx-apps/sms

Doesn’t impact anything if you don’t have it. Must be enabled with
default_setting voicemail_to_sms

Everything is disabled by default and the fields in voicemail_edit.php
are hidden by default.