### PR TITLE
Fix. Improve parameters patterns.

### DIFF
--- a/resources/install/scripts/resources/functions/database.lua
+++ b/resources/install/scripts/resources/functions/database.lua
@@ -23,7 +23,7 @@ local unpack = unpack or table.unpack
 
 local NULL, DEFAULT = {}, {}
 
-local param_pattern = "[:]([^%d%s][%a%d_]+)"
+local param_pattern = "%f[%a%d:][:]([%a][%a%d_]*)"
 
 --
 -- Substitude named parameters to query


### PR DESCRIPTION
E.g. now it handle queries like
```Lua
local sql = "select :J::text as value"
print(dbh:first_value(sql, {J='hello'}))
```