### PR TITLE
Fix recording setting in extension

### DIFF
--- a/app/extensions/extension_edit.php
+++ b/app/extensions/extension_edit.php
@@ -675,7 +675,9 @@ if (count($_POST) > 0 && strlen($_POST["persistformvar"]) == 0) {
 					}
 					$sql .= "call_group = '$call_group', ";
 					$sql .= "call_screen_enabled = '$call_screen_enabled', ";
+					if (permission_exists('extension_user_record')) {
 					$sql .= "user_record = '$user_record', ";
+					}
 					$sql .= "hold_music = '$hold_music', ";
 					$sql .= "auth_acl = '$auth_acl', ";
 					$sql .= "cidr = '$cidr', ";

--- a/app/extensions/extension_edit.php
+++ b/app/extensions/extension_edit.php
@@ -676,7 +676,7 @@ if (count($_POST) > 0 && strlen($_POST["persistformvar"]) == 0) {
 					$sql .= "call_group = '$call_group', ";
 					$sql .= "call_screen_enabled = '$call_screen_enabled', ";
 					if (permission_exists('extension_user_record')) {
-					$sql .= "user_record = '$user_record', ";
+						$sql .= "user_record = '$user_record', ";
 					}
 					$sql .= "hold_music = '$hold_music', ";
 					$sql .= "auth_acl = '$auth_acl', ";


### PR DESCRIPTION
If as a superadmin you add recording to an extension, then the admin for the domain (ie member of group: admin) goes in and edits the extension, the recording property will be set to false.