### PR TITLE
Fix globals variable scope in 4.2

### DIFF
--- a/app/provision/resources/classes/provision.php
+++ b/app/provision/resources/classes/provision.php
@@ -672,7 +672,7 @@ include "root.php";
 							$sql .= "WHEN 'programmable' THEN 3 ";
 							$sql .= "WHEN 'expansion' THEN 4 ";
 							$sql .= "ELSE 100 END, ";
-							if ($db_type == "mysql") {
+							if ($GLOBALS['db_type'] == "mysql") {
 								$sql .= "device_key_id ASC, ";
 							}
 							else {


### PR DESCRIPTION
Some PHP installations won't recognize such as $db_type as a global variable if is inside a class. Using the super variable $GLOBALS makes sure the global variables are reached.