### PR TITLE
show shell exec errors.  Nicer hide/show.

### DIFF
--- a/app/exec/exec.php
+++ b/app/exec/exec.php
@@ -128,6 +128,7 @@
 							$('#iframe').prop('src','');
 							$('#sql_response').hide();
 						<?php } ?>
+						$('#response').show();
 						break;
 				<?php } ?>
 				<?php if (permission_exists('exec_php')) { ?>
@@ -142,6 +143,7 @@
 							$('#iframe').prop('src','');
 							$('#sql_response').hide();
 						<?php } ?>
+						$('#response').show();
 						break;
 				<?php } ?>
 				<?php if (permission_exists('exec_command')) { ?>
@@ -156,6 +158,7 @@
 							$('#iframe').prop('src','');
 							$('#sql_response').hide();
 						<?php } ?>
+						$('#response').show();
 						break;
 				<?php } ?>
 				<?php if (permission_exists('exec_sql')) { ?>
@@ -164,6 +167,7 @@
 						editor.getSession().setMode('ace/mode/sql');
 						$('#mode option[value=sql]').prop('selected',true);
 						$('.sql_controls').show();
+						$('#response').hide();
 						break;
 				<?php } ?>
 				default:
@@ -443,7 +447,7 @@
 			switch ($handler) {
 				case 'shell':
 					if (permission_exists('exec_command')) {
-						$result = htmlentities(shell_exec($cmd));
+						$result = htmlentities(shell_exec($cmd . " 2>&1"));
 					}
 					break;
 				case 'php':


### PR DESCRIPTION
test #1:
enter an invalid command for the shell.  e.g. "asdf" then click execute.

expected result:
You get some type of result about invalid command.

Actual result: nothing shows up.  You have no idea if your command worked or not.

fixed result: When doing an exec include errors in the response: 2>&1

Test #2:
Enter something invalid in the switch command.  e.g. "asdf".  Click Execute.  Change to SQL.  Enter something valid e.g. "select * from v_users;"  Click execute.

Expected result:
You see the SQL output right below your "select * from v_users;" input text box.

Actual result:
Because the output from the previous switch/php/shell is not hidden the SQL output is pushed down off the screen.  Unless the user scrolls down they will not see the result and think their SQL command didn't actually work.

Fixed results:
When you do switch/phps/shell show the Response section.
When you do sql hide the response section.

This way only the relevant response/sql_response is shown to avoid confusion/screen clutter.