### PR TITLE
fixes bug #2270 reported by volga629

### DIFF
--- a/resources/install/scripts/fax_retry.lua
+++ b/resources/install/scripts/fax_retry.lua
@@ -416,6 +416,11 @@
 	freeswitch.consoleLog("INFO","[FAX] mailfrom_address: ".. from_address .."\n");
 	freeswitch.consoleLog("INFO","[FAX] mailto_address: ".. email_address .."\n");
 	freeswitch.consoleLog("INFO","[FAX] hangup_cause_q850: '" .. hangup_cause_q850 .. "'\n");
+	
+-- build headers
+	email_type = "email2fax";
+	x_headers = 'X-Headers: {"X-FusionPBX-Email-Type":"'..email_type..'",';
+	x_headers = x_headers..'"X-FusionPBX-Domain-UUID":"'..domain_uuid..'"}';	
 
 -- if the fax failed then try again
 	if (fax_success == "0") then
@@ -491,7 +496,7 @@
 				email_address = email_address:gsub("\\,", ",");
 				freeswitch.email(email_address,
 									email_address,
-									"To: "..email_address.."\nFrom: "..from_address.."\nSubject: Fax to: "..number_dialed.." was INVALID",
+									"To: "..email_address.."\nFrom: "..from_address.."\nSubject: Fax to: "..number_dialed.." was INVALID\n"..x_headers,
 									email_message_fail ,
 									fax_file
 								);
@@ -504,7 +509,7 @@
 				email_address = email_address:gsub("\\,", ",");
 				freeswitch.email(email_address,
 									email_address,
-									"To: "..email_address.."\nFrom: "..from_address.."\nSubject: Fax to: "..number_dialed.." was BUSY",
+									"To: "..email_address.."\nFrom: "..from_address.."\nSubject: Fax to: "..number_dialed.." was BUSY\n"..x_headers,
 									email_message_fail ,
 									fax_file
 								);
@@ -519,7 +524,7 @@
 
 				freeswitch.email(email_address,
 									email_address,
-									"To: "..email_address.."\nFrom: "..from_address.."\nSubject: Fax to: "..number_dialed.." FAILED",
+									"To: "..email_address.."\nFrom: "..from_address.."\nSubject: Fax to: "..number_dialed.." FAILED\n"..x_headers,
 									email_message_fail ,
 									fax_file
 								);
@@ -555,7 +560,7 @@
 
 		freeswitch.email(email_address,
 				email_address,
-				"To: "..email_address.."\nFrom: "..from_address.."\nSubject: Fax to: "..number_dialed.." SENT",
+				"To: "..email_address.."\nFrom: "..from_address.."\nSubject: Fax to: "..number_dialed.." SENT\n"..x_headers,
 				email_message_success ,
 				fax_file
 			);


### PR DESCRIPTION
Please do further testing/review and give comments and suggest cleanup, etc.

This bug is only tripped if all of the following are true:
a) fax send fails
b) email notification of fax failure also fails
c) Other?

how to test
- have a 100% working fax to email setup.
- Change Advanced->defaults->email and set the port to be something invalid.
- e.g. smtp port 9999 is invalid
- send a test fax to something without a fax
- e.g. I just faxed my own DID which does NOT have fax answering

- each time the phone rings answer...wait 5 seconds, and then hang up
- note: it will retry sending the fax 5 times so repeat the above.

- on the last try it will give up, and try to send the failure email
- the email will fail (bad port) and then it will insert the failed email into v_emails
- the insert will fail and nothing in v_emails

Error was caused by trying to insert '' into the domain_uuid field.
'' is invalid in a uuid field, but null is okay.

The null is caused by no x-headers being passed.  So these two fields end up null:
$headers["X-FusionPBX-Domain-UUID"]
$headers["X-FusionPBX-Email-Type"]

Fix: feed the X-Header in the calling lua code.