### PR TITLE
Stop warning message appearing

### DIFF
--- a/app/call_centers/call_center_queue_edit.php
+++ b/app/call_centers/call_center_queue_edit.php
@@ -631,8 +631,10 @@ if (count($_POST)>0 && strlen($_POST["persistformvar"]) == 0) {
 		if (permission_exists('call_center_tier_add')) {
 			//get agents
 			$sql = "select agent_name from v_call_center_agents where domain_uuid = '".$_SESSION['domain_uuid']."' ";
-			foreach($assigned_agents as $assigned_agent) {
-				$sql .= "and agent_name <> '".$assigned_agent."' ";
+			if ($assigned_agents){
+				foreach($assigned_agents as $assigned_agent) {
+					$sql .= "and agent_name <> '".$assigned_agent."' ";
+				}
 			}
 			$sql .= "order by agent_name asc";
 			$prep_statement = $db->prepare(check_sql($sql));


### PR DESCRIPTION
Stops php warning message appearing when there are no assigned agents

(Warning: Invalid argument supplied for foreach() in /var/www/fusionpbx/app/call_centers/call_center_queue_edit.php on line 635)