### PR TITLE
Fix. Russia has 11 digits (close #2303)

### DIFF
--- a/resources/install/scripts/app/toll_allow/index.lua
+++ b/resources/install/scripts/app/toll_allow/index.lua
@@ -61,10 +61,10 @@
 			};
 			RU = {
 				{"international", "810%d+|8[89]40%d+|87%d%d%d%d%d%d%d%d%d"};
-				{"mobile",        "89%d%d%d%d%d%d%d%d%d"                  };
-				{"tollfree",      "8800%d%d%d%d%d%d%d|10[1-9]"            };
-				{"landline",      "8[3-68]%d%d%d%d%d%d%d%d%d%d"           };
-				{"unknown",       ""                                      };
+				{"mobile",        "89%d%d%d%d%d%d%d%d%d"                          };
+				{"tollfree",      "8800%d%d%d%d%d%d%d|10[1-9]"                    };
+				{"landline",      "8[3-68]%d%d%d%d%d%d%d%d%d"                     };
+				{"unknown",       ""                                              };
 			};
 		}
 


### PR DESCRIPTION
There also some `interesting` destinations.
E.g. prefixes `79298 3-9` and `792981 0-2` is South Ossetia.
And codes like `7997445 0-6` may be very costly (I saw price up to 20$/min in some carriers).
