### PR TITLE
Alian ajx timeout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ resources/config.php
 secure/mailto.bat
 secure/*.db
 secure/*.sqlite
+/.settings/
+/.buildpath

--- a/app/call_center_active/call_center_active.php
+++ b/app/call_center_active/call_center_active.php
@@ -46,7 +46,19 @@ else {
 	$document['title'] = $text['title-call_center_queue_activity'];
 
 ?><script type="text/javascript">
+var pageLoadedTime = new Date().getTime();
+var continuePopupShown = false;
+
 function loadXmlHttp(url, id) {
+	if (continuePopupShown == true) {
+    return;
+	}
+	if ( new Date().getTime() > pageLoadedTime + 1800000 ) {
+		continuePopupShown = true;
+	  alert("Are you still there? Please click OK to continue...");
+	  location.reload();
+	  return;
+	}
 	var f = this;
 	f.xmlHttp = null;
 	/*@cc_on @*/ // used here and below, limits try/catch to those IE browsers that both benefit from and support it

--- a/app/calls_active/calls_active.php
+++ b/app/calls_active/calls_active.php
@@ -64,6 +64,8 @@ else {
 		var refresh = 1500;
 		var source_url = 'calls_active_inc.php?';
 		var timer_id;
+		var pageLoadedTime = new Date().getTime();
+		var continuePopupShown = false;
 		<?php
 		if ($show == 'all') {
 			echo "source_url = source_url + '&show=all';";
@@ -73,6 +75,15 @@ else {
 		}
 		?>
 		var ajax_get = function () {
+			if (continuePopupShown == true) {
+			    return;
+			}
+			if ( new Date().getTime() > pageLoadedTime + 1800000 ) {
+				continuePopupShown = true;
+			  alert("Are you still there? Please click OK to continue...");
+			  location.reload();
+			  return;
+			}
 			$.ajax({
 				url: source_url, success: function(response){
 					$("#ajax_reponse").html(response);

--- a/app/conferences_active/conferences_active.php
+++ b/app/conferences_active/conferences_active.php
@@ -41,7 +41,20 @@ else {
 
 require_once "resources/header.php";
 ?><script type="text/javascript">
+var pageLoadedTime = new Date().getTime();
+var continuePopupShown = false;
+
 function loadXmlHttp(url, id) {
+	if (continuePopupShown == true) {
+	    return;
+	}
+	if ( new Date().getTime() > pageLoadedTime + 1800000 ) {
+		continuePopupShown = true;
+	  alert("Are you still there? Please click OK to continue...");
+	  location.reload();
+	  return;
+	}
+	
 	var f = this;
 	f.xmlHttp = null;
 	/*@cc_on @*/ // used here and below, limits try/catch to those IE browsers that both benefit from and support it

--- a/app/fifo_list/fifo_list.php
+++ b/app/fifo_list/fifo_list.php
@@ -42,7 +42,19 @@ require_once "resources/header.php";
 $document['title'] = $text['title-active_queues'];
 
 ?><script type="text/javascript">
+var pageLoadedTime = new Date().getTime();
+var continuePopupShown = false;
+
 function loadXmlHttp(url, id) {
+	if (continuePopupShown == true) {
+	    return;
+	}
+	if ( new Date().getTime() > pageLoadedTime + 1800000 ) {
+		continuePopupShown = true;
+	  alert("Are you still there? Please click OK to continue...");
+	  location.reload();
+	  return;
+	}
 	var f = this;
 	f.xmlHttp = null;
 	/*@cc_on @*/ // used here and below, limits try/catch to those IE browsers that both benefit from and support it

--- a/app/operator_panel/index.php
+++ b/app/operator_panel/index.php
@@ -85,8 +85,19 @@ require_once "resources/header.php";
 	var refresh = 1500;
 	var source_url = 'index_inc.php?' <?php if (isset($_GET['debug'])) { echo " + '&debug'"; } ?>;
 	var interval_timer_id;
+	var pageLoadedTime = new Date().getTime();
+	var continuePopupShown = false;
 
 	function loadXmlHttp(url, id) {
+		if (continuePopupShown == true) {
+		    return;
+		}
+		if ( new Date().getTime() > pageLoadedTime + 1800000 ) {
+			continuePopupShown = true;
+		  alert("Are you still there? Please click OK to continue...");
+		  location.reload();
+		  return;
+		}
 		var f = this;
 		f.xmlHttp = null;
 		/*@cc_on @*/ // used here and below, limits try/catch to those IE browsers that both benefit from and support it

--- a/app/registrations/status_registrations.php
+++ b/app/registrations/status_registrations.php
@@ -56,7 +56,19 @@ require_once "resources/check_auth.php";
 		var source_url = 'status_registrations_inc.php?profile=<?php echo $profile; ?>&show=<?php echo $show; ?>';
 		var interval_timer_id;
 
+		var pageLoadedTime = new Date().getTime();
+		var continuePopupShown = false;
+
 		function loadXmlHttp(url, id) {
+			if (continuePopupShown == true) {
+			    return;
+			}
+			if ( new Date().getTime() > pageLoadedTime + 1800000 ) {
+				continuePopupShown = true;
+			  alert("Are you still there? Please click OK to continue...");
+			  location.reload();
+			  return;
+			}
 			var f = this;
 			f.xmlHttp = null;
 			/*@cc_on @*/ // used here and below, limits try/catch to those IE browsers that both benefit from and support it


### PR DESCRIPTION
hi mcrane,

This prompts the user to continue after 30 mins when the user is on an ajax auto-refreshed page.

Stops users from requesting refreshes after 30 mins when they leave for the wee-end ;-) Security: unattended computers don't stay logged in for ever. Resources waste: Log filling + This gets even nastier when the user somehow gets logged out (internet connection goes down, server restart, etc.) Then the browser keep on trying to fetch the xml and gets redirected to the login page. The ajax than fetches around 2.8 GB per day; css etc. as we discussed earlier:

XX.XX.XX.XX - XXXX [14/Jan/2017:23:59:59 -0500] "GET /app/call_center_active/call_center_active_inc.php?queue_name=Every-day-queue HTTP/1.1" 302 - "https://www.XXXX.com/app/call_center_active/call_center_active.php?queue_name=Every-day-queue" "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.87 Safari/537.36"
XX.XX.XX.XX - XXXX [14/Jan/2017:23:59:59 -0500] "GET /login.php?path=%2Fapp%2Fcall_center_active%2Fcall_center_active_inc.php%3Fqueue_name%3DEvery-day-queue HTTP/1.1" 200 2987 "https://www.XXXX.com/app/call_center_active/call_center_active.php?queue_name=Every-day-queue" "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.87 Safari/537.36"
XX.XX.XX.XX - XXXX [14/Jan/2017:23:59:59 -0500] "GET /resources/bootstrap/css/bootstrap-colorpicker.min.css HTTP/1.1" 200 1010 "https://www.XXXX.com/app/call_center_active/call_center_active.php?queue_name=Every-day-queue" "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.87 Safari/537.36"
XX.XX.XX.XX - XXXX [14/Jan/2017:23:59:59 -0500] "GET /resources/bootstrap/css/bootstrap-datetimepicker.min.css HTTP/1.1" 200 1318 "https://www.XXXX.com/app/call_center_active/call_center_active.php?queue_name=Every-day-queue" "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.87 Safari/537.36"
XX.XX.XX.XX - XXXX [14/Jan/2017:23:59:59 -0500] "GET /resources/bootstrap/css/bootstrap.min.css HTTP/1.1" 200 19751 "https://www.XXXX.com/app/call_center_active/call_center_active.php?queue_name=Every-day-queue" "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.87 Safari/537.36"
XX.XX.XX.XX - XXXX [14/Jan/2017:23:59:59 -0500] "GET /themes/default/css.php?login=default HTTP/1.1" 200 5913 "https://www.XXXX.com/app/call_center_active/call_center_active.php?queue_name=Every-day-queue" "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.87 Safari/537.36"
XX.XX.XX.XX  - XXXX [15/Jan/2017:00:00:00 -0500] "GET /resources/bootstrap/fonts/glyphicons-halflings-regular.woff2 HTTP/1.1" 200 18030 "https://www.XXXX.com/resources/bootstrap/css/bootstrap.min.css" "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.87 Safari/537.36"

Obviously, the 30 mins, timeout should be configurable (disabled == max_int timeout). Also, the text:
"Are you still there? Please click OK to continue..." should also be put somewhere to enable easy multi-language support so let's call this a proof of concept. I could do those changes for you if you let me know where to put it (e.g. timeout value and text) and if you are interested with this functionality.

When user comes back on Monday morning, and clicks on continue, he gets properly redirected to the login page.

Note that svg_graph.php as also the same king of potential; leaving the seesion going for ever and submitting requests every 3 seconds for ever on an unattended computer but I just disabled svg_graph in permissions for now.

Thanks mcrane! ;-)

