### PR TITLE
Fix a bug that breaks load balancing

### DIFF
--- a/resources/install/scripts/app/xml_handler/resources/scripts/directory/directory.lua
+++ b/resources/install/scripts/app/xml_handler/resources/scripts/directory/directory.lua
@@ -157,13 +157,8 @@
 								require "resources.functions.file_exists";
 
 							--connect to the switch database
-								if (file_exists(database_dir.."/core.db")) then
-									--dbh_switch = freeswitch.Dbh("core:core"); -- when using sqlite
-									dbh_switch = freeswitch.Dbh("sqlite://"..database_dir.."/core.db");
-								else
-									require "resources.functions.database_handle";
-									dbh_switch = database_handle('switch');
-								end
+								require "resources.functions.database_handle";
+								dbh_switch = database_handle('switch');
 
 							--get the destination hostname from the registration
 								sql = "SELECT hostname FROM registrations ";


### PR DESCRIPTION
Some Freeswitch deployments will create an empty core.db file (no tables inside) even when the core-db-dsn and core-recovery-db-dsn options are set. 

There is no reason to try looking for the core.db file when using balancing. The existence of an empty core.db file breaks the balancing.

This patch is totally safe, as line 141 only executes this code if balancing is on.