### PR TITLE
Add. Support remote reboot Panasonic devices.

### DIFF
--- a/app/devices/resources/classes/device.php
+++ b/app/devices/resources/classes/device.php
@@ -154,8 +154,9 @@ include "root.php";
 					if (preg_match('/^es\d\d\d.*$/i', $agent)) {
 						return "escene";
 					}
-			}
-
+					if (preg_match('/^.*?panasonic.*$/i', $agent)) {
+						return "panasonic";
+					}
 			// unknown vendor
 				return "";
 		}

--- a/resources/install/scripts/app/event_notify/index.lua
+++ b/resources/install/scripts/app/event_notify/index.lua
@@ -124,8 +124,19 @@
 			event:addHeader('event-string', 'check-sync;reboot=false');
 		end
 	end
+
 --snom
 	if (vendor == "snom") then
+		if (command == "reboot") then
+			event:addHeader('event-string', 'check-sync;reboot=true');
+		end
+		if (command == "check_sync") then
+			event:addHeader('event-string', 'check-sync;reboot=true');
+		end
+	end
+
+--panasonic
+	if (vendor == "panasonic") then
 		if (command == "reboot") then
 			event:addHeader('event-string', 'check-sync;reboot=true');
 		end


### PR DESCRIPTION
Tested with Panasonic KX-TGP500 Firmware 22.90
User agent string `Panasonic_KX-TGP500B09/22.90 (<MAC>)`