### PR TITLE
Push t41p DND fix from master to 4.2

### DIFF
--- a/resources/templates/provision/yealink/t41p/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t41p/{$mac}.cfg
@@ -3011,9 +3011,9 @@ programablekey.{$row.device_key_id}.label = {$row.device_key_label}
 #programablekey.2.history_type =
 #programablekey.2.label =
 
-#N/A - Disable DND
-programablekey.3.type = 0
-programablekey.3.line =
+#DND
+programablekey.3.type = 5
+programablekey.3.line = 1
 programablekey.3.value =
 programablekey.3.xml_phonebook =
 programablekey.3.history_type =


### PR DESCRIPTION
The T41p provisioning template in 4.2 breaks the DND key which is resolved in template in master. Fixes should be pushed to 4.2 branch.