### PR TITLE
use local mkdir if $_SESSION['event_socket_ip_address'] pints to loca…

### DIFF
--- a/resources/functions.php
+++ b/resources/functions.php
@@ -1897,6 +1897,16 @@ function number_pad($number,$n) {
 	}
 
 	function event_socket_mkdir($dir) {
+		
+		switch($_SESSION['event_socket_ip_address'])){
+			case 'localhost':
+			case '127.0.0.1':
+			case '::1':
+			case '':
+				mkdir ($dir, 02770, true);
+				return true;
+				break;
+			default:
 		//connect to fs
 			$fp = event_socket_create($_SESSION['event_socket_ip_address'], $_SESSION['event_socket_port'], $_SESSION['event_socket_password']);
 			if (!$fp) {
@@ -1913,6 +1923,7 @@ function number_pad($number,$n) {
 						return true;
 					}
 			}
+		}
 		//can not create directory
 			return false;
 	}


### PR DESCRIPTION
…lhost

if $_SESSION['event_socket_ip_address'] points to the local host, it is better to use local PHP mkdir rather than waste resources connecting to the event socket and running a lua script.