### PR TITLE
Yealink Provisioning - Add Trusted Cert Variable

### DIFF
--- a/resources/templates/provision/yealink/cp860/y000000000037.cfg
+++ b/resources/templates/provision/yealink/cp860/y000000000037.cfg
@@ -1007,7 +1007,7 @@ bw.feature_key_sync = 0
 #######################################################################################
 #Enable or disable the phone to only accept the certificates in the Trusted Certificates list;
 #0-Disabled, 1-Enabled (default);
-security.trust_certificates =
+security.trust_certificates = {if $trusted_cert_only == "false"}0{elseif $trusted_cert_only == "true"}1{/if}
 
 #Define the login username and password of the user, var and administrator.
 #If you change the username of the administrator from "admin" to "admin1", your new administrator's username should be configured as: security.user_name.admin = admin1.

--- a/resources/templates/provision/yealink/t20p/y000000000007.cfg
+++ b/resources/templates/provision/yealink/t20p/y000000000007.cfg
@@ -376,7 +376,7 @@ voice.group_spk_vol =
 
 #Enable or disable the phone to only accept the certificates in the Trusted Certificates list;
 #0-Disabled, 1-Enabled (default);
-security.trust_certificates =
+security.trust_certificates = {if $trusted_cert_only == "false"}0{elseif $trusted_cert_only == "true"}1{/if}
 
 #Define the login username and password of the user, var and administrator.
 #If your username is defined as: security.user_name.admin = adminuser.

--- a/resources/templates/provision/yealink/t21p/y000000000052.cfg
+++ b/resources/templates/provision/yealink/t21p/y000000000052.cfg
@@ -968,7 +968,7 @@ bw.feature_key_sync = 0
 #######################################################################################
 #Enable or disable the phone to only accept the certificates in the Trusted Certificates list;
 #0-Disabled, 1-Enabled (default);
-security.trust_certificates =
+security.trust_certificates = {if $trusted_cert_only == "false"}0{elseif $trusted_cert_only == "true"}1{/if}
 
 #Define the login username and password of the user, var and administrator.
 #If you change the username of the administrator from "admin" to "admin1", your new administrator's username should be configured as: security.user_name.admin = admin1.

--- a/resources/templates/provision/yealink/t22p/y000000000005.cfg
+++ b/resources/templates/provision/yealink/t22p/y000000000005.cfg
@@ -376,7 +376,7 @@ voice.group_spk_vol =
 
 #Enable or disable the phone to only accept the certificates in the Trusted Certificates list;
 #0-Disabled, 1-Enabled (default);
-security.trust_certificates =
+security.trust_certificates = {if $trusted_cert_only == "false"}0{elseif $trusted_cert_only == "true"}1{/if}
 
 #Define the login username and password of the user, var and administrator.
 #If your username is defined as: security.user_name.admin = adminuser.

--- a/resources/templates/provision/yealink/t23g/y000000000044.cfg
+++ b/resources/templates/provision/yealink/t23g/y000000000044.cfg
@@ -977,7 +977,7 @@ bw.feature_key_sync = 0
 #######################################################################################
 #Enable or disable the phone to only accept the certificates in the Trusted Certificates list;
 #0-Disabled, 1-Enabled (default);
-security.trust_certificates =
+security.trust_certificates = {if $trusted_cert_only == "false"}0{elseif $trusted_cert_only == "true"}1{/if}
 
 #Define the login username and password of the user, var and administrator.
 #If you change the username of the administrator from "admin" to "admin1", your new administrator's username should be configured as: security.user_name.admin = admin1.

--- a/resources/templates/provision/yealink/t23p/y000000000044.cfg
+++ b/resources/templates/provision/yealink/t23p/y000000000044.cfg
@@ -968,7 +968,7 @@ bw.feature_key_sync = 0
 #######################################################################################
 #Enable or disable the phone to only accept the certificates in the Trusted Certificates list;
 #0-Disabled, 1-Enabled (default);
-security.trust_certificates =
+security.trust_certificates = {if $trusted_cert_only == "false"}0{elseif $trusted_cert_only == "true"}1{/if}
 
 #Define the login username and password of the user, var and administrator.
 #If you change the username of the administrator from "admin" to "admin1", your new administrator's username should be configured as: security.user_name.admin = admin1.

--- a/resources/templates/provision/yealink/t26p/y000000000004.cfg
+++ b/resources/templates/provision/yealink/t26p/y000000000004.cfg
@@ -376,7 +376,7 @@ voice.group_spk_vol =
 
 #Enable or disable the phone to only accept the certificates in the Trusted Certificates list;
 #0-Disabled, 1-Enabled (default);
-security.trust_certificates =
+security.trust_certificates = {if $trusted_cert_only == "false"}0{elseif $trusted_cert_only == "true"}1{/if}
 
 #Define the login username and password of the user, var and administrator.
 #If your username is defined as: security.user_name.admin = adminuser.

--- a/resources/templates/provision/yealink/t27p/y000000000045.cfg
+++ b/resources/templates/provision/yealink/t27p/y000000000045.cfg
@@ -977,7 +977,7 @@ bw.feature_key_sync = 0
 #######################################################################################
 #Enable or disable the phone to only accept the certificates in the Trusted Certificates list;
 #0-Disabled, 1-Enabled (default);
-security.trust_certificates =
+security.trust_certificates = {if $trusted_cert_only == "false"}0{elseif $trusted_cert_only == "true"}1{/if}
 
 #Define the login username and password of the user, var and administrator.
 #If you change the username of the administrator from "admin" to "admin1", your new administrator's username should be configured as: security.user_name.admin = admin1.

--- a/resources/templates/provision/yealink/t28p/y000000000000.cfg
+++ b/resources/templates/provision/yealink/t28p/y000000000000.cfg
@@ -376,7 +376,7 @@ voice.group_spk_vol =
 
 #Enable or disable the phone to only accept the certificates in the Trusted Certificates list;
 #0-Disabled, 1-Enabled (default);
-security.trust_certificates =
+security.trust_certificates = {if $trusted_cert_only == "false"}0{elseif $trusted_cert_only == "true"}1{/if}
 
 #Define the login username and password of the user, var and administrator.
 #If your username is defined as: security.user_name.admin = adminuser.

--- a/resources/templates/provision/yealink/t29g/y000000000046.cfg
+++ b/resources/templates/provision/yealink/t29g/y000000000046.cfg
@@ -977,7 +977,7 @@ bw.feature_key_sync = 0
 #######################################################################################
 #Enable or disable the phone to only accept the certificates in the Trusted Certificates list;
 #0-Disabled, 1-Enabled (default);
-security.trust_certificates =
+security.trust_certificates = {if $trusted_cert_only == "false"}0{elseif $trusted_cert_only == "true"}1{/if}
 
 #Define the login username and password of the user, var and administrator.
 #If you change the username of the administrator from "admin" to "admin1", your new administrator's username should be configured as: security.user_name.admin = admin1.

--- a/resources/templates/provision/yealink/t32g/y000000000032.cfg
+++ b/resources/templates/provision/yealink/t32g/y000000000032.cfg
@@ -376,7 +376,7 @@ voice.group_spk_vol =
 
 #Enable or disable the phone to only accept the certificates in the Trusted Certificates list;
 #0-Disabled, 1-Enabled (default);
-security.trust_certificates =
+security.trust_certificates = {if $trusted_cert_only == "false"}0{elseif $trusted_cert_only == "true"}1{/if}
 
 #Define the login username and password of the user, var and administrator.
 #If your username is defined as: security.user_name.admin = adminuser.
@@ -590,7 +590,7 @@ programablekey.1.history_type =
 programablekey.1.label =
 
 ##########################################################################################
-##         	              Expansion Key   £¨For T38G only£©                             ##
+##         	              Expansion Key   Â£Â¨For T38G onlyÂ£Â©                             ##
 ##########################################################################################
 #X ranges from 1 to 6, Y ranges from 1 to 39.
 #expansion_module.x.key.y.type = 37 (Switch by default)
@@ -1111,7 +1111,7 @@ phone_setting.lock =
 phone_setting.phone_lock.unlock_pin =
 phone_setting.phone_lock.lock_time_out =
 
-#Configure the ring tone for the phone. System ring tones are: Ring1.wav (default), Ring2.wav¡­¡­Ring8.wav.
+#Configure the ring tone for the phone. System ring tones are: Ring1.wav (default), Ring2.wavÂ¡Â­Â¡Â­Ring8.wav.
 #You can configure the custom ring tone (Busy.wav) for the phone, the value is: phone_setting.ring_type = Busy.wav
 phone_setting.ring_type =
 

--- a/resources/templates/provision/yealink/t38g/y000000000038.cfg
+++ b/resources/templates/provision/yealink/t38g/y000000000038.cfg
@@ -376,7 +376,7 @@ voice.group_spk_vol =
 
 #Enable or disable the phone to only accept the certificates in the Trusted Certificates list;
 #0-Disabled, 1-Enabled (default);
-security.trust_certificates =
+security.trust_certificates = {if $trusted_cert_only == "false"}0{elseif $trusted_cert_only == "true"}1{/if}
 
 #Define the login username and password of the user, var and administrator.
 #If your username is defined as: security.user_name.admin = adminuser.
@@ -590,7 +590,7 @@ programablekey.1.history_type =
 programablekey.1.label =
 
 ##########################################################################################
-##                         Expansion Key   £¨For T38G only£©                             ##
+##                         Expansion Key   Â£Â¨For T38G onlyÂ£Â©                             ##
 ##########################################################################################
 #X ranges from 1 to 6, Y ranges from 1 to 39.
 #expansion_module.x.key.y.type = 37 (Switch by default)

--- a/resources/templates/provision/yealink/t40p/y000000000054.cfg
+++ b/resources/templates/provision/yealink/t40p/y000000000054.cfg
@@ -977,7 +977,7 @@ bw.feature_key_sync = 0
 #######################################################################################
 #Enable or disable the phone to only accept the certificates in the Trusted Certificates list;
 #0-Disabled, 1-Enabled (default);
-security.trust_certificates =
+security.trust_certificates = {if $trusted_cert_only == "false"}0{elseif $trusted_cert_only == "true"}1{/if}
 
 #Define the login username and password of the user, var and administrator.
 #If you change the username of the administrator from "admin" to "admin1", your new administrator's username should be configured as: security.user_name.admin = admin1.

--- a/resources/templates/provision/yealink/t41p/y000000000036.cfg
+++ b/resources/templates/provision/yealink/t41p/y000000000036.cfg
@@ -977,7 +977,7 @@ bw.feature_key_sync = 0
 #######################################################################################
 #Enable or disable the phone to only accept the certificates in the Trusted Certificates list;
 #0-Disabled, 1-Enabled (default);
-security.trust_certificates =
+security.trust_certificates = {if $trusted_cert_only == "false"}0{elseif $trusted_cert_only == "true"}1{/if}
 
 #Define the login username and password of the user, var and administrator.
 #If you change the username of the administrator from "admin" to "admin1", your new administrator's username should be configured as: security.user_name.admin = admin1.

--- a/resources/templates/provision/yealink/t42g/y000000000029.cfg
+++ b/resources/templates/provision/yealink/t42g/y000000000029.cfg
@@ -977,7 +977,7 @@ bw.feature_key_sync = 0
 #######################################################################################
 #Enable or disable the phone to only accept the certificates in the Trusted Certificates list;
 #0-Disabled, 1-Enabled (default);
-security.trust_certificates =
+security.trust_certificates = {if $trusted_cert_only == "false"}0{elseif $trusted_cert_only == "true"}1{/if}
 
 #Define the login username and password of the user, var and administrator.
 #If you change the username of the administrator from "admin" to "admin1", your new administrator's username should be configured as: security.user_name.admin = admin1.

--- a/resources/templates/provision/yealink/t46g/y000000000028.cfg
+++ b/resources/templates/provision/yealink/t46g/y000000000028.cfg
@@ -977,7 +977,7 @@ bw.feature_key_sync = 0
 #######################################################################################
 #Enable or disable the phone to only accept the certificates in the Trusted Certificates list;
 #0-Disabled, 1-Enabled (default);
-security.trust_certificates =
+security.trust_certificates = {if $trusted_cert_only == "false"}0{elseif $trusted_cert_only == "true"}1{/if}
 
 #Define the login username and password of the user, var and administrator.
 #If you change the username of the administrator from "admin" to "admin1", your new administrator's username should be configured as: security.user_name.admin = admin1.

--- a/resources/templates/provision/yealink/t46s/y000000000066.cfg
+++ b/resources/templates/provision/yealink/t46s/y000000000066.cfg
@@ -977,7 +977,7 @@ bw.feature_key_sync = 0
 #######################################################################################
 #Enable or disable the phone to only accept the certificates in the Trusted Certificates list;
 #0-Disabled, 1-Enabled (default);
-security.trust_certificates =
+security.trust_certificates = {if $trusted_cert_only == "false"}0{elseif $trusted_cert_only == "true"}1{/if}
 
 #Define the login username and password of the user, var and administrator.
 #If you change the username of the administrator from "admin" to "admin1", your new administrator's username should be configured as: security.user_name.admin = admin1.

--- a/resources/templates/provision/yealink/t48g/y000000000035.cfg
+++ b/resources/templates/provision/yealink/t48g/y000000000035.cfg
@@ -977,7 +977,7 @@ bw.feature_key_sync = 0
 #######################################################################################
 #Enable or disable the phone to only accept the certificates in the Trusted Certificates list;
 #0-Disabled, 1-Enabled (default);
-security.trust_certificates =
+security.trust_certificates = {if $trusted_cert_only == "false"}0{elseif $trusted_cert_only == "true"}1{/if}
 
 #Define the login username and password of the user, var and administrator.
 #If you change the username of the administrator from "admin" to "admin1", your new administrator's username should be configured as: security.user_name.admin = admin1.

--- a/resources/templates/provision/yealink/t49g/y000000000051.cfg
+++ b/resources/templates/provision/yealink/t49g/y000000000051.cfg
@@ -977,7 +977,7 @@ bw.feature_key_sync = 0
 #######################################################################################
 #Enable or disable the phone to only accept the certificates in the Trusted Certificates list;
 #0-Disabled, 1-Enabled (default);
-security.trust_certificates =
+security.trust_certificates = {if $trusted_cert_only == "false"}0{elseif $trusted_cert_only == "true"}1{/if}
 
 #Define the login username and password of the user, var and administrator.
 #If you change the username of the administrator from "admin" to "admin1", your new administrator's username should be configured as: security.user_name.admin = admin1.

--- a/resources/templates/provision/yealink/vp530/y000000000023.cfg
+++ b/resources/templates/provision/yealink/vp530/y000000000023.cfg
@@ -290,7 +290,7 @@ voice.ring_vol =
 
 #Enable or disable the phone to only accept the certificates in the Trusted Certificates list;
 #0-Disabled, 1-Enabled (default);
-security.trust_certificates =
+security.trust_certificates = {if $trusted_cert_only == "false"}0{elseif $trusted_cert_only == "true"}1{/if}
 
 #Set the password of the user or the administrator, the value format is: user:password or admin:password;
 #security.user_password = admin:admin123

--- a/resources/templates/provision/yealink/w52p/y000000000025.cfg
+++ b/resources/templates/provision/yealink/w52p/y000000000025.cfg
@@ -190,7 +190,7 @@ bw.feature_key_sync =
 
 #Enable or disable the phone to only accept the certificates in the Trusted Certificates list;
 #0-Disabled, 1-Enabled (default);
-security.trust_certificates =
+security.trust_certificates = {if $trusted_cert_only == "false"}0{elseif $trusted_cert_only == "true"}1{/if}
 
 #Set the password of the user or the administrator, the value format is: user:password or admin:password;
 {if isset($user_name) }


### PR DESCRIPTION
Allows trusted certificate signing enforcement to be enabled or disabled via variable $trusted_cert_only.

If set to true, enforcement is enabled.
If set to false, enforcement is disabled.
If not set or any other value is entered, provisioning templates set nothing for this field.

