### PR TITLE
Make sure the provision temporal directory exists

### DIFF
--- a/app/provision/resources/classes/provision.php
+++ b/app/provision/resources/classes/provision.php
@@ -1056,6 +1056,7 @@ include "root.php";
 												$file_contents = $this->render();
 
 											//write the file
+												mkdir($directory,0777,true);
 												$fh = fopen($dest_path,"w") or die("Unable to write to $directory for provisioning. Make sure the path exists and permissons are set correctly.");
 												fwrite($fh, $file_contents);
 												fclose($fh);


### PR DESCRIPTION
New Linux distributions are using PrivateTmp=true (systemd) which it is good from the security point of view but it creates a blank /tmp directory which it needs to create the directories to let this work. This patch just add a way to create the directory, if it already exist, it will be harmless