### PR TITLE
Fix disappearing voicemail_description.

### DIFF
--- a/app/extensions/extension_edit.php
+++ b/app/extensions/extension_edit.php
@@ -99,6 +99,7 @@
 			$voicemail_mail_to = $_POST["voicemail_mail_to"];
 			$voicemail_file = $_POST["voicemail_file"];
 			$voicemail_local_after_email = $_POST["voicemail_local_after_email"];
+			$voicemail_description = $_POST["voicemail_description"];
 			$user_context = $_POST["user_context"];
 			$range = $_POST["range"];
 			$autogen_users = $_POST["autogen_users"];
@@ -398,6 +399,9 @@
 									$array["voicemails"][$i]["voicemail_file"] = $voicemail_file;
 									$array["voicemails"][$i]["voicemail_local_after_email"] = $voicemail_local_after_email;
 									$array["voicemails"][$i]["voicemail_enabled"] = $voicemail_enabled;
+									if ( empty($voicemail_description)){
+										$voicemail_description = $description;
+									}
 									$array["voicemails"][$i]["voicemail_description"] = $voicemail_description;
 							}
 
@@ -645,6 +649,7 @@
 					$voicemail_file = $row["voicemail_file"];
 					$voicemail_local_after_email = $row["voicemail_local_after_email"];
 					$voicemail_enabled = $row["voicemail_enabled"];
+					$voicemail_description = $row["voicemail_description"];
 				}
 				unset ($prep_statement);
 			//clean the variables
@@ -1296,6 +1301,7 @@
 	if (permission_exists('voicemail_edit') && is_dir($_SERVER["DOCUMENT_ROOT"].PROJECT_PATH.'/app/voicemails')) {
 		echo "<tr>\n";
 		echo "<td class='vncell' valign='top' align='left' nowrap='nowrap'>\n";
+		echo "<input type='hidden' name='voicemail_description' value='".$voicemail_description."'>\n";
 		echo "    ".$text['label-voicemail_enabled']."\n";
 		echo "</td>\n";
 		echo "<td class='vtable' align='left'>\n";


### PR DESCRIPTION
Editing an extension causes the voicemail_description filed to disappear in v_voicemails.
* Preserves voicemail_description if present in v_voicemails table.
* Creates voicemail_description if empty in v_voicemails.