### PR TITLE
Update 010_user_exists.xml

### DIFF
--- a/app/dialplan/resources/switch/conf/dialplan/010_user_exists.xml
+++ b/app/dialplan/resources/switch/conf/dialplan/010_user_exists.xml
@@ -18,6 +18,7 @@
 			<action application="set" data="call_timeout=${user_data ${destination_number}@${domain_name} var call_timeout}"/>
 			<action application="set" data="missed_call_app=${user_data ${destination_number}@${domain_name} var missed_call_app}"/>
 			<action application="set" data="missed_call_data=${user_data ${destination_number}@${domain_name} var missed_call_data}"/>
+			<action application="set" data="toll_allow=${user_data ${destination_number}@${domain_name} var toll_allow}"/>
 			<action application="set" data="call_screen_enabled=${user_data ${destination_number}@${domain_name} var call_screen_enabled}" inline="true"/>
 		</condition>
 	</extension>


### PR DESCRIPTION
If toll_allow is set on an extension, an outside caller dialing a direct number will not be transferred back out to cfwd-no-answer external number unless the toll_allow variable is read in the dialplan.