### PR TITLE
Fix user_dashboard broken user_edit link

### DIFF
--- a/core/user_settings/user_dashboard.php
+++ b/core/user_settings/user_dashboard.php
@@ -73,7 +73,7 @@
 	echo "			<b>".$text['header-user_dashboard']."</b><br />";
 	echo "		</td>\n";
 	echo "		<td valign='top' style='text-align: right; white-space: nowrap;'>\n";
-	echo "			".$text['label-welcome']." <a href='".PROJECT_PATH."/core/user_settings/user_edit.php'>".$_SESSION["username"]."</a>";
+	echo "			".$text['label-welcome']." <a href='".PROJECT_PATH."/core/users/user_edit.php?id=user'>".$_SESSION["username"]."</a>";
 	echo "		</td>\n";
 	echo "	</tr>\n";
 	echo "	<tr>\n";


### PR DESCRIPTION
On the user_dashboard clicking on the username brings you to a 404 page.
Fixed link path.