### PR TITLE
Let the apps be more self-contained regarding LUA scripts

### DIFF
--- a/app/scripts/resources/classes/scripts.php
+++ b/app/scripts/resources/classes/scripts.php
@@ -106,6 +106,13 @@ if (!class_exists('scripts')) {
 					if (is_readable($dst_dir)) {
 						recursive_copy($src_dir,$dst_dir);
 						unset($src_dir);
+						
+						// Copy the app/*/resource/install/scripts
+						$app_scripts = glob($_SERVER["DOCUMENT_ROOT"].PROJECT_PATH.'app/*/resource/install/scripts');
+						foreach ($app_scripts as $app_script){
+							recursive_copy($app_script, $dst_dir);
+						}
+						unset($app_scripts);
 					}else{
 						throw new Exception("Cannot read from '$src_dir' to get the scripts");
 					}


### PR DESCRIPTION
At this moment, all LUA scripts must be at resources/install/script, this patch allows applications to be more self-contained by having app/*/resources/install/scripts directory, which it will be copied to the scripts_dir directory as well.

I would like to discuss the addition to this into 4.2.3