### PR TITLE
[4.2] Add help link to menu for admin and superadmin

### DIFF
--- a/app/help/app_config.php
+++ b/app/help/app_config.php
@@ -1,0 +1,12 @@
+<?php
+
+	$apps[$x]['name'] = "Help";
+	$apps[$x]['uuid'] = "9e0e39d0-4b5f-44ef-afc6-648ae121ab15";
+	$apps[$x]['category'] = "Menu";
+	$apps[$x]['subcategory'] = "";
+	$apps[$x]['version'] = "1";
+	$apps[$x]['license'] = "Mozilla Public License 1.1";
+	$apps[$x]['url'] = "http://www.fusionpbx.com";
+	$apps[$x]['description']['en-us'] = "Add help menu items";
+
+?>

--- a/app/help/app_menu.php
+++ b/app/help/app_menu.php
@@ -1,0 +1,13 @@
+<?php
+
+	$apps[$x]['menu'][0]['title']['en-us'] = "Help";
+	$apps[$x]['menu'][0]['uuid'] = "00e51f5c-0fb0-11e7-93ae-92361f002671";
+	$apps[$x]['menu'][0]['parent_uuid'] = "";
+	$apps[$x]['menu'][0]['category'] = "external";
+	$apps[$x]['menu'][0]['icon'] = "glyphicon-question-sign";
+	$apps[$x]['menu'][0]['path'] = "http://docs.fusionpbx.com";
+	$apps[$x]['menu'][0]['order'] = "100";
+	$apps[$x]['menu'][0]['groups'][] = "admin";
+	$apps[$x]['menu'][0]['groups'][] = "superadmin";
+
+?>

--- a/themes/default/template.php
+++ b/themes/default/template.php
@@ -452,6 +452,8 @@
 						<ul class="nav navbar-nav">
 							<?php
 							foreach ($menu_array as $index_main => $menu_parent) {
+								$mod_li = "";
+								$mod_a_1 = "";
 								$submenu = false;
 								if (is_array($menu_parent['menu_items']) && sizeof($menu_parent['menu_items']) > 0) {
 									$mod_li = "class='dropdown' ";


### PR DESCRIPTION
Fix for $mod_li and $mod_a_li not being blanked/reset foreach menu
parent item rendered, causing the first menu with sub items to force sub
item rendering for all remaining menu items