### PR TITLE
BugFix-[master]-sub item rendering

### DIFF
--- a/themes/default/template.php
+++ b/themes/default/template.php
@@ -454,6 +454,8 @@
 						<ul class="nav navbar-nav">
 							<?php
 							foreach ($menu_array as $index_main => $menu_parent) {
+								$mod_li = "";
+								$mod_a_1 = "";
 								$submenu = false;
 								if (is_array($menu_parent['menu_items']) && sizeof($menu_parent['menu_items']) > 0) {
 									$mod_li = "class='dropdown' ";


### PR DESCRIPTION
Fix for $mod_li and $mod_a_li not being blanked/reset foreach menu
parent item rendered, causing the first menu with sub items to force sub
item rendering for all remaining menu items