### PR TITLE
Added variables to disable call waiting and t.38 faxing

### DIFF
--- a/resources/templates/provision/grandstream/ht702/{$mac}.xml
+++ b/resources/templates/provision/grandstream/ht702/{$mac}.xml
@@ -3,7 +3,10 @@
 <config version="1">
 
 <!--  Configuration template for HT701 and HT702 firmware version 1.0.5.2 -->
-
+<!-- VARIABLES for FusionPBX:
+     disable_cw: set to 1 disables call waiting (used for PBX/FAX interconnects)
+     disable_t38: set to 1 sets pass-through fax mode
+ -->
 <!-- Advanced Settings. -->
 
 
@@ -69,7 +72,7 @@
 
 <!-- Firmware Server Path -->
 <!-- Server address -->
-<P192>fm.grandstream.com/gs</P192>
+<P192>{$domain_name}{$project_path}/app/provision</P192>
 
 <!-- Config Server Path -->
 <!-- Server address;  -->
@@ -533,7 +536,9 @@
 <!-- Disable Call-Waiting. 0 - No, 1 - Yes -->
 <!-- Number: 0, 1 -->
 <!-- Mandatory -->
-<P91>0</P91>
+{if $disable_cw == '1'}<P91>1</P91>
+    {else}<P91>0</P91>
+    {/if}
 
 <!-- Disable Call-Waiting Caller ID. 0 - No, 1 - Yes -->
 <!-- Number: 0, 1 -->
@@ -742,7 +747,10 @@
 <!-- FAX Mode. 0 - T.38 (Auto Detect), 1 - Pass Through -->
 <!-- Number: 0, 1 -->
 <!-- Mandatory -->
-<P228>0</P228>
+{if $disable_t38 == '1'}<P228>1</P228>
+    {else}<P228>0</P228>
+    {/if}
+
 
 <!-- Re-INVITE After Fax Tone Detected. 0 - Disabled, 1 - Enabled. -->
 <!-- Number: 0, 1 -->
@@ -1192,7 +1200,9 @@
 <!-- Disable Call-Waiting. 0 - No, 1 - Yes -->
 <!-- Number: 0, 1 -->
 <!-- Mandatory -->
-<P791>0</P791>
+{if $disable_cw == '1'}<P791>1</P791>
+    {else}<P791>0</P791>
+    {/if}
 
 <!-- Disable Call-Waiting Caller ID. 0 - No, 1 - Yes -->
 <!-- Number: 0, 1 -->
@@ -1399,7 +1409,9 @@
 <!-- FAX Mode. 0 - T.38 (Auto Detect), 1 - Pass Through -->
 <!-- Number: 0, 1 -->
 <!-- Mandatory -->
-<P710>0</P710>
+{if $disable_t38 == '1'}<P710>1</P710>
+    {else}<P710>0</P710>
+    {/if}
 
 <!-- Re-INVITE After Fax Tone Detected. 0 - Disabled, 1 - Enabled. -->
 <!-- Number: 0, 1 -->

--- a/resources/templates/provision/grandstream/ht702/{$mac}.xml
+++ b/resources/templates/provision/grandstream/ht702/{$mac}.xml
@@ -4,8 +4,8 @@
 
 <!--  Configuration template for HT701 and HT702 firmware version 1.0.5.2 -->
 <!-- VARIABLES for FusionPBX:
-     disable_cw: set to 1 disables call waiting (used for PBX/FAX interconnects)
-     disable_t38: set to 1 sets pass-through fax mode
+     grandstream_disable_call_waiting: set to 1 disables call waiting (used for PBX/FAX interconnects)
+     grandstream_disable_fax_t38: set to 1 sets pass-through fax mode
  -->
 <!-- Advanced Settings. -->
 
@@ -536,7 +536,7 @@
 <!-- Disable Call-Waiting. 0 - No, 1 - Yes -->
 <!-- Number: 0, 1 -->
 <!-- Mandatory -->
-{if $disable_cw == '1'}<P91>1</P91>
+{if $grandstream_disable_call_waiting == '1'}<P91>1</P91>
     {else}<P91>0</P91>
     {/if}
 
@@ -747,7 +747,7 @@
 <!-- FAX Mode. 0 - T.38 (Auto Detect), 1 - Pass Through -->
 <!-- Number: 0, 1 -->
 <!-- Mandatory -->
-{if $disable_t38 == '1'}<P228>1</P228>
+{if $grandstream_disable_fax_t38 == '1'}<P228>1</P228>
     {else}<P228>0</P228>
     {/if}
 
@@ -1200,7 +1200,7 @@
 <!-- Disable Call-Waiting. 0 - No, 1 - Yes -->
 <!-- Number: 0, 1 -->
 <!-- Mandatory -->
-{if $disable_cw == '1'}<P791>1</P791>
+{if $grandstream_disable_call_waiting == '1'}<P791>1</P791>
     {else}<P791>0</P791>
     {/if}
 
@@ -1409,7 +1409,7 @@
 <!-- FAX Mode. 0 - T.38 (Auto Detect), 1 - Pass Through -->
 <!-- Number: 0, 1 -->
 <!-- Mandatory -->
-{if $disable_t38 == '1'}<P710>1</P710>
+{if $grandstream_disable_fax_t38 == '1'}<P710>1</P710>
     {else}<P710>0</P710>
     {/if}
 


### PR DESCRIPTION
This adds some variables and comments to the ATA config to allow disabling of call waiting and t.38 faxing (needed in the case of integration with a physical PBX or fax machine, and t.38 isn't supported by all carriers)