### PR TITLE
Bug fix for two grandstream templates (Please backport to 4.2)

### DIFF
--- a/resources/templates/provision/grandstream/gxp2140/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp2140/{$mac}.xml
@@ -576,7 +576,7 @@
 {if $row.device_key_type == "voicemail"}    <P{$type_id}>6</P{$type_id}>{/if}
 {if $row.device_key_type == "call return"}    <P{$type_id}>7</P{$type_id}>{/if}
 {if $row.device_key_type == "transfer"}    <P{$type_id}>8</P{$type_id}>{/if}
-{if $row.device_key_type == "call park"}    <P{$type_id}>19</P{$type_id}>{/if}
+{if $row.device_key_type == "call park"}    <P{$type_id}>16</P{$type_id}>{/if}
 {if $row.device_key_type == "intercom"}    <P{$type_id}>10</P{$type_id}>{/if}
 {if $row.device_key_type == "ldap search"}    <P{$type_id}>11</P{$type_id}>{/if}
 

--- a/resources/templates/provision/grandstream/gxp2170/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp2170/{$mac}.xml
@@ -576,7 +576,7 @@
 {if $row.device_key_type == "voicemail"}    <P{$type_id}>6</P{$type_id}>{/if}
 {if $row.device_key_type == "call return"}    <P{$type_id}>7</P{$type_id}>{/if}
 {if $row.device_key_type == "transfer"}    <P{$type_id}>8</P{$type_id}>{/if}
-{if $row.device_key_type == "call park"}    <P{$type_id}>19</P{$type_id}>{/if}
+{if $row.device_key_type == "call park"}    <P{$type_id}>16</P{$type_id}>{/if}
 {if $row.device_key_type == "intercom"}    <P{$type_id}>10</P{$type_id}>{/if}
 {if $row.device_key_type == "ldap search"}    <P{$type_id}>11</P{$type_id}>{/if}
 

--- a/resources/templates/provision/grandstream/ht702/{$mac}.xml
+++ b/resources/templates/provision/grandstream/ht702/{$mac}.xml
@@ -3,7 +3,10 @@
 <config version="1">
 
 <!--  Configuration template for HT701 and HT702 firmware version 1.0.5.2 -->
-
+<!-- VARIABLES for FusionPBX:
+     disable_cw: set to 1 disables call waiting (used for PBX/FAX interconnects)
+     disable_t38: set to 1 sets pass-through fax mode
+ -->
 <!-- Advanced Settings. -->
 
 
@@ -69,7 +72,7 @@
 
 <!-- Firmware Server Path -->
 <!-- Server address -->
-<P192>fm.grandstream.com/gs</P192>
+<P192>{$domain_name}{$project_path}/app/provision</P192>
 
 <!-- Config Server Path -->
 <!-- Server address;  -->
@@ -533,7 +536,9 @@
 <!-- Disable Call-Waiting. 0 - No, 1 - Yes -->
 <!-- Number: 0, 1 -->
 <!-- Mandatory -->
-<P91>0</P91>
+{if $disable_cw == '1'}<P91>1</P91>
+    {else}<P91>0</P91>
+    {/if}
 
 <!-- Disable Call-Waiting Caller ID. 0 - No, 1 - Yes -->
 <!-- Number: 0, 1 -->
@@ -742,7 +747,10 @@
 <!-- FAX Mode. 0 - T.38 (Auto Detect), 1 - Pass Through -->
 <!-- Number: 0, 1 -->
 <!-- Mandatory -->
-<P228>0</P228>
+{if $disable_t38 == '1'}<P228>1</P228>
+    {else}<P228>0</P228>
+    {/if}
+
 
 <!-- Re-INVITE After Fax Tone Detected. 0 - Disabled, 1 - Enabled. -->
 <!-- Number: 0, 1 -->
@@ -1192,7 +1200,9 @@
 <!-- Disable Call-Waiting. 0 - No, 1 - Yes -->
 <!-- Number: 0, 1 -->
 <!-- Mandatory -->
-<P791>0</P791>
+{if $disable_cw == '1'}<P791>1</P791>
+    {else}<P791>0</P791>
+    {/if}
 
 <!-- Disable Call-Waiting Caller ID. 0 - No, 1 - Yes -->
 <!-- Number: 0, 1 -->
@@ -1399,7 +1409,9 @@
 <!-- FAX Mode. 0 - T.38 (Auto Detect), 1 - Pass Through -->
 <!-- Number: 0, 1 -->
 <!-- Mandatory -->
-<P710>0</P710>
+{if $disable_t38 == '1'}<P710>1</P710>
+    {else}<P710>0</P710>
+    {/if}
 
 <!-- Re-INVITE After Fax Tone Detected. 0 - Disabled, 1 - Enabled. -->
 <!-- Number: 0, 1 -->

--- a/resources/templates/provision/grandstream/ht702/{$mac}.xml
+++ b/resources/templates/provision/grandstream/ht702/{$mac}.xml
@@ -4,8 +4,8 @@
 
 <!--  Configuration template for HT701 and HT702 firmware version 1.0.5.2 -->
 <!-- VARIABLES for FusionPBX:
-     disable_cw: set to 1 disables call waiting (used for PBX/FAX interconnects)
-     disable_t38: set to 1 sets pass-through fax mode
+     grandstream_disable_call_waiting: set to 1 disables call waiting (used for PBX/FAX interconnects)
+     grandstream_disable_fax_t38: set to 1 sets pass-through fax mode
  -->
 <!-- Advanced Settings. -->
 
@@ -536,7 +536,7 @@
 <!-- Disable Call-Waiting. 0 - No, 1 - Yes -->
 <!-- Number: 0, 1 -->
 <!-- Mandatory -->
-{if $disable_cw == '1'}<P91>1</P91>
+{if $grandstream_disable_call_waiting == '1'}<P91>1</P91>
     {else}<P91>0</P91>
     {/if}
 
@@ -747,7 +747,7 @@
 <!-- FAX Mode. 0 - T.38 (Auto Detect), 1 - Pass Through -->
 <!-- Number: 0, 1 -->
 <!-- Mandatory -->
-{if $disable_t38 == '1'}<P228>1</P228>
+{if $grandstream_disable_fax_t38 == '1'}<P228>1</P228>
     {else}<P228>0</P228>
     {/if}
 
@@ -1200,7 +1200,7 @@
 <!-- Disable Call-Waiting. 0 - No, 1 - Yes -->
 <!-- Number: 0, 1 -->
 <!-- Mandatory -->
-{if $disable_cw == '1'}<P791>1</P791>
+{if $grandstream_disable_call_waiting == '1'}<P791>1</P791>
     {else}<P791>0</P791>
     {/if}
 
@@ -1409,7 +1409,7 @@
 <!-- FAX Mode. 0 - T.38 (Auto Detect), 1 - Pass Through -->
 <!-- Number: 0, 1 -->
 <!-- Mandatory -->
-{if $disable_t38 == '1'}<P710>1</P710>
+{if $grandstream_disable_fax_t38 == '1'}<P710>1</P710>
     {else}<P710>0</P710>
     {/if}
 


### PR DESCRIPTION
cis-scott found a bug with the handling of the expansion module programming (a typo from when I wrote the code); this pull fixes the two affected files: gxp2170/{$mac}.xml and gxp2140/{$mac}.xml.   call park type for expansion module should be code 16, not code 19.