### PR TITLE
Make presence for conferences work out of the box

### DIFF
--- a/app/conference_centers/conference_room_edit.php
+++ b/app/conference_centers/conference_room_edit.php
@@ -113,7 +113,7 @@ else {
 			$default_language = 'en';
 			$default_dialect = 'us';
 			$default_voice = 'callie';
-			$switch_cmd = "conference ".$meeting_uuid."-".$_SESSION['domain_name']." play ".$_SESSION['switch']['sounds']['dir']."/".$default_language."/".$default_dialect."/".$default_voice."/ivr/ivr-recording_started.wav";
+			$switch_cmd = "conference ".$meeting_uuid."@".$_SESSION['domain_name']." play ".$_SESSION['switch']['sounds']['dir']."/".$default_language."/".$default_dialect."/".$default_voice."/ivr/ivr-recording_started.wav";
 		//connect to event socket
 			$fp = event_socket_create($_SESSION['event_socket_ip_address'], $_SESSION['event_socket_port'], $_SESSION['event_socket_password']);
 			if ($fp) {

--- a/app/conference_centers/conference_rooms.php
+++ b/app/conference_centers/conference_rooms.php
@@ -75,7 +75,7 @@ else {
 					$default_language = 'en';
 					$default_dialect = 'us';
 					$default_voice = 'callie';
-					$switch_cmd = "conference ".$meeting_uuid."-".$_SESSION['domain_name']." play ".$_SESSION['switch']['sounds']['dir']."/".$default_language."/".$default_dialect."/".$default_voice."/ivr/ivr-recording_started.wav";
+					$switch_cmd = "conference ".$meeting_uuid."@".$_SESSION['domain_name']." play ".$_SESSION['switch']['sounds']['dir']."/".$default_language."/".$default_dialect."/".$default_voice."/ivr/ivr-recording_started.wav";
 				//connect to event socket
 					$fp = event_socket_create($_SESSION['event_socket_ip_address'], $_SESSION['event_socket_port'], $_SESSION['event_socket_password']);
 					if ($fp) {
@@ -135,7 +135,7 @@ else {
 			//show the conferences that have a matching domain
 				$tmp_domain = substr($conference_name, -strlen($_SESSION['domain_name']));
 				if ($tmp_domain == $_SESSION['domain_name']) {
-					$meeting_uuid = substr($conference_name, 0, strlen($conference_name) - strlen('-'.$_SESSION['domain_name']));
+					$meeting_uuid = substr($conference_name, 0, strlen($conference_name) - strlen('@'.$_SESSION['domain_name']));
 					$conference[$meeting_uuid]["conference_name"] = $conference_name;
 					$conference[$meeting_uuid]["session_uuid"] = $session_uuid;
 					$conference[$meeting_uuid]["member_count"] = $member_count;

--- a/app/conferences/conference_edit.php
+++ b/app/conferences/conference_edit.php
@@ -211,7 +211,7 @@
 						$dialplan_detail_type = 'conference';
 						$pin_number = ''; if (strlen($conference_pin_number) > 0) { $pin_number = "+".$conference_pin_number; }
 						$flags = ''; if (strlen($conference_flags) > 0) { $flags = "+flags{".$conference_flags."}"; }
-						$dialplan_detail_data = $conference_name.'-'.$_SESSION['domain_name']."@".$conference_profile.$pin_number.$flags;
+						$dialplan_detail_data = $conference_name.'@'.$_SESSION['domain_name']."@".$conference_profile.$pin_number.$flags;
 						$dialplan_detail_order = '020';
 						$dialplan_detail_group = '2';
 						dialplan_detail_add($_SESSION['domain_uuid'], $dialplan_uuid, $dialplan_detail_tag, $dialplan_detail_order, $dialplan_detail_group, $dialplan_detail_type, $dialplan_detail_data);
@@ -263,7 +263,7 @@
 					//update dialplan detail action
 						$pin_number = ''; if (strlen($conference_pin_number) > 0) { $pin_number = "+".$conference_pin_number; }
 						$flags = ''; if (strlen($conference_flags) > 0) { $flags = "+flags{".$conference_flags."}"; }
-						$dialplan_detail_data = $conference_name.'-'.$_SESSION['domain_name']."@".$conference_profile.$pin_number.$flags;
+						$dialplan_detail_data = $conference_name.'@'.$_SESSION['domain_name']."@".$conference_profile.$pin_number.$flags;
 						$sql = "update v_dialplan_details set ";
 						$sql .= "dialplan_detail_data = '".$dialplan_detail_data."' ";
 						$sql .= "where domain_uuid = '".$_SESSION['domain_uuid']."' ";

--- a/app/conferences_active/conference_interactive_inc.php
+++ b/app/conferences_active/conference_interactive_inc.php
@@ -43,7 +43,7 @@ else {
 	$conference_uuid = check_str($_REQUEST["c"]);
 
 //replace the space with underscore
-	$conference_name = $conference_uuid.'-'.$_SESSION['domain_name'];
+	$conference_name = $conference_uuid.'@'.$_SESSION['domain_name'];
 
 //create the conference list command
 	$switch_cmd = "conference '".$conference_name."' xml_list";

--- a/app/conferences_active/conferences_active_inc.php
+++ b/app/conferences_active/conferences_active_inc.php
@@ -83,7 +83,7 @@ else {
 		//show the conferences that have a matching domain
 			$tmp_domain = substr($name, -strlen($_SESSION['domain_name']));
 			if ($tmp_domain == $_SESSION['domain_name']) {
-				$conference_name = substr($name, 0, strlen($name) - strlen('-'.$_SESSION['domain_name']));
+				$conference_name = substr($name, 0, strlen($name) - strlen('@'.$_SESSION['domain_name']));
 				if (is_uuid($conference_name)) {
 					$meeting_uuid = $conference_name;
 					$sql = "select ";

--- a/resources/install/scripts/app/conference_center/index.lua
+++ b/resources/install/scripts/app/conference_center/index.lua
@@ -287,7 +287,7 @@
 
 		--if the conference is empty
 			if (conference_session_uuid) then
-				cmd = "conference "..meeting_uuid.."-"..domain_name.." xml_list";
+				cmd = "conference "..meeting_uuid.."@"..domain_name.." xml_list";
 				result = trim(api:executeString(cmd));
 				if (string.sub(result, -9) == "not found") then
 					--get the conference start_epoch
@@ -597,7 +597,7 @@
 		else
 			if (meeting_uuid) then
 				--check if the conference exists
-					cmd = "conference "..meeting_uuid.."-"..domain_name.." xml_list";
+					cmd = "conference "..meeting_uuid.."@"..domain_name.." xml_list";
 					result = trim(api:executeString(cmd));
 					if (string.sub(result, -9) == "not found") then
 						conference_exists = false;
@@ -618,7 +618,7 @@
 							--max members must be 2 or more
 							session:execute("set","conference_max_members="..max_members);
 							if (conference_exists) then
-								cmd = "conference "..meeting_uuid.."-"..domain_name.." get count";
+								cmd = "conference "..meeting_uuid.."@"..domain_name.." get count";
 								count = trim(api:executeString(cmd));
 								if (count ~= nil) then
 									if (tonumber(count) >= tonumber(max_members)) then
@@ -687,7 +687,7 @@
 					end
 
 				--get the conference xml_list
-					cmd = "conference "..meeting_uuid.."-"..domain_name.." xml_list";
+					cmd = "conference "..meeting_uuid.."@"..domain_name.." xml_list";
 					freeswitch.consoleLog("INFO","" .. cmd .. "\n");
 					result = trim(api:executeString(cmd));
 
@@ -723,7 +723,7 @@
 						--play a message that the conference is being a recorded
 							session:execute("playback", sounds_dir.."/"..default_language.."/"..default_dialect.."/"..default_voice.."/ivr/ivr-recording_started.wav");
 						--play a message that the conference is being a recorded
-							--cmd = "conference "..meeting_uuid.."-"..domain_name.." play "..sounds_dir.."/"..default_language.."/"..default_dialect.."/"..default_voice.."/ivr/ivr-recording_started.wav";
+							--cmd = "conference "..meeting_uuid.."@"..domain_name.." play "..sounds_dir.."/"..default_language.."/"..default_dialect.."/"..default_voice.."/ivr/ivr-recording_started.wav";
 							--freeswitch.consoleLog("notice", "[conference center] ".. cmd .."\n");
 							--response = api:executeString(cmd);
 					end
@@ -731,24 +731,24 @@
 				--announce the caller
 					if (announce == "true") then
 						--announce the caller - play the recording
-							cmd = "conference "..meeting_uuid.."-"..domain_name.." play " .. temp_dir:gsub("\\", "/") .. "/conference-"..uuid..".wav";
+							cmd = "conference "..meeting_uuid.."@"..domain_name.." play " .. temp_dir:gsub("\\", "/") .. "/conference-"..uuid..".wav";
 							--freeswitch.consoleLog("notice", "[conference center] ".. cmd .."\n");
 							response = api:executeString(cmd);
 						--play has entered the conference
-							cmd = "conference "..meeting_uuid.."-"..domain_name.." play "..sounds_dir.."/"..default_language.."/"..default_dialect.."/"..default_voice.."/conference/conf-has_joined.wav";
+							cmd = "conference "..meeting_uuid.."@"..domain_name.." play "..sounds_dir.."/"..default_language.."/"..default_dialect.."/"..default_voice.."/conference/conf-has_joined.wav";
 							--freeswitch.consoleLog("notice", "[conference center] ".. cmd .."\n");
 							response = api:executeString(cmd);
 					else
 						if (not conference_locked) then
 							if (sounds == "true") then
-								cmd = "conference "..meeting_uuid.."-"..domain_name.." play "..enter_sound;
+								cmd = "conference "..meeting_uuid.."@"..domain_name.." play "..enter_sound;
 								response = api:executeString(cmd);
 							end
 						end
 					end
 
 				--get the conference member count
-					cmd = "conference "..meeting_uuid.."-"..domain_name.." list count";
+					cmd = "conference "..meeting_uuid.."@"..domain_name.." list count";
 					--freeswitch.consoleLog("notice", "[conference center] cmd: ".. cmd .."\n");
 					member_count = api:executeString(cmd);
 					if (string.sub(trim(member_count), -9) == "not found") then
@@ -773,7 +773,7 @@
 						api:executeString(cmd);
 					end
 				--send the call to the conference
-					cmd = meeting_uuid.."-"..domain_name.."@"..profile.."+flags{".. flags .."}";
+					cmd = meeting_uuid.."@"..domain_name.."@"..profile.."+flags{".. flags .."}";
 					freeswitch.consoleLog("INFO","[conference center] conference " .. cmd .. "\n");
 					session:execute("conference", cmd);
 			end

--- a/resources/install/scripts/app/conference_center/resources/scripts/start_recording.lua
+++ b/resources/install/scripts/app/conference_center/resources/scripts/start_recording.lua
@@ -17,7 +17,7 @@
 	api = freeswitch.API();
 
 --check if the conference exists
-	cmd = "conference "..meeting_uuid.."-"..domain_name.." xml_list";
+	cmd = "conference "..meeting_uuid.."@"..domain_name.." xml_list";
 	freeswitch.consoleLog("INFO","" .. cmd .. "\n");
 	result = trim(api:executeString(cmd));
 	if (string.sub(result, -9) == "not found") then
@@ -44,7 +44,7 @@
 
 		--send a command to record the conference
 			if (not file_exists(recording..".wav")) then
-				cmd = "conference "..meeting_uuid.."-"..domain_name.." record "..recording..".wav";
+				cmd = "conference "..meeting_uuid.."@"..domain_name.." record "..recording..".wav";
 				freeswitch.consoleLog("notice", "[start-recording] cmd: " .. cmd .. "\n");
 				response = api:executeString(cmd);
 			end


### PR DESCRIPTION
Use '@' instead of '-' for separating conference name and domain, which
is what FreeSWITCH mod_conference uses.