### PR TITLE
Update app_config.php

### DIFF
--- a/app/voicemails/app_config.php
+++ b/app/voicemails/app_config.php
@@ -70,7 +70,26 @@
 		$apps[$x]['permissions'][$y]['groups'][] = "superadmin";
 		$apps[$x]['permissions'][$y]['groups'][] = "admin";
 		$y++;
-
+		$apps[$x]['permissions'][$y]['name'] = "voicemail_option_add";
+		$apps[$x]['permissions'][$y]['groups'][] = "superadmin";
+		$apps[$x]['permissions'][$y]['groups'][] = "admin";
+		$apps[$x]['permissions'][$y]['groups'][] = "user";		
+		$y++;
+		$apps[$x]['permissions'][$y]['name'] = "voicemail_option_edit";
+		$apps[$x]['permissions'][$y]['groups'][] = "superadmin";
+		$apps[$x]['permissions'][$y]['groups'][] = "admin";
+		$apps[$x]['permissions'][$y]['groups'][] = "user";		
+		$y++;
+		$apps[$x]['permissions'][$y]['name'] = "voicemail_option_view";
+		$apps[$x]['permissions'][$y]['groups'][] = "superadmin";
+		$apps[$x]['permissions'][$y]['groups'][] = "admin";
+		$apps[$x]['permissions'][$y]['groups'][] = "user";		
+		$y++;
+		$apps[$x]['permissions'][$y]['name'] = "voicemail_option_delete";
+		$apps[$x]['permissions'][$y]['groups'][] = "superadmin";
+		$apps[$x]['permissions'][$y]['groups'][] = "admin";
+		$apps[$x]['permissions'][$y]['groups'][] = "user";		
+		$y++;
 	//default settings
 		$y=0;
 		$apps[$x]['default_settings'][$y]['default_setting_uuid'] = '1cf61dea-42b5-4799-b9fa-f2c3bd29e933';


### PR DESCRIPTION
Add the necessary permissions in order to use the database save function (fusion 4.3) when coding for voicemail option adds/deletes/updates.

I realize these voicemail permissions overall will probably get cleaned up even more once the whole app is updated to use the database function, but this is a stop gap measure. I am working on adding voicemail options to the Bulk Account Settings app and I'm stuck without these permissions. The function is kicking a out 403 Forbidden.