### PR TITLE
Enhance add message stack

### DIFF
--- a/core/users/user_edit.php
+++ b/core/users/user_edit.php
@@ -63,8 +63,7 @@
 		}
 		unset($prep_statement, $row);
 		if ($total_users >= $_SESSION['limit']['users']['numeric']) {
-			$_SESSION['message_mood'] = 'negative';
-			$_SESSION['message'] = $text['message-maximum_users'].' '.$_SESSION['limit']['users']['numeric'];
+			messages::add(text['message-maximum_users'].' '.$_SESSION['limit']['users']['numeric'], 'negative');
 			header('Location: users.php');
 			exit;
 		}
@@ -91,7 +90,7 @@
 			$sql .= "and user_uuid = '".$user_uuid."' ";
 			$db->exec(check_sql($sql));
 		//redirect the user
-			$_SESSION["message"] = $text['message-update'];
+			messages::add($text['message-update']);
 			header("Location: user_edit.php?id=".$user_uuid);
 			return;
 	}
@@ -147,8 +146,7 @@ if (count($_POST) > 0 && $_POST["persistform"] != "1") {
 		}
 
 		if ($msg_error != '') {
-			$_SESSION["message"] = $msg_error;
-			$_SESSION["message_mood"] = 'negative';
+			messages::add($msg_error, 'negative');
 			if ($action == 'edit') {
 				header("Location: user_edit.php?id=".$user_uuid);
 			}
@@ -454,7 +452,7 @@ if (count($_POST) > 0 && $_POST["persistform"] != "1") {
 		}
 
 	//redirect the browser
-		$_SESSION["message"] = $text['message-update'];
+		messages::add($text['message-update']);
 		if ($_REQUEST['action'] == $text['button-add'] || !permission_exists('user_edit')) {
 			header("Location: user_edit.php?id=".$user_uuid);
 		}
@@ -679,7 +677,7 @@ if (count($_POST) > 0 && $_POST["persistform"] != "1") {
 	echo "		<select id='user_time_zone' name='user_time_zone' class='formfld' style=''>\n";
 	echo "		<option value=''></option>\n";
 	//$list = DateTimeZone::listAbbreviations();
-    $time_zone_identifiers = DateTimeZone::listIdentifiers();
+	$time_zone_identifiers = DateTimeZone::listIdentifiers();
 	$previous_category = '';
 	$x = 0;
 	foreach ($time_zone_identifiers as $key => $row) {

--- a/resources/classes/messages.php
+++ b/resources/classes/messages.php
@@ -1,0 +1,70 @@
+<?php
+/*
+	FusionPBX
+	Version: MPL 1.1
+
+	The contents of this file are subject to the Mozilla Public License Version
+	1.1 (the "License"); you may not use this file except in compliance with
+	the License. You may obtain a copy of the License at
+	http://www.mozilla.org/MPL/
+
+	Software distributed under the License is distributed on an "AS IS" basis,
+	WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License
+	for the specific language governing rights and limitations under the
+	License.
+
+	The Original Code is FusionPBX
+
+	The Initial Developer of the Original Code is
+	Mark J Crane <markjcrane@fusionpbx.com>
+	Portions created by the Initial Developer are Copyright (C) 2017
+	the Initial Developer. All Rights Reserved.
+
+	Contributor(s):
+	Mark J Crane <markjcrane@fusionpbx.com>
+	Matthew Vale <github@mafoo.org>
+*/
+
+if (!class_exists('messages')) {
+	class messages {
+
+		static function add($message, $mood = NULL, $delay = NULL) {
+			$_SESSION["messages"][] = array(message => $message, mood => $mood, delay => $delay);
+		}
+		
+		static function html($clear_messages = true) {
+			$html = "";
+			if (strlen($_SESSION['message']) > 0) {
+				$message_text = addslashes($_SESSION['message']);
+				$message_mood = $_SESSION['message_mood'] ?: 'default';
+				$message_delay = $_SESSION['message_delay'];
+
+				$html .= "display_message('".$message_text."', '".$message_mood."'";
+				if ($message_delay != '') {
+					$html .= ", '".$message_delay."'";
+				}
+				$html .= ");\n";
+			}
+			if(count($_SESSION['messages']) > 0 ){
+				foreach ($_SESSION['messages'] as $message) {
+					$message_text = addslashes($message['message']);
+					$message_mood = $message['mood'] ?: 'default';
+					$message_delay = $message['delay'];
+
+					$html .= "display_message('".$message_text."', '".$message_mood."'";
+					if ($message_delay != '') {
+						$html .= ", '".$message_delay."'";
+					}
+					$html .= ");\n";
+				}
+			}
+			if($clear_messages) {
+				unset($_SESSION['message'], $_SESSION['message_mood'], $_SESSION['message_delay']);
+				unset($_SESSION['messages']);
+			}
+			return $html;
+		}
+	}
+}
+
+?>

--- a/themes/default/css.php
+++ b/themes/default/css.php
@@ -1392,6 +1392,46 @@ $default_login = ($_REQUEST['login'] == 'default') ? true : false;
 		color: <?php echo $_SESSION['theme']['message_alert_color']['text']; ?>;
 		}
 
+/* MESSAGES STACK *******************************************************/
+
+	#messages_container {
+		z-index: 99998;
+		position: absolute;
+		top: 0;
+		left: 0;
+		right: 0;
+		padding: 0;
+		}
+
+	.message_text {
+		z-index: 99999;
+		margin: 0 auto;
+		padding: 0.5em 0;
+		text-align: center;
+		font-family: arial, san-serif;
+		font-size: 10pt;
+		display: block;
+		border-bottom: solid 1px;
+		}
+
+	.message_mood_default {
+		color: <?php echo $_SESSION['theme']['message_default_color']['text']; ?>;
+		background: <?php echo $_SESSION['theme']['message_default_background_color']['text']; ?>;
+		border-bottom-color: <?php echo $_SESSION['theme']['message_default_color']['text']; ?>;
+		}
+
+	.message_mood_negative {
+		color: <?php echo $_SESSION['theme']['message_negative_color']['text']; ?>;
+		background: <?php echo $_SESSION['theme']['message_negative_background_color']['text']; ?>;
+		border-bottom-color: <?php echo $_SESSION['theme']['message_negative_color']['text']; ?>;
+		}
+
+	.message_mood_alert {
+		color: <?php echo $_SESSION['theme']['message_alert_color']['text']; ?>;
+		background: <?php echo $_SESSION['theme']['message_alert_background_color']['text']; ?>;
+		border-bottom-color: <?php echo $_SESSION['theme']['message_alert_color']['text']; ?>;
+		}
+
 /* OPERATOR PANEL ****************************************************************/
 
 	div.op_ext {

--- a/themes/default/template.php
+++ b/themes/default/template.php
@@ -66,43 +66,27 @@
 
 	//display message bar via js
 		function display_message(msg, mood, delay) {
-			var mood = (typeof mood !== 'undefined') ? mood : 'default';
-			var delay = (typeof delay !== 'undefined') ? delay : <?php echo (1000 * (float) $_SESSION['theme']['message_delay']['text']); ?>;
-			if (msg != '') {
-				var inner_width = $(window).width();
-				// add class by mood
-				$("#message_container").addClass('message_container_mood_'+mood);
-				$("#message_text").addClass('message_text_mood_'+mood);
-				// output message
-				$("#message_text").html(msg);
-				$("#message_container").css({height: $("#message_text").css("height")});
-				$("#message_container").css({width: inner_width});
-				$("#message_text").show().animate({top: '+=80'}, 500).animate({opacity: 1}, 'fast').delay(delay).animate({top: '-=80'}, 1000).animate({opacity: 0});
-				$("#message_container").show().animate({top: '+=80'}, 500).animate({opacity: <?php echo $_SESSION['theme']['message_opacity']['text']; ?>}, "fast").delay(delay).animate({top: '-=80'}, 1000).animate({opacity: 0}, function() {
-					$("#message_container").removeClass('message_container_mood_'+mood);
-				});
+			mood = (typeof mood !== 'undefined') ? mood : 'default';
+			delay = (typeof delay !== 'undefined') ? delay : <?php echo (1000 * (float) $_SESSION['theme']['message_delay']['text']); ?>;
+			if (msg !== '') {
+				var message_text = $(document.createElement('div'));
+				message_text.addClass('message_text message_mood_'+mood);
+				message_text.html(msg);
+				message_text.click(function() {
+					var object = $(this);
+					object.clearQueue().finish();
+					object.css({height: '3em'});
+					object.animate({height: '0', 'font-size': '0', 'border-bottom-width': '0'}, 1000).animate({opacity: 0});
+				} );
+				$("#messages_container").append(message_text);
+				message_text.animate({height: '3em'}, 500).animate({opacity: 1}, 'fast').delay(delay).animate({height: '0', 'font-size': '0', 'border-bottom-width': '0'}, 1000).animate({opacity: 0});
 			}
 		}
 
 	$(document).ready(function() {
 
-		//set response message, if any
-			<?php
-			if (strlen($_SESSION['message']) > 0) {
-				$message_text = addslashes($_SESSION['message']);
-				$message_mood = $_SESSION['message_mood'];
-				$message_delay = $_SESSION['message_delay'];
-
-				echo "display_message('".$message_text."'";
-				echo ($message_mood != '') ? ", '".$message_mood."'" : ", 'default'";
-				if ($message_delay != '') {
-					echo ", '".$message_delay."'";
-				}
-				echo "); ";
-				unset($_SESSION['message'], $_SESSION['message_mood'], $_SESSION['message_delay']);
-			}
-			?>
-
+		//render the messages
+			<?php echo messages::html(); ?>
 
 		//hide message bar on hover
 			$("#message_text").mouseover(function() { $(this).hide(); $("#message_container").hide(); });
@@ -253,8 +237,8 @@
 				
 				$('audio').each(function(){
 					if ($(this).get(0) != recording_audio) {
-					    $(this).get(0).pause(); // Stop playing
-					    $(this).get(0).currentTime = 0; // Reset time
+						$(this).get(0).pause(); // Stop playing
+						$(this).get(0).currentTime = 0; // Reset time
 					}
 				});
 			}
@@ -301,15 +285,14 @@
 </head>
 
 <?php
-//add multi-lingual support
+//add multilingual support
 	$language = new text;
 	$text = $language->get(null,'themes/default');
 ?>
 
 <body onload="<?php echo $onload;?>">
 
-	<div id='message_container' class='message_container_mood_default'></div>
-	<div id='message_text' class='message_container_text_default'></div>
+	<div id='messages_container'></div>
 
 	<?php
 	//logged in show the domains block


### PR DESCRIPTION
Support legacy $_SESSION['message_*']
Use new messages class
New function messages::add($message, $mood, $delay) to simplify adding messages
- [x] Tested on debian 8, Host firefox client

simplification of giving messages, allows multiple messages to be displayed with individual moods and delays
