### PR TITLE
Fix MySQL syntax

### DIFF
--- a/core/install/resources/classes/install_fusionpbx.php
+++ b/core/install/resources/classes/install_fusionpbx.php
@@ -659,7 +659,7 @@ include "root.php";
 				$this->write_progress("... superuser exists as '" . $this->admin_uuid . "', updating password");
 				$sql = "update v_users ";
 				$sql .= "set password = '".md5($salt.$this->admin_password)."' ";
-				$sql .= "set salt = '$salt' ";
+				$sql .= ",salt = '$salt' ";
 				$sql .= "where USER_uuid = '".$this->admin_uuid."' ";
 				$this->write_debug($sql);
 				$this->dbh->exec(check_sql($sql));
@@ -712,7 +712,7 @@ include "root.php";
 			$prep_statement = $this->dbh->prepare(check_sql($sql));
 			$prep_statement->execute();
 			$row = $prep_statement->fetch(PDO::FETCH_ASSOC);
-			if ($row['count'] == 0) {
+			if ($row['count(*)'] == 0) {
 				$sql = "insert into v_contacts ";
 				$sql .= "(";
 				$sql .= "domain_uuid, ";
@@ -742,7 +742,7 @@ include "root.php";
 			$prep_statement = $this->dbh->prepare(check_sql($sql));
 			$prep_statement->execute();
 			$row = $prep_statement->fetch(PDO::FETCH_ASSOC);
-			if ($row['count'] == 0) {
+			if ($row['count(*)'] == 0) {
 				//add the user to the superadmin group
 				$sql = "insert into v_group_users ";
 				$sql .= "(";


### PR DESCRIPTION
Tested on CentOS v7 using MariaDB v5.5.52 and PHP v5.4.16

When reinstalling using the same superuser, install will fail due to incorrect MySQL syntax.  `SET` is used twice instead of once and separating the two commands with a `,`

After that correction the install is able to proceed to the next step which fails because `row['count']` does not exist and is actually `row['count(*)']`.  It will always match `==0` and incorrectly try execute the insertion of the duplicate `v_contact`.