### PR TITLE
Enhance [master] provide $app_path during upgrade

### DIFF
--- a/resources/classes/domains.php
+++ b/resources/classes/domains.php
@@ -239,6 +239,8 @@ if (!class_exists('domains')) {
 				$db = $this->db;
 				$x=0;
 				foreach ($config_list as &$config_path) {
+					$app_path = dirname($config_path);
+					$app_path = preg_replace('/\A.*(\/.*\/.*)\z/', '$1', $app_path);
 					include($config_path);
 					$x++;
 				}

--- a/resources/classes/menu.php
+++ b/resources/classes/menu.php
@@ -69,6 +69,8 @@ if (!class_exists('menu')) {
 					$config_list = glob($_SERVER["DOCUMENT_ROOT"].PROJECT_PATH."/*/*/app_menu.php");
 					$x = 0;
 					foreach ($config_list as &$config_path) {
+						$app_path = dirname($config_path);
+						$app_path = preg_replace('/\A.*(\/.*\/.*)\z/', '$1', $app_path);
 						$y = 0;
 						try {
 							//echo "[".$x ."] ".$config_path."\n";


### PR DESCRIPTION
if a application is installed via a symlink PHP will resolve the symlink
for `__DIR__` and `__FILE__` making it impossible for an application to work
out it's relative path withing the fusion system.
By providing $app_path during upgrade routines an application will
beable to provide the correct link for menu items (e.g.
/opt/languages/index.php) instead of having to hard code it where it
could change depending on how the application was installed