### PR TITLE
Use the correct CID

### DIFF
--- a/app/calls/resources/classes/call_forward.php
+++ b/app/calls/resources/classes/call_forward.php
@@ -112,6 +112,11 @@ include "root.php";
 						$dial_string .= "user/".$this->forward_all_destination."@".$_SESSION['domain_name'];
 					}
 					else {
+						$dial_string .='{origination_caller_id_number=${cond(${from_user_exists} == true ? ${outbound_caller_id_number} : ${origination_caller_id_number})}}';
+						$dial_string .='{effective_caller_id_number=${cond(${from_user_exists} == true ? ${outbound_caller_id_number} : ${effective_caller_id_number})}}';
+						$dial_string .='{origination_caller_id_name=${cond(${from_user_exists} == true ? ${outbound_caller_id_name} : ${origination_caller_id_name})}}';
+						$dial_string .='{effective_caller_id_name=${cond(${from_user_exists} == true ? ${outbound_caller_id_name} : ${effective_caller_id_name})}}';
+
 						if ($_SESSION['domain']['bridge']['text'] == "outbound" || $_SESSION['domain']['bridge']['text'] == "bridge") {
 							$bridge = outbound_route_to_bridge ($_SESSION['domain_uuid'], $this->forward_all_destination);
 							$dial_string .= $bridge[0];

--- a/app/calls/resources/classes/call_forward.php
+++ b/app/calls/resources/classes/call_forward.php
@@ -90,10 +90,12 @@ include "root.php";
 							if (strlen($row_caller['destination_description']) > 0) {
 								$dial_string_caller_id_name = $row_caller['destination_description'];
 								$dial_string .= ",origination_caller_id_name=$dial_string_caller_id_name";
+								$dial_string .= ",effective_caller_id_name=$dial_string_caller_id_name";
 							}
 							if (strlen($row_caller['destination_number']) > 0) {
 								$dial_string_caller_id_number = $row_caller['destination_number'];
 								$dial_string .= ",origination_caller_id_number=$dial_string_caller_id_number";
+								$dial_string .= ",effective_caller_id_number=$dial_string_caller_id_number";
 								$dial_string .= ",outbound_caller_id_number=$dial_string_caller_id_number";
 							}
 						}
@@ -104,6 +106,8 @@ include "root.php";
 							$dial_string .= ",outbound_caller_id_number=".$this->outbound_caller_id_number;
 							$dial_string .= ",origination_caller_id_name=".$this->outbound_caller_id_name;
 							$dial_string .= ",origination_caller_id_number=".$this->outbound_caller_id_number;
+							$dial_string .= ",effective_caller_id_name=".$this->outbound_caller_id_name;
+							$dial_string .= ",effective_caller_id_number=".$this->outbound_caller_id_number;
 						}
 					}
 

--- a/app/calls/resources/classes/follow_me.php
+++ b/app/calls/resources/classes/follow_me.php
@@ -372,6 +372,9 @@ include "root.php";
 								$dial_string .= ",outbound_caller_id_number=".$this->outbound_caller_id_number;
 								$dial_string .= ",origination_caller_id_name=".$this->outbound_caller_id_name;
 								$dial_string .= ",origination_caller_id_number=".$this->outbound_caller_id_number;
+								$dial_string .= ",effective_caller_id_name=".$this->outbound_caller_id_name;
+								$dial_string .= ",effective_caller_id_number=".$this->outbound_caller_id_number;
+
 							}
 							else{
 								$dial_string .='origination_caller_id_number=${cond(${from_user_exists} == true ? ${outbound_caller_id_number} : ${origination_caller_id_number})}';

--- a/app/calls/resources/classes/follow_me.php
+++ b/app/calls/resources/classes/follow_me.php
@@ -374,7 +374,10 @@ include "root.php";
 								$dial_string .= ",origination_caller_id_number=".$this->outbound_caller_id_number;
 							}
 							else{
-								$dial_string .= "outbound_caller_id_number=$dial_string_caller_id_number";
+								$dial_string .='origination_caller_id_number=${cond(${from_user_exists} == true ? ${outbound_caller_id_number} : ${origination_caller_id_number})}';
+								$dial_string .=',effective_caller_id_number=${cond(${from_user_exists} == true ? ${outbound_caller_id_number} : ${effective_caller_id_number})}';
+								$dial_string .=',origination_caller_id_name=${cond(${from_user_exists} == true ? ${outbound_caller_id_name} : ${origination_caller_id_name})}';
+								$dial_string .=',effective_caller_id_name=${cond(${from_user_exists} == true ? ${outbound_caller_id_name} : ${effective_caller_id_name})}';
 							}
 							$dial_string .= ",presence_id=".$this->extension."@".$_SESSION['domain_name'];
 							if ($row["follow_me_prompt"] == "1") {


### PR DESCRIPTION
If one extension is forwarding to the PSTN and another extension calls, the PSTN gets the extension number instead the outbound caller id. For example, my cellphone gets 101 as caller instead 5551011234