### PR TITLE
New FAKE Call Block Option

### DIFF
--- a/app/call_block/app_languages.php
+++ b/app/call_block/app_languages.php
@@ -353,6 +353,20 @@ $text['label-hold']['ru-ru'] = "Удержание";
 $text['label-hold']['sv-se'] = "";
 $text['label-hold']['uk-ua'] = "";
 
+$text['label-fake']['en-us'] = "Fake";
+$text['label-fake']['es-cl'] = "Falso";
+$text['label-fake']['pt-pt'] = "Falso";
+$text['label-fake']['fr-fr'] = "Faux";
+$text['label-fake']['nl-nl'] = "";
+$text['label-fake']['pt-br'] = "Falso";
+$text['label-fake']['pl'] = "";
+$text['label-fake']['sv-se'] = "";
+$text['label-fake']['uk'] = "";
+$text['label-fake']['ro'] = "";
+$text['label-fake']['de-at'] = "";
+$text['label-fake']['ar-eg'] = "";
+$text['label-fake']['he'] = "";
+
 $text['label-voicemail']['en-us'] = "Voicemail";
 $text['label-voicemail']['ar-eg'] = "";
 $text['label-voicemail']['de-at'] = "Mailbox";

--- a/app/call_block/call_block_edit.php
+++ b/app/call_block/call_block_edit.php
@@ -304,6 +304,12 @@ if (count($_POST)>0 && strlen($_POST["persistformvar"]) == 0) {
 	else {
 		echo "	<option value='Hold'>".$text['label-hold']."</option>\n";
 	}
+	if ($action == "Fake") {
+		echo "  <option value='Fake' selected='selected'>".$text['label-fake']."</option>\n";
+	}
+	else {
+		echo "  <option value='Fake'>".$text['label-fake']."</option>\n";
+	}
 	call_block_get_extensions($extension);
 	echo "	</select>\n";
 	echo "<br />\n";


### PR DESCRIPTION
I had a trunk that was working very odd. If the PBX sends a SIP answer different than 200 (4xx, 5xx, 6xx), the carrier pushes its voicemail instead of a busy/rejected tone.

This patch allows adding a fake answer. The switch will answer but the caller will listen to the ring tone sequence.
Times and tone sequence is totally configurable through default settings.

I will text you to discuss backporting