### PR TITLE
Add. Allow use `call_flow_subscribe.lua` with feature codes without `flow+` prefix

### DIFF
--- a/app/call_flows/call_flow_edit.php
+++ b/app/call_flows/call_flow_edit.php
@@ -163,6 +163,10 @@
 			$destination_extension = str_replace("+", "\+", $destination_extension);
 
 			$destination_feature = $call_flow_feature_code;
+			// Allows dial feature code as `flow+<feature_code>`
+			if (substr($destination_feature, 0, 5) != 'flow+') {
+				$destination_feature = '(?:flow+)?' . $destination_feature;
+			}
 			$destination_feature = str_replace("*", "\*", $destination_feature);
 			$destination_feature = str_replace("+", "\+", $destination_feature);
 

--- a/resources/install/scripts/call_flow.lua
+++ b/resources/install/scripts/call_flow.lua
@@ -207,6 +207,12 @@ if (session:ready()) then
 				call_flow_feature_code.."@"..domain_name,
 				call_flow_uuid
 			);
+			if string.find(call_flow_feature_code, 'flow+', nil, true) ~= 1 then
+				presence_in.turn_lamp( toggle == "false",
+					'flow+'..call_flow_feature_code.."@"..domain_name,
+					call_flow_uuid
+				);
+			end
 
 		--active label
 			local active_flow_label = (toggle == "true") and call_flow_label or call_flow_alternate_label


### PR DESCRIPTION
This PR allows create call flow extension with some feature code (e.g. `*401`)
Then on the phone you can configure BLF like `flow+*401` and use `call_flow_subscribe` to
track current status of this call flow. BLF like `*401` will also works but only if
use `call_flow_monitor` script.
Also it is possible dial `flow+*401` as well as `*401` to toggle call flow state.