### PR TITLE
BugFix [4.2] - menu class

### DIFF
--- a/resources/classes/menu.php
+++ b/resources/classes/menu.php
@@ -62,6 +62,7 @@ if (!class_exists('menu')) {
 
 		//restore the menu
 			public function restore() {
+				
 				//set the variables
 					$db = $this->db;
 
@@ -85,6 +86,9 @@ if (!class_exists('menu')) {
 					if ($db_type == "sqlite") {
 						$db->beginTransaction();
 					}
+
+				//get the list of languages
+					$language = new text;
 
 				//use the app array to restore the default menu
 					foreach ($apps as $row) {
@@ -155,7 +159,10 @@ if (!class_exists('menu')) {
 											unset($sql);
 
 										//set the menu languages
-											foreach ($menu["title"] as $menu_language => $menu_item_title) {
+											foreach ($language->languages as $menu_language) {
+												$menu_item_title = $menu["title"][$menu_language];
+												if(strlen($menu_item_title) == 0)
+													$menu_item_title = $menu["title"]['en-us'];
 												$menu_language_uuid = uuid();
 												$sql = "insert into v_menu_languages ";
 												$sql .= "(";

--- a/resources/classes/text.php
+++ b/resources/classes/text.php
@@ -6,11 +6,27 @@
  */
 class text {
 
+	public $languages;
+
 	/**
 	 * Called when the object is created
 	 */
 	public function __construct() {
-		//place holder
+		//define the text array
+			$text = array();
+
+		//get the global app_languages.php so we can get the list of languages
+			include $_SERVER["PROJECT_ROOT"]."/resources/app_languages.php";
+
+		//get the list of languages, remove en-us, sort it then put en-us in front
+			unset($text['language-name']['en-us']);
+			$languages = array_keys($text['language-name']);
+			asort($languages);
+			array_unshift($languages, 'en-us');
+
+		//support legacy variable
+			$_SESSION['app']['languages'] = $languages;
+			$this->languages = $languages;
 	}
 
 	/**


### PR DESCRIPTION
when a translation is missing/blank take it from en-us
take the list of lanaguages from text class so all languages get a value
(should fix missing logout button in some languages)
add languages to text class as required by this patch