### PR TITLE
BugFix [master] - database class app_uuid

### DIFF
--- a/app/number_translation/resources/classes/number_translation.php
+++ b/app/number_translation/resources/classes/number_translation.php
@@ -106,6 +106,7 @@ include "root.php";
 							}
 							$database = new database;
 							$database->app_name = 'number_translations';
+							$database->app_uuid = '6ad54de6-4909-11e7-a919-92ebcb67fe33';
 							$database->save($array);
 							if ($this->display_type == "text") {
 								if ($database->message['code'] != '200') { 

--- a/resources/classes/database.php
+++ b/resources/classes/database.php
@@ -48,6 +48,8 @@ include "root.php";
 			public $count;
 			public $sql;
 			public $result;
+			public $app_name;
+			public $app_uuid;
 
 			public function connect() {
 
@@ -881,7 +883,7 @@ include "root.php";
 						$sql .= "database_transaction_uuid, ";
 						$sql .= "domain_uuid, ";
 						$sql .= "user_uuid, ";
-						if (isset($this->app_uuid)) {
+						if (strlen($this->app_uuid) > 0) {
 							$sql .= "app_uuid, ";
 						}
 						$sql .= "app_name, ";
@@ -898,7 +900,7 @@ include "root.php";
 						$sql .= "'".uuid()."', ";
 						$sql .= "'".$domain_uuid."', ";
 						$sql .= "'".$_SESSION['user_uuid']."', ";
-						if (isset($this->app_uuid)) {
+						if (strlen($this->app_uuid) > 0) {
 							$sql .= "'".$this->app_uuid."', ";
 						}
 						$sql .= "'".$this->app_name."', ";
@@ -1608,7 +1610,7 @@ include "root.php";
 						$sql .= "database_transaction_uuid, ";
 						$sql .= "domain_uuid, ";
 						$sql .= "user_uuid, ";
-						if (isset($this->app_uuid)) {
+						if (strlen($this->app_uuid) > 0) {
 							$sql .= "app_uuid, ";
 						}
 						$sql .= "app_name, ";
@@ -1625,7 +1627,7 @@ include "root.php";
 						$sql .= "'".uuid()."', ";
 						$sql .= "'".$domain_uuid."', ";
 						$sql .= "'".$_SESSION['user_uuid']."', ";
-						if (isset($this->app_uuid)) {
+						if (strlen($this->app_uuid) > 0) {
 							$sql .= "'".$this->app_uuid."', ";
 						}
 						$sql .= "'".$this->app_name."', ";


### PR DESCRIPTION
if $database->app_uuid is not set it would use '' in some conditions which isset would test true.
This fix uses strlen instead, but also fixes number_transations app that highlighted the flaw