### PR TITLE
Enhance [master] - database class

### DIFF
--- a/app/database_transactions/app_defaults.php
+++ b/app/database_transactions/app_defaults.php
@@ -1,0 +1,58 @@
+<?php
+/*
+	FusionPBX
+	Version: MPL 1.1
+
+	The contents of this file are subject to the Mozilla Public License Version
+	1.1 (the "License"); you may not use this file except in compliance with
+	the License. You may obtain a copy of the License at
+	http://www.mozilla.org/MPL/
+
+	Software distributed under the License is distributed on an "AS IS" basis,
+	WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License
+	for the specific language governing rights and limitations under the
+	License.
+
+	The Original Code is FusionPBX
+
+	The Initial Developer of the Original Code is
+	Mark J Crane <markjcrane@fusionpbx.com>
+	Portions created by the Initial Developer are Copyright (C) 2008-2017
+	the Initial Developer. All Rights Reserved.
+
+	Contributor(s):
+	Matthew Vale <github@mafoo.org>
+*/
+
+	if ($domains_processed == 1) {
+		//check if the SYSTEM_USER has been defined
+			$sql = "select count(*) as num_rows from v_users ";
+			$sql .= "where user_uuid = '00000000-0000-0000-0000-000000000000' ";
+			$prep_statement = $db->prepare(check_sql($sql));
+			if ($prep_statement) {
+				$prep_statement->execute();
+				$result = $prep_statement->fetch(PDO::FETCH_ASSOC);
+				if ($result['num_rows'] == 0) {
+					$sql = "insert into v_users ";
+					$sql .= "(";
+					$sql .= "user_uuid, ";
+					$sql .= "domain_uuid, ";
+					$sql .= "username, ";
+					$sql .= "user_enabled ";
+					$sql .= ") ";
+					$sql .= "values ";
+					$sql .= "(";
+					$sql .= "'00000000-0000-0000-0000-000000000000', ";
+					$sql .= "'00000000-0000-0000-0000-000000000000', ";
+					$sql .= "'SYSTEM_USER', ";
+					$sql .= "'false' ";
+					$sql .= ");";
+					$db->exec($sql);
+					if ($display_type == "text") {
+						echo "Added SYSTEM_USER\n";
+					}
+				}
+			}
+			unset($result, $sql, $prep_statement);
+	}
+?>

--- a/resources/classes/database.php
+++ b/resources/classes/database.php
@@ -873,8 +873,9 @@ include "root.php";
 				//commit the atomic transaction
 					//$this->db->commit();
 
-				//get the domain uuid
+				//get uuids
 					$domain_uuid = $_SESSION['domain_uuid'];
+					$user_uuid = ( strlen($_SESSION['user_uuid']) > 0 ? $_SESSION['user_uuid'] : '00000000-0000-0000-0000-000000000000');
 
 				//log the transaction results
 					if (file_exists($_SERVER["PROJECT_ROOT"]."/app/database_transactions/app_config.php")) {
@@ -899,7 +900,7 @@ include "root.php";
 						$sql .= "(";
 						$sql .= "'".uuid()."', ";
 						$sql .= "'".$domain_uuid."', ";
-						$sql .= "'".$_SESSION['user_uuid']."', ";
+						$sql .= "'".$user_uuid."', ";
 						if (strlen($this->app_uuid) > 0) {
 							$sql .= "'".$this->app_uuid."', ";
 						}
@@ -1600,8 +1601,9 @@ include "root.php";
 				//commit the atomic transaction
 					$this->db->commit();
 
-				//get the domain uuid
+				//get uuids
 					$domain_uuid = $_SESSION['domain_uuid'];
+					$user_uuid = ( strlen($_SESSION['user_uuid']) > 0 ? $_SESSION['user_uuid'] : '00000000-0000-0000-0000-000000000000');
 
 				//log the transaction results
 					if (file_exists($_SERVER["PROJECT_ROOT"]."/app/database_transactions/app_config.php")) {
@@ -1626,7 +1628,7 @@ include "root.php";
 						$sql .= "(";
 						$sql .= "'".uuid()."', ";
 						$sql .= "'".$domain_uuid."', ";
-						$sql .= "'".$_SESSION['user_uuid']."', ";
+						$sql .= "'".$user_uuid."', ";
 						if (strlen($this->app_uuid) > 0) {
 							$sql .= "'".$this->app_uuid."', ";
 						}


### PR DESCRIPTION
If an application uses database class to do it's save operation for app_defaults, when it is executed via the commandline there is no $_SESSION['user_uuid'] so this causes the transaction to fail.
This update is to use the correct uuid-null string when there is no user_uuid
add a SYSTEM_USER with the null-uuid so database transaction will render
this was highlighted by the new number_translation app.