### PR TITLE
Hide pin codes when a user pushes the redial button

### DIFF
--- a/resources/templates/provision/yealink/t21p/y000000000052.cfg
+++ b/resources/templates/provision/yealink/t21p/y000000000052.cfg
@@ -722,7 +722,7 @@ features.hotline_delay =
 ##                                   Features DTMF                                   ##
 #######################################################################################
 #Enable or disable the phone to suppress the display of DTMF digits; 0-Disabled (default), 1-Enabled;
-features.dtmf.hide =
+features.dtmf.hide ={yealink_dtmf_hide}
 
 #Enables or disables the IP phone to display the DTMF digits for a short period before displaying as asterisks; 0-Disabled (default), 1-Enabled;
 features.dtmf.hide_delay =


### PR DESCRIPTION
This is a security risk as other users can push redial and see the pin code