### PR TITLE
Fix Attended Transfer Caller ID Display

### DIFF
--- a/resources/templates/provision/grandstream/gxp2130/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp2130/{$mac}.xml
@@ -223,7 +223,7 @@
 <!--  Caller ID Display. 0 - Auto, 1 - Disabled, 2 - From Header. Default is 0 -->
 <!--  Number: 0, 1, 2 -->
 <!--  Mandatory -->
-<P2324>2</P2324>
+<P2324>0</P2324>
 
 <!--  Add Auth Header On Initial REGISTER -->
 <!--  0 - No, 1 - Yes. Default is 0 -->
@@ -992,7 +992,7 @@
 <!--  Caller ID Display. 0 - Auto, 1 - Disabled, 2 - From Header. Default is 0 -->
 <!--  Number: 0, 1, 2 -->
 <!--  Mandatory -->
-<P2424>2</P2424>
+<P2424>0</P2424>
 
 <!--  Add Auth Header On Initial REGISTER -->
 <!--  0 - No, 1 - Yes. Default is 0 -->
@@ -1746,7 +1746,7 @@
 <!--  Caller ID Display. 0 - Auto, 1 - Disabled, 2 - From Header. Default is 0 -->
 <!--  Number: 0, 1, 2 -->
 <!--  Mandatory -->
-<P2524>2</P2524>
+<P2524>0</P2524>
 
 <!--  Add Auth Header On Initial REGISTER -->
 <!--  0 - No, 1 - Yes. Default is 0 -->
@@ -4009,7 +4009,7 @@
 <!--  Caller ID Display. 0 - Auto, 1 - Disabled, 2 - From Header. Default is 0 -->
 <!--  Number: 0, 1, 2 -->
 <!--  Mandatory -->
-<P2824>2</P2824>
+<P2824>0</P2824>
 
 <!--  Add Auth Header On Initial REGISTER -->
 <!--  0 - No, 1 - Yes. Default is 0 -->

--- a/resources/templates/provision/grandstream/gxp2135/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp2135/{$mac}.xml
@@ -223,7 +223,7 @@
 <!--  Caller ID Display. 0 - Auto, 1 - Disabled, 2 - From Header. Default is 0 -->
 <!--  Number: 0, 1, 2 -->
 <!--  Mandatory -->
-<P2324>2</P2324>
+<P2324>0</P2324>
 
 <!--  Add Auth Header On Initial REGISTER -->
 <!--  0 - No, 1 - Yes. Default is 0 -->
@@ -992,7 +992,7 @@
 <!--  Caller ID Display. 0 - Auto, 1 - Disabled, 2 - From Header. Default is 0 -->
 <!--  Number: 0, 1, 2 -->
 <!--  Mandatory -->
-<P2424>2</P2424>
+<P2424>0</P2424>
 
 <!--  Add Auth Header On Initial REGISTER -->
 <!--  0 - No, 1 - Yes. Default is 0 -->
@@ -1746,7 +1746,7 @@
 <!--  Caller ID Display. 0 - Auto, 1 - Disabled, 2 - From Header. Default is 0 -->
 <!--  Number: 0, 1, 2 -->
 <!--  Mandatory -->
-<P2524>2</P2524>
+<P2524>0</P2524>
 
 <!--  Add Auth Header On Initial REGISTER -->
 <!--  0 - No, 1 - Yes. Default is 0 -->
@@ -2499,7 +2499,7 @@
 <!--  Caller ID Display. 0 - Auto, 1 - Disabled, 2 - From Header. Default is 0 -->
 <!--  Number: 0, 1, 2 -->
 <!--  Mandatory -->
-<P2624>2</P2624>
+<P2624>0</P2624>
 
 <!--  Add Auth Header On Initial REGISTER -->
 <!--  0 - No, 1 - Yes. Default is 0 -->
@@ -3254,7 +3254,7 @@
 <!--  Caller ID Display. 0 - Auto, 1 - Disabled, 2 - From Header. Default is 0 -->
 <!--  Number: 0, 1, 2 -->
 <!--  Mandatory -->
-<P2724>2</P2724>
+<P2724>0</P2724>
 
 <!--  Add Auth Header On Initial REGISTER -->
 <!--  0 - No, 1 - Yes. Default is 0 -->
@@ -4009,7 +4009,7 @@
 <!--  Caller ID Display. 0 - Auto, 1 - Disabled, 2 - From Header. Default is 0 -->
 <!--  Number: 0, 1, 2 -->
 <!--  Mandatory -->
-<P2824>2</P2824>
+<P2824>0</P2824>
 
 <!--  Add Auth Header On Initial REGISTER -->
 <!--  0 - No, 1 - Yes. Default is 0 -->

--- a/resources/templates/provision/grandstream/gxp2140/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp2140/{$mac}.xml
@@ -223,7 +223,7 @@
 <!--  Caller ID Display. 0 - Auto, 1 - Disabled, 2 - From Header. Default is 0 -->
 <!--  Number: 0, 1, 2 -->
 <!--  Mandatory -->
-<P2324>2</P2324>
+<P2324>0</P2324>
 
 <!--  Add Auth Header On Initial REGISTER -->
 <!--  0 - No, 1 - Yes. Default is 0 -->
@@ -992,7 +992,7 @@
 <!--  Caller ID Display. 0 - Auto, 1 - Disabled, 2 - From Header. Default is 0 -->
 <!--  Number: 0, 1, 2 -->
 <!--  Mandatory -->
-<P2424>2</P2424>
+<P2424>0</P2424>
 
 <!--  Add Auth Header On Initial REGISTER -->
 <!--  0 - No, 1 - Yes. Default is 0 -->
@@ -1746,7 +1746,7 @@
 <!--  Caller ID Display. 0 - Auto, 1 - Disabled, 2 - From Header. Default is 0 -->
 <!--  Number: 0, 1, 2 -->
 <!--  Mandatory -->
-<P2524>2</P2524>
+<P2524>0</P2524>
 
 <!--  Add Auth Header On Initial REGISTER -->
 <!--  0 - No, 1 - Yes. Default is 0 -->
@@ -2499,7 +2499,7 @@
 <!--  Caller ID Display. 0 - Auto, 1 - Disabled, 2 - From Header. Default is 0 -->
 <!--  Number: 0, 1, 2 -->
 <!--  Mandatory -->
-<P2624>2</P2624>
+<P2624>0</P2624>
 
 <!--  Add Auth Header On Initial REGISTER -->
 <!--  0 - No, 1 - Yes. Default is 0 -->
@@ -3254,7 +3254,7 @@
 <!--  Caller ID Display. 0 - Auto, 1 - Disabled, 2 - From Header. Default is 0 -->
 <!--  Number: 0, 1, 2 -->
 <!--  Mandatory -->
-<P2724>2</P2724>
+<P2724>0</P2724>
 
 <!--  Add Auth Header On Initial REGISTER -->
 <!--  0 - No, 1 - Yes. Default is 0 -->
@@ -4009,7 +4009,7 @@
 <!--  Caller ID Display. 0 - Auto, 1 - Disabled, 2 - From Header. Default is 0 -->
 <!--  Number: 0, 1, 2 -->
 <!--  Mandatory -->
-<P2824>2</P2824>
+<P2824>0</P2824>
 
 <!--  Add Auth Header On Initial REGISTER -->
 <!--  0 - No, 1 - Yes. Default is 0 -->

--- a/resources/templates/provision/grandstream/gxp2160/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp2160/{$mac}.xml
@@ -223,7 +223,7 @@
 <!--  Caller ID Display. 0 - Auto, 1 - Disabled, 2 - From Header. Default is 0 -->
 <!--  Number: 0, 1, 2 -->
 <!--  Mandatory -->
-<P2324>2</P2324>
+<P2324>0</P2324>
 
 <!--  Add Auth Header On Initial REGISTER -->
 <!--  0 - No, 1 - Yes. Default is 0 -->
@@ -992,7 +992,7 @@
 <!--  Caller ID Display. 0 - Auto, 1 - Disabled, 2 - From Header. Default is 0 -->
 <!--  Number: 0, 1, 2 -->
 <!--  Mandatory -->
-<P2424>2</P2424>
+<P2424>0</P2424>
 
 <!--  Add Auth Header On Initial REGISTER -->
 <!--  0 - No, 1 - Yes. Default is 0 -->
@@ -1746,7 +1746,7 @@
 <!--  Caller ID Display. 0 - Auto, 1 - Disabled, 2 - From Header. Default is 0 -->
 <!--  Number: 0, 1, 2 -->
 <!--  Mandatory -->
-<P2524>2</P2524>
+<P2524>0</P2524>
 
 <!--  Add Auth Header On Initial REGISTER -->
 <!--  0 - No, 1 - Yes. Default is 0 -->
@@ -2499,7 +2499,7 @@
 <!--  Caller ID Display. 0 - Auto, 1 - Disabled, 2 - From Header. Default is 0 -->
 <!--  Number: 0, 1, 2 -->
 <!--  Mandatory -->
-<P2624>2</P2624>
+<P2624>0</P2624>
 
 <!--  Add Auth Header On Initial REGISTER -->
 <!--  0 - No, 1 - Yes. Default is 0 -->
@@ -3254,7 +3254,7 @@
 <!--  Caller ID Display. 0 - Auto, 1 - Disabled, 2 - From Header. Default is 0 -->
 <!--  Number: 0, 1, 2 -->
 <!--  Mandatory -->
-<P2724>2</P2724>
+<P2724>0</P2724>
 
 <!--  Add Auth Header On Initial REGISTER -->
 <!--  0 - No, 1 - Yes. Default is 0 -->
@@ -4009,7 +4009,7 @@
 <!--  Caller ID Display. 0 - Auto, 1 - Disabled, 2 - From Header. Default is 0 -->
 <!--  Number: 0, 1, 2 -->
 <!--  Mandatory -->
-<P2824>2</P2824>
+<P2824>0</P2824>
 
 <!--  Add Auth Header On Initial REGISTER -->
 <!--  0 - No, 1 - Yes. Default is 0 -->

--- a/resources/templates/provision/grandstream/gxp2170/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp2170/{$mac}.xml
@@ -223,7 +223,7 @@
 <!--  Caller ID Display. 0 - Auto, 1 - Disabled, 2 - From Header. Default is 0 -->
 <!--  Number: 0, 1, 2 -->
 <!--  Mandatory -->
-<P2324>2</P2324>
+<P2324>0</P2324>
 
 <!--  Add Auth Header On Initial REGISTER -->
 <!--  0 - No, 1 - Yes. Default is 0 -->
@@ -992,7 +992,7 @@
 <!--  Caller ID Display. 0 - Auto, 1 - Disabled, 2 - From Header. Default is 0 -->
 <!--  Number: 0, 1, 2 -->
 <!--  Mandatory -->
-<P2424>2</P2424>
+<P2424>0</P2424>
 
 <!--  Add Auth Header On Initial REGISTER -->
 <!--  0 - No, 1 - Yes. Default is 0 -->
@@ -1746,7 +1746,7 @@
 <!--  Caller ID Display. 0 - Auto, 1 - Disabled, 2 - From Header. Default is 0 -->
 <!--  Number: 0, 1, 2 -->
 <!--  Mandatory -->
-<P2524>2</P2524>
+<P2524>0</P2524>
 
 <!--  Add Auth Header On Initial REGISTER -->
 <!--  0 - No, 1 - Yes. Default is 0 -->
@@ -2499,7 +2499,7 @@
 <!--  Caller ID Display. 0 - Auto, 1 - Disabled, 2 - From Header. Default is 0 -->
 <!--  Number: 0, 1, 2 -->
 <!--  Mandatory -->
-<P2624>2</P2624>
+<P2624>0</P2624>
 
 <!--  Add Auth Header On Initial REGISTER -->
 <!--  0 - No, 1 - Yes. Default is 0 -->
@@ -3254,7 +3254,7 @@
 <!--  Caller ID Display. 0 - Auto, 1 - Disabled, 2 - From Header. Default is 0 -->
 <!--  Number: 0, 1, 2 -->
 <!--  Mandatory -->
-<P2724>2</P2724>
+<P2724>0</P2724>
 
 <!--  Add Auth Header On Initial REGISTER -->
 <!--  0 - No, 1 - Yes. Default is 0 -->
@@ -4009,7 +4009,7 @@
 <!--  Caller ID Display. 0 - Auto, 1 - Disabled, 2 - From Header. Default is 0 -->
 <!--  Number: 0, 1, 2 -->
 <!--  Mandatory -->
-<P2824>2</P2824>
+<P2824>0</P2824>
 
 <!--  Add Auth Header On Initial REGISTER -->
 <!--  0 - No, 1 - Yes. Default is 0 -->


### PR DESCRIPTION
Caller ID Display was not working for Attended Transfer.  Set "Caller ID Display" back to defaults "Auto" and Attended Transfer Caller ID Display works properly.   Thanks to matthewearl for hints on on #fusionpbx irc. 