### PR TITLE
Use effective_caller_id_number instead of caller_id_number when storing voicemail messages

### DIFF
--- a/resources/install/scripts/app/voicemail/index.lua
+++ b/resources/install/scripts/app/voicemail/index.lua
@@ -74,6 +74,7 @@
 			destination_number = session:getVariable("destination_number");
 			caller_id_name = session:getVariable("caller_id_name");
 			caller_id_number = session:getVariable("caller_id_number");
+			effective_caller_id_number = session:getVariable("effective_caller_id_number");
 			voicemail_greeting_number = session:getVariable("voicemail_greeting_number");
 			skip_instructions = session:getVariable("skip_instructions");
 			skip_greeting = session:getVariable("skip_greeting");
@@ -85,6 +86,11 @@
 			voicemail_authorized = session:getVariable("voicemail_authorized");
 			sip_from_user = session:getVariable("sip_from_user");
 			sip_number_alias = session:getVariable("sip_number_alias");
+
+		--modify caller_id_number if effective_caller_id_number is set
+			if (effective_caller_id_number ~= nil) then
+				caller_id_number = effective_caller_id_number;
+			end
 
 		--set default values
 			if (string.sub(caller_id_number, 1, 1) == "/") then


### PR DESCRIPTION
This resolves issue #2333. On systems where 9 is used to make an external call we can use effective_caller_id_number in the inbound plan to modify the incoming CLI - for example to insert digit 9. This modified number is then passed to the extensions and the users handset's will store this modified CLI for redial and call history.

This pull request modifies the voicemail recording to use the effective_caller_id_number variable when available when saving voicemail messages, meaning that option 5 to return the call will work in the same manner. Without it, on a system that is using 9 for an outside line, the call back option in voicemail simply hangs up as it has stored the unmodified CLI for which there is no matching outbound dialplan.

