### PR TITLE
Update click_to_call.php

### DIFF
--- a/app/click_to_call/click_to_call.php
+++ b/app/click_to_call/click_to_call.php
@@ -145,8 +145,7 @@ if (is_array($_REQUEST) && !empty($_REQUEST['src']) && !empty($_REQUEST['dest'])
 				}
 				else { //not sip-uri
 					$bridge_array = outbound_route_to_bridge($_SESSION['domain_uuid'], $dest);
-					//$switch_cmd = $destination_common."}".$bridge_array[0].")";  // wouldn't set cdr destination correctly, so below used instead
-					$switch_cmd = " &transfer('".$dest." XML ".$context."')";
+					$switch_cmd = " &bridge({origination_caller_id_name='$dest_cid_name',origination_caller_id_number=$dest_cid_number,call_direction=outbound}".$bridge_array[0];
 				}
 			}
 		}


### PR DESCRIPTION
Use of transfer instead of Bridge did not allow setting of outbound caller ID. E.G. When using click to dial to call two external numbers and setting the "Destination Caller ID Number" this setting would be ignored and the source caller ID info would be passed.