### PR TITLE
Add IVR Menu Language Option

### DIFF
--- a/app/ivr_menus/app_languages.php
+++ b/app/ivr_menus/app_languages.php
@@ -54,6 +54,15 @@ $text['message-maximum_ivr_menus']['pl'] = "Maksymalna ilość zapowiedzi głoso
 $text['message-maximum_ivr_menus']['sv-se'] = "Max Antal IVR Menyer: ";
 $text['message-maximum_ivr_menus']['de-at'] = "Maximale Anzahl an Automatischen Vermittlungen:";
 
+$text['label-language']['en-us'] = "Language";
+$text['label-language']['es-cl'] = "Idioma";
+$text['label-language']['pt-pt'] = "Língua";
+$text['label-language']['fr-fr'] = "Langue";
+$text['label-language']['pt-br'] = "Língua";
+$text['label-language']['pl'] = "Język";
+$text['label-language']['sv-se'] = "Språk";
+$text['label-language']['de-at'] = "Sprache";
+
 $text['label-tts_voice']['en-us'] = "TTS Voice";
 $text['label-tts_voice']['es-cl'] = "Voz TTS";
 $text['label-tts_voice']['pt-pt'] = "Voz TTS";
@@ -296,6 +305,15 @@ $text['header-ivr_menu']['pt-br'] = "Menu IVR";
 $text['header-ivr_menu']['pl'] = "Menu zapowiedzi głosowej (IVR)";
 $text['header-ivr_menu']['sv-se'] = "IVR Meny";
 $text['header-ivr_menu']['de-at'] = "Automatische Vermittlung";
+
+$text['description-language']['en-us'] = "IVR greeting language. (ex. en, fr, es)";
+$text['description-language']['es-cl'] = "Menú idioma de grabación. (ex. en, fr, es)";
+$text['description-language']['pt-pt'] = "Idioma de gravação do menu. (ex. en, fr, pt)";
+$text['description-language']['fr-fr'] = "Langue des enregistrements pour le menu. (ex. en, fr, es)";
+$text['description-language']['pt-br'] = "Idioma de gravação do menu. (ex. en, fr, pt)";
+$text['description-language']['pl'] = "Język zapisu menu. (ex. en, fr, pl)";
+$text['description-language']['sv-se'] = "Menyinspelningsspråk. (ex. en, fr, sv)";
+$text['description-language']['de-at'] = "'Menüaufzeichnungssprache. (ex. en, fr, de)";
 
 $text['description-tts_voice']['en-us'] = "Text to speech voice.";
 $text['description-tts_voice']['es-cl'] = "Voz de texto a voz";

--- a/app/ivr_menus/ivr_menu_edit.php
+++ b/app/ivr_menus/ivr_menu_edit.php
@@ -82,6 +82,7 @@
 		//get ivr menu
 			$ivr_menu_name = check_str($_POST["ivr_menu_name"]);
 			$ivr_menu_extension = check_str($_POST["ivr_menu_extension"]);
+			$ivr_menu_language = check_str($_POST["ivr_menu_language"]);
 			$ivr_menu_greet_long = check_str($_POST["ivr_menu_greet_long"]);
 			$ivr_menu_greet_short = check_str($_POST["ivr_menu_greet_short"]);
 			$ivr_menu_options = $_POST["ivr_menu_options"];
@@ -128,6 +129,7 @@
 			$msg = '';
 			if (strlen($ivr_menu_name) == 0) { $msg .= $text['message-required'].$text['label-name']."<br>\n"; }
 			if (strlen($ivr_menu_extension) == 0) { $msg .= $text['message-required'].$text['label-extension']."<br>\n"; }
+			if (strlen($ivr_menu_language) == 0) { $msg .= $text['message-required'].$text['label-language']."<br>\n"; }
 			if (strlen($ivr_menu_greet_long) == 0) { $msg .= $text['message-required'].$text['label-greet_long']."<br>\n"; }
 			//if (strlen($ivr_menu_greet_short) == 0) { $msg .= $text['message-required'].$text['label-greet_short']."<br>\n"; }
 			//if (strlen($ivr_menu_invalid_sound) == 0) { $msg .= $text['message-required'].$text['label-invalid_sound']."<br>\n"; }
@@ -254,6 +256,7 @@
 			$dialplan_uuid = $row["dialplan_uuid"];
 			$ivr_menu_name = $row["ivr_menu_name"];
 			$ivr_menu_extension = $row["ivr_menu_extension"];
+			$ivr_menu_language = $row["ivr_menu_language"];
 			$ivr_menu_greet_long = $row["ivr_menu_greet_long"];
 			$ivr_menu_greet_short = $row["ivr_menu_greet_short"];
 			$ivr_menu_invalid_sound = $row["ivr_menu_invalid_sound"];
@@ -318,6 +321,7 @@
 	if (strlen($ivr_menu_ringback) == 0) { $ivr_menu_ringback = 'local_stream://default'; }
 	if (strlen($ivr_menu_invalid_sound) == 0) { $ivr_menu_invalid_sound = 'ivr/ivr-that_was_an_invalid_entry.wav'; }
 	//if (strlen($ivr_menu_confirm_key) == 0) { $ivr_menu_confirm_key = '#'; }
+	if (strlen($ivr_menu_language) == 0) { $ivr_menu_language = 'en'; }
 	if (strlen($ivr_menu_tts_engine) == 0) { $ivr_menu_tts_engine = 'flite'; }
 	if (strlen($ivr_menu_tts_voice) == 0) { $ivr_menu_tts_voice = 'rms'; }
 	if (strlen($ivr_menu_confirm_attempts) == 0) { $ivr_menu_confirm_attempts = '1'; }
@@ -409,6 +413,17 @@
 	echo "  <input class='formfld' type='text' name='ivr_menu_extension' maxlength='255' value='$ivr_menu_extension' required='required'>\n";
 	echo "<br />\n";
 	echo $text['description-extension']."\n";
+	echo "</td>\n";
+	echo "</tr>\n";
+	
+	echo "<tr>\n";
+	echo "<td class='vncellreq' valign='top' align='left' nowrap>\n";
+	echo "	".$text['label-language']."\n";
+	echo "</td>\n";
+	echo "<td class='vtable' align='left'>\n";
+	echo "  <input class='formfld' type='text' name='ivr_menu_language' maxlength='255' value='$ivr_menu_language' required='required'>\n";
+	echo "<br />\n";
+	echo $text['description-language']."\n";
 	echo "</td>\n";
 	echo "</tr>\n";
 

--- a/app/ivr_menus/resources/classes/ivr_menu.php
+++ b/app/ivr_menus/resources/classes/ivr_menu.php
@@ -34,6 +34,7 @@ include "root.php";
 		public $ivr_menu_uuid;
 		public $ivr_menu_name;
 		public $ivr_menu_extension;
+		public $ivr_menu_language;
 		public $ivr_menu_greet_long;
 		public $ivr_menu_greet_short;
 		public $ivr_menu_invalid_sound;
@@ -360,6 +361,12 @@ include "root.php";
 				$details[$x]['dialplan_detail_data'] = 'hangup_after_bridge=true';
 				$details[$x]['dialplan_detail_order'] = '020';
 
+				
+				
+				
+				
+				
+				
 				$x++;
 				$details[$x]['dialplan_detail_tag'] = 'action'; //condition, action, antiaction
 				$details[$x]['dialplan_detail_type'] = 'set';
@@ -369,8 +376,8 @@ include "root.php";
 				else {
 					$details[$x]['dialplan_detail_data'] = 'ringback='.$field['ivr_menu_ringback'];
 				}
-				$details[$x]['dialplan_detail_order'] = '025';
-
+				$details[$x]['dialplan_detail_order'] = '025';				
+				
 				$x++;
 				$details[$x]['dialplan_detail_tag'] = 'action'; //condition, action, antiaction
 				$details[$x]['dialplan_detail_type'] = 'set';
@@ -381,12 +388,23 @@ include "root.php";
 					$details[$x]['dialplan_detail_data'] = 'transfer_ringback='.$field['ivr_menu_ringback'];
 				}
 				$details[$x]['dialplan_detail_order'] = '030';
-
+				
+				$x++;
+				$details[$x]['dialplan_detail_tag'] = 'action'; //condition, action, antiaction
+				$details[$x]['dialplan_detail_type'] = 'set';
+				if ($field['ivr_menu_language'] == "") {
+					$details[$x]['dialplan_detail_data'] = 'default_language=en';
+				}
+				else {
+					$details[$x]['dialplan_detail_data'] = 'default_language='.$field['ivr_menu_language'];
+				}
+				$details[$x]['dialplan_detail_order'] = '035';
+				
 				$x++;
 				$details[$x]['dialplan_detail_tag'] = 'action'; //condition, action, antiaction
 				$details[$x]['dialplan_detail_type'] = 'set';
 				$details[$x]['dialplan_detail_data'] = 'ivr_menu_uuid='.$this->ivr_menu_uuid;
-				$details[$x]['dialplan_detail_order'] = '035';
+				$details[$x]['dialplan_detail_order'] = '040';
 
 				$x++;
 				$details[$x]['dialplan_detail_tag'] = 'action'; //condition, action, antiaction
@@ -398,14 +416,14 @@ include "root.php";
 					$details[$x]['dialplan_detail_type'] = 'ivr';
 					$details[$x]['dialplan_detail_data'] = $this->ivr_menu_uuid;
 				}
-				$details[$x]['dialplan_detail_order'] = '040';
+				$details[$x]['dialplan_detail_order'] = '045';
 
 				if (strlen($field['ivr_menu_exit_app']) > 0) {
 					$x++;
 					$details[$x]['dialplan_detail_tag'] = 'action'; //condition, action, antiaction
 					$details[$x]['dialplan_detail_type'] = $field['ivr_menu_exit_app'];
 					$details[$x]['dialplan_detail_data'] = $field['ivr_menu_exit_data'];
-					$details[$x]['dialplan_detail_order'] = '045';
+					$details[$x]['dialplan_detail_order'] = '050';
 					$x++;
 				}
 


### PR DESCRIPTION
Added a field on the ivr_menu_edit page which allows the default_language variable to be set. This is required to fix a bug where when phrases are set to a language other than the default_langauge for the domain, Freeswitch is unable to load the phrase and the call gets disconnected.

Also made changes to ivr_menu in order to make sure dialplan is generated correctly with the new variable. Would apply on next user-resave of the IVR.

Defaults to en unless the user overrides this. Maybe eventually pull the current domain default language, but shouldn't be a big deal as everything is running with en by default anyways.

**IMPORTANT:** As is, the code requires the addition of the _ivr_menu_language_ field in the _v_ivr_menus_ table.

**IMPORTANT:** I use the 4.2 branch so this pull request is for 4.2. I don't think there should be any problems merging with Master but I have not tested on that branch.