### PR TITLE
Update template

### DIFF
--- a/resources/templates/provision/aastra/673x/{$mac}.cfg
+++ b/resources/templates/provision/aastra/673x/{$mac}.cfg
@@ -55,7 +55,7 @@ time server2: {$ntp_server_secondary}
 
 # === Advanced Network Settings ===
 upnp manager: 0                               # Enable/Disable Universal Plug and Play
-lldp: 0                                       # Enable/Disable Link-Layer Discovery Protocol
+#lldp: 0                                       # Enable/Disable Link-Layer Discovery Protocol
 
 
 # #################
@@ -100,6 +100,9 @@ sip vmail: {$voicemail_number}              # Voice Mail Extenstion
 sip transport protocol: 1      # 0 - UDP and TCP; 1 - UDP; 2 - TCP; 4 - Transport Layer Security (TLS)
 sip rport: 1                   # Random SIP port
 
+#Do not interrupt active call with broadcast
+sip intercom allow barge in: 0
+
 # === SIP TLS ===
 #sip persistent tls keep alive: 60          # Keep Alive Interval In seconds
 #sip send sips over tls: 0
@@ -114,7 +117,9 @@ sip rport: 1                   # Random SIP port
 # SIP settings - per-line
 # #################
 {foreach $lines as $row}
+sip line{$row.line_number} display name: {$row.display_name}  # Caller ID
 sip line{$row.line_number} screen name: {$row.display_name}
+sip line{$row.line_number} screen name 2: {$row.user_id}
 sip line{$row.line_number} user name: {$row.user_id}  # used in SIP URI
 sip line{$row.line_number} password: {$row.password}
 sip line{$row.line_number} auth name: {$row.user_id}  # used in Authorization header field of SIP REGISTER request


### PR DESCRIPTION
Do not disable LLDP. LLDP can push the phone to separate VLAN if set by switch and it will lose connection and go to web recovery mode.
Add second screen name line to display extension #.
Add line display name (Caller ID in web interface).