### PR TITLE
Fix. Cache class.

### DIFF
--- a/resources/install/scripts/resources/functions/file.lua
+++ b/resources/install/scripts/resources/functions/file.lua
@@ -9,7 +9,7 @@ local base64 = base64
 local function write_file(fname, data, mode)
 	local file, err = io.open(fname, mode or "wb")
 	if not file then
-		log.err("Can not open file to write:" .. tostring(err))
+		-- log.err("Can not open file to write:" .. tostring(err))
 		return nil, err
 	end
 	file:write(data)
@@ -25,7 +25,7 @@ end
 local function read_file(fname, mode)
 	local file, err = io.open(fname, mode or "rb")
 	if not file then
-		log.err("Can not open file to read:" .. tostring(err))
+		-- log.err("Can not open file to read:" .. tostring(err))
 		return nil, err
 	end
 	local data = file:read("*all")
@@ -54,4 +54,5 @@ return {
 	write_base64 = write_base64;
 	exists       = file_exists;
 	remove       = os.remove;
+	rename       = os.rename;
 }


### PR DESCRIPTION
 * `send_event` raise error so `Cache.del` did not remove key or send any event
 * use `memcache` method by default even if `cache` table does not defined in config
 * `Cache.get` did not return any data when use `memcache` method
 * `Cache.get` did not close file. (Its should not be a big problem because GC should do it by self).
 * `Cache.get` can returns some undefined global value. (if method is `file` and file not exists then method returns global `result` value)
 * `Cache.get` does not need check for file existence
 * Value escaping does not needed for `file` method
 * Needed different key escaping for `memcache` and `file` methods
 * Update self test
