### PR TITLE
Detect DTMF when call originates from PSTN

### DIFF
--- a/resources/install/scripts/app/conference_center/index.lua
+++ b/resources/install/scripts/app/conference_center/index.lua
@@ -373,7 +373,9 @@
 
 --make sure the session is ready
 	if (session:ready()) then
-
+		-- start expecting dtmf
+			session:execute("start_dtmf","")
+	
 		--answer the call
 			session:preAnswer();
 


### PR DESCRIPTION
After setting up the Conference Centre/Conferece Room, I discovered it was not detecting the PINs entered when the call originated from the PSTN via my ITSP. It worked OK, if the call came from a local extension.
This fixes it. Thanks to lesson learnt from earlier in the day - and thanks to MafooUK on IRC