### PR TITLE
VM Password Complexity through the Phone

### DIFF
--- a/resources/install/scripts/app/voicemail/index.lua
+++ b/resources/install/scripts/app/voicemail/index.lua
@@ -183,6 +183,20 @@
 						remote_access = settings['voicemail']['remote_access']['boolean'];
 					end
 				end
+
+				password_complexity = '';
+				if (settings['voicemail']['password_complexity'] ~= nil) then
+					if (settings['voicemail']['password_complexity']['boolean'] ~= nil) then
+						password_complexity = settings['voicemail']['password_complexity']['boolean'];
+					end
+				end
+
+				password_min_length = '';
+				if (settings['voicemail']['password_min_length'] ~= nil) then
+					if (settings['voicemail']['password_min_length']['numeric'] ~= nil) then
+						password_min_length = settings['voicemail']['password_min_length']['numeric'];
+					end
+				end
 			end
 
 			if settings['voicemail'] then

--- a/resources/install/scripts/app/voicemail/resources/functions/change_password.lua
+++ b/resources/install/scripts/app/voicemail/resources/functions/change_password.lua
@@ -28,21 +28,86 @@
 		if (session:ready()) then
 			--flush dtmf digits from the input buffer
 				session:flushDigits();
+			--set password valitity in case of hangup
+				valid_password = "false";
 			--please enter your password followed by pound
 				dtmf_digits = '';
 				password = macro(session, "password_new", 20, 5000, '');
-			--update the voicemail password
-				local sql = [[UPDATE v_voicemails
-					set voicemail_password = :password
-					WHERE domain_uuid = :domain_uuid
-					AND voicemail_id = :voicemail_id 
-					AND voicemail_enabled = 'true' ]];
-				local params = {password = password, domain_uuid = domain_uuid,
-					voicemail_id = voicemail_id};
-				if (debug["sql"]) then
-					freeswitch.consoleLog("notice", "[voicemail] SQL: " .. sql .. "; params:" .. json.encode(params) .. "\n");
+				if (password_complexity ~= "true") then
+					valid_password = "true";
 				end
-				dbh:query(sql, params);
+			--check password comlexity
+				if (password_complexity == "true") then 
+					--check for length
+						if (string.len(password) < tonumber(password_min_length)) then
+							password_error_flag = "1";
+							dtmf_digits = '';
+							--freeswitch.consoleLog("notice", "[voicemail] Not long enough \n");
+							macro(session, "password_below_minimum", 20, 3000, password_min_length);
+							timeouts = 0;
+							if (menu == "tutorial") then
+								change_password(voicemail_id, "tutorial");
+							end
+							if (menu == "advanced") then
+								change_password(voicemail_id, "advanced");
+							end
+						end
+					
+					--check for repeating digits
+						local repeating = {"000", "111", "222", "333", "444", "555", "666", "777", "888", "999"};
+						for i = 1, 10 do
+							if (string.match(password, repeating[i])) then
+								password_error_flag = "1";
+								dtmf_digits = '';
+								--freeswitch.consoleLog("notice", "[voicemail] You can't use repeating digits like ".. repeating[i] .."  \n");
+								macro(session, "password_not_secure", 20, 3000);
+								timeouts = 0;
+								if (menu == "tutorial") then
+									change_password(voicemail_id, "tutorial");
+								end
+								if (menu == "advanced") then
+									change_password(voicemail_id, "advanced");
+								end
+							end	
+						end
+
+					--check for squential digits
+						local sequential = {"012", "123", "345", "456", "567", "678", "789", "987"};
+						for i = 1, 8 do
+							if (string.match(password, sequential[i])) then
+								password_error_flag = "1";
+								dtmf_digits = '';
+								--freeswitch.consoleLog("notice", "[voicemail] You can't use sequential digits like ".. sequential[i] .."  \n");
+								macro(session, "password_not_secure", 20, 3000);
+								timeouts = 0;
+								if (menu == "tutorial") then
+									change_password(voicemail_id, "tutorial");
+								end
+								if (menu == "advanced") then
+									change_password(voicemail_id, "advanced");
+								end
+							end	
+						end
+					--password is valid
+						if (password_error_flag ~= "1") then 
+							freeswitch.consoleLog("notice", "[voicemail] Password is valid! \n");
+							valid_password = "true";
+						end
+				end
+			--update the voicemail password
+				if (valid_password == "true") then 
+					local sql = [[UPDATE v_voicemails
+						set voicemail_password = :password
+						WHERE domain_uuid = :domain_uuid
+						AND voicemail_id = :voicemail_id 
+						AND voicemail_enabled = 'true' ]];
+					local params = {password = password, domain_uuid = domain_uuid,
+						voicemail_id = voicemail_id};
+					if (debug["sql"]) then
+						freeswitch.consoleLog("notice", "[voicemail] SQL: " .. sql .. "; params:" .. json.encode(params) .. "\n");
+					end
+					dbh:query(sql, params);
+				end
 			--has been changed to
 				dtmf_digits = '';
 				macro(session, "password_changed", 20, 3000, password);

--- a/resources/install/scripts/app/voicemail/resources/functions/macro.lua
+++ b/resources/install/scripts/app/voicemail/resources/functions/macro.lua
@@ -264,6 +264,16 @@
 					if (name == "goodbye") then
 						table.insert(actions, {app="streamFile",data="voicemail/vm-goodbye.wav"});
 					end
+				--Password is not secure
+					if (name == "password_not_secure") then
+						table.insert(actions, {app="streamFile",data="voicemail/vm-password_is_not_secure.wav"});
+					end
+				--Password is below minimum length
+					if (name == "password_below_minimum") then
+						table.insert(actions, {app="streamFile",data="voicemail/vm-pin_below_minimum_length.wav"});
+						table.insert(actions, {app="streamFile",data="voicemail/vm-minimum_pin_length_is.wav"});
+						table.insert(actions, {app="streamFile",data="digits/"..param..".wav"});
+					end
 			--Tutorial
 				--Tutorial intro
 					if (name == "tutorial_intro") then


### PR DESCRIPTION
Adds the ability to check for password complexity and minimum length while changing your vm password through the phone. 

Also, fixes a bug where the password was changed if the caller hung up in the middle of changing their password. 