### PR TITLE
Enhance [master] - .htaccess

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,43 +1,43 @@
-RewriteEngine	On
+RewriteEngine    On
 
 # $mac or $mac.cfg/xml
-RewriteRule     ^.*([A-Fa-f0-9]{12})(?:\.xml|\.cfg)?$							app/provision/index.php?mac=$1 [QSA]
+RewriteRule     ^.*([A-Fa-f0-9]{12})(?:\.xml|\.cfg)?$                           app/provision/index.php?mac=$1 [QSA]
 
 # $m:a:c or $m:a:c.cfg/xml
-RewriteRule     ^.*((?:[A-Fa-f0-9]{2}[:-]){5}[A-Fa-f0-9]{2})(?:\.xml|\.cfg)?$	app/provision/index.php?mac=$1 [QSA]
+RewriteRule     ^.*((?:[A-Fa-f0-9]{2}[:-]){5}[A-Fa-f0-9]{2})(?:\.xml|\.cfg)?$   app/provision/index.php?mac=$1 [QSA]
 
 # kt*-$mac.xml
-RewriteRule     ^kt.*?-([A-Fa-f0-9]{12})\.xml$								app/provision/index.php?mac=$1 [QSA]
+RewriteRule     ^kt.*?-([A-Fa-f0-9]{12})\.xml$                                  app/provision/index.php?mac=$1 [QSA]
 
 # cfg-$mac.xml
-RewriteRule     ^.*cfg([A-Fa-f0-9]{12})\.xml$									app/provision/index.php?mac=$1 [QSA]
+RewriteRule     ^.*cfg([A-Fa-f0-9]{12})\.xml$                                   app/provision/index.php?mac=$1 [QSA]
 
 #Snom m3
-RewriteRule     ^m3/settings/([A-Fa-f0-9]{12})(?:\.cfg)?$					app/provision/index.php?mac=$1 [QSA]
+RewriteRule     ^m3/settings/([A-Fa-f0-9]{12})(?:\.cfg)?$                       app/provision/index.php?mac=$1 [QSA]
 
 #Grandstream
-RewriteRule     ^.*/cfg([A-Fa-f0-9]{12})(?:\.xml|\.cfg)?$			app/provision/?mac=$1 [QSA]
+RewriteRule     ^.*/cfg([A-Fa-f0-9]{12})(?:\.xml|\.cfg)?$                       app/provision/?mac=$1 [QSA]
 
 #Yealink and Polycom
-RewriteRule     ^.*/([A-Fa-f0-9]{12})(?:\.xml|\.cfg)?$				app/provision/index.php?mac=$1 [QSA]
+RewriteRule     ^.*/([A-Fa-f0-9]{12})(?:\.xml|\.cfg)?$                          app/provision/index.php?mac=$1 [QSA]
 
 #Polycom
-RewriteRule     ^.*/000000000000.cfg$								app/provision/?mac=$1&file={$mac}.cfg [QSA]
-RewriteRule     ^.*/features.cfg$									app/provision/?mac=$1&file=features.cfg [QSA]
-RewriteRule     ^.*/([A-Fa-f0-9]{12})-sip.cfg$						app/provision/?mac=$1&file=sip.cfg [QSA]
-RewriteRule     ^.*/([A-Fa-f0-9]{12})-phone.cfg$						app/provision/?mac=$1 [QSA]
-RewriteRule     ^.*/([A-Fa-f0-9]{12})-registration.cfg$				app/provision/?mac=$1&file={$mac}-registration.cfg [QSA]
-RewriteRule     ^.*/([A-Fa-f0-9]{12})-site.cfg$						app/provision/?mac=$1&file=site.cfg [QSA]
-RewriteRule     ^.*/([A-Fa-f0-9]{12})-web.cfg$						app/provision/?mac=$1&file=web.cfg [QSA]
-RewriteRule     ^.*/([A-Fa-f0-9]{12})-directory.xml$					app/provision/?mac=$1&file=directory.xml [QSA]
+RewriteRule     ^provision/000000000000.cfg$                                    app/provision/?mac=$1&file={$mac}.cfg [QSA]
+RewriteRule     ^provision/features.cfg$                                        app/provision/?mac=$1&file=features.cfg [QSA]
+RewriteRule     ^provision/([A-Fa-f0-9]{12})-sip.cfg$                           app/provision/?mac=$1&file=sip.cfg [QSA]
+RewriteRule     ^provision/([A-Fa-f0-9]{12})-phone.cfg$                         app/provision/?mac=$1 [QSA]
+RewriteRule     ^provision/([A-Fa-f0-9]{12})-registration.cfg$                  app/provision/?mac=$1&file={$mac}-registration.cfg [QSA]
+RewriteRule     ^provision/([A-Fa-f0-9]{12})-site.cfg$                          app/provision/?mac=$1&file=site.cfg [QSA]
+RewriteRule     ^provision/([A-Fa-f0-9]{12})-web.cfg$                           app/provision/?mac=$1&file=web.cfg [QSA]
+RewriteRule     ^provision/([A-Fa-f0-9]{12})-directory.xml$                     app/provision/?mac=$1&file=directory.xml [QSA]
 
 #Escene
-RewriteRule     ^.*/provision/([0-9]{1,11})_Extern.xml$              app/provision/?ext=$1&file={$mac}_extern.xml [QSA]
-RewriteRule     ^.*/provision/([0-9]{1,11})_Phonebook.xml$           app/provision/?ext=$1&file={$mac}_phonebook.xml [QSA]
+RewriteRule     ^.*/([0-9]{1,11})_Extern.xml$                                   app/provision/?ext=$1&file={$mac}_extern.xml [QSA]
+RewriteRule     ^.*/([0-9]{1,11})_Phonebook.xml$                                app/provision/?ext=$1&file={$mac}_phonebook.xml [QSA]
 
 Options -Indexes
 
 #PHP settings
-php_value upload_max_filesize	25M
-php_value post_max_size			35M
-php_value memory_limit			512M
+php_value upload_max_filesize   25M
+php_value post_max_size         35M
+php_value memory_limit          512M


### PR DESCRIPTION
convert tabs to fixed spacing so consistently displays in all editors
update polycoms to use anchor to provision to minimize rewrite looping
.htaccess's RewriteRule operates relative to it's dir so anchoring to ^provision is correct even for where fusion is on a sub folder