### PR TITLE
use UUID native function if extension available

### DIFF
--- a/resources/functions.php
+++ b/resources/functions.php
@@ -117,26 +117,31 @@
 
 	if (!function_exists('uuid')) {
 		function uuid() {
-			//uuid version 4
-			return sprintf( '%04x%04x-%04x-%04x-%04x-%04x%04x%04x',
-				// 32 bits for "time_low"
-				mt_rand( 0, 0xffff ), mt_rand( 0, 0xffff ),
+			if(!extension_loaded('uuid')){
+				//uuid version 4
+				return sprintf( '%04x%04x-%04x-%04x-%04x-%04x%04x%04x',
+					// 32 bits for "time_low"
+					mt_rand( 0, 0xffff ), mt_rand( 0, 0xffff ),
 
-				// 16 bits for "time_mid"
-				mt_rand( 0, 0xffff ),
+					// 16 bits for "time_mid"
+					mt_rand( 0, 0xffff ),
 
-				// 16 bits for "time_hi_and_version",
-				// four most significant bits holds version number 4
-				mt_rand( 0, 0x0fff ) | 0x4000,
+					// 16 bits for "time_hi_and_version",
+					// four most significant bits holds version number 4
+					mt_rand( 0, 0x0fff ) | 0x4000,
 
-				// 16 bits, 8 bits for "clk_seq_hi_res",
-				// 8 bits for "clk_seq_low",
-				// two most significant bits holds zero and one for variant DCE1.1
-				mt_rand( 0, 0x3fff ) | 0x8000,
+					// 16 bits, 8 bits for "clk_seq_hi_res",
+					// 8 bits for "clk_seq_low",
+					// two most significant bits holds zero and one for variant DCE1.1
+					mt_rand( 0, 0x3fff ) | 0x8000,
 
-				// 48 bits for "node"
-				mt_rand( 0, 0xffff ), mt_rand( 0, 0xffff ), mt_rand( 0, 0xffff )
-			);
+					// 48 bits for "node"
+					mt_rand( 0, 0xffff ), mt_rand( 0, 0xffff ), mt_rand( 0, 0xffff )
+				);
+			}
+			else{
+				return uuid_create();
+			}
 		}
 		//echo uuid();
 	}


### PR DESCRIPTION
If the module extension is installed, use it. It's faster, it uses system libs. Otherwise, fallback to your random uuid way.