### PR TITLE
Updated /scripts/app/conference_center/index.lua

### DIFF
--- a/resources/install/scripts/app/conference_center/index.lua
+++ b/resources/install/scripts/app/conference_center/index.lua
@@ -775,7 +775,7 @@
 					end
 				--record the conference
 					if (record == "true") then
-						cmd="sched_api (+5 none lua app/conference_center/resources/scripts/start_recording.lua "..meeting_uuid.." "..domain_name.." "..record_ext.." )";
+						cmd="sched_api +5 none lua "..scripts_dir.."/app/conference_center/resources/scripts/start_recording.lua "..meeting_uuid.." "..domain_name.." "..record_ext;
 						api:executeString(cmd);
 					end
 				--send the call to the conference


### PR DESCRIPTION
Removal of the  ( ) in the sched_api cmd string allows the start_recording.lua to function as designed. 
Added "..scripts_dir.." as well.