### PR TITLE
Update ivr.conf.lua for better debugging

### DIFF
--- a/resources/install/scripts/app/xml_handler/resources/scripts/configuration/ivr.conf.lua
+++ b/resources/install/scripts/app/xml_handler/resources/scripts/configuration/ivr.conf.lua
@@ -279,7 +279,7 @@
 
 		--send the xml to the console
 			if (debug["xml_string"]) then
-				local file = assert(io.open(temp_dir .. "/ivr.conf.xml", "w"));
+				local file = assert(io.open(temp_dir .. "/ivr-"..ivr_menu_uuid..".conf.xml", "w"));
 				file:write(XML_STRING);
 				file:close();
 			end


### PR DESCRIPTION
when debug["xml_string"] is on, it will overwrite /tmp/ivr.conf.xml file each hit an ivr goes. this makes very hard to trouble shoot in a living system. this patch allows to put one ivr menu per file.