### PR TITLE
Fix Fusion to work with Homer out of the box

### DIFF
--- a/resources/install/scripts/app/xml_handler/resources/scripts/configuration/sofia.conf.lua
+++ b/resources/install/scripts/app/xml_handler/resources/scripts/configuration/sofia.conf.lua
@@ -82,7 +82,7 @@
 			table.insert(xml, [[				<param name="log-level" value="0"/>]]);
 			--table.insert(xml, [[				<param name="auto-restart" value="false"/>]]);
 			table.insert(xml, [[				<param name="debug-presence" value="0"/>]]);
-			--table.insert(xml, [[				<param name="capture-server" value="udp:homer.domain.com:5060"/>]]);
+			table.insert(xml, [[				<param name="capture-server" value="$${capture_server_uri}"/>]]);
 			table.insert(xml, [[			</global_settings>]]);
 			table.insert(xml, [[			<profiles>]]);
 


### PR DESCRIPTION
Adding this will make fusion work out of the box by only adding the capture_server_uri variable in vars.xml (or variable menu). This will prevent each time a domain is added (or upgrade script is run) will take out the changes