### PR TITLE
Change Column to allow for more characters

### DIFF
--- a/resources/install/sql/switch.sql
+++ b/resources/install/sql/switch.sql
@@ -448,7 +448,7 @@ CREATE TABLE sip_subscriptions (
     network_ip character varying(255),
     version integer DEFAULT 0 NOT NULL,
     orig_proto character varying(255),
-    full_to character varying(255),
+    full_to character varying(1024),
 sip_subscription_uuid uuid PRIMARY KEY default gen_random_uuid()
 );
 ALTER TABLE sip_subscriptions OWNER TO fusionpbx;


### PR DESCRIPTION
255 characters is too small for phones with 15+ BLF lines. 

The phone will generate a postgres ERROR:  value too long for type character varying(255)