### PR TITLE
Fix MWI for Extensions that with 0

### DIFF
--- a/resources/install/scripts/app/voicemail/resources/functions/listen_to_recording.lua
+++ b/resources/install/scripts/app/voicemail/resources/functions/listen_to_recording.lua
@@ -217,6 +217,10 @@
 				elseif (dtmf_digits == "7") then
 					delete_recording(voicemail_id, uuid);
 					message_waiting(voicemail_id, domain_uuid);
+					--fix for extensions that start with 0 (Ex: 0712)
+						if (voicemail_id_copy ~= voicemail_id  and voicemail_id_copy ~= nil) then
+							message_waiting(voicemail_id_copy, domain_uuid);
+						end
 				elseif (dtmf_digits == "8") then
 					forward_to_extension(voicemail_id, uuid);
 					dtmf_digits = '';

--- a/resources/install/scripts/app/voicemail/resources/functions/menu_messages.lua
+++ b/resources/install/scripts/app/voicemail/resources/functions/menu_messages.lua
@@ -44,10 +44,10 @@
 					--get the voicemail_id
 					--fix for extensions that start with 0 (Ex: 0712)
 							sql = [[SELECT voicemail_id FROM v_voicemails WHERE voicemail_uuid = :voicemail_uuid]];
+							local params = {voicemail_uuid = voicemail_uuid};
 							if (debug["sql"]) then
 								freeswitch.consoleLog("notice", "[voicemail] SQL: " .. sql .. "; params:" .. json.encode(params) .. "\n");
 							end
-							local params = {voicemail_uuid = voicemail_uuid};
 							dbh:query(sql, params, function(result)
 								voicemail_id_copy = result["voicemail_id"];
 							end);

--- a/resources/install/scripts/app/voicemail/resources/functions/menu_messages.lua
+++ b/resources/install/scripts/app/voicemail/resources/functions/menu_messages.lua
@@ -41,6 +41,17 @@
 		--message_status new,saved
 			if (session:ready()) then
 				if (voicemail_id ~= nil) then
+					--get the voicemail_id
+					--fix for extensions that start with 0 (Ex: 0712)
+							sql = [[SELECT voicemail_id FROM v_voicemails WHERE voicemail_uuid = :voicemail_uuid]];
+							if (debug["sql"]) then
+								freeswitch.consoleLog("notice", "[voicemail] SQL: " .. sql .. "; params:" .. json.encode(params) .. "\n");
+							end
+							local params = {voicemail_uuid = voicemail_uuid};
+							dbh:query(sql, params, function(result)
+								voicemail_id_copy = result["voicemail_id"];
+							end);
+
 					local sql = [[SELECT voicemail_message_uuid, created_epoch, caller_id_name, caller_id_number 
 						FROM v_voicemail_messages
 						WHERE domain_uuid = :domain_uuid
@@ -85,6 +96,10 @@
 					)
 				--send the message waiting event
 					mwi_notify(voicemail_id.."@"..domain_name, new_messages, saved_messages)
+					--fix for extensions that start with 0 (Ex: 0712)
+						if (voicemail_id_copy ~= voicemail_id  and voicemail_id_copy ~= nil) then
+							message_waiting(voicemail_id_copy, domain_uuid);
+						end
 			end
 
 		--set the display


### PR DESCRIPTION
MWI was not turning off after messages were deleted for extensions that start with 0. This requires that real voicemail_id to be pulled from the database and not just taken from the destination number. To get around this we try to send mwi to the original vociemail_id (destination number) and voicemail_id_copy (from database). Index.lua is already doing something similar.