### PR TITLE
fix the toll_allow select

### DIFF
--- a/app/extensions/extension_edit.php
+++ b/app/extensions/extension_edit.php
@@ -1678,10 +1678,10 @@ if (count($_POST) > 0 && strlen($_POST["persistformvar"]) == 0) {
 		echo "</td>\n";
 		echo "<td class='vtable' align='left'>\n";
 		if (is_array($_SESSION['toll allow']['name'])) {
-			echo "	<select class='formfld' name='toll_allow'>\n";
+			echo "	<select class='formfld' name='toll_allow' id='toll_allow'>\n";
 			echo "		<option value=''></option>\n";
 			foreach ($_SESSION['toll allow']['name'] as $name) {
-				if ($_SESSION['call group']['name'] == $call_group) {
+				if ($name == $toll_allow) {
 					echo "		<option value='$name' selected='selected'>$name</option>\n";
 				}
 				else {


### PR DESCRIPTION
I am not very sure but seems that since last Chrome update, this select box stop working if there is no id property in the select tag.
Anyway, the old if statement is wrong, it is not comparing against $toll_allow and since we are using a foreach, it is cleaner using $name than the big session variable indexes