### PR TITLE
Update to provisioning engine

### DIFF
--- a/app/provision/index.php
+++ b/app/provision/index.php
@@ -71,10 +71,15 @@
 	if (empty($mac)){
 		//set the http user agent
 			//$_SERVER['HTTP_USER_AGENT'] = "Yealink SIP-T38G  38.70.0.125 00:15:65:00:00:00";
+			//$_SERVER['HTTP_USER_AGENT'] = "Yealink SIP-T56A  58.80.0.25 001565f429a4"; 
 		//Yealink: 17 digit mac appended to the user agent, so check for a space exactly 17 digits before the end.
 			if (strtolower(substr($_SERVER['HTTP_USER_AGENT'],0,7)) == "yealink" || strtolower(substr($_SERVER['HTTP_USER_AGENT'],0,5)) == "vp530") {
-				$mac = substr($_SERVER['HTTP_USER_AGENT'],-17);
-				$mac = preg_replace("#[^a-fA-F0-9./]#", "", $mac);
+				if (strstr(substr($_SERVER['HTTP_USER_AGENT'],-4), ':')) { //remove colons if they exist
+					$mac = substr($_SERVER['HTTP_USER_AGENT'],-17);
+					$mac = preg_replace("#[^a-fA-F0-9./]#", "", $mac);
+				} else { //take mac as is - fixes T5X series
+					$mac = substr($_SERVER['HTTP_USER_AGENT'],-12);
+				}
 			}
 		//Panasonic: $_SERVER['HTTP_USER_AGENT'] = "Panasonic_KX-UT670/01.022 (0080f000000)"
 			if (substr($_SERVER['HTTP_USER_AGENT'],0,9) == "Panasonic") {


### PR DESCRIPTION
Adding this fix enables both remote phone book and provisioning to work correctly on the newly released android based Yealink devices.

It appears that during the provisioning process, the T5X series supply a colon formatted mac address in their user agent.

However, when requesting a remote phone book, the presented user agent has no colons. This allows both formats to work as expected.