### PR TITLE
Fix. Export call direction to B-Leg.

### DIFF
--- a/app/dialplan_outbound/dialplan_outbound_add.php
+++ b/app/dialplan_outbound/dialplan_outbound_add.php
@@ -416,7 +416,7 @@
 						$array['dialplans'][$x]['dialplan_details'][$y]['domain_uuid'] = $_SESSION['domain_uuid'];
 						$array['dialplans'][$x]['dialplan_details'][$y]['dialplan_uuid'] = $dialplan_uuid;
 						$array['dialplans'][$x]['dialplan_details'][$y]['dialplan_detail_tag'] = 'action';
-						$array['dialplans'][$x]['dialplan_details'][$y]['dialplan_detail_type'] = 'set';
+						$array['dialplans'][$x]['dialplan_details'][$y]['dialplan_detail_type'] = 'export';
 						$array['dialplans'][$x]['dialplan_details'][$y]['dialplan_detail_data'] = 'call_direction=outbound';
 						$array['dialplans'][$x]['dialplan_details'][$y]['dialplan_detail_order'] = $y * 10;
 						$array['dialplans'][$x]['dialplan_details'][$y]['dialplan_detail_group'] = '0';

--- a/app/dialplans/resources/classes/dialplan.php
+++ b/app/dialplans/resources/classes/dialplan.php
@@ -835,7 +835,7 @@ include "root.php";
 														}
 													}
 												//add the call direction and domain name and uuid
-													$xml .= "		<action application=\"set\" data=\"call_direction=inbound\" inline=\"true\"/>\n";
+													$xml .= "		<action application=\"export\" data=\"call_direction=inbound\" inline=\"true\"/>\n";
 													if ($domain_uuid != null and $domain_uuid != '') {
 														$domain_name = $domains[$domain_uuid];
 														$xml .= "		<action application=\"set\" data=\"domain_uuid=" . $domain_uuid . "\" inline=\"true\"/>\n";

--- a/app/dialplans/resources/switch/conf/dialplan/020_call_direction.xml
+++ b/app/dialplans/resources/switch/conf/dialplan/020_call_direction.xml
@@ -1,7 +1,7 @@
 <context name="{v_context}">
 	<extension name="call-direction" number="" continue="true" app_uuid="3780f814-5543-4350-b65d-563512d1fe71" enabled="true">
 		<condition field="${call_direction}" expression="^(inbound|outbound|local)$" break="never">
-			<anti-action application="set" data="call_direction=local" inline="true"/>
+			<anti-action application="export" data="call_direction=local" inline="true"/>
 		</condition>
 	</extension>
 </context>


### PR DESCRIPTION
It is needed to use with b-leg filtering.

There exists some other places where fusion set call_direction.
Did not try figureout when they used