### PR TITLE
fix polycom error during bootup

### DIFF
--- a/resources/templates/provision/polycom/3.x/{$mac}.cfg
+++ b/resources/templates/provision/polycom/3.x/{$mac}.cfg
@@ -60,7 +60,7 @@
 		tcpIpApp.sntp.daylightSavings.stop.month="{$daylight_savings_stop_month}"
 		tcpIpApp.sntp.daylightSavings.stop.date="{$daylight_savings_stop_day}"
 		tcpIpApp.sntp.daylightSavings.stop.time="{$daylight_savings_stop_time}"
-		tcpIpApp.sntp.daylightSavings.stop.dayOfWeek="0"
+		tcpIpApp.sntp.daylightSavings.stop.dayOfWeek="1"
 		tcpIpApp.sntp.daylightSavings.stop.dayOfWeek.lastInMonth="0"
 	/>
 	<DIALPLAN

--- a/resources/templates/provision/polycom/4.x/{$mac}.cfg
+++ b/resources/templates/provision/polycom/4.x/{$mac}.cfg
@@ -64,7 +64,7 @@
 		tcpIpApp.sntp.daylightSavings.stop.month="{$daylight_savings_stop_month}"
 		tcpIpApp.sntp.daylightSavings.stop.date="{$daylight_savings_stop_day}"
 		tcpIpApp.sntp.daylightSavings.stop.time="{$daylight_savings_stop_time}"
-		tcpIpApp.sntp.daylightSavings.stop.dayOfWeek="0"
+		tcpIpApp.sntp.daylightSavings.stop.dayOfWeek="1"
 		tcpIpApp.sntp.daylightSavings.stop.dayOfWeek.lastInMonth="0"
 	/>
 	<DIALPLAN

--- a/resources/templates/provision/polycom/5.x/{$mac}.cfg
+++ b/resources/templates/provision/polycom/5.x/{$mac}.cfg
@@ -84,7 +84,7 @@
 		tcpIpApp.sntp.daylightSavings.stop.month="{$daylight_savings_stop_month}"
 		tcpIpApp.sntp.daylightSavings.stop.date="{$daylight_savings_stop_day}"
 		tcpIpApp.sntp.daylightSavings.stop.time="{$daylight_savings_stop_time}"
-		tcpIpApp.sntp.daylightSavings.stop.dayOfWeek="0"
+		tcpIpApp.sntp.daylightSavings.stop.dayOfWeek="1"
 		tcpIpApp.sntp.daylightSavings.stop.dayOfWeek.lastInMonth="0"
 	/>
 	<DIALPLAN


### PR DESCRIPTION
This is backed up by...
1. phone boot log has errors when set to 0
2. documentation says valid values are 1-7, default being 1.