### PR TITLE
Change. Treat `sofia xmlstatus` as UTF8

### DIFF
--- a/app/registrations/resources/classes/registrations.php
+++ b/app/registrations/resources/classes/registrations.php
@@ -68,6 +68,7 @@ if (!class_exists('registrations')) {
 						$xml_response = str_replace("</profile-info>", "</profile_info>", $xml_response);
 						if (strlen($xml_response) > 101) {
 							try {
+								$xml_response = str_ireplace("<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>", "<?xml version=\"1.0\" encoding=\"UTF-8\"?>", $xml_response);
 								$xml = new SimpleXMLElement($xml_response);
 							}
 							catch(Exception $e) {


### PR DESCRIPTION
FS Always mark xml as ISO-8859-1, but pass info as-is.
So if user send its contact info as UTF-8 then we get
corrupted xml. But RFC describe text as UTF8

[RFC 3261 - 25.1 Basic Rules](https://tools.ietf.org/html/rfc3261#section-25.1)
```
qdtext = LWS / %x21 / %x23-5B / %x5D-7E / UTF8-NONASCII
```