### PR TITLE
More ways of adding recordings to CDR's

### DIFF
--- a/app/xml_cdr/resources/classes/xml_cdr.php
+++ b/app/xml_cdr/resources/classes/xml_cdr.php
@@ -403,6 +403,11 @@ if (!class_exists('xml_cdr')) {
 					$record_name = urldecode($xml->variables->record_name);
 					$record_length = urldecode($xml->variables->billsec);
 				}
+				elseif (urldecode($xml->variables->current_application) == 'record_session') {
+					$record_path = dirname(urldecode($xml->variables->current_application_data));
+					$record_name = basename(urldecode($xml->variables->current_application_data));
+					$record_length = urldecode($xml->variables->record_seconds);
+				}
 				elseif (strlen($xml->variables->record_session) > 0) {
 					$record_path = dirname(urldecode($xml->variables->record_session));
 					$record_name = basename(urldecode($xml->variables->record_session));
@@ -423,6 +428,16 @@ if (!class_exists('xml_cdr')) {
 						$record_length = urldecode($xml->variables->duration);
 					}
 				}
+				elseif (strlen($xml->variables->{'nolocal:api_on_answer'}) > 0) {
+					$command = str_replace("\n", " ", urldecode($xml->variables->{'nolocal:api_on_answer'}));
+					$parts = explode(" ", $command);
+					if ($parts[0] == "uuid_record") {
+						$recording = $parts[3];
+						$record_path = dirname($recording);
+						$record_name = basename($recording);
+						$record_length = urldecode($xml->variables->duration);
+					}
+				}				
 				elseif (strlen($xml->variables->current_application_data) > 0) {
 					$commands = explode(",", urldecode($xml->variables->current_application_data));
 					foreach ($commands as $command) {


### PR DESCRIPTION
This grabs a recording if started by bind_digit_action "*2" or by "nolocal:api_on_answer=uuid_record ${uuid} start ${recordings_dir}/${domain_name}/archive/${strftime(%Y)}/${strftime(%b)}/${strftime(%d)}/${uuid}.${record_ext}".