### PR TITLE
Add. Use `route_to_bridge` module to build routes for ring groups.

### DIFF
--- a/resources/install/scripts/app/ring_groups/index.lua
+++ b/resources/install/scripts/app/ring_groups/index.lua
@@ -569,7 +569,7 @@
 						dial_string = "[sip_invite_domain="..domain_name..",call_direction="..call_direction..","..group_confirm.."leg_timeout="..destination_timeout..","..delay_name.."="..destination_delay.."]" .. row.destination_number;
 					else
 						--external number
-						dial_string = ''
+						dial_string = nil
 
 						local session_mt = {__index = function(_, k) return session:getVariable(k) end}
 						local params = setmetatable({
@@ -747,12 +747,16 @@
 								or session:getVariable("originate_disposition") == "failure"
 							) then
 								--execute the time out action
-									session:execute(ring_group_timeout_app, ring_group_timeout_data);
+									if ring_group_timeout_app and #ring_group_timeout_app > 0 then
+										session:execute(ring_group_timeout_app, ring_group_timeout_data);
+									end
 							end
 						else
 							if (ring_group_timeout_app ~= nil) then
 								--execute the time out action
-									session:execute(ring_group_timeout_app, ring_group_timeout_data);
+									if ring_group_timeout_app and #ring_group_timeout_app > 0 then
+										session:execute(ring_group_timeout_app, ring_group_timeout_data);
+									end
 							else
 								local sql = "SELECT ring_group_timeout_app, ring_group_timeout_data FROM v_ring_groups ";
 								sql = sql .. "where ring_group_uuid = :ring_group_uuid";
@@ -762,7 +766,9 @@
 								end
 								dbh:query(sql, params, function(row)
 									--execute the time out action
-										session:execute(row.ring_group_timeout_app, row.ring_group_timeout_data);
+										if row.ring_group_timeout_app and #row.ring_group_timeout_app > 0 then
+											session:execute(row.ring_group_timeout_app, row.ring_group_timeout_data);
+										end
 								end);
 							end
 						end

--- a/resources/install/scripts/resources/functions/route_to_bridge.lua
+++ b/resources/install/scripts/resources/functions/route_to_bridge.lua
@@ -48,20 +48,34 @@ local function pcre_self_test()
 	io.write(' - ok\n')
 end
 
-local select_routes_sql = [[
-select *
-from v_dialplans
-where (domain_uuid = :domain_uuid or domain_uuid is null)
-  and (hostname = :hostname or hostname is null) 
-  and app_uuid = '8c914ec3-9fc0-8ab5-4cda-6c9288bdc9a3'
-  and dialplan_enabled = 'true'
-order by dialplan_order asc
-]]
-
-local select_extensions_sql = [[
-select * from v_dialplan_details 
-where dialplan_uuid = :dialplan_uuid
-order by dialplan_detail_group asc, dialplan_detail_order asc
+local select_outbound_dialplan_sql = [[SELECT
+		d.dialplan_uuid,
+		d.dialplan_context,
+		d.dialplan_continue,
+		s.dialplan_detail_group,
+		s.dialplan_detail_break,
+		s.dialplan_detail_data,
+		s.dialplan_detail_inline,
+		s.dialplan_detail_tag,
+		s.dialplan_detail_type
+	FROM v_dialplans as d, v_dialplan_details as s
+	WHERE  (d.domain_uuid = :domain_uuid OR d.domain_uuid IS NULL)
+	AND (d.hostname = :hostname OR d.hostname IS NULL)
+	AND d.app_uuid = '8c914ec3-9fc0-8ab5-4cda-6c9288bdc9a3'
+	AND d.dialplan_enabled = 'true'
+	AND d.dialplan_uuid = s.dialplan_uuid
+	ORDER BY
+		d.dialplan_order ASC,
+		d.dialplan_name ASC,
+		d.dialplan_uuid ASC,
+		s.dialplan_detail_group ASC,
+		CASE s.dialplan_detail_tag
+			WHEN 'condition' THEN 1
+			WHEN 'action' THEN 2
+			WHEN 'anti-action' THEN 3
+			ELSE 100
+		END,
+		s.dialplan_detail_order ASC
 ]]
 
 local function append(t, v)
@@ -87,6 +101,11 @@ local function check_conditions(group, fields)
 		last = (n == #group.conditions)
 
 		local value = fields[condition.type]
+		if (not value) and (condition_type ~= '') then -- try var name
+			local condition_type = string.match(condition.type, '^%${(.*)}$')
+			if condition_type then value = fields[condition_type] end
+		end
+
 		if (not value) and (condition.type ~= '') then -- skip unkonw fields
 			log.errf('Unsupportded condition: %s', condition.type)
 			matches, pass = {}, false
@@ -253,51 +272,121 @@ local function self_test()
 	end
 end
 
-local function outbound_route_to_bridge(dbh, domain_uuid, fields)
-	local actions, dial_string = {}
-	require "resources.functions.trim";
-	local hostname = trim(api:execute("switchname", ""));
+local function outbound_route_to_bridge(dbh, domain_uuid, fields, actions)
+	actions = actions or {}
 
-	local params = {}
-	dbh:query(select_routes_sql, {domain_uuid=domain_uuid,hostname=hostname}, function(route)
-		local extension = {}
-		params.dialplan_uuid = route.dialplan_uuid
-		dbh:query(select_extensions_sql, params, function(ext)
-			local group_no = tonumber(ext.dialplan_detail_group)
-			local tag      = ext.dialplan_detail_tag
-			local element = {
-				type      =          ext.dialplan_detail_type;
-				data      =          ext.dialplan_detail_data;
-				break_on  =          ext.dialplan_detail_break;
-				inline    =          ext.dialplan_detail_inline;
-			}
+	local hostname = fields.hostname
+	if not hostname  then
+		require "resources.functions.trim";
+		hostname = trim(api:execute("switchname", ""))
+	end
 
-			local group = extension[ group_no ] or {
-				conditions   = {};
-				actions      = {};
-				anti_actions = {};
-			}
-			extension[ group_no ] = group
+	-- try filter by context
+	local context = fields.context
+	if context == '' then context = nil end
 
-			if tag == 'condition'   then append(group.conditions,   element) end
-			if tag == 'action'      then append(group.actions,      element) end
-			if tag == 'anti-action' then append(group.anti_actions, element) end
-		end)
-
-		local n = #actions
-
-		extension_to_bridge(extension, actions, fields)
-
-		if actions.bridge or (n > #actions and route.dialplan_continue == 'false') then
-			return 1
+	local current_dialplan_uuid, extension
+	dbh:query(select_outbound_dialplan_sql, {domain_uuid=domain_uuid, hostname=hostname}, function(route)
+		if context and context ~= route.dialplan_context then
+			-- skip dialplan for wrong contexts
+			return
 		end
+
+		if current_dialplan_uuid ~= route.dialplan_uuid then
+			if extension then
+				local n = #actions
+				extension_to_bridge(extension, actions, fields)
+				-- if we found bridge or add any action and there no continue flag
+				if actions.bridge or (n > #actions and route.dialplan_continue == 'false') then
+					extension = nil
+					return 1
+				end
+			end
+			extension = {}
+			current_dialplan_uuid = route.dialplan_uuid
+		end
+
+		local group_no = tonumber(route.dialplan_detail_group)
+		local tag      = route.dialplan_detail_tag
+		local element = {
+			type      =  route.dialplan_detail_type;
+			data      =  route.dialplan_detail_data;
+			break_on  =  route.dialplan_detail_break;
+			inline    =  route.dialplan_detail_inline;
+		}
+
+		local group = extension[ group_no ] or {
+			conditions   = {};
+			actions      = {};
+			anti_actions = {};
+		}
+		extension[ group_no ] = group
+
+		if tag == 'condition'   then append(group.conditions,   element) end
+		if tag == 'action'      then append(group.actions,      element) end
+		if tag == 'anti-action' then append(group.anti_actions, element) end
 	end)
+
+	if extension and next(extension) then
+		extension_to_bridge(extension, actions, fields)
+	end
 
 	if actions.bridge then return actions end
 end
 
+local function apply_vars(actions, fields)
+	for i, action in ipairs(actions) do
+		actions[i] = string.gsub(action, '%${(.-)}', function(var)
+			local value = fields[var] or ''
+			if value == '' then return "''" end
+			if not string.find(value, "[',]") then return value end
+			return "'" .. string.gsub(value, "'", "\\'") .. "'"
+		end)
+	end
+	return actions
+end
+
+local function wrap_dbh(t)
+	local i = 0
+	return {query = function(self, s, p, f)
+		while true do
+			i = i + 1
+			local row = t[i]
+			if not row then break end
+
+			local r = f(row)
+			if r == 1 then break end
+		end
+	end}
+end
+
+local function preload_dialplan(dbh, domain_uuid, fields)
+	local hostname = fields and fields.hostname
+	if not hostname  then
+		require "resources.functions.trim";
+		hostname = trim(api:execute("switchname", ""))
+	end
+
+	-- try filter by context
+	local context = fields and fields.context
+	if context == '' then context = nil end
+
+	local dialplan = {}
+	dbh:query(select_outbound_dialplan_sql, {domain_uuid=domain_uuid, hostname=hostname}, function(route)
+		if context and context ~= route.dialplan_context then
+			-- skip dialplan for wrong contexts
+			return
+		end
+		dialplan[#dialplan + 1] = route
+	end)
+
+	return wrap_dbh(dialplan), dialplan
+end
+
 return setmetatable({
 	__self_test = self_test;
+	apply_vars = apply_vars;
+	preload_dialplan = preload_dialplan;
 }, {__call = function(_, ...)
 	return outbound_route_to_bridge(...)
 end})

--- a/resources/install/scripts/resources/functions/route_to_bridge.lua
+++ b/resources/install/scripts/resources/functions/route_to_bridge.lua
@@ -192,8 +192,8 @@ local function group_to_bridge(actions, group, fields)
 
 				key, value = split_first(value, '=', true)
 				if key then
-					local bleg_only = (action.type == 'export') and (string.sub(value, 1, 8) == 'nolocal:')
-					if bleg_only then value = string.sub(value, 9) end
+					local bleg_only = (action.type == 'export') and (string.sub(key, 1, 8) == 'nolocal:')
+					if bleg_only then key = string.sub(key, 9) end
 
 					value = apply_match(value, matches)
 					value = apply_var(value, fields)

--- a/resources/install/scripts/resources/functions/route_to_bridge.lua
+++ b/resources/install/scripts/resources/functions/route_to_bridge.lua
@@ -618,14 +618,14 @@ end
 
 local function wrap_dbh(t)
 	local i = 0
-	return {query = function(self, s, p, f)
+	return {query = function(self, sql, params, callback)
 		while true do
 			i = i + 1
 			local row = t[i]
 			if not row then break end
 
-			local r = f(row)
-			if r == 1 then break end
+			local result = callback(row)
+			if result == 1 then break end
 		end
 	end}
 end

--- a/resources/install/scripts/resources/functions/route_to_bridge.lua
+++ b/resources/install/scripts/resources/functions/route_to_bridge.lua
@@ -547,6 +547,19 @@ local function self_test()
 	log = old_log
 end
 
+-- Returns array of set/export actions and bridge command.
+--
+-- This function does not set any var to session.
+--
+-- @param dbh database connection
+-- @param domain_uuid
+-- @param fields list of avaliable channel variables.
+--   if `context` provided then dialplan will be filtered by this var
+--   `__api__`  key can be used to pass freeswitch.API object for execute
+--   some functions in actions (e.g. `s=${user_data ...}`)
+-- @param actions optional list of predefined actions
+-- @return array part of table will contain list of actions.
+--     `bridge` key will contain bridge statement
 local function outbound_route_to_bridge(dbh, domain_uuid, fields, actions)
 	actions = actions or {}
 
@@ -630,6 +643,9 @@ local function wrap_dbh(t)
 	end}
 end
 
+-- Load all extension for outbound routes and
+-- returns object which can be used instead real DBH object to build
+-- dialplan for specific destination_number
 local function preload_dialplan(dbh, domain_uuid, fields)
 	local hostname = fields and fields.hostname
 	if not hostname  then


### PR DESCRIPTION
This commit has several improvements
1. Select only needed fields. (do not select quite big XML text strings)
2. Filter routes also by context name
3. Filter dialplans also by hostname
4. Handle conditions based not only `destination_number`
5. Handle `break` and `continue` attributes for extensions
6. Escape vars inside dial-string
7. Add log messages similar as FS dialplan do
8. Handle inline set/export actions
Also its fix bug when script may set 
```Lua
dial_string = "regex m:~"..destination_number.."~"..r.dialplan_detail_data
```
