### PR TITLE
Fix. Dialplan may loose its app_uuid

### DIFF
--- a/app/dialplans/dialplan_xml.php
+++ b/app/dialplans/dialplan_xml.php
@@ -107,7 +107,7 @@
 			messages::add($text['message-update']);
 
 		//redirect the user
-			header("Location: dialplan_edit.php?id=".$dialplan_uuid."&".((strlen($app_uuid) > 0) ? "?app_uuid=".$app_uuid : null));
+			header("Location: dialplan_edit.php?id=".$dialplan_uuid."&".((strlen($app_uuid) > 0) ? "app_uuid=".$app_uuid : null));
 			exit;
 
 	}
@@ -129,7 +129,7 @@
 	echo"				<span class=\"title\">".$text['title-dialplan_edit']."</span><br />\n";
 	echo "			</td>\n";
 	echo "			<td width='70%' align='right'>\n";
-	echo "				<input type='button' class='btn' name='' alt='".$text['button-back']."' onclick=\"window.location='dialplan_edit.php?id=".$dialplan_uuid."&".((strlen($app_uuid) > 0) ? "?app_uuid=".$app_uuid : null)."';\" value='".$text['button-back']."'>\n";
+	echo "				<input type='button' class='btn' name='' alt='".$text['button-back']."' onclick=\"window.location='dialplan_edit.php?id=".$dialplan_uuid."&".((strlen($app_uuid) > 0) ? "app_uuid=".$app_uuid : null)."';\" value='".$text['button-back']."'>\n";
 	echo "				<input type='submit' class='btn' value='".$text['button-save']."'>\n";
 	echo "			</td>\n";
 	echo "		</tr>\n";


### PR DESCRIPTION
When in dialplan edit form press `XML` and then `Back`
Fusion build wrong URL like `&?app_uuid` so if then press
save server will do not get this arg and assign new random app_uuid.