### PR TITLE
Change. Do not clear call forward number when disable via `*73/*74`

### DIFF
--- a/app/dialplans/resources/switch/conf/dialplan/500_call-forward.xml
+++ b/app/dialplans/resources/switch/conf/dialplan/500_call-forward.xml
@@ -2,15 +2,18 @@
 	<extension name="call-forward" number="*72,*73,*74" continue="false" app_uuid="b4b32fb4-0181-4876-9bec-b9dff1299d60" enabled="true">
 		<condition field="destination_number" expression="^\*72$" break="on-true">
 			<action application="set" data="enabled=true"/>
+			<action application="unset" data="forward_all_destination"/>
 			<action application="lua" data="call_forward.lua"/>
 		</condition>
 		<condition field="destination_number" expression="^\*73$" break="on-true">
 			<action application="set" data="enabled=false"/>
+			<action application="unset" data="forward_all_destination"/>
 			<action application="lua" data="call_forward.lua"/>
 		</condition>
 		<condition field="destination_number" expression="^\*74$" break="on-true">
 			<action application="set" data="request_id=true"/>
 			<action application="set" data="enabled=toggle"/>
+			<action application="unset" data="forward_all_destination"/>
 			<action application="lua" data="call_forward.lua"/>
 		</condition>
 		<condition field="destination_number" expression="^forward\+(\Q${caller_id_number}\E)(?:\/(\d+))?$" break="on-true">


### PR DESCRIPTION
Old algorithm was
  * when user dial `*72/*74` to *enable* call forward
     - if extension has call forward number this number keep without changes
     - in other case user should enter new number
  * when user dial `*73/*74` to *disable* call forward
     - call forward number set to NULL so there no way set it again without enter it again

So in this case there no way to do disable->enable call forward without enter number.

New algorithm is
  * when call forward disabling script does not clear call forward number.
  * when user dial *72(enable) it should *always* enter new number
  * when user dial *74(toggle) it try use existed number and there exists one
    script ask enter number.

So it is possible to do just enable/disable with *74 and enter new number with *72
In fact it only changes one case when user enter call forward number via GUI
and then enable it via *72.

*Note* To work need change dialplan because now `forward_all_destination` set but `user_exists`
extension. So if not do unset this var script will not ask to enter new number.