### PR TITLE
Rendering error of .cfg file in XML format

### DIFF
--- a/app/provision/index.php
+++ b/app/provision/index.php
@@ -444,8 +444,14 @@
 			header("Content-Type: text/plain; charset=iso-8859-1");
 			header("Content-Length: ".strlen($file_contents));
 		} else {
-			header("Content-Type: text/xml; charset=utf-8");
-			header("Content-Length: ".strlen($file_contents));
+                        $result = simplexml_load_string ($file_contents, 'SimpleXmlElement', LIBXML_NOERROR+LIBXML_ERR_FATAL+LIBXML_ERR_NONE);
+                        if (false == $result){
+                            header("Content-Type: text/plain");
+                            header("Content-Length: ".strval(strlen($file_contents)));
+                        } else {
+                            header("Content-Type: text/xml; charset=utf-8");
+                            header("Content-Length: ".strlen($file_contents));
+                        }
 		}
 	}
 	echo $file_contents;


### PR DESCRIPTION
Check whether loaded file is xml or not, if not xml than set Content-Type to text/plain