### PR TITLE
Fix. Create database scheme before trying insert record to `v_database`

### DIFF
--- a/core/install/resources/classes/install_fusionpbx.php
+++ b/core/install/resources/classes/install_fusionpbx.php
@@ -378,7 +378,7 @@ include "root.php";
 			//add the database structure
 				require_once "resources/classes/schema.php";
 				$schema = new schema;
-				//echo $schema->schema();
+				echo $schema->schema();
 
 			//get the contents of the sql file
 				if (file_exists('/usr/share/examples/fusionpbx/sql/pgsql.sql')){


### PR DESCRIPTION
Problem that `create_database_pgsql` does not create actual scheme
but `create_odbc_database_connection` try insert record to v_database and
installation fails.