### PR TITLE
Fix tone_stream in default dialplan

### DIFF
--- a/app/dialplans/resources/switch/conf/dialplan/370_tone_stream.xml
+++ b/app/dialplans/resources/switch/conf/dialplan/370_tone_stream.xml
@@ -2,7 +2,7 @@
 	<extension name="tone_stream" number="*9198" continue="false" app_uuid="98ccdb0b-c074-4f74-b28a-9528372faa7d">
 		<condition field="destination_number" expression="^\*9198$">
 			<action application="answer"/>
-			<action application="playback" data="{loops=10}tone_stream://path=${base_dir}/conf/tetris.ttml"/>
+			<action application="playback" data="{loops=10}tone_stream://path=${conf_dir}/conf/tetris.ttml"/>
 		</condition>
 	</extension>
 </context>


### PR DESCRIPTION
Just trying out fusionpbx and wondered why the tone_stream wasn't working.. now fixed (and listening to tetris)!