### PR TITLE
BugFix - [master] - make hangup and failure use send_mail()

### DIFF
--- a/resources/install/scripts/app/failure_handler/index.lua
+++ b/resources/install/scripts/app/failure_handler/index.lua
@@ -34,6 +34,9 @@
 	require "resources.functions.trim";
 	require "resources.functions.base64";
 
+--load libraries
+	require 'resources.functions.send_mail'
+
 --check the missed calls
 	function missed()
 		if (missed_call_app ~= nil and missed_call_data ~= nil) then
@@ -55,10 +58,12 @@
 					end
 
 				--prepare the headers
-					headers = '{"X-FusionPBX-Domain-UUID":"'..domain_uuid..'",';
-					headers = headers..'"X-FusionPBX-Domain-Name":"'..domain_name..'",';
-					headers = headers..'"X-FusionPBX-Call-UUID":"'..uuid..'",';
-					headers = headers..'"X-FusionPBX-Email-Type":"missed"}';
+					local headers = {
+						["X-FusionPBX-Domain-UUID"] = domain_uuid;
+						["X-FusionPBX-Domain-Name"] = domain_name;
+						["X-FusionPBX-Call-UUID"]   = uuid;
+						["X-FusionPBX-Email-Type"]  = 'missed';
+					}
 
 				--prepare the subject
 					local f = io.open(file_subject, "r");
@@ -88,13 +93,15 @@
 					body = body:gsub([["]], "&#34;");
 					body = trim(body);
 
-				--send the email
-					cmd = "luarun email.lua "..missed_call_data.." "..missed_call_data.." "..headers.." '"..subject.."' '"..body.."'";
+				--send the emails
+					send_mail(headers,
+						missed_call_data,
+						{subject, body}
+					);
+
 					if (debug["info"]) then
-						freeswitch.consoleLog("notice", "[missed call] cmd: " .. cmd .. "\n");
+						freeswitch.consoleLog("notice", "[missed call] " .. caller_id_number .. "->" .. sip_to_user .. "emailed to " .. missed_call_data .. "\n");
 					end
-					api = freeswitch.API();
-					result = api:executeString(cmd);
 			end
 		end
 	end


### PR DESCRIPTION
change the failure_handler and hangup apps use
resources.functions.send_mail so they can use the correct smtp_from*
settings