### PR TITLE
Yealink T52s/T54s: Add Variables from T4x Templates + New Ones

### DIFF
--- a/resources/templates/provision/yealink/t52s/y000000000074.cfg
+++ b/resources/templates/provision/yealink/t52s/y000000000074.cfg
@@ -6,7 +6,7 @@
 ##                                    Network CDP                                    ##
 #######################################################################################
 static.network.cdp.enable = {$yealink_cdp_enable}
-static.network.cdp.packet_interval =
+static.network.cdp.packet_interval = {$yealink_cdp_packet_interval}
 
 
 #######################################################################################
@@ -37,17 +37,17 @@ static.network.ipv6_prefix =
 ##(X ranges from 1 to 5)
 ##Only T54S/T52S/T48G/T48S/T46G/T46S/T42S/T41S/T29G/T27G Models support these parameters.
 
-static.wifi.enable =
-static.wifi.1.label =
-static.wifi.1.ssid =
-static.wifi.1.priority =
-static.wifi.1.security_mode =
-static.wifi.1.cipher_type =
-static.wifi.1.password =
-static.wifi.1.eap_type =
-static.wifi.1.eap_user_name =
-static.wifi.1.eap_password =
-static.wifi.show_scan_prompt =
+static.wifi.enable = {$yealink_wifi_enable}
+static.wifi.1.label = {$yealink_wifi_1_label}
+static.wifi.1.ssid = {$yealink_wifi_1_ssid}
+static.wifi.1.priority = {$yealink_wifi_1_priority}
+static.wifi.1.security_mode = {$yealink_wifi_1_security}
+static.wifi.1.cipher_type = {$yealink_wifi_1_cipher}
+static.wifi.1.password = {$yealink_wifi_1_password}
+static.wifi.1.eap_type = {$yealink_wifi_1_type}
+static.wifi.1.eap_user_name = {$yealink_wifi_1_username}
+static.wifi.1.eap_password = {$yealink_wifi_1_password}
+static.wifi.show_scan_prompt = {$yealink_wifi_scan_prompt}
 
 
 #######################################################################################
@@ -90,7 +90,7 @@ static.network.internet_port.speed_duplex =
 ##                                   Network LLDP                                    ##
 #######################################################################################
 static.network.lldp.enable = {$yealink_lldp_enable}
-static.network.lldp.packet_interval =
+static.network.lldp.packet_interval = {$yealink_lldp_packet_interval}
 
 
 #######################################################################################
@@ -100,13 +100,13 @@ static.network.vlan.dhcp_enable =
 static.network.vlan.dhcp_option =
 static.network.vlan.vlan_change.enable =
 
-static.network.vlan.pc_port_priority =
-static.network.vlan.pc_port_vid =
+static.network.vlan.pc_port_priority = {$yealink_vlan_pc_cos}
+static.network.vlan.pc_port_vid = {$yealink_vlan_pc_id}
 static.network.vlan.pc_port_enable =
 
-static.network.vlan.internet_port_priority =
-static.network.vlan.internet_port_vid =
-static.network.vlan.internet_port_enable =
+static.network.vlan.internet_port_priority = {$yealink_vlan_cos}
+static.network.vlan.internet_port_vid = {$yealink_vlan_id}
+{if isset($yealink_vlan_enable)}static.network.vlan.internet_port_enable = {$yealink_vlan_enable}{else}static.network.vlan.internet_port_enable = 0{/if}
 
 
 #######################################################################################
@@ -137,36 +137,36 @@ static.auto_provision.custom.upload_method =
 #######################################################################################
 ##                                    ZERO Touch                                     ##
 #######################################################################################
-static.zero_touch.enable =
-static.zero_touch.wait_time =
-static.features.hide_zero_touch_url.enable =
-static.zero_touch.network_fail_delay_times =
-static.zero_touch.network_fail_wait_times =
+static.zero_touch.enable = {$yealink_zero_touch_enable}
+static.zero_touch.wait_time = {$yealink_zero_touch_wait_time}
+static.features.hide_zero_touch_url.enable = {$yealink_zero_touch_hide}
+static.zero_touch.network_fail_delay_times = {$yealink_zero_touch_delay}
+static.zero_touch.network_fail_wait_times = {$yealink_zero_touch_wait}
 
 
 #######################################################################################
 ##                                   Autop URL                                       ##
 #######################################################################################
-static.auto_provision.server.url =
-static.auto_provision.server.username =
-static.auto_provision.server.password =
+static.auto_provision.server.url = {$yealink_provision_url}
+static.auto_provision.server.username = {$http_auth_username}
+static.auto_provision.server.password = {$http_auth_password}
 
 
 #######################################################################################
 ##                                   Autop Weekly                                    ##
 #######################################################################################
-static.auto_provision.weekly.enable =
-static.auto_provision.weekly.dayofweek =
-static.auto_provision.weekly.end_time =
-static.auto_provision.weekly.begin_time =
-static.auto_provision.weekly_upgrade_interval =
+static.auto_provision.weekly.enable = {$yealink_autop_weekly_enable}
+static.auto_provision.weekly.dayofweek = {$yealink_autop_weekly_dayofweek}
+static.auto_provision.weekly.end_time = {$yealink_autop_weekly_end_time}
+static.auto_provision.weekly.begin_time = {$yealink_autop_weekly_begin_time}
+static.auto_provision.weekly_upgrade_interval = {$yealink_autop_weekly_interval}
 
 
 #######################################################################################
 ##                                   Autop Repeat                                    ##
 #######################################################################################
-static.auto_provision.repeat.enable =
-static.auto_provision.repeat.minutes =
+static.auto_provision.repeat.enable = {$yealink_autop_repeat_enable}
+static.auto_provision.repeat.minutes = {$yealink_autop_repeat_minutes}
 
 
 #######################################################################################
@@ -179,7 +179,7 @@ static.auto_provision.dhcp_option.enable =
 #######################################################################################
 ##                                   Autop Mode                                      ##
 #######################################################################################
-static.auto_provision.power_on =
+static.auto_provision.power_on = {$yealink_autop_power_on}
 
 
 #######################################################################################
@@ -220,7 +220,7 @@ features.custom_version_info =
 #######################################################################################
 ##                                   Autop PNP                                       ##
 #######################################################################################
-static.auto_provision.pnp_enable =
+static.auto_provision.pnp_enable = {$yealink_autop_pnp}
 
 
 #######################################################################################
@@ -340,10 +340,10 @@ static.security.cn_validation =
 static.security.dev_cert = 
 static.security.ca_cert = 
 static.security.trust_certificates = 
-static.security.user_password = 
-static.security.user_name.var = 
-static.security.user_name.admin = 
-static.security.user_name.user = 
+static.security.user_password = {$admin_name}:{$admin_password}
+static.security.user_name.var = {$var_name}
+static.security.user_name.admin = {$admin_name}
+static.security.user_name.user = {$user_name}
 security.tls_cipher_list = 
 
 
@@ -363,8 +363,8 @@ static.server_certificates.delete =
 #######################################################################################
 ##                           Trusted Certificates                                    ##
 #######################################################################################
-static.trusted_certificates.url =
-static.trusted_certificates.delete =
+static.trusted_certificates.url = {$yealink_trusted_cert_url}
+static.trusted_certificates.delete = {$yealink_trusted_cert_delete}
 
 
 #######################################################################################
@@ -382,21 +382,21 @@ static.auto_provision.encryption.config =
 
 
 #######################################################################################
-##                                   Trnasfer                                        ##
+##                                   Transfer                                        ##
 #######################################################################################
-features.transfer_type=
-dialplan.transfer.mode =
-transfer.on_hook_trans_enable =
-transfer.tran_others_after_conf_enable =
-transfer.blind_tran_on_hook_enable =
-transfer.semi_attend_tran_enable =
-phone_setting.call_appearance.transfer_via_new_linekey=
+features.transfer_type= {$yealink_transfer_type}
+dialplan.transfer.mode = {$yealink_transfer_mode}
+transfer.on_hook_trans_enable = {$yealink_transfer_onhook}
+transfer.tran_others_after_conf_enable = {$yealink_transfer_after_conf}
+transfer.blind_tran_on_hook_enable = {$yealink_transfer_blind_on_hook}
+transfer.semi_attend_tran_enable = {$yealink_transfer_semi_attended}
+phone_setting.call_appearance.transfer_via_new_linekey= {$yealink_transfer_via_new_linekey}
 
 
 #######################################################################################
 ##                                   Conference                                      ##
 #######################################################################################
-features.conference.with_previous_call.enable =
+features.conference.with_previous_call.enable = 
 features.local_conf.combine_with_one_press.enable=
 phone_setting.call_appearance.conference_via_new_linekey=
 
@@ -435,8 +435,8 @@ features.password_dial.length=
 features.password_dial.prefix=
 features.password_dial.enable=
 features.group_listen_in_talking_enable=
-phone_setting.call_info_display_method=
-phone_setting.called_party_info_display.enable =
+phone_setting.call_info_display_method= 0
+phone_setting.called_party_info_display.enable = 1
 features.headset_training=
 features.headset_prior=
 features.dtmf.replace_tran =
@@ -470,15 +470,15 @@ custom_softkey_call_failed.url=
 ##                                   Features Bluetooth                              ##
 #######################################################################################
 ##Only T54S/T52S/T48G/T48S/T46G/T46S/T42S/T41S/T29G/T27G Models support the parameter.
-features.bluetooth_enable=
-features.bluetooth_adapter_name=
+features.bluetooth_enable= {$yealink_bt_enable}
+features.bluetooth_adapter_name= {$yealink_bt_name}
 
 
 #######################################################################################
 ##                                  Features USB Record                              ##
 #######################################################################################
 ##Only T54S/T52S/T48G/T48S/T46G/T46S/T42S/T41S/T29G/T27G Models support the parameter.
-features.usb_call_recording.enable =
+features.usb_call_recording.enable = {$yealink_usb_record_enable}
 
 
 #######################################################################################
@@ -517,23 +517,23 @@ voice.tone.secondary_dial=
 #######################################################################################
 ##                                   Jitter Buffer                                   ##
 #######################################################################################
-voice.jib.normal=
-voice.jib.max =
-voice.jib.min =
-voice.jib.adaptive =
+voice.jib.normal= {$yealink_jib_normal}
+voice.jib.max = {$yealink_jib_max}
+voice.jib.min = {$yealink_jib_min}
+voice.jib.adaptive = {$yealink_jib_adaptive}
 
-voice.jib.wifi.normal=
-voice.jib.wifi.max=
-voice.jib.wifi.min=
-voice.jib.wifi.adaptive=
+voice.jib.wifi.normal= {$yealink_jib_wifi_normal}
+voice.jib.wifi.max= {$yealink_jib_wifi_max}
+voice.jib.wifi.min= {$yealink_jib_wifi_min}
+voice.jib.wifi.adaptive= {$yealink_jib_wifi_adaptive}
 
 
 #######################################################################################
 ##                                   Echo Cancellation                               ##
 #######################################################################################
-voice.echo_cancellation =
-voice.cng =
-voice.vad =
+voice.echo_cancellation = {$yealink_echo_cancellation}
+voice.cng = {$yealink_cng}
+voice.vad = {$yealink_cng}
 
 
 ################################################################
@@ -572,14 +572,14 @@ sip.send_keepalive_by_socket=
 sip.reliable_protocol.timerae.enable=
 sip.listen_in_peer_localip.enable=
 sip.requesturi.e164.addglobalprefix=
-sip.trust_ctrl=
+sip.trust_ctrl = {$yealink_trust_ctrl}
 sip.mac_in_ua=
 
 sip.timer_t1=
 sip.timer_t2=
 sip.timer_t4=
 
-sip.listen_mode=
+sip.listen_mode= {if isset($yealink_sip_listen_port)}sip.listen_port = {$yealink_sip_listen_port}{else}sip.listen_port = 5060{/if}
 sip.listen_port=
 sip.tls_listen_port=
 sip.tcp_port_random_mode=
@@ -594,23 +594,19 @@ phone_setting.early_media.rtp_sniffer.timeout=
 ################################################################
 #                        NAT&ICE                              ##
 ################################################################
-network.static_nat.enable = {if isset($yealink_static_nat)}1{else}0{/if}
+static.sip.nat_turn.enable=
+static.sip.nat_turn.username=
+static.sip.nat_turn.password=
+static.sip.nat_turn.server=
+static.sip.nat_turn.port=
 
-network.static_nat.addr = {$yealink_static_nat}
+static.sip.nat_stun.enable=
+static.sip.nat_stun.server=
+static.sip.nat_stun.port=
 
-ice.enable =
-
-sip.nat_stun.enable = {if isset($stun_server)}1{else}0{/if}
-
-sip.nat_stun.server = {$stun_server}
-sip.nat_stun.port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
-
-
-sip.nat_turn.enable =
-sip.nat_turn.username =
-sip.nat_turn.password =
-sip.nat_turn.server =
-sip.nat_turn.port =
+static.ice.enable=
+static.network.static_nat.enable=
+static.network.static_nat.addr=
 
 
 #######################################################################################
@@ -643,44 +639,44 @@ features.rtp_symmetric.enable=
 #######################################################################################
 ##                                 RTCP-XR                                           ##
 #######################################################################################
-voice.rtcp.enable=
-voice.rtcp_cname=
-voice.rtcp_xr.enable=
-phone_setting.vq_rtcpxr_display_symm_oneway_delay.enable=
-phone_setting.vq_rtcpxr_display_round_trip_delay.enable=
-phone_setting.vq_rtcpxr_display_moscq.enable=
-phone_setting.vq_rtcpxr_display_moslq.enable = 
-phone_setting.vq_rtcpxr_display_packets_lost.enable=
-phone_setting.vq_rtcpxr_display_jitter_buffer_max.enable=
-phone_setting.vq_rtcpxr_display_jitter.enable=
-phone_setting.vq_rtcpxr_display_remote_codec.enable=
-phone_setting.vq_rtcpxr_display_local_codec.enable=
-phone_setting.vq_rtcpxr_display_remote_call_id.enable=
-phone_setting.vq_rtcpxr_display_local_call_id.enable=
-phone_setting.vq_rtcpxr_display_stop_time.enable=
-phone_setting.vq_rtcpxr_display_start_time.enable=
-phone_setting.vq_rtcpxr_interval_period=
-phone_setting.vq_rtcpxr_delay_threshold_critical=
-phone_setting.vq_rtcpxr_delay_threshold_warning=
-phone_setting.vq_rtcpxr_moslq_threshold_critical=
-phone_setting.vq_rtcpxr_moslq_threshold_warning=
-phone_setting.vq_rtcpxr.interval_report.enable=
-phone_setting.vq_rtcpxr.states_show_on_gui.enable=
-phone_setting.vq_rtcpxr.states_show_on_web.enable=
-phone_setting.vq_rtcpxr.session_report.enable=
+voice.rtcp.enable= {$yealink_rtcp_enable}
+voice.rtcp_cname= {$yealink_rtcp_cname}
+voice.rtcp_xr.enable= {$yealink_rtcpxr_enable}
+phone_setting.vq_rtcpxr_display_symm_oneway_delay.enable= {$yealink_rtcpxr_disp_enable}
+phone_setting.vq_rtcpxr_display_round_trip_delay.enable= {$yealink_rtcpxr_disp_enable}
+phone_setting.vq_rtcpxr_display_moscq.enable= {$yealink_rtcpxr_disp_enable}
+phone_setting.vq_rtcpxr_display_moslq.enable = {$yealink_rtcpxr_disp_enable}
+phone_setting.vq_rtcpxr_display_packets_lost.enable= {$yealink_rtcpxr_disp_enable}
+phone_setting.vq_rtcpxr_display_jitter_buffer_max.enable= {$yealink_rtcpxr_disp_enable}
+phone_setting.vq_rtcpxr_display_jitter.enable= {$yealink_rtcpxr_disp_enable}
+phone_setting.vq_rtcpxr_display_remote_codec.enable= {$yealink_rtcpxr_disp_enable}
+phone_setting.vq_rtcpxr_display_local_codec.enable= {$yealink_rtcpxr_disp_enable}
+phone_setting.vq_rtcpxr_display_remote_call_id.enable= {$yealink_rtcpxr_disp_enable}
+phone_setting.vq_rtcpxr_display_local_call_id.enable= {$yealink_rtcpxr_disp_enable}
+phone_setting.vq_rtcpxr_display_stop_time.enable= {$yealink_rtcpxr_disp_enable}
+phone_setting.vq_rtcpxr_display_start_time.enable= {$yealink_rtcpxr_disp_enable}
+phone_setting.vq_rtcpxr_interval_period= {$yealink_rtcpxr_interval}
+phone_setting.vq_rtcpxr_delay_threshold_critical= {$yealink_rtcpxr_delay_threshold_critical}
+phone_setting.vq_rtcpxr_delay_threshold_warning= {$yealink_rtcpxr_delay_threshold_warning}
+phone_setting.vq_rtcpxr_moslq_threshold_critical= {$yealink_rtcpxr_mos_threshold_critical}
+phone_setting.vq_rtcpxr_moslq_threshold_warning= {$yealink_rtcpxr_mos_threshold_warning}
+phone_setting.vq_rtcpxr.interval_report.enable= {$yealink_rtcpxr_interval_report_enable}
+phone_setting.vq_rtcpxr.states_show_on_gui.enable= {$yealink_rtcpxr_show_gui_enable}
+phone_setting.vq_rtcpxr.states_show_on_web.enable= {$yealink_rtcpxr_show_web_enable}
+phone_setting.vq_rtcpxr.session_report.enable= {$yealink_rtcpxr_report_enable}
 
 
 #######################################################################################
 ##                                   Contact                                         ##
 #######################################################################################
-static.directory_setting.url=
+static.directory_setting.url= https://{if isset($http_auth_username)}{$http_auth_username}:{$http_auth_password}@{/if}{$domain_name}/app/provision/?file=favorite_setting.xml
 super_search.url=
 
 local_contact.data.url=
 local_contact.data.delete=
 
 ##Only T54S/T52S/T48G/T48S/T46G/T46S/T29G Models support the parameter
-phone_setting.contact_photo_display.enable=
+phone_setting.contact_photo_display.enable= {$yealink_contact_photo_enable}
 
 phone_setting.incoming_call.horizontal_roll_interval=
 
@@ -744,27 +740,27 @@ remote_phonebook.data.5.url = {$yealink_remote_phonebook_5_url}
 #######################################################################################
 ##                                 LDAP                                              ##
 #######################################################################################
-ldap.enable=
-ldap.user=
-ldap.password=
-ldap.base=
-ldap.port=
-ldap.host=
+ldap.enable = {$ldap_enable}
+ldap.user = {$ldap_user}
+ldap.password = {$ldap_password}
+ldap.base = {$ldap_base}
+ldap.port = {$ldap_port}
+ldap.host = {$ldap_host}
 ldap.customize_label=
 ldap.incoming_call_special_search.enable=
 ldap.tls_mode=
 ldap.search_type=
 ldap.numb_display_mode=
-ldap.ldap_sort=
-ldap.call_in_lookup=
-ldap.version =
-ldap.display_name=
-ldap.numb_attr=
-ldap.name_attr=
-ldap.max_hits=
-ldap.number_filter=
-ldap.name_filter=
-ldap.call_out_lookup=
+ldap.ldap_sort = {$ldap_sort}
+ldap.call_in_lookup = {$ldap_call_in_lookup}
+ldap.version = {$ldap_version}
+ldap.display_name = {$ldap_display_name}
+ldap.numb_attr = {$ldap_numb_attr}
+ldap.name_attr = {$ldap_name_attr}
+ldap.max_hits = {$ldap_max_hits}
+ldap.number_filter = {$ldap_number_filter}
+ldap.name_filter = {$ldap_name_filter}
+ldap.call_out_lookup = {$ldap_dial_lookup}
 
 
 #######################################################################################
@@ -997,22 +993,22 @@ features.dnd.allow=
 features.dnd_mode=
 features.dnd.enable=
 
-features.dnd.off_code=
-features.dnd.on_code=
+features.dnd.off_code= *79
+features.dnd.on_code= *78
 
 features.dnd.emergency_authorized_number=
-features.dnd.emergency_enable=
+features.dnd.emergency_enable= 1
 features.dnd.large_icon.enable=
 
 
 #######################################################################################
 ##                               Phone Lock                                          ##
 #######################################################################################
-phone_setting.phone_lock.enable=
-phone_setting.phone_lock.lock_key_type=
-phone_setting.phone_lock.unlock_pin=
-phone_setting.emergency.number=
-phone_setting.phone_lock.lock_time_out=
+phone_setting.phone_lock.enable = {$yealink_lock_enable}
+phone_setting.phone_lock.lock_key_type = {$yealink_lock_key_type}
+phone_setting.phone_lock.unlock_pin = {$yealink_lock_pin}
+phone_setting.emergency.number = {$yealink_emergency_number}
+phone_setting.phone_lock.lock_time_out = {$yealink_lock_timeout}
 
 
 #######################################################################################
@@ -1038,9 +1034,9 @@ hotdesking.dsskey_outbound_enable=
 ##                               Voice Mail                                          ##
 #######################################################################################
 features.voice_mail_alert.enable=
-features.voice_mail_popup.enable=
+features.voice_mail_popup.enable = {$yealink_voice_mail_popup_enable}
 features.voice_mail_tone_enable=
-features.hide_feature_access_codes.enable=
+features.hide_feature_access_codes.enable = {$yealink_hide_feature_access_codes_enable}
 voice_mail.number.1=
 
 
@@ -1089,7 +1085,7 @@ features.ringer_device.is_use_headset=
 features.ip_call.auto_answer.enable=
 features.show_default_account=
 features.call.dialtone_time_out=
-features.missed_call_popup.enable=
+features.missed_call_popup.enable = {$yealink_missed_call_popup_enable}
 features.auto_answer_tone.enable=
 features.play_hold_tone.enable=
 features.key_as_send=
@@ -1097,7 +1093,7 @@ features.send_pound_key=
 features.busy_tone_delay=
 features.hotline_delay=
 features.hotline_number=
-features.direct_ip_call_enable=
+features.direct_ip_call_enable = {$yealink_direct_ip_call_enable}
 features.call_num_filter=
 features.call_completion_enable=
 features.allow_mute=
@@ -1107,12 +1103,12 @@ features.dnd_refuse_code=
 features.upload_server=
 features.dtmf.repetition=
 features.dtmf.hide_delay=
-features.dtmf.hide=
+features.dtmf.hide = {$yealink_dtmf_hide}
 features.play_local_dtmf_tone_enable =
 features.reboot_in_talk_enable =
 features.fwd_diversion_enable=
 
-call_waiting.enable=
+call_waiting.enable = {$yealink_call_waiting}
 call_waiting.tone=
 call_waiting.off_code=
 call_waiting.on_code=
@@ -1121,7 +1117,7 @@ auto_redial.times=
 auto_redial.interval=
 auto_redial.enable=
 
-sip.rfc2543_hold=
+sip.rfc2543_hold = {$yealink_rfc2543_hold}
 sip.use_23_as_pound=
 forward.international.enable=
 phone_setting.headsetkey_mode=
@@ -1188,10 +1184,10 @@ action_url.unregistered =
 phone_setting.hold_and_held_power_led_flash_enable=
 phone_setting.mute_power_led_flash_enable=
 phone_setting.talk_and_dial_power_led_enable=
-phone_setting.mail_power_led_flash_enable=
+phone_setting.mail_power_led_flash_enable = 1
 phone_setting.ring_power_led_flash_enable=
 phone_setting.common_power_led_enable=
-phone_setting.missed_call_power_led_flash.enable=
+phone_setting.missed_call_power_led_flash.enable = {$yealink_missed_call_power_led_flash_enable}
 
 
 #######################################################################################
@@ -1201,20 +1197,20 @@ lcl.datetime.date.format =
 auto_dst.url =
 local_time.manual_time_enable =
 local_time.manual_ntp_srv_prior =
-local_time.time_format =
+local_time.time_format = {$yealink_time_format}
 local_time.date_format = {$yealink_date_format}
-local_time.dhcp_time =
+local_time.dhcp_time = {$yealink_dhcp_time}
 
-local_time.summer_time =
-local_time.dst_time_type =
-local_time.start_time =
-local_time.end_time =
-local_time.offset_time =
-local_time.interval =
+local_time.summer_time = {$yealink_dst_enable}
+local_time.dst_time_type = {$yealink_dst_type}
+local_time.start_time = {$yealink_time_zone_start_time}
+local_time.end_time = {$yealink_time_zone_end_time}
+local_time.offset_time = {$yealink_offset_time}
+local_time.interval = {$yealink_time_update}
 
 local_time.ntp_server1 = {$ntp_server_primary}
 local_time.ntp_server2 = {$ntp_server_secondary}
-local_time.time_zone = {$yealink_time_zone_name}
+local_time.time_zone = {$yealink_time_zone}
 local_time.time_zone_name = {$yealink_time_zone_name}
 
 
@@ -1262,10 +1258,10 @@ lcd_logo.url=
 phone_setting.lcd_logo.mode=
 
 phone_setting.contrast=
-phone_setting.backlight_time=
-phone_setting.inactive_backlight_level=
+phone_setting.backlight_time = {$yealink_backlight_time}
+phone_setting.inactive_backlight_level = 1
 phone_setting.active_backlight_level=
-phone_setting.predial_autodial=
+phone_setting.predial_autodial = 1
 
 ringtone.url=
 ringtone.delete=
@@ -1373,41 +1369,41 @@ wui_lang.delete=
 gui_input_method.delete=
 gui_lang.url=
 gui_lang.delete=
-static.lang.gui=
-static.lang.wui=
+static.lang.gui= {$yealink_language_gui}
+static.lang.wui= {$yealink_language_web}
 
 
 #######################################################################################
 ##                                   Screensaver                                     ##
 #######################################################################################
-screensaver.type=
-screensaver.delete=
-screensaver.upload_url=
-features.blf_active_backlight.enable=
-screensaver.display_clock.enable=
-screensaver.clock_move_interval=
-screensaver.picture_change_interval=
-screensaver.wait_time=
-screensaver.xml_browser.url=
+screensaver.type= {$yealink_screensaver_type}
+screensaver.delete= {$yealink_screensaver_delete}
+screensaver.upload_url= {$yealink_screensaver_upload_url}
+features.blf_active_backlight.enable= 
+screensaver.display_clock.enable= {$yealink_screensaver_clock}
+screensaver.clock_move_interval= {$yealink_screensaver_clock_interval}
+screensaver.picture_change_interval= {$yealink_screensaver_pic_interval}
+screensaver.wait_time= {$yealink_screensaver_wait}
+screensaver.xml_browser.url= {$yealink_screensaver_xml_url}
 
 
 #######################################################################################
 ##                                  Power Saving                                     ##
 #######################################################################################
-features.power_saving.enable=
-features.power_saving.power_led_flash.on_time=
-features.power_saving.power_led_flash.off_time=
-features.power_saving.office_hour.monday=
-features.power_saving.office_hour.tuesday=
-features.power_saving.office_hour.wednesday=
-features.power_saving.office_hour.thursday=
-features.power_saving.office_hour.friday=
-features.power_saving.office_hour.saturday=
-features.power_saving.office_hour.sunday =
-features.power_saving.user_input_ext.idle_timeout=
-features.power_saving.off_hour.idle_timeout=
-features.power_saving.office_hour.idle_timeout=
-features.power_saving.intelligent_mode=
+features.power_saving.enable= {$yealink_powersave_enable}
+features.power_saving.power_led_flash.on_time= {$yealink_powersave_led_on_time}
+features.power_saving.power_led_flash.off_time= {$yealink_powersave_led_off_time}
+features.power_saving.office_hour.monday= {$yealink_powersave_hours_mon}
+features.power_saving.office_hour.tuesday= {$yealink_powersave_hours_tue}
+features.power_saving.office_hour.wednesday= {$yealink_powersave_wed}
+features.power_saving.office_hour.thursday= {$yealink_powersave_thu}
+features.power_saving.office_hour.friday= {$yealink_powersave_fri}
+features.power_saving.office_hour.saturday= {$yealink_powersave_sat}
+features.power_saving.office_hour.sunday = {$yealink_powersave_sun}
+features.power_saving.user_input_ext.idle_timeout= {$yealink_powersave_user_input_timeout}
+features.power_saving.off_hour.idle_timeout= {$yealink_powersave_off_hour_timeout}
+features.power_saving.office_hour.idle_timeout= {$yealink_powersave_office_hour_timeout}
+features.power_saving.intelligent_mode= {$yealink_powersave_intelligent_mode}
 
 
 #######################################################################################
@@ -1421,14 +1417,14 @@ features.power_saving.intelligent_mode=
 ##Single File Size: <=5MB 
 ##2MB of space should bereserved for the phone
 
-wallpaper_upload.url=
+wallpaper_upload.url= {$yealink_wallpaper_url}
 phone_setting.backgrounds=
 
 ## phone_setting.backgrounds_with_dsskey_unfold(Only support T48G/S)
-phone_setting.backgrounds_with_dsskey_unfold=
+phone_setting.backgrounds_with_dsskey_unfold= {$yealink_wallpaper_dsskey_unfold}
 
 ##expansion_module.backgrounds(Only support T54S/T52S)
-expansion_module.backgrounds=
+expansion_module.backgrounds= {$yealink_wallpaper_expansion}
 
 
 #######################################################################################
@@ -1478,11 +1474,11 @@ blf.enhanced.idle.talking.action=
 blf.enhanced.idle.callin.action=
 blf.enhanced.idle.idle.action=
 
-features.blf_list_version=
+features.blf_list_version = 0
 sip.sub_refresh_random=
 sip.terminate_notify_sub_delay_time=
 
-features.blf_led_mode=
+features.blf_led_mode = {$yealink_blf_led_mode}
 features.blf_pickup_only_send_code=
 
 
@@ -1590,7 +1586,7 @@ features.call_decline.enable =
 #######################################################################################
 ##                         BLF Ring Type                                             ##
 #######################################################################################
-features.blf.ring_type =
+features.blf.ring_type = {$yealink_blf_ring_type}
 
 
 #######################################################################################

--- a/resources/templates/provision/yealink/t54s/y000000000070.cfg
+++ b/resources/templates/provision/yealink/t54s/y000000000070.cfg
@@ -6,7 +6,7 @@
 ##                                    Network CDP                                    ##
 #######################################################################################
 static.network.cdp.enable = {$yealink_cdp_enable}
-static.network.cdp.packet_interval =
+static.network.cdp.packet_interval = {$yealink_cdp_packet_interval}
 
 
 #######################################################################################
@@ -37,17 +37,17 @@ static.network.ipv6_prefix =
 ##(X ranges from 1 to 5)
 ##Only T54S/T52S/T48G/T48S/T46G/T46S/T42S/T41S/T29G/T27G Models support these parameters.
 
-static.wifi.enable =
-static.wifi.1.label =
-static.wifi.1.ssid =
-static.wifi.1.priority =
-static.wifi.1.security_mode =
-static.wifi.1.cipher_type =
-static.wifi.1.password =
-static.wifi.1.eap_type =
-static.wifi.1.eap_user_name =
-static.wifi.1.eap_password =
-static.wifi.show_scan_prompt =
+static.wifi.enable = {$yealink_wifi_enable}
+static.wifi.1.label = {$yealink_wifi_1_label}
+static.wifi.1.ssid = {$yealink_wifi_1_ssid}
+static.wifi.1.priority = {$yealink_wifi_1_priority}
+static.wifi.1.security_mode = {$yealink_wifi_1_security}
+static.wifi.1.cipher_type = {$yealink_wifi_1_cipher}
+static.wifi.1.password = {$yealink_wifi_1_password}
+static.wifi.1.eap_type = {$yealink_wifi_1_type}
+static.wifi.1.eap_user_name = {$yealink_wifi_1_username}
+static.wifi.1.eap_password = {$yealink_wifi_1_password}
+static.wifi.show_scan_prompt = {$yealink_wifi_scan_prompt}
 
 
 #######################################################################################
@@ -90,7 +90,7 @@ static.network.internet_port.speed_duplex =
 ##                                   Network LLDP                                    ##
 #######################################################################################
 static.network.lldp.enable = {$yealink_lldp_enable}
-static.network.lldp.packet_interval =
+static.network.lldp.packet_interval = {$yealink_lldp_packet_interval}
 
 
 #######################################################################################
@@ -100,13 +100,13 @@ static.network.vlan.dhcp_enable =
 static.network.vlan.dhcp_option =
 static.network.vlan.vlan_change.enable =
 
-static.network.vlan.pc_port_priority =
-static.network.vlan.pc_port_vid =
+static.network.vlan.pc_port_priority = {$yealink_vlan_pc_cos}
+static.network.vlan.pc_port_vid = {$yealink_vlan_pc_id}
 static.network.vlan.pc_port_enable =
 
-static.network.vlan.internet_port_priority =
-static.network.vlan.internet_port_vid =
-static.network.vlan.internet_port_enable =
+static.network.vlan.internet_port_priority = {$yealink_vlan_cos}
+static.network.vlan.internet_port_vid = {$yealink_vlan_id}
+{if isset($yealink_vlan_enable)}static.network.vlan.internet_port_enable = {$yealink_vlan_enable}{else}static.network.vlan.internet_port_enable = 0{/if}
 
 
 #######################################################################################
@@ -137,36 +137,36 @@ static.auto_provision.custom.upload_method =
 #######################################################################################
 ##                                    ZERO Touch                                     ##
 #######################################################################################
-static.zero_touch.enable =
-static.zero_touch.wait_time =
-static.features.hide_zero_touch_url.enable =
-static.zero_touch.network_fail_delay_times =
-static.zero_touch.network_fail_wait_times =
+static.zero_touch.enable = {$yealink_zero_touch_enable}
+static.zero_touch.wait_time = {$yealink_zero_touch_wait_time}
+static.features.hide_zero_touch_url.enable = {$yealink_zero_touch_hide}
+static.zero_touch.network_fail_delay_times = {$yealink_zero_touch_delay}
+static.zero_touch.network_fail_wait_times = {$yealink_zero_touch_wait}
 
 
 #######################################################################################
 ##                                   Autop URL                                       ##
 #######################################################################################
-static.auto_provision.server.url =
-static.auto_provision.server.username =
-static.auto_provision.server.password =
+static.auto_provision.server.url = {$yealink_provision_url}
+static.auto_provision.server.username = {$http_auth_username}
+static.auto_provision.server.password = {$http_auth_password}
 
 
 #######################################################################################
 ##                                   Autop Weekly                                    ##
 #######################################################################################
-static.auto_provision.weekly.enable =
-static.auto_provision.weekly.dayofweek =
-static.auto_provision.weekly.end_time =
-static.auto_provision.weekly.begin_time =
-static.auto_provision.weekly_upgrade_interval =
+static.auto_provision.weekly.enable = {$yealink_autop_weekly_enable}
+static.auto_provision.weekly.dayofweek = {$yealink_autop_weekly_dayofweek}
+static.auto_provision.weekly.end_time = {$yealink_autop_weekly_end_time}
+static.auto_provision.weekly.begin_time = {$yealink_autop_weekly_begin_time}
+static.auto_provision.weekly_upgrade_interval = {$yealink_autop_weekly_interval}
 
 
 #######################################################################################
 ##                                   Autop Repeat                                    ##
 #######################################################################################
-static.auto_provision.repeat.enable =
-static.auto_provision.repeat.minutes =
+static.auto_provision.repeat.enable = {$yealink_autop_repeat_enable}
+static.auto_provision.repeat.minutes = {$yealink_autop_repeat_minutes}
 
 
 #######################################################################################
@@ -179,7 +179,7 @@ static.auto_provision.dhcp_option.enable =
 #######################################################################################
 ##                                   Autop Mode                                      ##
 #######################################################################################
-static.auto_provision.power_on =
+static.auto_provision.power_on = {$yealink_autop_power_on}
 
 
 #######################################################################################
@@ -220,7 +220,7 @@ features.custom_version_info =
 #######################################################################################
 ##                                   Autop PNP                                       ##
 #######################################################################################
-static.auto_provision.pnp_enable =
+static.auto_provision.pnp_enable = {$yealink_autop_pnp}
 
 
 #######################################################################################
@@ -340,10 +340,10 @@ static.security.cn_validation =
 static.security.dev_cert = 
 static.security.ca_cert = 
 static.security.trust_certificates = 
-static.security.user_password = 
-static.security.user_name.var = 
-static.security.user_name.admin = 
-static.security.user_name.user = 
+static.security.user_password = {$admin_name}:{$admin_password}
+static.security.user_name.var = {$var_name}
+static.security.user_name.admin = {$admin_name}
+static.security.user_name.user = {$user_name}
 security.tls_cipher_list = 
 
 
@@ -363,8 +363,8 @@ static.server_certificates.delete =
 #######################################################################################
 ##                           Trusted Certificates                                    ##
 #######################################################################################
-static.trusted_certificates.url =
-static.trusted_certificates.delete =
+static.trusted_certificates.url = {$yealink_trusted_cert_url}
+static.trusted_certificates.delete = {$yealink_trusted_cert_delete}
 
 
 #######################################################################################
@@ -382,21 +382,21 @@ static.auto_provision.encryption.config =
 
 
 #######################################################################################
-##                                   Trnasfer                                        ##
+##                                   Transfer                                        ##
 #######################################################################################
-features.transfer_type=
-dialplan.transfer.mode =
-transfer.on_hook_trans_enable =
-transfer.tran_others_after_conf_enable =
-transfer.blind_tran_on_hook_enable =
-transfer.semi_attend_tran_enable =
-phone_setting.call_appearance.transfer_via_new_linekey=
+features.transfer_type= {$yealink_transfer_type}
+dialplan.transfer.mode = {$yealink_transfer_mode}
+transfer.on_hook_trans_enable = {$yealink_transfer_onhook}
+transfer.tran_others_after_conf_enable = {$yealink_transfer_after_conf}
+transfer.blind_tran_on_hook_enable = {$yealink_transfer_blind_on_hook}
+transfer.semi_attend_tran_enable = {$yealink_transfer_semi_attended}
+phone_setting.call_appearance.transfer_via_new_linekey= {$yealink_transfer_via_new_linekey}
 
 
 #######################################################################################
 ##                                   Conference                                      ##
 #######################################################################################
-features.conference.with_previous_call.enable =
+features.conference.with_previous_call.enable = 
 features.local_conf.combine_with_one_press.enable=
 phone_setting.call_appearance.conference_via_new_linekey=
 
@@ -435,8 +435,8 @@ features.password_dial.length=
 features.password_dial.prefix=
 features.password_dial.enable=
 features.group_listen_in_talking_enable=
-phone_setting.call_info_display_method=
-phone_setting.called_party_info_display.enable =
+phone_setting.call_info_display_method= 0
+phone_setting.called_party_info_display.enable = 1
 features.headset_training=
 features.headset_prior=
 features.dtmf.replace_tran =
@@ -470,15 +470,15 @@ custom_softkey_call_failed.url=
 ##                                   Features Bluetooth                              ##
 #######################################################################################
 ##Only T54S/T52S/T48G/T48S/T46G/T46S/T42S/T41S/T29G/T27G Models support the parameter.
-features.bluetooth_enable=
-features.bluetooth_adapter_name=
+features.bluetooth_enable= {$yealink_bt_enable}
+features.bluetooth_adapter_name= {$yealink_bt_name}
 
 
 #######################################################################################
 ##                                  Features USB Record                              ##
 #######################################################################################
 ##Only T54S/T52S/T48G/T48S/T46G/T46S/T42S/T41S/T29G/T27G Models support the parameter.
-features.usb_call_recording.enable =
+features.usb_call_recording.enable = {$yealink_usb_record_enable}
 
 
 #######################################################################################
@@ -517,23 +517,23 @@ voice.tone.secondary_dial=
 #######################################################################################
 ##                                   Jitter Buffer                                   ##
 #######################################################################################
-voice.jib.normal=
-voice.jib.max =
-voice.jib.min =
-voice.jib.adaptive =
+voice.jib.normal= {$yealink_jib_normal}
+voice.jib.max = {$yealink_jib_max}
+voice.jib.min = {$yealink_jib_min}
+voice.jib.adaptive = {$yealink_jib_adaptive}
 
-voice.jib.wifi.normal=
-voice.jib.wifi.max=
-voice.jib.wifi.min=
-voice.jib.wifi.adaptive=
+voice.jib.wifi.normal= {$yealink_jib_wifi_normal}
+voice.jib.wifi.max= {$yealink_jib_wifi_max}
+voice.jib.wifi.min= {$yealink_jib_wifi_min}
+voice.jib.wifi.adaptive= {$yealink_jib_wifi_adaptive}
 
 
 #######################################################################################
 ##                                   Echo Cancellation                               ##
 #######################################################################################
-voice.echo_cancellation =
-voice.cng =
-voice.vad =
+voice.echo_cancellation = {$yealink_echo_cancellation}
+voice.cng = {$yealink_cng}
+voice.vad = {$yealink_cng}
 
 
 ################################################################
@@ -572,14 +572,14 @@ sip.send_keepalive_by_socket=
 sip.reliable_protocol.timerae.enable=
 sip.listen_in_peer_localip.enable=
 sip.requesturi.e164.addglobalprefix=
-sip.trust_ctrl=
+sip.trust_ctrl = {$yealink_trust_ctrl}
 sip.mac_in_ua=
 
 sip.timer_t1=
 sip.timer_t2=
 sip.timer_t4=
 
-sip.listen_mode=
+sip.listen_mode= {if isset($yealink_sip_listen_port)}sip.listen_port = {$yealink_sip_listen_port}{else}sip.listen_port = 5060{/if}
 sip.listen_port=
 sip.tls_listen_port=
 sip.tcp_port_random_mode=
@@ -639,44 +639,44 @@ features.rtp_symmetric.enable=
 #######################################################################################
 ##                                 RTCP-XR                                           ##
 #######################################################################################
-voice.rtcp.enable=
-voice.rtcp_cname=
-voice.rtcp_xr.enable=
-phone_setting.vq_rtcpxr_display_symm_oneway_delay.enable=
-phone_setting.vq_rtcpxr_display_round_trip_delay.enable=
-phone_setting.vq_rtcpxr_display_moscq.enable=
-phone_setting.vq_rtcpxr_display_moslq.enable = 
-phone_setting.vq_rtcpxr_display_packets_lost.enable=
-phone_setting.vq_rtcpxr_display_jitter_buffer_max.enable=
-phone_setting.vq_rtcpxr_display_jitter.enable=
-phone_setting.vq_rtcpxr_display_remote_codec.enable=
-phone_setting.vq_rtcpxr_display_local_codec.enable=
-phone_setting.vq_rtcpxr_display_remote_call_id.enable=
-phone_setting.vq_rtcpxr_display_local_call_id.enable=
-phone_setting.vq_rtcpxr_display_stop_time.enable=
-phone_setting.vq_rtcpxr_display_start_time.enable=
-phone_setting.vq_rtcpxr_interval_period=
-phone_setting.vq_rtcpxr_delay_threshold_critical=
-phone_setting.vq_rtcpxr_delay_threshold_warning=
-phone_setting.vq_rtcpxr_moslq_threshold_critical=
-phone_setting.vq_rtcpxr_moslq_threshold_warning=
-phone_setting.vq_rtcpxr.interval_report.enable=
-phone_setting.vq_rtcpxr.states_show_on_gui.enable=
-phone_setting.vq_rtcpxr.states_show_on_web.enable=
-phone_setting.vq_rtcpxr.session_report.enable=
+voice.rtcp.enable= {$yealink_rtcp_enable}
+voice.rtcp_cname= {$yealink_rtcp_cname}
+voice.rtcp_xr.enable= {$yealink_rtcpxr_enable}
+phone_setting.vq_rtcpxr_display_symm_oneway_delay.enable= {$yealink_rtcpxr_disp_enable}
+phone_setting.vq_rtcpxr_display_round_trip_delay.enable= {$yealink_rtcpxr_disp_enable}
+phone_setting.vq_rtcpxr_display_moscq.enable= {$yealink_rtcpxr_disp_enable}
+phone_setting.vq_rtcpxr_display_moslq.enable = {$yealink_rtcpxr_disp_enable}
+phone_setting.vq_rtcpxr_display_packets_lost.enable= {$yealink_rtcpxr_disp_enable}
+phone_setting.vq_rtcpxr_display_jitter_buffer_max.enable= {$yealink_rtcpxr_disp_enable}
+phone_setting.vq_rtcpxr_display_jitter.enable= {$yealink_rtcpxr_disp_enable}
+phone_setting.vq_rtcpxr_display_remote_codec.enable= {$yealink_rtcpxr_disp_enable}
+phone_setting.vq_rtcpxr_display_local_codec.enable= {$yealink_rtcpxr_disp_enable}
+phone_setting.vq_rtcpxr_display_remote_call_id.enable= {$yealink_rtcpxr_disp_enable}
+phone_setting.vq_rtcpxr_display_local_call_id.enable= {$yealink_rtcpxr_disp_enable}
+phone_setting.vq_rtcpxr_display_stop_time.enable= {$yealink_rtcpxr_disp_enable}
+phone_setting.vq_rtcpxr_display_start_time.enable= {$yealink_rtcpxr_disp_enable}
+phone_setting.vq_rtcpxr_interval_period= {$yealink_rtcpxr_interval}
+phone_setting.vq_rtcpxr_delay_threshold_critical= {$yealink_rtcpxr_delay_threshold_critical}
+phone_setting.vq_rtcpxr_delay_threshold_warning= {$yealink_rtcpxr_delay_threshold_warning}
+phone_setting.vq_rtcpxr_moslq_threshold_critical= {$yealink_rtcpxr_mos_threshold_critical}
+phone_setting.vq_rtcpxr_moslq_threshold_warning= {$yealink_rtcpxr_mos_threshold_warning}
+phone_setting.vq_rtcpxr.interval_report.enable= {$yealink_rtcpxr_interval_report_enable}
+phone_setting.vq_rtcpxr.states_show_on_gui.enable= {$yealink_rtcpxr_show_gui_enable}
+phone_setting.vq_rtcpxr.states_show_on_web.enable= {$yealink_rtcpxr_show_web_enable}
+phone_setting.vq_rtcpxr.session_report.enable= {$yealink_rtcpxr_report_enable}
 
 
 #######################################################################################
 ##                                   Contact                                         ##
 #######################################################################################
-static.directory_setting.url=
+static.directory_setting.url= https://{if isset($http_auth_username)}{$http_auth_username}:{$http_auth_password}@{/if}{$domain_name}/app/provision/?file=favorite_setting.xml
 super_search.url=
 
 local_contact.data.url=
 local_contact.data.delete=
 
 ##Only T54S/T52S/T48G/T48S/T46G/T46S/T29G Models support the parameter
-phone_setting.contact_photo_display.enable=
+phone_setting.contact_photo_display.enable= {$yealink_contact_photo_enable}
 
 phone_setting.incoming_call.horizontal_roll_interval=
 
@@ -740,27 +740,27 @@ remote_phonebook.data.5.url = {$yealink_remote_phonebook_5_url}
 #######################################################################################
 ##                                 LDAP                                              ##
 #######################################################################################
-ldap.enable=
-ldap.user=
-ldap.password=
-ldap.base=
-ldap.port=
-ldap.host=
+ldap.enable = {$ldap_enable}
+ldap.user = {$ldap_user}
+ldap.password = {$ldap_password}
+ldap.base = {$ldap_base}
+ldap.port = {$ldap_port}
+ldap.host = {$ldap_host}
 ldap.customize_label=
 ldap.incoming_call_special_search.enable=
 ldap.tls_mode=
 ldap.search_type=
 ldap.numb_display_mode=
-ldap.ldap_sort=
-ldap.call_in_lookup=
-ldap.version =
-ldap.display_name=
-ldap.numb_attr=
-ldap.name_attr=
-ldap.max_hits=
-ldap.number_filter=
-ldap.name_filter=
-ldap.call_out_lookup=
+ldap.ldap_sort = {$ldap_sort}
+ldap.call_in_lookup = {$ldap_call_in_lookup}
+ldap.version = {$ldap_version}
+ldap.display_name = {$ldap_display_name}
+ldap.numb_attr = {$ldap_numb_attr}
+ldap.name_attr = {$ldap_name_attr}
+ldap.max_hits = {$ldap_max_hits}
+ldap.number_filter = {$ldap_number_filter}
+ldap.name_filter = {$ldap_name_filter}
+ldap.call_out_lookup = {$ldap_dial_lookup}
 
 
 #######################################################################################
@@ -993,22 +993,22 @@ features.dnd.allow=
 features.dnd_mode=
 features.dnd.enable=
 
-features.dnd.off_code=
-features.dnd.on_code=
+features.dnd.off_code= *79
+features.dnd.on_code= *78
 
 features.dnd.emergency_authorized_number=
-features.dnd.emergency_enable=
+features.dnd.emergency_enable= 1
 features.dnd.large_icon.enable=
 
 
 #######################################################################################
 ##                               Phone Lock                                          ##
 #######################################################################################
-phone_setting.phone_lock.enable=
-phone_setting.phone_lock.lock_key_type=
-phone_setting.phone_lock.unlock_pin=
-phone_setting.emergency.number=
-phone_setting.phone_lock.lock_time_out=
+phone_setting.phone_lock.enable = {$yealink_lock_enable}
+phone_setting.phone_lock.lock_key_type = {$yealink_lock_key_type}
+phone_setting.phone_lock.unlock_pin = {$yealink_lock_pin}
+phone_setting.emergency.number = {$yealink_emergency_number}
+phone_setting.phone_lock.lock_time_out = {$yealink_lock_timeout}
 
 
 #######################################################################################
@@ -1034,9 +1034,9 @@ hotdesking.dsskey_outbound_enable=
 ##                               Voice Mail                                          ##
 #######################################################################################
 features.voice_mail_alert.enable=
-features.voice_mail_popup.enable=
+features.voice_mail_popup.enable = {$yealink_voice_mail_popup_enable}
 features.voice_mail_tone_enable=
-features.hide_feature_access_codes.enable=
+features.hide_feature_access_codes.enable = {$yealink_hide_feature_access_codes_enable}
 voice_mail.number.1=
 
 
@@ -1085,7 +1085,7 @@ features.ringer_device.is_use_headset=
 features.ip_call.auto_answer.enable=
 features.show_default_account=
 features.call.dialtone_time_out=
-features.missed_call_popup.enable=
+features.missed_call_popup.enable = {$yealink_missed_call_popup_enable}
 features.auto_answer_tone.enable=
 features.play_hold_tone.enable=
 features.key_as_send=
@@ -1093,7 +1093,7 @@ features.send_pound_key=
 features.busy_tone_delay=
 features.hotline_delay=
 features.hotline_number=
-features.direct_ip_call_enable=
+features.direct_ip_call_enable = {$yealink_direct_ip_call_enable}
 features.call_num_filter=
 features.call_completion_enable=
 features.allow_mute=
@@ -1103,12 +1103,12 @@ features.dnd_refuse_code=
 features.upload_server=
 features.dtmf.repetition=
 features.dtmf.hide_delay=
-features.dtmf.hide=
+features.dtmf.hide = {$yealink_dtmf_hide}
 features.play_local_dtmf_tone_enable =
 features.reboot_in_talk_enable =
 features.fwd_diversion_enable=
 
-call_waiting.enable=
+call_waiting.enable = {$yealink_call_waiting}
 call_waiting.tone=
 call_waiting.off_code=
 call_waiting.on_code=
@@ -1117,7 +1117,7 @@ auto_redial.times=
 auto_redial.interval=
 auto_redial.enable=
 
-sip.rfc2543_hold=
+sip.rfc2543_hold = {$yealink_rfc2543_hold}
 sip.use_23_as_pound=
 forward.international.enable=
 phone_setting.headsetkey_mode=
@@ -1184,10 +1184,10 @@ action_url.unregistered =
 phone_setting.hold_and_held_power_led_flash_enable=
 phone_setting.mute_power_led_flash_enable=
 phone_setting.talk_and_dial_power_led_enable=
-phone_setting.mail_power_led_flash_enable=
+phone_setting.mail_power_led_flash_enable = 1
 phone_setting.ring_power_led_flash_enable=
 phone_setting.common_power_led_enable=
-phone_setting.missed_call_power_led_flash.enable=
+phone_setting.missed_call_power_led_flash.enable = {$yealink_missed_call_power_led_flash_enable}
 
 
 #######################################################################################
@@ -1197,20 +1197,20 @@ lcl.datetime.date.format =
 auto_dst.url =
 local_time.manual_time_enable =
 local_time.manual_ntp_srv_prior =
-local_time.time_format =
+local_time.time_format = {$yealink_time_format}
 local_time.date_format = {$yealink_date_format}
-local_time.dhcp_time =
+local_time.dhcp_time = {$yealink_dhcp_time}
 
-local_time.summer_time =
-local_time.dst_time_type =
-local_time.start_time =
-local_time.end_time =
-local_time.offset_time =
-local_time.interval =
+local_time.summer_time = {$yealink_dst_enable}
+local_time.dst_time_type = {$yealink_dst_type}
+local_time.start_time = {$yealink_time_zone_start_time}
+local_time.end_time = {$yealink_time_zone_end_time}
+local_time.offset_time = {$yealink_offset_time}
+local_time.interval = {$yealink_time_update}
 
 local_time.ntp_server1 = {$ntp_server_primary}
 local_time.ntp_server2 = {$ntp_server_secondary}
-local_time.time_zone = {$yealink_time_zone_name}
+local_time.time_zone = {$yealink_time_zone}
 local_time.time_zone_name = {$yealink_time_zone_name}
 
 
@@ -1258,10 +1258,10 @@ lcd_logo.url=
 phone_setting.lcd_logo.mode=
 
 phone_setting.contrast=
-phone_setting.backlight_time=
-phone_setting.inactive_backlight_level=
+phone_setting.backlight_time = {$yealink_backlight_time}
+phone_setting.inactive_backlight_level = 1
 phone_setting.active_backlight_level=
-phone_setting.predial_autodial=
+phone_setting.predial_autodial = 1
 
 ringtone.url=
 ringtone.delete=
@@ -1369,41 +1369,41 @@ wui_lang.delete=
 gui_input_method.delete=
 gui_lang.url=
 gui_lang.delete=
-static.lang.gui=
-static.lang.wui=
+static.lang.gui= {$yealink_language_gui}
+static.lang.wui= {$yealink_language_web}
 
 
 #######################################################################################
 ##                                   Screensaver                                     ##
 #######################################################################################
-screensaver.type=
-screensaver.delete=
-screensaver.upload_url=
-features.blf_active_backlight.enable=
-screensaver.display_clock.enable=
-screensaver.clock_move_interval=
-screensaver.picture_change_interval=
-screensaver.wait_time=
-screensaver.xml_browser.url=
+screensaver.type= {$yealink_screensaver_type}
+screensaver.delete= {$yealink_screensaver_delete}
+screensaver.upload_url= {$yealink_screensaver_upload_url}
+features.blf_active_backlight.enable= 
+screensaver.display_clock.enable= {$yealink_screensaver_clock}
+screensaver.clock_move_interval= {$yealink_screensaver_clock_interval}
+screensaver.picture_change_interval= {$yealink_screensaver_pic_interval}
+screensaver.wait_time= {$yealink_screensaver_wait}
+screensaver.xml_browser.url= {$yealink_screensaver_xml_url}
 
 
 #######################################################################################
 ##                                  Power Saving                                     ##
 #######################################################################################
-features.power_saving.enable=
-features.power_saving.power_led_flash.on_time=
-features.power_saving.power_led_flash.off_time=
-features.power_saving.office_hour.monday=
-features.power_saving.office_hour.tuesday=
-features.power_saving.office_hour.wednesday=
-features.power_saving.office_hour.thursday=
-features.power_saving.office_hour.friday=
-features.power_saving.office_hour.saturday=
-features.power_saving.office_hour.sunday =
-features.power_saving.user_input_ext.idle_timeout=
-features.power_saving.off_hour.idle_timeout=
-features.power_saving.office_hour.idle_timeout=
-features.power_saving.intelligent_mode=
+features.power_saving.enable= {$yealink_powersave_enable}
+features.power_saving.power_led_flash.on_time= {$yealink_powersave_led_on_time}
+features.power_saving.power_led_flash.off_time= {$yealink_powersave_led_off_time}
+features.power_saving.office_hour.monday= {$yealink_powersave_hours_mon}
+features.power_saving.office_hour.tuesday= {$yealink_powersave_hours_tue}
+features.power_saving.office_hour.wednesday= {$yealink_powersave_wed}
+features.power_saving.office_hour.thursday= {$yealink_powersave_thu}
+features.power_saving.office_hour.friday= {$yealink_powersave_fri}
+features.power_saving.office_hour.saturday= {$yealink_powersave_sat}
+features.power_saving.office_hour.sunday = {$yealink_powersave_sun}
+features.power_saving.user_input_ext.idle_timeout= {$yealink_powersave_user_input_timeout}
+features.power_saving.off_hour.idle_timeout= {$yealink_powersave_off_hour_timeout}
+features.power_saving.office_hour.idle_timeout= {$yealink_powersave_office_hour_timeout}
+features.power_saving.intelligent_mode= {$yealink_powersave_intelligent_mode}
 
 
 #######################################################################################
@@ -1417,14 +1417,14 @@ features.power_saving.intelligent_mode=
 ##Single File Size: <=5MB 
 ##2MB of space should bereserved for the phone
 
-wallpaper_upload.url=
+wallpaper_upload.url= {$yealink_wallpaper_url}
 phone_setting.backgrounds=
 
 ## phone_setting.backgrounds_with_dsskey_unfold(Only support T48G/S)
-phone_setting.backgrounds_with_dsskey_unfold=
+phone_setting.backgrounds_with_dsskey_unfold= {$yealink_wallpaper_dsskey_unfold}
 
 ##expansion_module.backgrounds(Only support T54S/T52S)
-expansion_module.backgrounds=
+expansion_module.backgrounds= {$yealink_wallpaper_expansion}
 
 
 #######################################################################################
@@ -1474,11 +1474,11 @@ blf.enhanced.idle.talking.action=
 blf.enhanced.idle.callin.action=
 blf.enhanced.idle.idle.action=
 
-features.blf_list_version=
+features.blf_list_version = 0
 sip.sub_refresh_random=
 sip.terminate_notify_sub_delay_time=
 
-features.blf_led_mode=
+features.blf_led_mode = {$yealink_blf_led_mode}
 features.blf_pickup_only_send_code=
 
 
@@ -1586,7 +1586,7 @@ features.call_decline.enable =
 #######################################################################################
 ##                         BLF Ring Type                                             ##
 #######################################################################################
-features.blf.ring_type =
+features.blf.ring_type = {$yealink_blf_ring_type}
 
 
 #######################################################################################


### PR DESCRIPTION
Merged in all variables from the Yealink T4x templates (specifically based off T46s) to ensure the T52s and T54s phones provision with similar settings to the T4x phones.

Notable changes include admin user login password is now correctly set, timezone settings are fixed and many other changes. No behaviors have been hardcoded/changed that don't already exist on T4x phones so should not break any existing configurations.

In addition, there are a ton of new variables that can be set in the Fusion GUI. All these new changes should probably also be backported to all the other Yealink templates as well, time permitting.