### PR TITLE
BugFix [master] - default_settings anchors

### DIFF
--- a/core/default_settings/default_setting_edit.php
+++ b/core/default_settings/default_setting_edit.php
@@ -154,12 +154,12 @@
 				//set the message and redirect the user
 				if ($action == "add" && permission_exists('default_setting_add')) {
 					messages::add($text['message-add']);
-					header("Location: default_settings.php".(($search != '') ? "?search=".$search : null)."#".$default_setting_category);
+					header("Location: default_settings.php".(($search != '') ? "?search=".$search : null)."#anchor_".$default_setting_category);
 					return;
 				}
 				if ($action == "update" && permission_exists('default_setting_edit')) {
 					messages::add($text['message-update']);
-					header("Location: default_settings.php".(($search != '') ? "?search=".$search : null)."#".$default_setting_category);
+					header("Location: default_settings.php".(($search != '') ? "?search=".$search : null)."#anchor_".$default_setting_category);
 					return;
 				}
 			} //if ($_POST["persistformvar"] != "true")

--- a/core/default_settings/default_settings.php
+++ b/core/default_settings/default_settings.php
@@ -54,7 +54,7 @@ else {
 			unset($sql);
 
 			messages::add($text['message-update']);
-			header("Location: default_settings.php".(($search != '') ? "?search=".$search : null)."#".$category);
+			header("Location: default_settings.php".(($search != '') ? "?search=".$search : null)."#anchor_".$category);
 			exit;
 		}
 


### PR DESCRIPTION
update anchor names to use correct names, the mentioned commit changed the anchors over to use #anchor_{subcategory} from #{subcategory} but didn't correct all instances where anchors where called into the page
this commit broke it - https://github.com/fusionpbx/fusionpbx/commit/45bf2e5fd647200a02985819529dbb6fa0f84449