### PR TITLE
Fix. Use preloaded dialplan more then once.

### DIFF
--- a/resources/install/scripts/resources/functions/route_to_bridge.lua
+++ b/resources/install/scripts/resources/functions/route_to_bridge.lua
@@ -630,8 +630,8 @@ local function apply_vars(actions, fields)
 end
 
 local function wrap_dbh(t)
-	local i = 0
 	return {query = function(self, sql, params, callback)
+		local i = 0
 		while true do
 			i = i + 1
 			local row = t[i]


### PR DESCRIPTION
Problem was cause by query wrapper which do not reset counter before new call.

So preloaded dialplan can be use only once.
Can you please revert changes in ring group?
I have installation which depends on ability to set variables
via `user_data` in outbound dialplan,

My external routes has action like this
`export nolocal:param=${user_data(${caller_id_number}@${domain_name} var XXX)}`
