### PR TITLE
Update fax_emails.php

### DIFF
--- a/app/fax/fax_emails.php
+++ b/app/fax/fax_emails.php
@@ -98,6 +98,7 @@ if (sizeof($result) != 0) {
 		$fax_email_outbound_subject_tag = $row["fax_email_outbound_subject_tag"];
 		$fax_email_outbound_authorized_senders = $row["fax_email_outbound_authorized_senders"];
 		$fax_send_greeting = $row["fax_send_greeting"];
+		$fax_accountcode = $row["accountcode"];
 
 		//load default settings, then domain settings over top
 		unset($_SESSION);


### PR DESCRIPTION
Sending a fax via 'new' in the web GUI worked, but failed via sending per mail.
The account code was not set when sending via mail.
This is now fixed.