### PR TITLE
Update call_forward.lua

### DIFF
--- a/resources/install/scripts/call_forward.lua
+++ b/resources/install/scripts/call_forward.lua
@@ -24,9 +24,9 @@
 
 --set default variables
 	min_digits = "1";
-	max_digits = "11";
+	max_digits = "17";
 	max_tries = "3";
-	digit_timeout = "3000";
+	digit_timeout = "5000";
 
 --define the trim function
 	require "resources.functions.trim"


### PR DESCRIPTION
max_digit was too low. It was not possible to forward to a german mobile with 12 digits.
According to E.164 https://en.wikipedia.org/wiki/E.164 the maximum allowed length is 15 to be safe, the limit is now 17.
Also increased the timeout to 5 seconds.