### PR TITLE
Changed NOTIFY Event header for Grandstream phones

### DIFF
--- a/resources/install/scripts/app/event_notify/index.lua
+++ b/resources/install/scripts/app/event_notify/index.lua
@@ -91,7 +91,7 @@
 			event:addHeader('event-string', 'check-sync;reboot=true');
 		end
 		if (command == "check_sync") then
-			event:addHeader('event-string', 'check-sync;reboot=false');
+			event:addHeader('event-string', 'resync');
 		end
 	end
 


### PR DESCRIPTION
Changed SIP NOTIFY Event header for Grandstream phones to allow provisioning with out requiring a reboot of the device. Based on communication with a Grandstream support rep. Tested on Grandstream GXP2130 and GXP2160 models.