### PR TITLE
Fix dashboard disk space calculation

### DIFF
--- a/core/user_settings/user_dashboard.php
+++ b/core/user_settings/user_dashboard.php
@@ -941,18 +941,8 @@
 
 			//disk usage
 			if (PHP_OS == 'FreeBSD' || PHP_OS == 'Linux') {
-				$df = shell_exec("/usr/bin/which df");
-				if($df){
-					$tmp = shell_exec($df." /home 2>&1");
-				} else {
-					$tmp = shell_exec("df /home 2>&1");
-				}
-				$tmp = explode("\n", $tmp);
-				$tmp = preg_replace('!\s+!', ' ', $tmp[1]); // multiple > single space
-				$tmp = explode(' ', $tmp);
-				foreach ($tmp as $stat) {
-					if (substr_count($stat, '%') > 0) { $percent_disk_usage = rtrim($stat,'%'); break; }
-				}
+				$fractional_disk_usage = 1 - disk_free_space('/home') / disk_total_space('/home');
+				$percent_disk_usage = number_format(100*$fractional_disk_usage,0);
 
 				if ($percent_disk_usage != '') {
 					$hud[$n]['html'] .= "<span class='hud_stat' onclick=\"$('#hud_'+".$n."+'_details').slideToggle('fast');\">".$percent_disk_usage."</span>";

--- a/core/user_settings/user_dashboard.php
+++ b/core/user_settings/user_dashboard.php
@@ -940,7 +940,7 @@
 			$hud[$n]['html'] .= "<span class='hud_title' style='cursor: default;'>".$text['label-system_status']."</span>";
 
 			//disk usage
-			if (PHP_OS == 'FreeBSD' || PHP_OS == 'Linux') {
+			if ( (PHP_OS == 'FreeBSD' || PHP_OS == 'Linux') && file_exists('/home') ) {
 				$fractional_disk_usage = 1 - disk_free_space('/home') / disk_total_space('/home');
 				$percent_disk_usage = number_format(100*$fractional_disk_usage,0);
 


### PR DESCRIPTION
This pull request switches the disk space calculation from shelling out to using standard PHP functions. This fixes the calculation, which would previously appear as 0% on the dashboard.

Note that the percentage may be slightly different from what's reported by df, due to the presence of reserved blocks for root. 
