### PR TITLE
Update install_fusionpbx.php

### DIFF
--- a/core/install/resources/classes/install_fusionpbx.php
+++ b/core/install/resources/classes/install_fusionpbx.php
@@ -545,7 +545,7 @@ include "root.php";
 			//add the database structure
 				require_once "resources/classes/schema.php";
 				$schema = new schema;
-				//echo $schema->schema();
+				echo $schema->schema();
 
 			//add the defaults data into the database
 				//get the contents of the sql file


### PR DESCRIPTION
Fix so install works with MySQL.  

`create_database_mysql` does not create schema
but `create_odbc_database_connection` tries to insert records into non-existent `v_database` table and
installation fails.