### PR TITLE
Adding sip_h_Diversion channel variable to list of conditions in dialplan editor.

### DIFF
--- a/app/dialplans/dialplan_detail_edit.php
+++ b/app/dialplans/dialplan_detail_edit.php
@@ -344,6 +344,7 @@ function replace_param(obj){
 		echo "	<option value='\${sip_to_uri}'>\${sip_to_uri}</option>\n";
 		echo "	<option value='\${sip_to_user}'>\${sip_to_user}</option>\n";
 		echo "	<option value='\${sip_to_host}'>\${sip_to_host}</option>\n";
+		echo "  <option value='\${sip_h_Diversion}'>\$sip_h_Diversion}</option>\n";
 		echo "</optgroup>\n";
 	}
 	if (strlen($dialplan_detail_tag) == 0 || $dialplan_detail_tag == "action" || $dialplan_detail_tag == "anti-action") {

--- a/app/dialplans/dialplan_edit.php
+++ b/app/dialplans/dialplan_edit.php
@@ -673,6 +673,7 @@
 								echo "		<option value='\${sip_to_user}'>\${sip_to_user}</option>\n";
 								echo "		<option value='\${sip_to_host}'>\${sip_to_host}</option>\n";
 								echo "		<option value='\${toll_allow}'>\${toll_allow}</option>\n";
+								echo "		<option value='\${sip_h_Diversion}'>\$sip_h_Diversion}</option>\n";
 								echo "	</optgroup>\n";
 							//}
 							//if (strlen($dialplan_detail_tag) == 0 || $dialplan_detail_tag == "action" || $dialplan_detail_tag == "anti-action") {


### PR DESCRIPTION
Hello first time PR here in this project...

The idea behind this PR is to add the sip_h_Diversion header in the list of conditions for the dial plan editor.  A use case could be, for example, to detect that diversion header is present and then playback some kind of pre media such as "please wait while we connect your call" or what have you.