### PR TITLE
Allow call forwarding to be enabled and set by argument in INVITE.

### DIFF
--- a/app/dialplans/resources/switch/conf/dialplan/500_call-forward.xml
+++ b/app/dialplans/resources/switch/conf/dialplan/500_call-forward.xml
@@ -1,9 +1,9 @@
 <context name="{v_context}">
 	<extension name="call-forward" number="*72,*73,*74" continue="false" app_uuid="b4b32fb4-0181-4876-9bec-b9dff1299d60" enabled="true">
-		<condition field="destination_number" expression="^\*72$" break="on-true">
+		<condition field="destination_number" expression="^\*72(\d*)$" break="on-true">
 			<action application="set" data="request_id=false"/>
 			<action application="set" data="enabled=true"/>
-			<action application="lua" data="call_forward.lua"/>
+			<action application="lua" data="call_forward.lua $1"/>
 		</condition>
 		<condition field="destination_number" expression="^\*73$" break="on-true">
 			<action application="set" data="request_id=false"/>

--- a/resources/install/scripts/call_forward.lua
+++ b/resources/install/scripts/call_forward.lua
@@ -169,8 +169,15 @@
 
 	if not session:ready() then return end
 
---get the forward destination
-	if enabled == "true" and empty(forward_all_destination) then
+--get the destination by argument and set the forwarding destination 
+	destination_by_arg = argv[1];
+	
+	if enabled == "true" and destination_by_arg then
+		forward_all_destination = destination_by_arg;
+	end
+	
+--get the forward destination by IVR if destination has not been passed by argument
+	if enabled == "true" and empty(forward_all_destination) and not destination_by_arg then
 		forward_all_destination = session:playAndGetDigits(min_digits, max_digits, max_tries, digit_timeout, "#", sounds_dir.."/"..default_language.."/"..default_dialect.."/"..default_voice.."/ivr/ivr-enter_destination_telephone_number.wav", "", "\\d+");
 		if empty(forward_all_destination) then return end
 	end


### PR DESCRIPTION
 Useful for softkey on hard phones, where the phone wants to sent *72xxxxxxxx.
Modification does not change original functionality of IVR set of forwarding on dialing *72. 