### PR TITLE
Fix tone_stream

### DIFF
--- a/app/tones/app_config.php
+++ b/app/tones/app_config.php
@@ -40,8 +40,8 @@
 		$apps[$x]['destinations'][$y]['field']['name'] = "var_name";
 		$apps[$x]['destinations'][$y]['field']['destination'] = "var_filename";
 		$apps[$x]['destinations'][$y]['field']['description'] = "var_description";
-		$apps[$x]['destinations'][$y]['select_value']['dialplan'] = "play tone_stream://\${destination}";
-		$apps[$x]['destinations'][$y]['select_value']['ivr'] = "play tone_stream://\${destination}";
+		$apps[$x]['destinations'][$y]['select_value']['dialplan'] = "playback:tone_stream://\${destination}";
+		$apps[$x]['destinations'][$y]['select_value']['ivr'] = "playback:tone_stream://\${destination}";
 		$apps[$x]['destinations'][$y]['select_label'] = "\${name}";
 
 ?>


### PR DESCRIPTION
This error was being generated in freeswitch:
[ERR] switch_core_session.c:2683 Invalid Application play tone_stream

Needs to use application "playback" for tone_stream.

Had to use a colon instead of a space as the delimited. Otherwise it would parse the dialpan action as "playback tone_stream" and the data as "//%(274,0,913.8);%(274,0,1370.6);%(380,0,1776.7)"

Now shows -->  <action application="playback" data="tone_stream://%(274,0,913.8);%(274,0,1370.6);%(380,0,1776.7)"/>