### PR TITLE
Use Freeswitch for mkdir

### DIFF
--- a/resources/install/scripts/resources/functions/mkdir.lua
+++ b/resources/install/scripts/resources/functions/mkdir.lua
@@ -1,14 +1,15 @@
-
 --add the mkdir function
-	function mkdir(dir)
-		dir = dir:gsub([[\]], "/");
-		if (package.config:sub(1,1) == "/") then
-			--unix
-			cmd = [[mkdir -p "]] .. dir .. [["]];
-		elseif (package.config:sub(1,1) == [[\]]) then
-			--windows
-			cmd = [[mkdir "]] .. dir .. [["]];
-		end
-		os.execute(cmd);
-		return cmd;
-	end
+        function mkdir(dir)
+                api = freeswitch.API();
+                dir = dir:gsub([[\]], "/");
+                if (package.config:sub(1,1) == "/") then
+                        --unix
+                        cmd = [[mkdir -p "]] .. dir .. [["]];
+                elseif (package.config:sub(1,1) == [[\]]) then
+                        --windows
+                        cmd = [[mkdir "]] .. dir .. [["]];
+                end
+                -- os.execute(cmd);
+                api:executeString("system " .. cmd  );
+                return cmd;
+        end


### PR DESCRIPTION
This change reduces  the strain on the system by running the OS command through Freeswitch rather than directly from Lua. When running directly from Lua it causes RTP jitter in a high capacity system.