### PR TITLE
Fix a DELETE FROM SQL Sentence for VoiceMails [4.2]

### DIFF
--- a/app/voicemails/voicemail_edit.php
+++ b/app/voicemails/voicemail_edit.php
@@ -78,10 +78,10 @@
 		//delete the voicemail from the destionations
 			$sqld = "
 				delete from
-					v_voicemail_destinations as d
+					v_voicemail_destinations
 				where
-					d.voicemail_destination_uuid = '".$voicemail_destination_uuid."' and
-					d.voicemail_uuid = '".$voicemail_uuid."'";
+					voicemail_destination_uuid = '".$voicemail_destination_uuid."' and
+					voicemail_uuid = '".$voicemail_uuid."'";
 			$db->exec(check_sql($sqld));
 		//redirect the browser
 			$_SESSION["message"] = $text['message-delete'];


### PR DESCRIPTION
MariaDB/MySQL (and maybe other databases) are not compatible with a DELETE FROM table AS alias. Anyway, you don't need the AS alias part as you are just dealing with a single table in this sentence.