### PR TITLE
Fix Voicemail DELETE FROM SQL Sentence [4.4]

### DIFF
--- a/app/voicemails/voicemail_edit.php
+++ b/app/voicemails/voicemail_edit.php
@@ -82,10 +82,10 @@
 		//delete the voicemail from the destionations
 			$sqld = "
 				delete from
-					v_voicemail_destinations as d
+					v_voicemail_destinations
 				where
-					d.voicemail_destination_uuid = '".$voicemail_destination_uuid."' and
-					d.voicemail_uuid = '".$voicemail_uuid."'";
+					voicemail_destination_uuid = '".$voicemail_destination_uuid."' and
+					voicemail_uuid = '".$voicemail_uuid."'";
 			$db->exec(check_sql($sqld));
 		//redirect the browser
 			messages::add($text['message-delete']);


### PR DESCRIPTION
Same, the AS alias is not needed, it breaks MariaDB/MySQL and maybe other databases as well. Also, the SQL sentence is just dealing with one table, so it is not needed.