### PR TITLE
Fix Voicemail DELETE FROM SQL Query [4.5]

### DIFF
--- a/app/voicemails/voicemail_edit.php
+++ b/app/voicemails/voicemail_edit.php
@@ -82,10 +82,10 @@
 		//delete the voicemail from the destionations
 			$sqld = "
 				delete from
-					v_voicemail_destinations as d
+					v_voicemail_destination
 				where
-					d.voicemail_destination_uuid = '".$voicemail_destination_uuid."' and
-					d.voicemail_uuid = '".$voicemail_uuid."'";
+					voicemail_destination_uuid = '".$voicemail_destination_uuid."' and
+					voicemail_uuid = '".$voicemail_uuid."'";
 			$db->exec(check_sql($sqld));
 		//redirect the browser
 			messages::add($text['message-delete']);


### PR DESCRIPTION
As the other patches, the AS alias is not supported on MariaDB/MySQL and maybe other databases as well. You do not need an alias as you are just dealing with a single table.