### PR TITLE
Disable anonymous (ghost calling) on Grandstreams 

### DIFF
--- a/resources/templates/provision/grandstream/gxp2130/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp2130/{$mac}.xml
@@ -441,7 +441,7 @@
 <!--  Accept Incoming SIP from Proxy Only. 0 - No, 1 - Yes. Default is 0 -->
 <!--  Number: 0, 1 -->
 <!--  Mandatory -->
-<P2347>0</P2347>
+<P2347>1</P2347>
 
 <!--  Authenticate Incoming INVITE. 0 - No, 1 - Yes. Default is 0 -->
 <!--  Number: 0, 1 -->
@@ -1207,7 +1207,7 @@
 <!--  Accept Incoming SIP from Proxy Only. 0 - No, 1 - Yes. Default is 0 -->
 <!--  Number: 0, 1 -->
 <!--  Mandatory -->
-<P2447>0</P2447>
+<P2447>1</P2447>
 
 <!--  Authenticate Incoming INVITE. 0 - No, 1 - Yes. Default is 0 -->
 <!--  Number: 0, 1 -->
@@ -1961,7 +1961,7 @@
 <!--  Accept Incoming SIP from Proxy Only. 0 - No, 1 - Yes. Default is 0 -->
 <!--  Number: 0, 1 -->
 <!--  Mandatory -->
-<P2547>0</P2547>
+<P2547>1</P2547>
 
 <!--  Authenticate Incoming INVITE. 0 - No, 1 - Yes. Default is 0 -->
 <!--  Number: 0, 1 -->
@@ -2715,7 +2715,7 @@
 <!--  Accept Incoming SIP from Proxy Only. 0 - No, 1 - Yes. Default is 0 -->
 <!--  Number: 0, 1 -->
 <!--  Mandatory -->
-<P2647>0</P2647>
+<P2647>1</P2647>
 
 <!--  Authenticate Incoming INVITE. 0 - No, 1 - Yes. Default is 0 -->
 <!--  Number: 0, 1 -->
@@ -3469,7 +3469,7 @@
 <!--  Accept Incoming SIP from Proxy Only. 0 - No, 1 - Yes. Default is 0 -->
 <!--  Number: 0, 1 -->
 <!--  Mandatory -->
-<P2747>0</P2747>
+<P2747>1</P2747>
 
 <!--  Authenticate Incoming INVITE. 0 - No, 1 - Yes. Default is 0 -->
 <!--  Number: 0, 1 -->
@@ -4226,7 +4226,7 @@
 <!--  Accept Incoming SIP from Proxy Only. 0 - No, 1 - Yes. Default is 0 -->
 <!--  Number: 0, 1 -->
 <!--  Mandatory -->
-<P2847>0</P2847>
+<P2847>1</P2847>
 
 <!--  Authenticate Incoming INVITE. 0 - No, 1 - Yes. Default is 0 -->
 <!--  Number: 0, 1 -->

--- a/resources/templates/provision/grandstream/gxp2135/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp2135/{$mac}.xml
@@ -441,7 +441,7 @@
 <!--  Accept Incoming SIP from Proxy Only. 0 - No, 1 - Yes. Default is 0 -->
 <!--  Number: 0, 1 -->
 <!--  Mandatory -->
-<P2347>0</P2347>
+<P2347>1</P2347>
 
 <!--  Authenticate Incoming INVITE. 0 - No, 1 - Yes. Default is 0 -->
 <!--  Number: 0, 1 -->
@@ -1207,7 +1207,7 @@
 <!--  Accept Incoming SIP from Proxy Only. 0 - No, 1 - Yes. Default is 0 -->
 <!--  Number: 0, 1 -->
 <!--  Mandatory -->
-<P2447>0</P2447>
+<P2447>1</P2447>
 
 <!--  Authenticate Incoming INVITE. 0 - No, 1 - Yes. Default is 0 -->
 <!--  Number: 0, 1 -->
@@ -1961,7 +1961,7 @@
 <!--  Accept Incoming SIP from Proxy Only. 0 - No, 1 - Yes. Default is 0 -->
 <!--  Number: 0, 1 -->
 <!--  Mandatory -->
-<P2547>0</P2547>
+<P2547>1</P2547>
 
 <!--  Authenticate Incoming INVITE. 0 - No, 1 - Yes. Default is 0 -->
 <!--  Number: 0, 1 -->
@@ -2715,7 +2715,7 @@
 <!--  Accept Incoming SIP from Proxy Only. 0 - No, 1 - Yes. Default is 0 -->
 <!--  Number: 0, 1 -->
 <!--  Mandatory -->
-<P2647>0</P2647>
+<P2647>1</P2647>
 
 <!--  Authenticate Incoming INVITE. 0 - No, 1 - Yes. Default is 0 -->
 <!--  Number: 0, 1 -->
@@ -3469,7 +3469,7 @@
 <!--  Accept Incoming SIP from Proxy Only. 0 - No, 1 - Yes. Default is 0 -->
 <!--  Number: 0, 1 -->
 <!--  Mandatory -->
-<P2747>0</P2747>
+<P2747>1</P2747>
 
 <!--  Authenticate Incoming INVITE. 0 - No, 1 - Yes. Default is 0 -->
 <!--  Number: 0, 1 -->
@@ -4226,7 +4226,7 @@
 <!--  Accept Incoming SIP from Proxy Only. 0 - No, 1 - Yes. Default is 0 -->
 <!--  Number: 0, 1 -->
 <!--  Mandatory -->
-<P2847>0</P2847>
+<P2847>1</P2847>
 
 <!--  Authenticate Incoming INVITE. 0 - No, 1 - Yes. Default is 0 -->
 <!--  Number: 0, 1 -->

--- a/resources/templates/provision/grandstream/gxp2140/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp2140/{$mac}.xml
@@ -441,7 +441,7 @@
 <!--  Accept Incoming SIP from Proxy Only. 0 - No, 1 - Yes. Default is 0 -->
 <!--  Number: 0, 1 -->
 <!--  Mandatory -->
-<P2347>0</P2347>
+<P2347>1</P2347>
 
 <!--  Authenticate Incoming INVITE. 0 - No, 1 - Yes. Default is 0 -->
 <!--  Number: 0, 1 -->
@@ -1207,7 +1207,7 @@
 <!--  Accept Incoming SIP from Proxy Only. 0 - No, 1 - Yes. Default is 0 -->
 <!--  Number: 0, 1 -->
 <!--  Mandatory -->
-<P2447>0</P2447>
+<P2447>1</P2447>
 
 <!--  Authenticate Incoming INVITE. 0 - No, 1 - Yes. Default is 0 -->
 <!--  Number: 0, 1 -->
@@ -1961,7 +1961,7 @@
 <!--  Accept Incoming SIP from Proxy Only. 0 - No, 1 - Yes. Default is 0 -->
 <!--  Number: 0, 1 -->
 <!--  Mandatory -->
-<P2547>0</P2547>
+<P2547>1</P2547>
 
 <!--  Authenticate Incoming INVITE. 0 - No, 1 - Yes. Default is 0 -->
 <!--  Number: 0, 1 -->
@@ -2715,7 +2715,7 @@
 <!--  Accept Incoming SIP from Proxy Only. 0 - No, 1 - Yes. Default is 0 -->
 <!--  Number: 0, 1 -->
 <!--  Mandatory -->
-<P2647>0</P2647>
+<P2647>1</P2647>
 
 <!--  Authenticate Incoming INVITE. 0 - No, 1 - Yes. Default is 0 -->
 <!--  Number: 0, 1 -->
@@ -3469,7 +3469,7 @@
 <!--  Accept Incoming SIP from Proxy Only. 0 - No, 1 - Yes. Default is 0 -->
 <!--  Number: 0, 1 -->
 <!--  Mandatory -->
-<P2747>0</P2747>
+<P2747>1</P2747>
 
 <!--  Authenticate Incoming INVITE. 0 - No, 1 - Yes. Default is 0 -->
 <!--  Number: 0, 1 -->
@@ -4226,7 +4226,7 @@
 <!--  Accept Incoming SIP from Proxy Only. 0 - No, 1 - Yes. Default is 0 -->
 <!--  Number: 0, 1 -->
 <!--  Mandatory -->
-<P2847>0</P2847>
+<P2847>1</P2847>
 
 <!--  Authenticate Incoming INVITE. 0 - No, 1 - Yes. Default is 0 -->
 <!--  Number: 0, 1 -->

--- a/resources/templates/provision/grandstream/gxp2160/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp2160/{$mac}.xml
@@ -441,7 +441,7 @@
 <!--  Accept Incoming SIP from Proxy Only. 0 - No, 1 - Yes. Default is 0 -->
 <!--  Number: 0, 1 -->
 <!--  Mandatory -->
-<P2347>0</P2347>
+<P2347>1</P2347>
 
 <!--  Authenticate Incoming INVITE. 0 - No, 1 - Yes. Default is 0 -->
 <!--  Number: 0, 1 -->
@@ -1207,7 +1207,7 @@
 <!--  Accept Incoming SIP from Proxy Only. 0 - No, 1 - Yes. Default is 0 -->
 <!--  Number: 0, 1 -->
 <!--  Mandatory -->
-<P2447>0</P2447>
+<P2447>1</P2447>
 
 <!--  Authenticate Incoming INVITE. 0 - No, 1 - Yes. Default is 0 -->
 <!--  Number: 0, 1 -->
@@ -1961,7 +1961,7 @@
 <!--  Accept Incoming SIP from Proxy Only. 0 - No, 1 - Yes. Default is 0 -->
 <!--  Number: 0, 1 -->
 <!--  Mandatory -->
-<P2547>0</P2547>
+<P2547>1</P2547>
 
 <!--  Authenticate Incoming INVITE. 0 - No, 1 - Yes. Default is 0 -->
 <!--  Number: 0, 1 -->
@@ -2715,7 +2715,7 @@
 <!--  Accept Incoming SIP from Proxy Only. 0 - No, 1 - Yes. Default is 0 -->
 <!--  Number: 0, 1 -->
 <!--  Mandatory -->
-<P2647>0</P2647>
+<P2647>1</P2647>
 
 <!--  Authenticate Incoming INVITE. 0 - No, 1 - Yes. Default is 0 -->
 <!--  Number: 0, 1 -->
@@ -3469,7 +3469,7 @@
 <!--  Accept Incoming SIP from Proxy Only. 0 - No, 1 - Yes. Default is 0 -->
 <!--  Number: 0, 1 -->
 <!--  Mandatory -->
-<P2747>0</P2747>
+<P2747>1</P2747>
 
 <!--  Authenticate Incoming INVITE. 0 - No, 1 - Yes. Default is 0 -->
 <!--  Number: 0, 1 -->
@@ -4226,7 +4226,7 @@
 <!--  Accept Incoming SIP from Proxy Only. 0 - No, 1 - Yes. Default is 0 -->
 <!--  Number: 0, 1 -->
 <!--  Mandatory -->
-<P2847>0</P2847>
+<P2847>1</P2847>
 
 <!--  Authenticate Incoming INVITE. 0 - No, 1 - Yes. Default is 0 -->
 <!--  Number: 0, 1 -->

--- a/resources/templates/provision/grandstream/gxp2170/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp2170/{$mac}.xml
@@ -470,7 +470,7 @@
 <!-- # Accept Incoming SIP from Proxy Only. 0 - No, 1 - Yes. Default is 0 -->
 <!-- # Number: 0, 1 -->
 <!-- # Mandatory -->
-<P2347>0</P2347>
+<P2347>1</P2347>
 
 <!-- # Authenticate Incoming INVITE. 0 - No, 1 - Yes. Default is 0 -->
 <!-- # Number: 0, 1 -->
@@ -1304,7 +1304,7 @@
 <!-- # Accept Incoming SIP from Proxy Only. 0 - No, 1 - Yes. Default is 0 -->
 <!-- # Number: 0, 1 -->
 <!-- # Mandatory -->
-<P2447>0</P2447>
+<P2447>1</P2447>
 
 <!-- # Authenticate Incoming INVITE. 0 - No, 1 - Yes. Default is 0 -->
 <!-- # Number: 0, 1 -->
@@ -2141,7 +2141,7 @@
 <!-- # Accept Incoming SIP from Proxy Only. 0 - No, 1 - Yes. Default is 0 -->
 <!-- # Number: 0, 1 -->
 <!-- # Mandatory -->
-<P2547>0</P2547>
+<P2547>1</P2547>
 
 <!-- # Authenticate Incoming INVITE. 0 - No, 1 - Yes. Default is 0 -->
 <!-- # Number: 0, 1 -->
@@ -2978,7 +2978,7 @@
 <!-- # Accept Incoming SIP from Proxy Only. 0 - No, 1 - Yes. Default is 0 -->
 <!-- # Number: 0, 1 -->
 <!-- # Mandatory -->
-<P2647>0</P2647>
+<P2647>1</P2647>
 
 <!-- # Authenticate Incoming INVITE. 0 - No, 1 - Yes. Default is 0 -->
 <!-- # Number: 0, 1 -->
@@ -3815,7 +3815,7 @@
 <!-- # Accept Incoming SIP from Proxy Only. 0 - No, 1 - Yes. Default is 0 -->
 <!-- # Number: 0, 1 -->
 <!-- # Mandatory -->
-<P2747>0</P2747>
+<P2747>1</P2747>
 
 <!-- # Authenticate Incoming INVITE. 0 - No, 1 - Yes. Default is 0 -->
 <!-- # Number: 0, 1 -->
@@ -4655,7 +4655,7 @@
 <!-- # Accept Incoming SIP from Proxy Only. 0 - No, 1 - Yes. Default is 0 -->
 <!-- # Number: 0, 1 -->
 <!-- # Mandatory -->
-<P2847>0</P2847>
+<P2847>1</P2847>
 
 <!-- # Authenticate Incoming INVITE. 0 - No, 1 - Yes. Default is 0 -->
 <!-- # Number: 0, 1 -->


### PR DESCRIPTION
This prevents SIP anonymous calls, This should really be set as a default.