### PR TITLE
 Fix Yealink Programmable Key Template Conflicts 

### DIFF
--- a/app/ivr_menus/ivr_menu_edit.php
+++ b/app/ivr_menus/ivr_menu_edit.php
@@ -85,6 +85,7 @@
 		//get ivr menu
 			$ivr_menu_name = check_str($_POST["ivr_menu_name"]);
 			$ivr_menu_extension = check_str($_POST["ivr_menu_extension"]);
+			$ivr_menu_language = check_str($_POST["ivr_menu_language"]);
 			$ivr_menu_greet_long = check_str($_POST["ivr_menu_greet_long"]);
 			$ivr_menu_greet_short = check_str($_POST["ivr_menu_greet_short"]);
 			$ivr_menu_options = $_POST["ivr_menu_options"];
@@ -128,6 +129,7 @@
 			$msg = '';
 			if (strlen($ivr_menu_name) == 0) { $msg .= $text['message-required'].$text['label-name']."<br>\n"; }
 			if (strlen($ivr_menu_extension) == 0) { $msg .= $text['message-required'].$text['label-extension']."<br>\n"; }
+			//if (strlen($ivr_menu_language) == 0) { $msg .= $text['message-required'].$text['label-language']."<br>\n"; }
 			if (strlen($ivr_menu_greet_long) == 0) { $msg .= $text['message-required'].$text['label-greet_long']."<br>\n"; }
 			//if (strlen($ivr_menu_greet_short) == 0) { $msg .= $text['message-required'].$text['label-greet_short']."<br>\n"; }
 			//if (strlen($ivr_menu_invalid_sound) == 0) { $msg .= $text['message-required'].$text['label-invalid_sound']."<br>\n"; }
@@ -229,8 +231,6 @@
 					}
 
 				//build the xml dialplan
-					$ivr_menu_language = explode ("/",check_str($_POST["ivr_menu_language"]));
-					
 					$dialplan_xml = "<extension name=\"".$ivr_menu_name."\" continue=\"false\" uuid=\"".$dialplan_uuid."\">\n";
 					$dialplan_xml .= "	<condition field=\"destination_number\" expression=\"^".$ivr_menu_extension."\$\">\n";
 					$dialplan_xml .= "		<action application=\"answer\" data=\"\"/>\n";
@@ -238,9 +238,9 @@
 					$dialplan_xml .= "		<action application=\"set\" data=\"hangup_after_bridge=true\"/>\n";
 					$dialplan_xml .= "		<action application=\"set\" data=\"ringback=".$ivr_menu_ringback."\"/>\n";
 					$dialplan_xml .= "		<action application=\"set\" data=\"presence_id=".$ivr_menu_extension."@".$_SESSION['domain_name']."\"/>\n";
-					$dialplan_xml .= "		<action application=\"set\" data=\"default_language=".$ivr_menu_language[0]."\"/>\n";
-					$dialplan_xml .= "		<action application=\"set\" data=\"default_dialect=".$ivr_menu_language[1]."\"/>\n";
-					$dialplan_xml .= "		<action application=\"set\" data=\"default_voice=".$ivr_menu_language[2]."\"/>\n";
+					if  (strlen($ivr_menu_language) > 0) {
+						$dialplan_xml .= "		<action application=\"set\" data=\"default_language=".$ivr_menu_language."\"/>\n";
+					}
 					$dialplan_xml .= "		<action application=\"set\" data=\"transfer_ringback=".$ivr_menu_ringback."\"/>\n";
 					$dialplan_xml .= "		<action application=\"set\" data=\"ivr_menu_uuid=".$ivr_menu_uuid."\"/>\n";
 
@@ -339,8 +339,6 @@
 			$ivr_menu_name = $row["ivr_menu_name"];
 			$ivr_menu_extension = $row["ivr_menu_extension"];
 			$ivr_menu_language = $row["ivr_menu_language"];
-			$ivr_menu_dialect = $row["ivr_menu_dialect"];
-			$ivr_menu_voice = $row["ivr_menu_voice"];
 			$ivr_menu_greet_long = $row["ivr_menu_greet_long"];
 			$ivr_menu_greet_short = $row["ivr_menu_greet_short"];
 			$ivr_menu_invalid_sound = $row["ivr_menu_invalid_sound"];
@@ -405,9 +403,7 @@
 	if (strlen($ivr_menu_ringback) == 0) { $ivr_menu_ringback = 'local_stream://default'; }
 	if (strlen($ivr_menu_invalid_sound) == 0) { $ivr_menu_invalid_sound = 'ivr/ivr-that_was_an_invalid_entry.wav'; }
 	//if (strlen($ivr_menu_confirm_key) == 0) { $ivr_menu_confirm_key = '#'; }
-	if (strlen($ivr_menu_language_code) == 0) { $ivr_menu_language_code = 'en'; }
-	if (strlen($ivr_menu_dialect) == 0) { $ivr_menu_dialect = 'us'; }
-	if (strlen($ivr_menu_voice) == 0) { $ivr_menu_voice = 'callie'; }
+	if (strlen($ivr_menu_language) == 0) { $ivr_menu_language = 'en'; }
 	if (strlen($ivr_menu_tts_engine) == 0) { $ivr_menu_tts_engine = 'flite'; }
 	if (strlen($ivr_menu_tts_voice) == 0) { $ivr_menu_tts_voice = 'rms'; }
 	if (strlen($ivr_menu_confirm_attempts) == 0) { $ivr_menu_confirm_attempts = '1'; }
@@ -418,33 +414,6 @@
 	if (strlen($ivr_menu_direct_dial) == 0) { $ivr_menu_direct_dial = 'false'; }
 	if (strlen($ivr_menu_enabled) == 0) { $ivr_menu_enabled = 'true'; }
 	if (!isset($ivr_menu_exit_action)) { $ivr_menu_exit_action = ''; }
-
-//get installed languages
-$root = '/usr/share/freeswitch/sounds/';
-
-$maxDepth = 2;
-$minDepth = 2;
-
-$iter = new RecursiveIteratorIterator(
-	new RecursiveDirectoryIterator($root, RecursiveDirectoryIterator::SKIP_DOTS),
-	RecursiveIteratorIterator::SELF_FIRST,
-	RecursiveIteratorIterator::CATCH_GET_CHILD// Ignore "Permission denied"
-);
-
-$iter->setMaxDepth($maxDepth);
-
-$paths = array($root);
-foreach ($iter as $path => $dir) {
-	if ($iter->getDepth() >= $minDepth) {
-    	if ($dir->isDir()) {
-    		$cleanPath = str_replace($root,"",$path);
-    		if (preg_match("/^\w\w\/\w\w\/[a-z]*$/", $cleanPath)) {
-    			$paths[] = str_replace($root,"", $cleanPath);
-    		}
-    	}
-    }
-}
-array_shift($paths);
 
 //get the recordings
 	$sql = "select recording_name, recording_filename from v_recordings ";
@@ -534,28 +503,7 @@ array_shift($paths);
 	echo "	".$text['label-language']."\n";
 	echo "</td>\n";
 	echo "<td class='vtable' align='left'>\n";
-	echo "  <select class='formfld' type='text' name='ivr_menu_language' required='required'>\n";
-
-	if (empty($ivr_menu_language)) {
-		$defaultLang = "$ivr_menu_language_code-$ivr_menu_dialect $ivr_menu_voice";
-		$ivr_menu_language = "$ivr_menu_language_code/$ivr_menu_dialect/$ivr_menu_voice";
-		echo "		<option value='$ivr_menu_language'>$defaultLang</option>\n";
-	}
-	else {
-	$curLangA = explode ('/', $ivr_menu_language);
-	$curLang = $curLangA[0]."-".$curLangA[1]." ".$curLangA[2];
-	echo "		<option value='$ivr_menu_language'>$curLang</option>\n";
-	}
-	
-	foreach ($paths as $key=>$langParams) {
-		$langParam = explode ('/',$paths[$key]);
-		$language = $langParam[0];
-		$dialect = $langParam[1];
-		$voice = $langParam[2];
-		if ($curLang <> "$language-$dialect $voice" && $defaultLang <> "$language-$dialect $voice") {
-			echo "		<option value='$language/$dialect/$voice'>$language-$dialect $voice</option>\n";
-		}
-	}
+	echo "  <input class='formfld' type='text' name='ivr_menu_language' maxlength='255' value='$ivr_menu_language' required='required'>\n";
 	echo "<br />\n";
 	echo $text['description-language']."\n";
 	echo "</td>\n";

--- a/app/ivr_menus/ivr_menu_edit.php
+++ b/app/ivr_menus/ivr_menu_edit.php
@@ -85,7 +85,6 @@
 		//get ivr menu
 			$ivr_menu_name = check_str($_POST["ivr_menu_name"]);
 			$ivr_menu_extension = check_str($_POST["ivr_menu_extension"]);
-			$ivr_menu_language = check_str($_POST["ivr_menu_language"]);
 			$ivr_menu_greet_long = check_str($_POST["ivr_menu_greet_long"]);
 			$ivr_menu_greet_short = check_str($_POST["ivr_menu_greet_short"]);
 			$ivr_menu_options = $_POST["ivr_menu_options"];
@@ -129,7 +128,6 @@
 			$msg = '';
 			if (strlen($ivr_menu_name) == 0) { $msg .= $text['message-required'].$text['label-name']."<br>\n"; }
 			if (strlen($ivr_menu_extension) == 0) { $msg .= $text['message-required'].$text['label-extension']."<br>\n"; }
-			//if (strlen($ivr_menu_language) == 0) { $msg .= $text['message-required'].$text['label-language']."<br>\n"; }
 			if (strlen($ivr_menu_greet_long) == 0) { $msg .= $text['message-required'].$text['label-greet_long']."<br>\n"; }
 			//if (strlen($ivr_menu_greet_short) == 0) { $msg .= $text['message-required'].$text['label-greet_short']."<br>\n"; }
 			//if (strlen($ivr_menu_invalid_sound) == 0) { $msg .= $text['message-required'].$text['label-invalid_sound']."<br>\n"; }
@@ -231,6 +229,8 @@
 					}
 
 				//build the xml dialplan
+					$ivr_menu_language = explode ("/",check_str($_POST["ivr_menu_language"]));
+					
 					$dialplan_xml = "<extension name=\"".$ivr_menu_name."\" continue=\"false\" uuid=\"".$dialplan_uuid."\">\n";
 					$dialplan_xml .= "	<condition field=\"destination_number\" expression=\"^".$ivr_menu_extension."\$\">\n";
 					$dialplan_xml .= "		<action application=\"answer\" data=\"\"/>\n";
@@ -238,9 +238,9 @@
 					$dialplan_xml .= "		<action application=\"set\" data=\"hangup_after_bridge=true\"/>\n";
 					$dialplan_xml .= "		<action application=\"set\" data=\"ringback=".$ivr_menu_ringback."\"/>\n";
 					$dialplan_xml .= "		<action application=\"set\" data=\"presence_id=".$ivr_menu_extension."@".$_SESSION['domain_name']."\"/>\n";
-					if  (strlen($ivr_menu_language) > 0) {
-						$dialplan_xml .= "		<action application=\"set\" data=\"default_language=".$ivr_menu_language."\"/>\n";
-					}
+					$dialplan_xml .= "		<action application=\"set\" data=\"default_language=".$ivr_menu_language[0]."\"/>\n";
+					$dialplan_xml .= "		<action application=\"set\" data=\"default_dialect=".$ivr_menu_language[1]."\"/>\n";
+					$dialplan_xml .= "		<action application=\"set\" data=\"default_voice=".$ivr_menu_language[2]."\"/>\n";
 					$dialplan_xml .= "		<action application=\"set\" data=\"transfer_ringback=".$ivr_menu_ringback."\"/>\n";
 					$dialplan_xml .= "		<action application=\"set\" data=\"ivr_menu_uuid=".$ivr_menu_uuid."\"/>\n";
 
@@ -339,6 +339,8 @@
 			$ivr_menu_name = $row["ivr_menu_name"];
 			$ivr_menu_extension = $row["ivr_menu_extension"];
 			$ivr_menu_language = $row["ivr_menu_language"];
+			$ivr_menu_dialect = $row["ivr_menu_dialect"];
+			$ivr_menu_voice = $row["ivr_menu_voice"];
 			$ivr_menu_greet_long = $row["ivr_menu_greet_long"];
 			$ivr_menu_greet_short = $row["ivr_menu_greet_short"];
 			$ivr_menu_invalid_sound = $row["ivr_menu_invalid_sound"];
@@ -403,7 +405,9 @@
 	if (strlen($ivr_menu_ringback) == 0) { $ivr_menu_ringback = 'local_stream://default'; }
 	if (strlen($ivr_menu_invalid_sound) == 0) { $ivr_menu_invalid_sound = 'ivr/ivr-that_was_an_invalid_entry.wav'; }
 	//if (strlen($ivr_menu_confirm_key) == 0) { $ivr_menu_confirm_key = '#'; }
-	if (strlen($ivr_menu_language) == 0) { $ivr_menu_language = 'en'; }
+	if (strlen($ivr_menu_language_code) == 0) { $ivr_menu_language_code = 'en'; }
+	if (strlen($ivr_menu_dialect) == 0) { $ivr_menu_dialect = 'us'; }
+	if (strlen($ivr_menu_voice) == 0) { $ivr_menu_voice = 'callie'; }
 	if (strlen($ivr_menu_tts_engine) == 0) { $ivr_menu_tts_engine = 'flite'; }
 	if (strlen($ivr_menu_tts_voice) == 0) { $ivr_menu_tts_voice = 'rms'; }
 	if (strlen($ivr_menu_confirm_attempts) == 0) { $ivr_menu_confirm_attempts = '1'; }
@@ -414,6 +418,33 @@
 	if (strlen($ivr_menu_direct_dial) == 0) { $ivr_menu_direct_dial = 'false'; }
 	if (strlen($ivr_menu_enabled) == 0) { $ivr_menu_enabled = 'true'; }
 	if (!isset($ivr_menu_exit_action)) { $ivr_menu_exit_action = ''; }
+
+//get installed languages
+$root = '/usr/share/freeswitch/sounds/';
+
+$maxDepth = 2;
+$minDepth = 2;
+
+$iter = new RecursiveIteratorIterator(
+	new RecursiveDirectoryIterator($root, RecursiveDirectoryIterator::SKIP_DOTS),
+	RecursiveIteratorIterator::SELF_FIRST,
+	RecursiveIteratorIterator::CATCH_GET_CHILD// Ignore "Permission denied"
+);
+
+$iter->setMaxDepth($maxDepth);
+
+$paths = array($root);
+foreach ($iter as $path => $dir) {
+	if ($iter->getDepth() >= $minDepth) {
+    	if ($dir->isDir()) {
+    		$cleanPath = str_replace($root,"",$path);
+    		if (preg_match("/^\w\w\/\w\w\/[a-z]*$/", $cleanPath)) {
+    			$paths[] = str_replace($root,"", $cleanPath);
+    		}
+    	}
+    }
+}
+array_shift($paths);
 
 //get the recordings
 	$sql = "select recording_name, recording_filename from v_recordings ";
@@ -503,7 +534,28 @@
 	echo "	".$text['label-language']."\n";
 	echo "</td>\n";
 	echo "<td class='vtable' align='left'>\n";
-	echo "  <input class='formfld' type='text' name='ivr_menu_language' maxlength='255' value='$ivr_menu_language' required='required'>\n";
+	echo "  <select class='formfld' type='text' name='ivr_menu_language' required='required'>\n";
+
+	if (empty($ivr_menu_language)) {
+		$defaultLang = "$ivr_menu_language_code-$ivr_menu_dialect $ivr_menu_voice";
+		$ivr_menu_language = "$ivr_menu_language_code/$ivr_menu_dialect/$ivr_menu_voice";
+		echo "		<option value='$ivr_menu_language'>$defaultLang</option>\n";
+	}
+	else {
+	$curLangA = explode ('/', $ivr_menu_language);
+	$curLang = $curLangA[0]."-".$curLangA[1]." ".$curLangA[2];
+	echo "		<option value='$ivr_menu_language'>$curLang</option>\n";
+	}
+	
+	foreach ($paths as $key=>$langParams) {
+		$langParam = explode ('/',$paths[$key]);
+		$language = $langParam[0];
+		$dialect = $langParam[1];
+		$voice = $langParam[2];
+		if ($curLang <> "$language-$dialect $voice" && $defaultLang <> "$language-$dialect $voice") {
+			echo "		<option value='$language/$dialect/$voice'>$language-$dialect $voice</option>\n";
+		}
+	}
 	echo "<br />\n";
 	echo $text['description-language']."\n";
 	echo "</td>\n";

--- a/resources/templates/provision/yealink/t21p/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t21p/{$mac}.cfg
@@ -3024,46 +3024,6 @@ memorykey.{$row.device_key_id}.sub_type =
 
 
 ##########################################################################################
-##                         Programmable Key (For T38G only)                             ##
-##########################################################################################
-#X ranges from 1 to 15.
-#programablekey.x.type--Customize the programmable key type.
-#The valid types are:
-#0-N/A         2-Forward        5-DND           6-Redial     7-Call Return    8-SMS      9-Call Pickup  13-Spead Dial  14-Intercom
-#22-XML Group  23-Group Pickup  27-XML Browser  28-History   29-Directory     30-Menu    32-New SMS     33-Status      43-Local Phonebook
-#44-Broadsoft Phonebook    45-Local Group    46-Broadsoft Group   47-XML Phonebook   48-Switch Account Up   49-Switch Account Down    50-Keypad Lock
-#programablekey.x.line--Configure the desired line to apply the key feature. It ranges from 0 to 6.
-#The value 0 of the "proramablekey.x.line" stands for Auto, it means the first available line.
-#But, when the programmable key is configured as Pick Up, the value 0 stands for line 1.
-
-{foreach $keys["programmable"] as $row}
-
-
-programablekey.{$row.device_key_id}.type = {$row.device_key_type}
-programablekey.{$row.device_key_id}.line = {$row.device_key_line}
-programablekey.{$row.device_key_id}.value = {$row.device_key_value}
-programablekey.{$row.device_key_id}.xml_phonebook =
-programablekey.{$row.device_key_id}.history_type =
-programablekey.{$row.device_key_id}.label = {$row.device_key_label}
-
-{/foreach}
-
-
-#programablekey.x.value =
-#programablekey.x.xml_phonebook--Specify the desired remote phonebook/local group/BSFT phonebook for the programmable key. This parameter is only appilicable to the feature XML Group/Local Group/Broadsoft Group.
-#programablekey.x.history_type =
-
-#programablekey.x.label--This parameter is only available to the key 1 to key 4.
-
-#programablekey.1.type =
-#programablekey.1.line =
-#programablekey.1.value =
-#programablekey.1.xml_phonebook =
-#programablekey.1.history_type =
-#programablekey.1.label =
-
-
-##########################################################################################
 ##                                  Expansion Module 1                                  ##
 ##########################################################################################
 #X ranges from 1 to 16, Y ranges from 1 to 40.

--- a/resources/templates/provision/yealink/t23g/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t23g/{$mac}.cfg
@@ -2905,68 +2905,6 @@ memorykey.{$row.device_key_id}.sub_type =
 
 {/foreach}
 
-
-##########################################################################################
-##                         Programmable Key (For T38G only)                             ##
-##########################################################################################
-#X ranges from 1 to 15.
-#programablekey.x.type--Customize the programmable key type.
-#The valid types are:
-#0-N/A         2-Forward        5-DND           6-Redial     7-Call Return    8-SMS      9-Call Pickup  13-Spead Dial  14-Intercom
-#22-XML Group  23-Group Pickup  27-XML Browser  28-History   29-Directory     30-Menu    32-New SMS     33-Status      43-Local Phonebook
-#44-Broadsoft Phonebook    45-Local Group    46-Broadsoft Group   47-XML Phonebook   48-Switch Account Up   49-Switch Account Down    50-Keypad Lock
-#programablekey.x.line--Configure the desired line to apply the key feature. It ranges from 0 to 6.
-#The value 0 of the "proramablekey.x.line" stands for Auto, it means the first available line.
-#But, when the programmable key is configured as Pick Up, the value 0 stands for line 1.
-
-{foreach $keys["programmable"] as $row}
-programablekey.{$row.device_key_id}.type = {$row.device_key_type}
-programablekey.{$row.device_key_id}.line = {$row.device_key_line}
-programablekey.{$row.device_key_id}.value = {$row.device_key_value}
-programablekey.{$row.device_key_id}.xml_phonebook =
-programablekey.{$row.device_key_id}.history_type =
-programablekey.{$row.device_key_id}.label = {$row.device_key_label}
-
-{/foreach}
-
-#programablekey.x.value =
-#programablekey.x.xml_phonebook--Specify the desired remote phonebook/local group/BSFT phonebook for the programmable key. This parameter is only appilicable to the feature XML Group/Local Group/Broadsoft Group.
-#programablekey.x.history_type =
-
-#programablekey.x.label--This parameter is only available to the key 1 to key 4.
-
-#History
-#programablekey.1.type = 28
-#programablekey.1.line = 1
-#programablekey.1.value = 
-#programablekey.1.xml_phonebook =
-#programablekey.1.history_type =
-#programablekey.1.label =
-
-#Directory
-#programablekey.2.type = 29
-#programablekey.2.line = 1
-#programablekey.2.value =
-#programablekey.2.xml_phonebook =
-#programablekey.2.history_type =
-#programablekey.2.label =
-
-#DND
-programablekey.3.type = 5
-programablekey.3.line = 1
-programablekey.3.value =
-programablekey.3.xml_phonebook =
-programablekey.3.history_type =
-programablekey.3.label =
-
-#Menu
-#programablekey.4.type = 30
-#programablekey.4.line =
-#programablekey.4.value =
-#programablekey.4.xml_phonebook =
-#programablekey.4.history_type =
-#programablekey.4.label =
-
 ##########################################################################################
 ##                                  Expansion Module 1                                  ##
 ##########################################################################################

--- a/resources/templates/provision/yealink/t23p/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t23p/{$mac}.cfg
@@ -2908,67 +2908,6 @@ memorykey.{$row.device_key_id}.sub_type =
 
 
 ##########################################################################################
-##                         Programmable Key (For T38G only)                             ##
-##########################################################################################
-#X ranges from 1 to 15.
-#programablekey.x.type--Customize the programmable key type.
-#The valid types are:
-#0-N/A         2-Forward        5-DND           6-Redial     7-Call Return    8-SMS      9-Call Pickup  13-Spead Dial  14-Intercom
-#22-XML Group  23-Group Pickup  27-XML Browser  28-History   29-Directory     30-Menu    32-New SMS     33-Status      43-Local Phonebook
-#44-Broadsoft Phonebook    45-Local Group    46-Broadsoft Group   47-XML Phonebook   48-Switch Account Up   49-Switch Account Down    50-Keypad Lock
-#programablekey.x.line--Configure the desired line to apply the key feature. It ranges from 0 to 6.
-#The value 0 of the "proramablekey.x.line" stands for Auto, it means the first available line.
-#But, when the programmable key is configured as Pick Up, the value 0 stands for line 1.
-
-{foreach $keys["programmable"] as $row}
-programablekey.{$row.device_key_id}.type = {$row.device_key_type}
-programablekey.{$row.device_key_id}.line = {$row.device_key_line}
-programablekey.{$row.device_key_id}.value = {$row.device_key_value}
-programablekey.{$row.device_key_id}.xml_phonebook =
-programablekey.{$row.device_key_id}.history_type =
-programablekey.{$row.device_key_id}.label = {$row.device_key_label}
-
-{/foreach}
-
-#programablekey.x.value =
-#programablekey.x.xml_phonebook--Specify the desired remote phonebook/local group/BSFT phonebook for the programmable key. This parameter is only appilicable to the feature XML Group/Local Group/Broadsoft Group.
-#programablekey.x.history_type =
-
-#programablekey.x.label--This parameter is only available to the key 1 to key 4.
-
-#History
-#programablekey.1.type = 28
-#programablekey.1.line = 1
-#programablekey.1.value = 
-#programablekey.1.xml_phonebook =
-#programablekey.1.history_type =
-#programablekey.1.label =
-
-#Directory
-#programablekey.2.type = 29
-#programablekey.2.line = 1
-#programablekey.2.value =
-#programablekey.2.xml_phonebook =
-#programablekey.2.history_type =
-#programablekey.2.label =
-
-#DND
-programablekey.3.type = 5
-programablekey.3.line = 1
-programablekey.3.value =
-programablekey.3.xml_phonebook =
-programablekey.3.history_type =
-programablekey.3.label =
-
-#Menu
-#programablekey.4.type = 30
-#programablekey.4.line =
-#programablekey.4.value =
-#programablekey.4.xml_phonebook =
-#programablekey.4.history_type =
-#programablekey.4.label =
-
-##########################################################################################
 ##                                  Expansion Module 1                                  ##
 ##########################################################################################
 #X ranges from 1 to 16, Y ranges from 1 to 40.

--- a/resources/templates/provision/yealink/t26p/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t26p/{$mac}.cfg
@@ -2026,69 +2026,6 @@ memorykey.{$row.device_key_id}.sub_type =
 
 
 ##########################################################################################
-##                         Programmable Key (For T38G only)                             ##
-##########################################################################################
-#X ranges from 1 to 15.
-#programablekey.x.type--Customize the programmable key type.
-#The valid types are:
-#0-N/A         2-Forward        5-DND           6-Redial     7-Call Return    8-SMS      9-Call Pickup  13-Spead Dial  14-Intercom
-#22-XML Group  23-Group Pickup  27-XML Browser  28-History   29-Directory     30-Menu    32-New SMS     33-Status      43-Local Phonebook
-#44-Broadsoft Phonebook    45-Local Group    46-Broadsoft Group   47-XML Phonebook   48-Switch Account Up   49-Switch Account Down    50-Keypad Lock
-#programablekey.x.line--Configure the desired line to apply the key feature. It ranges from 0 to 6.
-#The value 0 of the "proramablekey.x.line" stands for Auto, it means the first available line.
-#But, when the programmable key is configured as Pick Up, the value 0 stands for line 1.
-
-{foreach $keys["programmable"] as $row}
-
-programablekey.{$row.device_key_id}.type = {$row.device_key_type}
-programablekey.{$row.device_key_id}.line = {$row.device_key_line}
-programablekey.{$row.device_key_id}.value = {$row.device_key_value}
-programablekey.{$row.device_key_id}.xml_phonebook =
-programablekey.{$row.device_key_id}.history_type =
-programablekey.{$row.device_key_id}.label = {$row.device_key_label}
-
-{/foreach}
-
-#programablekey.x.value =
-#programablekey.x.xml_phonebook--Specify the desired remote phonebook/local group/BSFT phonebook for the programmable key. This parameter is only appilicable to the feature XML Group/Local Group/Broadsoft Group.
-#programablekey.x.history_type =
-
-#programablekey.x.label--This parameter is only available to the key 1 to key 4.
-
-#History
-#programablekey.1.type = 28
-#programablekey.1.line = 1
-#programablekey.1.value = 
-#programablekey.1.xml_phonebook =
-#programablekey.1.history_type =
-#programablekey.1.label =
-
-#Directory
-#programablekey.2.type = 29
-#programablekey.2.line = 1
-#programablekey.2.value =
-#programablekey.2.xml_phonebook =
-#programablekey.2.history_type =
-#programablekey.2.label =
-
-#DND
-programablekey.3.type = 5
-programablekey.3.line = 1
-programablekey.3.value =
-programablekey.3.xml_phonebook =
-programablekey.3.history_type =
-programablekey.3.label =
-
-#Menu
-#programablekey.4.type = 30
-#programablekey.4.line =
-#programablekey.4.value =
-#programablekey.4.xml_phonebook =
-#programablekey.4.history_type =
-#programablekey.4.label =
-
-
-##########################################################################################
 ##                                  Expansion Module 1                                  ##
 ##########################################################################################
 #X ranges from 1 to 16, Y ranges from 1 to 40.

--- a/resources/templates/provision/yealink/t27g/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t27g/{$mac}.cfg
@@ -2908,67 +2908,6 @@ memorykey.{$row.device_key_id}.sub_type =
 
 
 ##########################################################################################
-##                         Programmable Key (For T38G only)                             ##
-##########################################################################################
-#X ranges from 1 to 15.
-#programablekey.x.type--Customize the programmable key type.
-#The valid types are:
-#0-N/A         2-Forward        5-DND           6-Redial     7-Call Return    8-SMS      9-Call Pickup  13-Spead Dial  14-Intercom
-#22-XML Group  23-Group Pickup  27-XML Browser  28-History   29-Directory     30-Menu    32-New SMS     33-Status      43-Local Phonebook
-#44-Broadsoft Phonebook    45-Local Group    46-Broadsoft Group   47-XML Phonebook   48-Switch Account Up   49-Switch Account Down    50-Keypad Lock
-#programablekey.x.line--Configure the desired line to apply the key feature. It ranges from 0 to 6.
-#The value 0 of the "proramablekey.x.line" stands for Auto, it means the first available line.
-#But, when the programmable key is configured as Pick Up, the value 0 stands for line 1.
-
-{foreach $keys["programmable"] as $row}
-programablekey.{$row.device_key_id}.type = {$row.device_key_type}
-programablekey.{$row.device_key_id}.line = {$row.device_key_line}
-programablekey.{$row.device_key_id}.value = {$row.device_key_value}
-programablekey.{$row.device_key_id}.xml_phonebook =
-programablekey.{$row.device_key_id}.history_type =
-programablekey.{$row.device_key_id}.label = {$row.device_key_label}
-
-{/foreach}
-
-#programablekey.x.value =
-#programablekey.x.xml_phonebook--Specify the desired remote phonebook/local group/BSFT phonebook for the programmable key. This parameter is only appilicable to the feature XML Group/Local Group/Broadsoft Group.
-#programablekey.x.history_type =
-
-#programablekey.x.label--This parameter is only available to the key 1 to key 4.
-
-#History
-#programablekey.1.type = 28
-#programablekey.1.line = 1
-#programablekey.1.value = 
-#programablekey.1.xml_phonebook =
-#programablekey.1.history_type =
-#programablekey.1.label =
-
-#Directory
-#programablekey.2.type = 29
-#programablekey.2.line = 1
-#programablekey.2.value =
-#programablekey.2.xml_phonebook =
-#programablekey.2.history_type =
-#programablekey.2.label =
-
-#DND
-programablekey.3.type = 5
-programablekey.3.line = 1
-programablekey.3.value =
-programablekey.3.xml_phonebook =
-programablekey.3.history_type =
-programablekey.3.label =
-
-#Menu
-#programablekey.4.type = 30
-#programablekey.4.line =
-#programablekey.4.value =
-#programablekey.4.xml_phonebook =
-#programablekey.4.history_type =
-#programablekey.4.label =
-
-##########################################################################################
 ##                                  Expansion Module 1                                  ##
 ##########################################################################################
 #X ranges from 1 to 16, Y ranges from 1 to 40.

--- a/resources/templates/provision/yealink/t27p/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t27p/{$mac}.cfg
@@ -2908,67 +2908,6 @@ memorykey.{$row.device_key_id}.sub_type =
 
 
 ##########################################################################################
-##                         Programmable Key (For T38G only)                             ##
-##########################################################################################
-#X ranges from 1 to 15.
-#programablekey.x.type--Customize the programmable key type.
-#The valid types are:
-#0-N/A         2-Forward        5-DND           6-Redial     7-Call Return    8-SMS      9-Call Pickup  13-Spead Dial  14-Intercom
-#22-XML Group  23-Group Pickup  27-XML Browser  28-History   29-Directory     30-Menu    32-New SMS     33-Status      43-Local Phonebook
-#44-Broadsoft Phonebook    45-Local Group    46-Broadsoft Group   47-XML Phonebook   48-Switch Account Up   49-Switch Account Down    50-Keypad Lock
-#programablekey.x.line--Configure the desired line to apply the key feature. It ranges from 0 to 6.
-#The value 0 of the "proramablekey.x.line" stands for Auto, it means the first available line.
-#But, when the programmable key is configured as Pick Up, the value 0 stands for line 1.
-
-{foreach $keys["programmable"] as $row}
-programablekey.{$row.device_key_id}.type = {$row.device_key_type}
-programablekey.{$row.device_key_id}.line = {$row.device_key_line}
-programablekey.{$row.device_key_id}.value = {$row.device_key_value}
-programablekey.{$row.device_key_id}.xml_phonebook =
-programablekey.{$row.device_key_id}.history_type =
-programablekey.{$row.device_key_id}.label = {$row.device_key_label}
-
-{/foreach}
-
-#programablekey.x.value =
-#programablekey.x.xml_phonebook--Specify the desired remote phonebook/local group/BSFT phonebook for the programmable key. This parameter is only appilicable to the feature XML Group/Local Group/Broadsoft Group.
-#programablekey.x.history_type =
-
-#programablekey.x.label--This parameter is only available to the key 1 to key 4.
-
-#History
-#programablekey.1.type = 28
-#programablekey.1.line = 1
-#programablekey.1.value = 
-#programablekey.1.xml_phonebook =
-#programablekey.1.history_type =
-#programablekey.1.label =
-
-#Directory
-#programablekey.2.type = 29
-#programablekey.2.line = 1
-#programablekey.2.value =
-#programablekey.2.xml_phonebook =
-#programablekey.2.history_type =
-#programablekey.2.label =
-
-#DND
-programablekey.3.type = 5
-programablekey.3.line = 1
-programablekey.3.value =
-programablekey.3.xml_phonebook =
-programablekey.3.history_type =
-programablekey.3.label =
-
-#Menu
-#programablekey.4.type = 30
-#programablekey.4.line =
-#programablekey.4.value =
-#programablekey.4.xml_phonebook =
-#programablekey.4.history_type =
-#programablekey.4.label =
-
-##########################################################################################
 ##                                  Expansion Module 1                                  ##
 ##########################################################################################
 #X ranges from 1 to 16, Y ranges from 1 to 40.

--- a/resources/templates/provision/yealink/t28p/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t28p/{$mac}.cfg
@@ -2027,69 +2027,6 @@ memorykey.{$row.device_key_id}.sub_type =
 
 
 ##########################################################################################
-##                         Programmable Key (For T38G only)                             ##
-##########################################################################################
-#X ranges from 1 to 15.
-#programablekey.x.type--Customize the programmable key type.
-#The valid types are:
-#0-N/A         2-Forward        5-DND           6-Redial     7-Call Return    8-SMS      9-Call Pickup  13-Spead Dial  14-Intercom
-#22-XML Group  23-Group Pickup  27-XML Browser  28-History   29-Directory     30-Menu    32-New SMS     33-Status      43-Local Phonebook
-#44-Broadsoft Phonebook    45-Local Group    46-Broadsoft Group   47-XML Phonebook   48-Switch Account Up   49-Switch Account Down    50-Keypad Lock
-#programablekey.x.line--Configure the desired line to apply the key feature. It ranges from 0 to 6.
-#The value 0 of the "proramablekey.x.line" stands for Auto, it means the first available line.
-#But, when the programmable key is configured as Pick Up, the value 0 stands for line 1.
-
-{foreach $keys["programmable"] as $row}
-
-programablekey.{$row.device_key_id}.type = {$row.device_key_type}
-programablekey.{$row.device_key_id}.line = {$row.device_key_line}
-programablekey.{$row.device_key_id}.value = {$row.device_key_value}
-programablekey.{$row.device_key_id}.xml_phonebook =
-programablekey.{$row.device_key_id}.history_type =
-programablekey.{$row.device_key_id}.label = {$row.device_key_label}
-
-{/foreach}
-
-#programablekey.x.value =
-#programablekey.x.xml_phonebook--Specify the desired remote phonebook/local group/BSFT phonebook for the programmable key. This parameter is only appilicable to the feature XML Group/Local Group/Broadsoft Group.
-#programablekey.x.history_type =
-
-#programablekey.x.label--This parameter is only available to the key 1 to key 4.
-
-#History
-#programablekey.1.type = 28
-#programablekey.1.line = 1
-#programablekey.1.value = 
-#programablekey.1.xml_phonebook =
-#programablekey.1.history_type =
-#programablekey.1.label =
-
-#Directory
-#programablekey.2.type = 29
-#programablekey.2.line = 1
-#programablekey.2.value =
-#programablekey.2.xml_phonebook =
-#programablekey.2.history_type =
-#programablekey.2.label =
-
-#DND
-programablekey.3.type = 5
-programablekey.3.line = 1
-programablekey.3.value =
-programablekey.3.xml_phonebook =
-programablekey.3.history_type =
-programablekey.3.label =
-
-#Menu
-#programablekey.4.type = 30
-#programablekey.4.line =
-#programablekey.4.value =
-#programablekey.4.xml_phonebook =
-#programablekey.4.history_type =
-#programablekey.4.label =
-
-
-##########################################################################################
 ##                                  Expansion Module 1                                  ##
 ##########################################################################################
 #X ranges from 1 to 16, Y ranges from 1 to 40.

--- a/resources/templates/provision/yealink/t29g/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t29g/{$mac}.cfg
@@ -2908,67 +2908,6 @@ memorykey.{$row.device_key_id}.sub_type =
 
 
 ##########################################################################################
-##                         Programmable Key (For T38G only)                             ##
-##########################################################################################
-#X ranges from 1 to 15.
-#programablekey.x.type--Customize the programmable key type.
-#The valid types are:
-#0-N/A         2-Forward        5-DND           6-Redial     7-Call Return    8-SMS      9-Call Pickup  13-Spead Dial  14-Intercom
-#22-XML Group  23-Group Pickup  27-XML Browser  28-History   29-Directory     30-Menu    32-New SMS     33-Status      43-Local Phonebook
-#44-Broadsoft Phonebook    45-Local Group    46-Broadsoft Group   47-XML Phonebook   48-Switch Account Up   49-Switch Account Down    50-Keypad Lock
-#programablekey.x.line--Configure the desired line to apply the key feature. It ranges from 0 to 6.
-#The value 0 of the "proramablekey.x.line" stands for Auto, it means the first available line.
-#But, when the programmable key is configured as Pick Up, the value 0 stands for line 1.
-
-{foreach $keys["programmable"] as $row}
-programablekey.{$row.device_key_id}.type = {$row.device_key_type}
-programablekey.{$row.device_key_id}.line = {$row.device_key_line}
-programablekey.{$row.device_key_id}.value = {$row.device_key_value}
-programablekey.{$row.device_key_id}.xml_phonebook =
-programablekey.{$row.device_key_id}.history_type =
-programablekey.{$row.device_key_id}.label = {$row.device_key_label}
-
-{/foreach}
-
-#programablekey.x.value =
-#programablekey.x.xml_phonebook--Specify the desired remote phonebook/local group/BSFT phonebook for the programmable key. This parameter is only appilicable to the feature XML Group/Local Group/Broadsoft Group.
-#programablekey.x.history_type =
-
-#programablekey.x.label--This parameter is only available to the key 1 to key 4.
-
-#History
-#programablekey.1.type = 28
-#programablekey.1.line = 1
-#programablekey.1.value = 
-#programablekey.1.xml_phonebook =
-#programablekey.1.history_type =
-#programablekey.1.label =
-
-#Directory
-#programablekey.2.type = 29
-#programablekey.2.line = 1
-#programablekey.2.value =
-#programablekey.2.xml_phonebook =
-#programablekey.2.history_type =
-#programablekey.2.label =
-
-#DND
-programablekey.3.type = 5
-programablekey.3.line = 1
-programablekey.3.value =
-programablekey.3.xml_phonebook =
-programablekey.3.history_type =
-programablekey.3.label =
-
-#Menu
-#programablekey.4.type = 30
-#programablekey.4.line =
-#programablekey.4.value =
-#programablekey.4.xml_phonebook =
-#programablekey.4.history_type =
-#programablekey.4.label =
-
-##########################################################################################
 ##                                  Expansion Module 1                                  ##
 ##########################################################################################
 #X ranges from 1 to 16, Y ranges from 1 to 40.

--- a/resources/templates/provision/yealink/t32g/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t32g/{$mac}.cfg
@@ -1979,36 +1979,6 @@ memorykey.{$row.device_key_id}.label = {$row.device_key_label}
 
 
 ##########################################################################################
-##                         Programmable Key (For T38G only)                             ##
-##########################################################################################
-#X ranges from 1 to 15.
-#programablekey.x.type--Customize the programmable key type.
-#The valid types are:
-#0-N/A         2-Forward        5-DND           6-Redial     7-Call Return    8-SMS      9-Call Pickup  13-Spead Dial  14-Intercom
-#22-XML Group  23-Group Pickup  27-XML Browser  28-History   29-Directory     30-Menu    32-New SMS     33-Status      43-Local Phonebook
-#44-Broadsoft Phonebook    45-Local Group    46-Broadsoft Group   47-XML Phonebook   48-Switch Account Up   49-Switch Account Down    50-Keypad Lock
-#programablekey.x.line--Configure the desired line to apply the key feature. It ranges from 0 to 6.
-#The value 0 of the "proramablekey.x.line" stands for Auto, it means the first available line.
-#But, when the programmable key is configured as Pick Up, the value 0 stands for line 1.
-
-#programablekey.x.value =
-#programablekey.x.xml_phonebook--Specify the desired remote phonebook/local group/BSFT phonebook for the programmable key. This parameter is only appilicable to the feature XML Group/Local Group/Broadsoft Group.
-#programablekey.x.history_type =
-
-#programablekey.x.label--This parameter is only available to the key 1 to key 4.
-
-{foreach $keys["programmable"] as $row}
-programablekey.{$row.device_key_id}.type = {$row.device_key_type}
-programablekey.{$row.device_key_id}.line = {$row.device_key_line}
-programablekey.{$row.device_key_id}.value = {$row.device_key_value}
-programablekey.{$row.device_key_id}.xml_phonebook =
-programablekey.{$row.device_key_id}.history_type =
-programablekey.{$row.device_key_id}.label = {$row.device_key_label}
-
- {/foreach}
-
-
-##########################################################################################
 ##                                  Expansion Module 1                                  ##
 ##########################################################################################
 #X ranges from 1 to 16, Y ranges from 1 to 40.

--- a/resources/templates/provision/yealink/t38g/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t38g/{$mac}.cfg
@@ -1971,35 +1971,6 @@ memorykey.{$row.device_key_id}.label = {$row.device_key_label}
 
 
 ##########################################################################################
-##                         Programmable Key (For T38G only)                             ##
-##########################################################################################
-#X ranges from 1 to 15.
-#programablekey.x.type--Customize the programmable key type.
-#The valid types are:
-#0-N/A         2-Forward        5-DND           6-Redial     7-Call Return    8-SMS      9-Call Pickup  13-Spead Dial  14-Intercom
-#22-XML Group  23-Group Pickup  27-XML Browser  28-History   29-Directory     30-Menu    32-New SMS     33-Status      43-Local Phonebook
-#44-Broadsoft Phonebook    45-Local Group    46-Broadsoft Group   47-XML Phonebook   48-Switch Account Up   49-Switch Account Down    50-Keypad Lock
-#programablekey.x.line--Configure the desired line to apply the key feature. It ranges from 0 to 6.
-#The value 0 of the "proramablekey.x.line" stands for Auto, it means the first available line.
-#But, when the programmable key is configured as Pick Up, the value 0 stands for line 1.
-
-#programablekey.x.value =
-#programablekey.x.xml_phonebook--Specify the desired remote phonebook/local group/BSFT phonebook for the programmable key. This parameter is only appilicable to the feature XML Group/Local Group/Broadsoft Group.
-#programablekey.x.history_type =
-
-#programablekey.x.label--This parameter is only available to the key 1 to key 4.
-
-{foreach $keys["programmable"] as $row}
-programablekey.{$row.device_key_id}.type = {$row.device_key_type}
-programablekey.{$row.device_key_id}.line = {$row.device_key_line}
-programablekey.{$row.device_key_id}.value = {$row.device_key_value}
-programablekey.{$row.device_key_id}.xml_phonebook =
-programablekey.{$row.device_key_id}.history_type =
-programablekey.{$row.device_key_id}.label = {$row.device_key_label}
- {/foreach}
-
-
-##########################################################################################
 ##                                  Expansion Module 1                                  ##
 ##########################################################################################
 #X ranges from 1 to 16, Y ranges from 1 to 40.

--- a/resources/templates/provision/yealink/t40g/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t40g/{$mac}.cfg
@@ -3012,67 +3012,6 @@ memorykey.{$row.device_key_id}.sub_type =
 
 
 ##########################################################################################
-##                         Programmable Key (For T38G only)                             ##
-##########################################################################################
-#X ranges from 1 to 15.
-#programablekey.x.type--Customize the programmable key type.
-#The valid types are:
-#0-N/A         2-Forward        5-DND           6-Redial     7-Call Return    8-SMS      9-Call Pickup  13-Spead Dial  14-Intercom
-#22-XML Group  23-Group Pickup  27-XML Browser  28-History   29-Directory     30-Menu    32-New SMS     33-Status      43-Local Phonebook
-#44-Broadsoft Phonebook    45-Local Group    46-Broadsoft Group   47-XML Phonebook   48-Switch Account Up   49-Switch Account Down    50-Keypad Lock
-#programablekey.x.line--Configure the desired line to apply the key feature. It ranges from 0 to 6.
-#The value 0 of the "proramablekey.x.line" stands for Auto, it means the first available line.
-#But, when the programmable key is configured as Pick Up, the value 0 stands for line 1.
-
-{foreach $keys["programmable"] as $row}
-programablekey.{$row.device_key_id}.type = {$row.device_key_type}
-programablekey.{$row.device_key_id}.line = {$row.device_key_line}
-programablekey.{$row.device_key_id}.value = {$row.device_key_value}
-programablekey.{$row.device_key_id}.xml_phonebook =
-programablekey.{$row.device_key_id}.history_type =
-programablekey.{$row.device_key_id}.label = {$row.device_key_label}
-
-{/foreach}
-
-#programablekey.x.value =
-#programablekey.x.xml_phonebook--Specify the desired remote phonebook/local group/BSFT phonebook for the programmable key. This parameter is only appilicable to the feature XML Group/Local Group/Broadsoft Group.
-#programablekey.x.history_type =
-
-#programablekey.x.label--This parameter is only available to the key 1 to key 4.
-
-#History
-#programablekey.1.type = 28
-#programablekey.1.line = 1
-#programablekey.1.value = 
-#programablekey.1.xml_phonebook =
-#programablekey.1.history_type =
-#programablekey.1.label =
-
-#Directory
-#programablekey.2.type = 29
-#programablekey.2.line = 1
-#programablekey.2.value =
-#programablekey.2.xml_phonebook =
-#programablekey.2.history_type =
-#programablekey.2.label =
-
-#DND
-programablekey.3.type = 5
-programablekey.3.line = 1
-programablekey.3.value =
-programablekey.3.xml_phonebook =
-programablekey.3.history_type =
-programablekey.3.label =
-
-#Menu
-#programablekey.4.type = 30
-#programablekey.4.line =
-#programablekey.4.value =
-#programablekey.4.xml_phonebook =
-#programablekey.4.history_type =
-#programablekey.4.label =
-
-##########################################################################################
 ##                                  Expansion Module 1                                  ##
 ##########################################################################################
 #X ranges from 1 to 16, Y ranges from 1 to 40.

--- a/resources/templates/provision/yealink/t40p/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t40p/{$mac}.cfg
@@ -3012,67 +3012,6 @@ memorykey.{$row.device_key_id}.sub_type =
 
 
 ##########################################################################################
-##                         Programmable Key (For T38G only)                             ##
-##########################################################################################
-#X ranges from 1 to 15.
-#programablekey.x.type--Customize the programmable key type.
-#The valid types are:
-#0-N/A         2-Forward        5-DND           6-Redial     7-Call Return    8-SMS      9-Call Pickup  13-Spead Dial  14-Intercom
-#22-XML Group  23-Group Pickup  27-XML Browser  28-History   29-Directory     30-Menu    32-New SMS     33-Status      43-Local Phonebook
-#44-Broadsoft Phonebook    45-Local Group    46-Broadsoft Group   47-XML Phonebook   48-Switch Account Up   49-Switch Account Down    50-Keypad Lock
-#programablekey.x.line--Configure the desired line to apply the key feature. It ranges from 0 to 6.
-#The value 0 of the "proramablekey.x.line" stands for Auto, it means the first available line.
-#But, when the programmable key is configured as Pick Up, the value 0 stands for line 1.
-
-{foreach $keys["programmable"] as $row}
-programablekey.{$row.device_key_id}.type = {$row.device_key_type}
-programablekey.{$row.device_key_id}.line = {$row.device_key_line}
-programablekey.{$row.device_key_id}.value = {$row.device_key_value}
-programablekey.{$row.device_key_id}.xml_phonebook =
-programablekey.{$row.device_key_id}.history_type =
-programablekey.{$row.device_key_id}.label = {$row.device_key_label}
-
-{/foreach}
-
-#programablekey.x.value =
-#programablekey.x.xml_phonebook--Specify the desired remote phonebook/local group/BSFT phonebook for the programmable key. This parameter is only appilicable to the feature XML Group/Local Group/Broadsoft Group.
-#programablekey.x.history_type =
-
-#programablekey.x.label--This parameter is only available to the key 1 to key 4.
-
-#History
-#programablekey.1.type = 28
-#programablekey.1.line = 1
-#programablekey.1.value = 
-#programablekey.1.xml_phonebook =
-#programablekey.1.history_type =
-#programablekey.1.label =
-
-#Directory
-#programablekey.2.type = 29
-#programablekey.2.line = 1
-#programablekey.2.value =
-#programablekey.2.xml_phonebook =
-#programablekey.2.history_type =
-#programablekey.2.label =
-
-#DND
-programablekey.3.type = 5
-programablekey.3.line = 1
-programablekey.3.value =
-programablekey.3.xml_phonebook =
-programablekey.3.history_type =
-programablekey.3.label =
-
-#Menu
-#programablekey.4.type = 30
-#programablekey.4.line =
-#programablekey.4.value =
-#programablekey.4.xml_phonebook =
-#programablekey.4.history_type =
-#programablekey.4.label =
-
-##########################################################################################
 ##                                  Expansion Module 1                                  ##
 ##########################################################################################
 #X ranges from 1 to 16, Y ranges from 1 to 40.

--- a/resources/templates/provision/yealink/t41p/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t41p/{$mac}.cfg
@@ -3012,67 +3012,6 @@ memorykey.{$row.device_key_id}.sub_type =
 
 
 ##########################################################################################
-##                         Programmable Key (For T38G only)                             ##
-##########################################################################################
-#X ranges from 1 to 15.
-#programablekey.x.type--Customize the programmable key type.
-#The valid types are:
-#0-N/A         2-Forward        5-DND           6-Redial     7-Call Return    8-SMS      9-Call Pickup  13-Spead Dial  14-Intercom
-#22-XML Group  23-Group Pickup  27-XML Browser  28-History   29-Directory     30-Menu    32-New SMS     33-Status      43-Local Phonebook
-#44-Broadsoft Phonebook    45-Local Group    46-Broadsoft Group   47-XML Phonebook   48-Switch Account Up   49-Switch Account Down    50-Keypad Lock
-#programablekey.x.line--Configure the desired line to apply the key feature. It ranges from 0 to 6.
-#The value 0 of the "proramablekey.x.line" stands for Auto, it means the first available line.
-#But, when the programmable key is configured as Pick Up, the value 0 stands for line 1.
-
-{foreach $keys["programmable"] as $row}
-programablekey.{$row.device_key_id}.type = {$row.device_key_type}
-programablekey.{$row.device_key_id}.line = {$row.device_key_line}
-programablekey.{$row.device_key_id}.value = {$row.device_key_value}
-programablekey.{$row.device_key_id}.xml_phonebook =
-programablekey.{$row.device_key_id}.history_type =
-programablekey.{$row.device_key_id}.label = {$row.device_key_label}
-
-{/foreach}
-
-#programablekey.x.value =
-#programablekey.x.xml_phonebook--Specify the desired remote phonebook/local group/BSFT phonebook for the programmable key. This parameter is only appilicable to the feature XML Group/Local Group/Broadsoft Group.
-#programablekey.x.history_type =
-
-#programablekey.x.label--This parameter is only available to the key 1 to key 4.
-
-#History
-#programablekey.1.type = 28
-#programablekey.1.line = 1
-#programablekey.1.value = 
-#programablekey.1.xml_phonebook =
-#programablekey.1.history_type =
-#programablekey.1.label =
-
-#Directory
-#programablekey.2.type = 29
-#programablekey.2.line = 1
-#programablekey.2.value =
-#programablekey.2.xml_phonebook =
-#programablekey.2.history_type =
-#programablekey.2.label =
-
-#DND
-programablekey.3.type = 5
-programablekey.3.line = 1
-programablekey.3.value =
-programablekey.3.xml_phonebook =
-programablekey.3.history_type =
-programablekey.3.label =
-
-#Menu
-#programablekey.4.type = 30
-#programablekey.4.line =
-#programablekey.4.value =
-#programablekey.4.xml_phonebook =
-#programablekey.4.history_type =
-#programablekey.4.label =
-
-##########################################################################################
 ##                                  Expansion Module 1                                  ##
 ##########################################################################################
 #X ranges from 1 to 16, Y ranges from 1 to 40.

--- a/resources/templates/provision/yealink/t41s/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t41s/{$mac}.cfg
@@ -3012,67 +3012,6 @@ memorykey.{$row.device_key_id}.sub_type =
 
 
 ##########################################################################################
-##                         Programmable Key (For T38G only)                             ##
-##########################################################################################
-#X ranges from 1 to 15.
-#programablekey.x.type--Customize the programmable key type.
-#The valid types are:
-#0-N/A         2-Forward        5-DND           6-Redial     7-Call Return    8-SMS      9-Call Pickup  13-Spead Dial  14-Intercom
-#22-XML Group  23-Group Pickup  27-XML Browser  28-History   29-Directory     30-Menu    32-New SMS     33-Status      43-Local Phonebook
-#44-Broadsoft Phonebook    45-Local Group    46-Broadsoft Group   47-XML Phonebook   48-Switch Account Up   49-Switch Account Down    50-Keypad Lock
-#programablekey.x.line--Configure the desired line to apply the key feature. It ranges from 0 to 6.
-#The value 0 of the "proramablekey.x.line" stands for Auto, it means the first available line.
-#But, when the programmable key is configured as Pick Up, the value 0 stands for line 1.
-
-{foreach $keys["programmable"] as $row}
-programablekey.{$row.device_key_id}.type = {$row.device_key_type}
-programablekey.{$row.device_key_id}.line = {$row.device_key_line}
-programablekey.{$row.device_key_id}.value = {$row.device_key_value}
-programablekey.{$row.device_key_id}.xml_phonebook =
-programablekey.{$row.device_key_id}.history_type =
-programablekey.{$row.device_key_id}.label = {$row.device_key_label}
-
-{/foreach}
-
-#programablekey.x.value =
-#programablekey.x.xml_phonebook--Specify the desired remote phonebook/local group/BSFT phonebook for the programmable key. This parameter is only appilicable to the feature XML Group/Local Group/Broadsoft Group.
-#programablekey.x.history_type =
-
-#programablekey.x.label--This parameter is only available to the key 1 to key 4.
-
-#History
-#programablekey.1.type = 28
-#programablekey.1.line = 1
-#programablekey.1.value = 
-#programablekey.1.xml_phonebook =
-#programablekey.1.history_type =
-#programablekey.1.label =
-
-#Directory
-#programablekey.2.type = 29
-#programablekey.2.line = 1
-#programablekey.2.value =
-#programablekey.2.xml_phonebook =
-#programablekey.2.history_type =
-#programablekey.2.label =
-
-#DND
-programablekey.3.type = 5
-programablekey.3.line = 1
-programablekey.3.value =
-programablekey.3.xml_phonebook =
-programablekey.3.history_type =
-programablekey.3.label =
-
-#Menu
-#programablekey.4.type = 30
-#programablekey.4.line =
-#programablekey.4.value =
-#programablekey.4.xml_phonebook =
-#programablekey.4.history_type =
-#programablekey.4.label =
-
-##########################################################################################
 ##                                  Expansion Module 1                                  ##
 ##########################################################################################
 #X ranges from 1 to 16, Y ranges from 1 to 40.

--- a/resources/templates/provision/yealink/t42g/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t42g/{$mac}.cfg
@@ -2908,67 +2908,6 @@ memorykey.{$row.device_key_id}.sub_type =
 
 
 ##########################################################################################
-##                         Programmable Key (For T38G only)                             ##
-##########################################################################################
-#X ranges from 1 to 15.
-#programablekey.x.type--Customize the programmable key type.
-#The valid types are:
-#0-N/A         2-Forward        5-DND           6-Redial     7-Call Return    8-SMS      9-Call Pickup  13-Spead Dial  14-Intercom
-#22-XML Group  23-Group Pickup  27-XML Browser  28-History   29-Directory     30-Menu    32-New SMS     33-Status      43-Local Phonebook
-#44-Broadsoft Phonebook    45-Local Group    46-Broadsoft Group   47-XML Phonebook   48-Switch Account Up   49-Switch Account Down    50-Keypad Lock
-#programablekey.x.line--Configure the desired line to apply the key feature. It ranges from 0 to 6.
-#The value 0 of the "proramablekey.x.line" stands for Auto, it means the first available line.
-#But, when the programmable key is configured as Pick Up, the value 0 stands for line 1.
-
-{foreach $keys["programmable"] as $row}
-programablekey.{$row.device_key_id}.type = {$row.device_key_type}
-programablekey.{$row.device_key_id}.line = {$row.device_key_line}
-programablekey.{$row.device_key_id}.value = {$row.device_key_value}
-programablekey.{$row.device_key_id}.xml_phonebook =
-programablekey.{$row.device_key_id}.history_type =
-programablekey.{$row.device_key_id}.label = {$row.device_key_label}
-
-{/foreach}
-
-#programablekey.x.value =
-#programablekey.x.xml_phonebook--Specify the desired remote phonebook/local group/BSFT phonebook for the programmable key. This parameter is only appilicable to the feature XML Group/Local Group/Broadsoft Group.
-#programablekey.x.history_type =
-
-#programablekey.x.label--This parameter is only available to the key 1 to key 4.
-
-#History
-#programablekey.1.type = 28
-#programablekey.1.line = 1
-#programablekey.1.value = 
-#programablekey.1.xml_phonebook =
-#programablekey.1.history_type =
-#programablekey.1.label =
-
-#Directory
-#programablekey.2.type = 29
-#programablekey.2.line = 1
-#programablekey.2.value =
-#programablekey.2.xml_phonebook =
-#programablekey.2.history_type =
-#programablekey.2.label =
-
-#DND
-programablekey.3.type = 5
-programablekey.3.line = 1
-programablekey.3.value =
-programablekey.3.xml_phonebook =
-programablekey.3.history_type =
-programablekey.3.label =
-
-#Menu
-#programablekey.4.type = 30
-#programablekey.4.line =
-#programablekey.4.value =
-#programablekey.4.xml_phonebook =
-#programablekey.4.history_type =
-#programablekey.4.label =
-
-##########################################################################################
 ##                                  Expansion Module 1                                  ##
 ##########################################################################################
 #X ranges from 1 to 16, Y ranges from 1 to 40.

--- a/resources/templates/provision/yealink/t42s/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t42s/{$mac}.cfg
@@ -3012,67 +3012,6 @@ memorykey.{$row.device_key_id}.sub_type =
 
 
 ##########################################################################################
-##                         Programmable Key (For T38G only)                             ##
-##########################################################################################
-#X ranges from 1 to 15.
-#programablekey.x.type--Customize the programmable key type.
-#The valid types are:
-#0-N/A         2-Forward        5-DND           6-Redial     7-Call Return    8-SMS      9-Call Pickup  13-Spead Dial  14-Intercom
-#22-XML Group  23-Group Pickup  27-XML Browser  28-History   29-Directory     30-Menu    32-New SMS     33-Status      43-Local Phonebook
-#44-Broadsoft Phonebook    45-Local Group    46-Broadsoft Group   47-XML Phonebook   48-Switch Account Up   49-Switch Account Down    50-Keypad Lock
-#programablekey.x.line--Configure the desired line to apply the key feature. It ranges from 0 to 6.
-#The value 0 of the "proramablekey.x.line" stands for Auto, it means the first available line.
-#But, when the programmable key is configured as Pick Up, the value 0 stands for line 1.
-
-{foreach $keys["programmable"] as $row}
-programablekey.{$row.device_key_id}.type = {$row.device_key_type}
-programablekey.{$row.device_key_id}.line = {$row.device_key_line}
-programablekey.{$row.device_key_id}.value = {$row.device_key_value}
-programablekey.{$row.device_key_id}.xml_phonebook =
-programablekey.{$row.device_key_id}.history_type =
-programablekey.{$row.device_key_id}.label = {$row.device_key_label}
-
-{/foreach}
-
-#programablekey.x.value =
-#programablekey.x.xml_phonebook--Specify the desired remote phonebook/local group/BSFT phonebook for the programmable key. This parameter is only appilicable to the feature XML Group/Local Group/Broadsoft Group.
-#programablekey.x.history_type =
-
-#programablekey.x.label--This parameter is only available to the key 1 to key 4.
-
-#History
-#programablekey.1.type = 28
-#programablekey.1.line = 1
-#programablekey.1.value = 
-#programablekey.1.xml_phonebook =
-#programablekey.1.history_type =
-#programablekey.1.label =
-
-#Directory
-#programablekey.2.type = 29
-#programablekey.2.line = 1
-#programablekey.2.value =
-#programablekey.2.xml_phonebook =
-#programablekey.2.history_type =
-#programablekey.2.label =
-
-#DND
-programablekey.3.type = 5
-programablekey.3.line = 1
-programablekey.3.value =
-programablekey.3.xml_phonebook =
-programablekey.3.history_type =
-programablekey.3.label =
-
-#Menu
-#programablekey.4.type = 30
-#programablekey.4.line =
-#programablekey.4.value =
-#programablekey.4.xml_phonebook =
-#programablekey.4.history_type =
-#programablekey.4.label =
-
-##########################################################################################
 ##                                  Expansion Module 1                                  ##
 ##########################################################################################
 #X ranges from 1 to 16, Y ranges from 1 to 40.

--- a/resources/templates/provision/yealink/t46g/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t46g/{$mac}.cfg
@@ -2908,67 +2908,6 @@ memorykey.{$row.device_key_id}.sub_type =
 
 
 ##########################################################################################
-##                         Programmable Key (For T38G only)                             ##
-##########################################################################################
-#X ranges from 1 to 15.
-#programablekey.x.type--Customize the programmable key type.
-#The valid types are:
-#0-N/A         2-Forward        5-DND           6-Redial     7-Call Return    8-SMS      9-Call Pickup  13-Spead Dial  14-Intercom
-#22-XML Group  23-Group Pickup  27-XML Browser  28-History   29-Directory     30-Menu    32-New SMS     33-Status      43-Local Phonebook
-#44-Broadsoft Phonebook    45-Local Group    46-Broadsoft Group   47-XML Phonebook   48-Switch Account Up   49-Switch Account Down    50-Keypad Lock
-#programablekey.x.line--Configure the desired line to apply the key feature. It ranges from 0 to 6.
-#The value 0 of the "proramablekey.x.line" stands for Auto, it means the first available line.
-#But, when the programmable key is configured as Pick Up, the value 0 stands for line 1.
-
-{foreach $keys["programmable"] as $row}
-programablekey.{$row.device_key_id}.type = {$row.device_key_type}
-programablekey.{$row.device_key_id}.line = {$row.device_key_line}
-programablekey.{$row.device_key_id}.value = {$row.device_key_value}
-programablekey.{$row.device_key_id}.xml_phonebook =
-programablekey.{$row.device_key_id}.history_type =
-programablekey.{$row.device_key_id}.label = {$row.device_key_label}
-
-{/foreach}
-
-#programablekey.x.value =
-#programablekey.x.xml_phonebook--Specify the desired remote phonebook/local group/BSFT phonebook for the programmable key. This parameter is only appilicable to the feature XML Group/Local Group/Broadsoft Group.
-#programablekey.x.history_type =
-
-#programablekey.x.label--This parameter is only available to the key 1 to key 4.
-
-#History
-#programablekey.1.type = 28
-#programablekey.1.line = 1
-#programablekey.1.value = 
-#programablekey.1.xml_phonebook =
-#programablekey.1.history_type =
-#programablekey.1.label =
-
-#Directory
-#programablekey.2.type = 29
-#programablekey.2.line = 1
-#programablekey.2.value =
-#programablekey.2.xml_phonebook =
-#programablekey.2.history_type =
-#programablekey.2.label =
-
-#DND
-programablekey.3.type = 5
-programablekey.3.line = 1
-programablekey.3.value =
-programablekey.3.xml_phonebook =
-programablekey.3.history_type =
-programablekey.3.label =
-
-#Menu
-#programablekey.4.type = 30
-#programablekey.4.line =
-#programablekey.4.value =
-#programablekey.4.xml_phonebook =
-#programablekey.4.history_type =
-#programablekey.4.label =
-
-##########################################################################################
 ##                                  Expansion Module 1                                  ##
 ##########################################################################################
 #X ranges from 1 to 16, Y ranges from 1 to 40.

--- a/resources/templates/provision/yealink/t46s/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t46s/{$mac}.cfg
@@ -2908,67 +2908,6 @@ memorykey.{$row.device_key_id}.sub_type =
 
 
 ##########################################################################################
-##                         Programmable Key (For T38G only)                             ##
-##########################################################################################
-#X ranges from 1 to 15.
-#programablekey.x.type--Customize the programmable key type.
-#The valid types are:
-#0-N/A         2-Forward        5-DND           6-Redial     7-Call Return    8-SMS      9-Call Pickup  13-Spead Dial  14-Intercom
-#22-XML Group  23-Group Pickup  27-XML Browser  28-History   29-Directory     30-Menu    32-New SMS     33-Status      43-Local Phonebook
-#44-Broadsoft Phonebook    45-Local Group    46-Broadsoft Group   47-XML Phonebook   48-Switch Account Up   49-Switch Account Down    50-Keypad Lock
-#programablekey.x.line--Configure the desired line to apply the key feature. It ranges from 0 to 6.
-#The value 0 of the "proramablekey.x.line" stands for Auto, it means the first available line.
-#But, when the programmable key is configured as Pick Up, the value 0 stands for line 1.
-
-{foreach $keys["programmable"] as $row}
-programablekey.{$row.device_key_id}.type = {$row.device_key_type}
-programablekey.{$row.device_key_id}.line = {$row.device_key_line}
-programablekey.{$row.device_key_id}.value = {$row.device_key_value}
-programablekey.{$row.device_key_id}.xml_phonebook =
-programablekey.{$row.device_key_id}.history_type =
-programablekey.{$row.device_key_id}.label = {$row.device_key_label}
-
-{/foreach}
-
-#programablekey.x.value =
-#programablekey.x.xml_phonebook--Specify the desired remote phonebook/local group/BSFT phonebook for the programmable key. This parameter is only appilicable to the feature XML Group/Local Group/Broadsoft Group.
-#programablekey.x.history_type =
-
-#programablekey.x.label--This parameter is only available to the key 1 to key 4.
-
-#History
-#programablekey.1.type = 28
-#programablekey.1.line = 1
-#programablekey.1.value = 
-#programablekey.1.xml_phonebook =
-#programablekey.1.history_type =
-#programablekey.1.label =
-
-#Directory
-#programablekey.2.type = 29
-#programablekey.2.line = 1
-#programablekey.2.value =
-#programablekey.2.xml_phonebook =
-#programablekey.2.history_type =
-#programablekey.2.label =
-
-#DND
-programablekey.3.type = 5
-programablekey.3.line = 1
-programablekey.3.value =
-programablekey.3.xml_phonebook =
-programablekey.3.history_type =
-programablekey.3.label =
-
-#Menu
-#programablekey.4.type = 30
-#programablekey.4.line =
-#programablekey.4.value =
-#programablekey.4.xml_phonebook =
-#programablekey.4.history_type =
-#programablekey.4.label =
-
-##########################################################################################
 ##                                  Expansion Module 1                                  ##
 ##########################################################################################
 #X ranges from 1 to 16, Y ranges from 1 to 40.

--- a/resources/templates/provision/yealink/t48g/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t48g/{$mac}.cfg
@@ -2908,67 +2908,6 @@ memorykey.{$row.device_key_id}.sub_type =
 
 
 ##########################################################################################
-##                         Programmable Key (For T38G only)                             ##
-##########################################################################################
-#X ranges from 1 to 15.
-#programablekey.x.type--Customize the programmable key type.
-#The valid types are:
-#0-N/A         2-Forward        5-DND           6-Redial     7-Call Return    8-SMS      9-Call Pickup  13-Spead Dial  14-Intercom
-#22-XML Group  23-Group Pickup  27-XML Browser  28-History   29-Directory     30-Menu    32-New SMS     33-Status      43-Local Phonebook
-#44-Broadsoft Phonebook    45-Local Group    46-Broadsoft Group   47-XML Phonebook   48-Switch Account Up   49-Switch Account Down    50-Keypad Lock
-#programablekey.x.line--Configure the desired line to apply the key feature. It ranges from 0 to 6.
-#The value 0 of the "proramablekey.x.line" stands for Auto, it means the first available line.
-#But, when the programmable key is configured as Pick Up, the value 0 stands for line 1.
-
-{foreach $keys["programmable"] as $row}
-programablekey.{$row.device_key_id}.type = {$row.device_key_type}
-programablekey.{$row.device_key_id}.line = {$row.device_key_line}
-programablekey.{$row.device_key_id}.value = {$row.device_key_value}
-programablekey.{$row.device_key_id}.xml_phonebook =
-programablekey.{$row.device_key_id}.history_type =
-programablekey.{$row.device_key_id}.label = {$row.device_key_label}
-
-{/foreach}
-
-#programablekey.x.value =
-#programablekey.x.xml_phonebook--Specify the desired remote phonebook/local group/BSFT phonebook for the programmable key. This parameter is only appilicable to the feature XML Group/Local Group/Broadsoft Group.
-#programablekey.x.history_type =
-
-#programablekey.x.label--This parameter is only available to the key 1 to key 4.
-
-#History
-#programablekey.1.type = 28
-#programablekey.1.line = 1
-#programablekey.1.value = 
-#programablekey.1.xml_phonebook =
-#programablekey.1.history_type =
-#programablekey.1.label =
-
-#Directory
-#programablekey.2.type = 29
-#programablekey.2.line = 1
-#programablekey.2.value =
-#programablekey.2.xml_phonebook =
-#programablekey.2.history_type =
-#programablekey.2.label =
-
-#DND
-programablekey.3.type = 5
-programablekey.3.line = 1
-programablekey.3.value =
-programablekey.3.xml_phonebook =
-programablekey.3.history_type =
-programablekey.3.label =
-
-#Menu
-#programablekey.4.type = 30
-#programablekey.4.line =
-#programablekey.4.value =
-#programablekey.4.xml_phonebook =
-#programablekey.4.history_type =
-#programablekey.4.label =
-
-##########################################################################################
 ##                                  Expansion Module 1                                  ##
 ##########################################################################################
 #X ranges from 1 to 16, Y ranges from 1 to 40.

--- a/resources/templates/provision/yealink/t48s/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t48s/{$mac}.cfg
@@ -3012,67 +3012,6 @@ memorykey.{$row.device_key_id}.sub_type =
 
 
 ##########################################################################################
-##                         Programmable Key (For T38G only)                             ##
-##########################################################################################
-#X ranges from 1 to 15.
-#programablekey.x.type--Customize the programmable key type.
-#The valid types are:
-#0-N/A         2-Forward        5-DND           6-Redial     7-Call Return    8-SMS      9-Call Pickup  13-Spead Dial  14-Intercom
-#22-XML Group  23-Group Pickup  27-XML Browser  28-History   29-Directory     30-Menu    32-New SMS     33-Status      43-Local Phonebook
-#44-Broadsoft Phonebook    45-Local Group    46-Broadsoft Group   47-XML Phonebook   48-Switch Account Up   49-Switch Account Down    50-Keypad Lock
-#programablekey.x.line--Configure the desired line to apply the key feature. It ranges from 0 to 6.
-#The value 0 of the "proramablekey.x.line" stands for Auto, it means the first available line.
-#But, when the programmable key is configured as Pick Up, the value 0 stands for line 1.
-
-{foreach $keys["programmable"] as $row}
-programablekey.{$row.device_key_id}.type = {$row.device_key_type}
-programablekey.{$row.device_key_id}.line = {$row.device_key_line}
-programablekey.{$row.device_key_id}.value = {$row.device_key_value}
-programablekey.{$row.device_key_id}.xml_phonebook =
-programablekey.{$row.device_key_id}.history_type =
-programablekey.{$row.device_key_id}.label = {$row.device_key_label}
-
-{/foreach}
-
-#programablekey.x.value =
-#programablekey.x.xml_phonebook--Specify the desired remote phonebook/local group/BSFT phonebook for the programmable key. This parameter is only appilicable to the feature XML Group/Local Group/Broadsoft Group.
-#programablekey.x.history_type =
-
-#programablekey.x.label--This parameter is only available to the key 1 to key 4.
-
-#History
-#programablekey.1.type = 28
-#programablekey.1.line = 1
-#programablekey.1.value = 
-#programablekey.1.xml_phonebook =
-#programablekey.1.history_type =
-#programablekey.1.label =
-
-#Directory
-#programablekey.2.type = 29
-#programablekey.2.line = 1
-#programablekey.2.value =
-#programablekey.2.xml_phonebook =
-#programablekey.2.history_type =
-#programablekey.2.label =
-
-#DND
-programablekey.3.type = 5
-programablekey.3.line = 1
-programablekey.3.value =
-programablekey.3.xml_phonebook =
-programablekey.3.history_type =
-programablekey.3.label =
-
-#Menu
-#programablekey.4.type = 30
-#programablekey.4.line =
-#programablekey.4.value =
-#programablekey.4.xml_phonebook =
-#programablekey.4.history_type =
-#programablekey.4.label =
-
-##########################################################################################
 ##                                  Expansion Module 1                                  ##
 ##########################################################################################
 #X ranges from 1 to 16, Y ranges from 1 to 40.

--- a/resources/templates/provision/yealink/t49g/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t49g/{$mac}.cfg
@@ -3012,67 +3012,6 @@ memorykey.{$row.device_key_id}.sub_type =
 
 
 ##########################################################################################
-##                         Programmable Key (For T38G only)                             ##
-##########################################################################################
-#X ranges from 1 to 15.
-#programablekey.x.type--Customize the programmable key type.
-#The valid types are:
-#0-N/A         2-Forward        5-DND           6-Redial     7-Call Return    8-SMS      9-Call Pickup  13-Spead Dial  14-Intercom
-#22-XML Group  23-Group Pickup  27-XML Browser  28-History   29-Directory     30-Menu    32-New SMS     33-Status      43-Local Phonebook
-#44-Broadsoft Phonebook    45-Local Group    46-Broadsoft Group   47-XML Phonebook   48-Switch Account Up   49-Switch Account Down    50-Keypad Lock
-#programablekey.x.line--Configure the desired line to apply the key feature. It ranges from 0 to 6.
-#The value 0 of the "proramablekey.x.line" stands for Auto, it means the first available line.
-#But, when the programmable key is configured as Pick Up, the value 0 stands for line 1.
-
-{foreach $keys["programmable"] as $row}
-programablekey.{$row.device_key_id}.type = {$row.device_key_type}
-programablekey.{$row.device_key_id}.line = {$row.device_key_line}
-programablekey.{$row.device_key_id}.value = {$row.device_key_value}
-programablekey.{$row.device_key_id}.xml_phonebook =
-programablekey.{$row.device_key_id}.history_type =
-programablekey.{$row.device_key_id}.label = {$row.device_key_label}
-
-{/foreach}
-
-#programablekey.x.value =
-#programablekey.x.xml_phonebook--Specify the desired remote phonebook/local group/BSFT phonebook for the programmable key. This parameter is only appilicable to the feature XML Group/Local Group/Broadsoft Group.
-#programablekey.x.history_type =
-
-#programablekey.x.label--This parameter is only available to the key 1 to key 4.
-
-#History
-#programablekey.1.type = 28
-#programablekey.1.line = 1
-#programablekey.1.value = 
-#programablekey.1.xml_phonebook =
-#programablekey.1.history_type =
-#programablekey.1.label =
-
-#Directory
-#programablekey.2.type = 29
-#programablekey.2.line = 1
-#programablekey.2.value =
-#programablekey.2.xml_phonebook =
-#programablekey.2.history_type =
-#programablekey.2.label =
-
-#N/A - Disable DND
-programablekey.3.type = 5
-programablekey.3.line = 1
-programablekey.3.value =
-programablekey.3.xml_phonebook =
-programablekey.3.history_type =
-programablekey.3.label =
-
-#Menu
-#programablekey.4.type = 30
-#programablekey.4.line =
-#programablekey.4.value =
-#programablekey.4.xml_phonebook =
-#programablekey.4.history_type =
-#programablekey.4.label =
-
-##########################################################################################
 ##                                  Expansion Module 1                                  ##
 ##########################################################################################
 #X ranges from 1 to 16, Y ranges from 1 to 40.

--- a/resources/templates/provision/yealink/vp530/{$mac}.cfg
+++ b/resources/templates/provision/yealink/vp530/{$mac}.cfg
@@ -3015,68 +3015,6 @@ memorykey.{$row.device_key_id}.sub_type =
 
 
 ##########################################################################################
-##                         Programmable Key (For T38G only)                             ##
-##########################################################################################
-#X ranges from 1 to 15.
-#programablekey.x.type--Customize the programmable key type.
-#The valid types are:
-#0-N/A         2-Forward        5-DND           6-Redial     7-Call Return    8-SMS      9-Call Pickup  13-Spead Dial  14-Intercom
-#22-XML Group  23-Group Pickup  27-XML Browser  28-History   29-Directory     30-Menu    32-New SMS     33-Status      43-Local Phonebook
-#44-Broadsoft Phonebook    45-Local Group    46-Broadsoft Group   47-XML Phonebook   48-Switch Account Up   49-Switch Account Down    50-Keypad Lock
-#programablekey.x.line--Configure the desired line to apply the key feature. It ranges from 0 to 6.
-#The value 0 of the "proramablekey.x.line" stands for Auto, it means the first available line.
-#But, when the programmable key is configured as Pick Up, the value 0 stands for line 1.
-
-{foreach $keys["programmable"] as $row}
-
-programablekey.{$row.device_key_id}.type = {$row.device_key_type}
-programablekey.{$row.device_key_id}.line = {$row.device_key_line}
-programablekey.{$row.device_key_id}.value = {$row.device_key_value}
-programablekey.{$row.device_key_id}.xml_phonebook =
-programablekey.{$row.device_key_id}.history_type =
-programablekey.{$row.device_key_id}.label = {$row.device_key_label}
-
-{/foreach}
-
-#programablekey.x.value =
-#programablekey.x.xml_phonebook--Specify the desired remote phonebook/local group/BSFT phonebook for the programmable key. This parameter is only appilicable to the feature XML Group/Local Group/Broadsoft Group.
-#programablekey.x.history_type =
-
-#programablekey.x.label--This parameter is only available to the key 1 to key 4.
-
-#History
-#programablekey.1.type = 28
-#programablekey.1.line = 1
-#programablekey.1.value = 
-#programablekey.1.xml_phonebook =
-#programablekey.1.history_type =
-#programablekey.1.label =
-
-#Directory
-#programablekey.2.type = 29
-#programablekey.2.line = 1
-#programablekey.2.value =
-#programablekey.2.xml_phonebook =
-#programablekey.2.history_type =
-#programablekey.2.label =
-
-#DND
-programablekey.3.type = 5
-programablekey.3.line = 1
-programablekey.3.value =
-programablekey.3.xml_phonebook =
-programablekey.3.history_type =
-programablekey.3.label =
-
-#Menu
-#programablekey.4.type = 30
-#programablekey.4.line =
-#programablekey.4.value =
-#programablekey.4.xml_phonebook =
-#programablekey.4.history_type =
-#programablekey.4.label =
-
-##########################################################################################
 ##                                  Expansion Module 1                                  ##
 ##########################################################################################
 #X ranges from 1 to 16, Y ranges from 1 to 40.


### PR DESCRIPTION
Some Yealink templates have hard-coded programmable key options in {$mac.cfg}.

A recent pull request was made to allow provisioning options to be configured on all phones through the  y000000000000.cfg files. This pull request resolves a conflict when configuring the programmable keys in the templates by simply removing the old hard-code options that exist in the {$mac.cfg} files for all devices.