### PR TITLE
Changed VM authentication to store user ext

### DIFF
--- a/resources/install/scripts/pin_number.lua
+++ b/resources/install/scripts/pin_number.lua
@@ -136,8 +136,8 @@
 				dbh:query(sql, params, function(row)
 					--set the variable to true
 						auth = true;
-					--set the authorized pin number that was used
-						session:setVariable("pin_number", digits);
+					--set the authorized user extension that was used
+						session:setVariable("pin_number", user_ext);
 				end);
 			else
 				pin_number_table = explode(",",pin_number);


### PR DESCRIPTION
From an auditing perspective, it's more useful to have what extension was used to authorize the call, rather than the extension's password that was used.