### PR TITLE
Wired up configurable firmware versions for Grandstream Devices

### DIFF
--- a/resources/templates/provision/grandstream/README.md
+++ b/resources/templates/provision/grandstream/README.md
@@ -1,4 +1,3 @@
-======================
 Device Specific Firmware Versions
 ======================
 Select Grandstream phones (particularly the GXP2140 and similar) need firmware upgrades in a certain order.

--- a/resources/templates/provision/grandstream/README.md
+++ b/resources/templates/provision/grandstream/README.md
@@ -1,0 +1,19 @@
+======================
+Device Specific Firmware Versions
+======================
+Select Grandstream phones (particularly the GXP2140 and similar) need firmware upgrades in a certain order.
+Grandstream also offers beta firmware quite often, which you may want to test on only some devices.
+
+We've attempted to make the process of changing firmware easier, by serving a phone with the firmware specified in a field called
+Firmware under Accounts => Devices then click on the MAC address of the relevant device, filling in said field.
+
+To use configurable firmware locations, enable device_firmware for the superadmin group under Advanced => Group Manager, set the
+URL for grandstream_firmware_path under Advanced => Default Variables and set Enabled to True for grandstream_firmware_path.
+
+We would suggest creating a folder called firmware on the webserver that you host the firmware on, setting grandstream_firmware_path
+to the full URL (excluding the protocol - leave off the `http://`) for example `mydomain.com/firmware` or `mydomain.com/firmware/grandstream`
+if you are hosting multiple different vendors firmware images. When a device goes to hit this server, it will attempt to load
+`<grandstream_firmware_path>/<device model>/<firmware version>/<firmware file>`, or `mydomain.com/firmware/gxp2140/1.0.9.69/gxp2140fw.bin`
+in our case, assuming we have a Grandstream GXP2140 phone and we are feeding it firmware version 1.0.9.69. For Grandstream phones,
+the firmware filename is relatively static, and the files Grandstream distributes are generally named correctly for their phones
+to download.

--- a/resources/templates/provision/grandstream/dp715.sm/{$mac}.xml
+++ b/resources/templates/provision/grandstream/dp715.sm/{$mac}.xml
@@ -67,7 +67,13 @@
 <P212>2</P212>
 
 <!-- Firmware Server Path -->
-<P192>{domain_name}/firmware/gs</P192>
+{if isset($grandstream_firmware_path) && isset($firmware_version)}
+<P192>{$grandstream_firmware_path}/dp715/{$firmware_version}</P192>
+{elseif isset($grandstream_firmware_path)}
+<P192>{$grandstream_firmware_path}/dp715</P192>
+{else}
+<P192>{$domain_name}{$project_path}/app/provision</P192>
+{/if}
 
 <!-- Config Server Path -->
 <P237>{$domain_name}{$project_path}/app/provision</P237>

--- a/resources/templates/provision/grandstream/dp715/{$mac}.xml
+++ b/resources/templates/provision/grandstream/dp715/{$mac}.xml
@@ -29,12 +29,14 @@
 		<P212>1</P212>
 		<!-- Firmware Server Path -->
 	
-		{if isset($grandstream_firmware_path)}
-		<P192>{$grandstream_firmware_path}</P192>
+		{if isset($grandstream_firmware_path) && isset($firmware_version)}
+		<P192>{$grandstream_firmware_path}/dp715/{$firmware_version}</P192>
+		{elseif isset($grandstream_firmware_path)}
+		<P192>{$grandstream_firmware_path}/dp715</P192>
 		{else}
 		<P192>{$domain_name}{$project_path}/app/provision</P192>
 		{/if}
-	
+
 		<!-- Config Server Path -->
 		<P237>{$domain_name}{$project_path}/app/provision</P237>
 		<!-- XML Config File Password -->

--- a/resources/templates/provision/grandstream/dp750/{$mac}.xml
+++ b/resources/templates/provision/grandstream/dp750/{$mac}.xml
@@ -2571,8 +2571,10 @@
 
 <!-- Firmware Server Path -->
 <!-- String: serveraddress  -->
-{if isset($grandstream_firmware_path)}
-<P192>{$grandstream_firmware_path}</P192>
+{if isset($grandstream_firmware_path) && isset($firmware_version)}
+<P192>{$grandstream_firmware_path}/dp750/{$firmware_version}</P192>
+{elseif isset($grandstream_firmware_path)}
+<P192>{$grandstream_firmware_path}/dp750</P192>
 {else}
 <P192>{$domain_name}{$project_path}/app/provision</P192>
 {/if}

--- a/resources/templates/provision/grandstream/dp750/{$mac}.xml
+++ b/resources/templates/provision/grandstream/dp750/{$mac}.xml
@@ -2264,16 +2264,8 @@
 <!-- Handset Line Settings -->
 <!-- HS 1 Line Settings -->
 <!-- Number: 0 - 10, according with None and account 1 - 10. First line Default is 1 (account 1), other line have default is 0 - NULL. -->
-{if isset($handset_1_line_1) }
-<P4300>{$handset_1_line_1}</P4300>
-{else}
 <P4300>1</P4300>
-{/if}
-{if isset($handset_1_line_2) }
-<P4301>{$handset_1_line_2}</P4301>
-{else}
-<P4301>2</P4301>
-{/if}
+<P4301>0</P4301>
 <P4302>0</P4302>
 <P4303>0</P4303>
 <P4304>0</P4304>
@@ -2285,16 +2277,8 @@
 
 <!-- HS 2 Line Settings -->
 <!-- Number: 0 - 10, according with None and account 1 - 10. First line Default is 1 (account 1), other line have default is 0 - NULL. -->
-{if isset($handset_2_line_1) }
-<P4310>{$handset_2_line_1}</P4310>
-{else}
 <P4310>1</P4310>
-{/if}
-{if isset($handset_2_line_2) }
-<P4311>{$handset_2_line_2}</P4311>
-{else}
-<P4311>2</P4311>
-{/if}
+<P4311>0</P4311>
 <P4312>0</P4312>
 <P4313>0</P4313>
 <P4314>0</P4314>
@@ -2306,16 +2290,8 @@
 
 <!-- HS 3 Line Settings -->
 <!-- Number: 0 - 10, according with None and account 1 - 10. First line Default is 1 (account 1), other line have default is 0 - NULL. -->
-{if isset($handset_3_line_1) }
-<P4320>{$handset_3_line_1}</P4320>
-{else}
 <P4320>1</P4320>
-{/if}
-{if isset($handset_3_line_2) }
-<P4321>{$handset_3_line_2}</P4321>
-{else}
-<P4321>2</P4321>
-{/if}
+<P4321>0</P4321>
 <P4322>0</P4322>
 <P4323>0</P4323>
 <P4324>0</P4324>
@@ -2327,16 +2303,8 @@
 
 <!-- HS 4 Line Settings -->
 <!-- Number: 0 - 10, according with None and account 1 - 10. First line Default is 1 (account 1), other line have default is 0 - NULL. -->
-{if isset($handset_4_line_1) }
-<P4250>{$handset_4_line_1}</P4250>
-{else}
 <P4250>1</P4250>
-{/if}
-{if isset($handset_4_line_2) }
-<P4251>{$handset_4_line_2}</P4251>
-{else}
-<P4251>2</P4251>
-{/if}
+<P4251>0</P4251>
 <P21320>0</P21320>
 <P21321>0</P21321>
 <P21322>0</P21322>
@@ -2348,16 +2316,8 @@
 
 <!-- HS 5 Line Settings -->
 <!-- Number: 0 - 10, according with None and account 1 - 10. First line Default is 1 (account 1), other line have default is 0 - NULL. -->
-{if isset($handset_5_line_1) }
-<P21328>{$handset_5_line_1}</P21328>
-{else}
 <P21328>1</P21328>
-{/if}
-{if isset($handset_5_line_2) }
-<P21329>{$handset_5_line_2}</P21329>
-{else}
-<P21329>2</P21329>
-{/if}
+<P21329>0</P21329>
 <P21330>0</P21330>
 <P21331>0</P21331>
 <P21332>0</P21332>

--- a/resources/templates/provision/grandstream/dp750/{$mac}.xml
+++ b/resources/templates/provision/grandstream/dp750/{$mac}.xml
@@ -2264,8 +2264,16 @@
 <!-- Handset Line Settings -->
 <!-- HS 1 Line Settings -->
 <!-- Number: 0 - 10, according with None and account 1 - 10. First line Default is 1 (account 1), other line have default is 0 - NULL. -->
+{if isset($handset_1_line_1) }
+<P4300>{$handset_1_line_1}</P4300>
+{else}
 <P4300>1</P4300>
-<P4301>0</P4301>
+{/if}
+{if isset($handset_1_line_2) }
+<P4301>{$handset_1_line_2}</P4301>
+{else}
+<P4301>2</P4301>
+{/if}
 <P4302>0</P4302>
 <P4303>0</P4303>
 <P4304>0</P4304>
@@ -2277,8 +2285,16 @@
 
 <!-- HS 2 Line Settings -->
 <!-- Number: 0 - 10, according with None and account 1 - 10. First line Default is 1 (account 1), other line have default is 0 - NULL. -->
+{if isset($handset_2_line_1) }
+<P4310>{$handset_2_line_1}</P4310>
+{else}
 <P4310>1</P4310>
-<P4311>0</P4311>
+{/if}
+{if isset($handset_2_line_2) }
+<P4311>{$handset_2_line_2}</P4311>
+{else}
+<P4311>2</P4311>
+{/if}
 <P4312>0</P4312>
 <P4313>0</P4313>
 <P4314>0</P4314>
@@ -2290,8 +2306,16 @@
 
 <!-- HS 3 Line Settings -->
 <!-- Number: 0 - 10, according with None and account 1 - 10. First line Default is 1 (account 1), other line have default is 0 - NULL. -->
+{if isset($handset_3_line_1) }
+<P4320>{$handset_3_line_1}</P4320>
+{else}
 <P4320>1</P4320>
-<P4321>0</P4321>
+{/if}
+{if isset($handset_3_line_2) }
+<P4321>{$handset_3_line_2}</P4321>
+{else}
+<P4321>2</P4321>
+{/if}
 <P4322>0</P4322>
 <P4323>0</P4323>
 <P4324>0</P4324>
@@ -2303,8 +2327,16 @@
 
 <!-- HS 4 Line Settings -->
 <!-- Number: 0 - 10, according with None and account 1 - 10. First line Default is 1 (account 1), other line have default is 0 - NULL. -->
+{if isset($handset_4_line_1) }
+<P4250>{$handset_4_line_1}</P4250>
+{else}
 <P4250>1</P4250>
-<P4251>0</P4251>
+{/if}
+{if isset($handset_4_line_2) }
+<P4251>{$handset_4_line_2}</P4251>
+{else}
+<P4251>2</P4251>
+{/if}
 <P21320>0</P21320>
 <P21321>0</P21321>
 <P21322>0</P21322>
@@ -2316,8 +2348,16 @@
 
 <!-- HS 5 Line Settings -->
 <!-- Number: 0 - 10, according with None and account 1 - 10. First line Default is 1 (account 1), other line have default is 0 - NULL. -->
+{if isset($handset_5_line_1) }
+<P21328>{$handset_5_line_1}</P21328>
+{else}
 <P21328>1</P21328>
-<P21329>0</P21329>
+{/if}
+{if isset($handset_5_line_2) }
+<P21329>{$handset_5_line_2}</P21329>
+{else}
+<P21329>2</P21329>
+{/if}
 <P21330>0</P21330>
 <P21331>0</P21331>
 <P21332>0</P21332>

--- a/resources/templates/provision/grandstream/gxp110x/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp110x/{$mac}.xml
@@ -921,8 +921,10 @@
 
 <!-- Firmware Server Path -->
 <!-- String -->
-{if isset($grandstream_firmware_path)}
-<P192>{$grandstream_firmware_path}</P192>
+{if isset($grandstream_firmware_path) && isset($firmware_version)}
+<P192>{$grandstream_firmware_path}/gxp110x/{$firmware_version}</P192>
+{elseif isset($grandstream_firmware_path)}
+<P192>{$grandstream_firmware_path}/gxp110x</P192>
 {else}
 <P192>{$domain_name}{$project_path}/app/provision</P192>
 {/if}

--- a/resources/templates/provision/grandstream/gxp116x/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp116x/{$mac}.xml
@@ -795,8 +795,10 @@
 
 <!--  Firmware Server Path -->
 <!--  String -->
-{if isset($grandstream_firmware_path)}
-<P192>{$grandstream_firmware_path}</P192>
+{if isset($grandstream_firmware_path) && isset($firmware_version)}
+<P192>{$grandstream_firmware_path}/gxp116x/{$firmware_version}</P192>
+{elseif isset($grandstream_firmware_path)}
+<P192>{$grandstream_firmware_path}/gxp116x</P192>
 {else}
 <P192>{$domain_name}{$project_path}/app/provision</P192>
 {/if}

--- a/resources/templates/provision/grandstream/gxp140x/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp140x/{$mac}.xml
@@ -1165,13 +1165,15 @@
     <P212>2</P212>
     <!--  Firmware Server Path -->
     <!--  String -->
-    
-    {if isset($grandstream_firmware_path)}
-    <P192>{$grandstream_firmware_path}</P192>
+
+    {if isset($grandstream_firmware_path) && isset($firmware_version)}
+    <P192>{$grandstream_firmware_path}/gxp140x/{$firmware_version}</P192>
+    {elseif isset($grandstream_firmware_path)}
+    <P192>{$grandstream_firmware_path}/gxp140x</P192>
     {else}
     <P192>{$domain_name}{$project_path}/app/provision</P192>
     {/if}
-    
+
     <!--  Config Server Path -->
     <!--  String -->
     <P237>{$domain_name}{$project_path}/app/provision</P237>
@@ -1313,7 +1315,7 @@
     <!--  This is a string of up to 256 characters that should contain a path to the XML file. It MUST be in the host/path format. -->
     <!--  For example: directory.grandstream.com/engineering -->
     <!--  String -->
-    
+
     {if isset($contact_grandstream)}
 <P331>{$grandstream_phonebook_xml_server_path}{$mac}/</P331>
 {elseif isset($grandstream_phonebook_xml_server_path)}
@@ -1321,7 +1323,7 @@
 {else}
 <P331></P331>
 {/if}
-    
+
     <!--  Phonebook Download Interval (in minutes) -->
     <!--  Valid value range is 5-720. Default is 0 for disabled -->
     <!--  Number: 0, 5-720;  -->

--- a/resources/templates/provision/grandstream/gxp140xbk/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp140xbk/{$mac}.xml
@@ -1165,13 +1165,15 @@
     <P212>2</P212>
     <!--  Firmware Server Path -->
     <!--  String -->
-    
-    {if isset($grandstream_firmware_path)}
-    <P192>{$grandstream_firmware_path}</P192>
+
+    {if isset($grandstream_firmware_path) && isset($firmware_version)}
+    <P192>{$grandstream_firmware_path}/gxp140x/{$firmware_version}</P192>
+    {elseif isset($grandstream_firmware_path)}
+    <P192>{$grandstream_firmware_path}/gxp140x</P192>
     {else}
     <P192>{$domain_name}{$project_path}/app/provision</P192>
     {/if}
-    
+
     <!--  Config Server Path -->
     <!--  String -->
     <P237>{$domain_name}{$project_path}/app/provision</P237>
@@ -1313,7 +1315,7 @@
     <!--  This is a string of up to 256 characters that should contain a path to the XML file. It MUST be in the host/path format. -->
     <!--  For example: directory.grandstream.com/engineering -->
     <!--  String -->
-    
+
     {if isset($contact_grandstream)}
 <P331>{$grandstream_phonebook_xml_server_path}{$mac}/</P331>
 {elseif isset($grandstream_phonebook_xml_server_path)}
@@ -1321,7 +1323,7 @@
 {else}
 <P331></P331>
 {/if}
-    
+
     <!--  Phonebook Download Interval (in minutes) -->
     <!--  Valid value range is 5-720. Default is 0 for disabled -->
     <!--  Number: 0, 5-720;  -->

--- a/resources/templates/provision/grandstream/gxp1450/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp1450/{$mac}.xml
@@ -1550,8 +1550,10 @@
 
 <!-- Firmware Server Path -->
 <!-- String -->
-{if isset($grandstream_firmware_path)}
-<P192>{$grandstream_firmware_path}</P192>
+{if isset($grandstream_firmware_path) && isset($firmware_version)}
+<P192>{$grandstream_firmware_path}/gxp1450/{$firmware_version}</P192>
+{elseif isset($grandstream_firmware_path)}
+<P192>{$grandstream_firmware_path}/gxp1450</P192>
 {else}
 <P192>{$domain_name}{$project_path}/app/provision</P192>
 {/if}

--- a/resources/templates/provision/grandstream/gxp1450bk/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp1450bk/{$mac}.xml
@@ -1357,8 +1357,10 @@
 <!-- Mandatory -->
 <P212>2</P212>
 
-{if isset($grandstream_firmware_path)}
-<P192>{$grandstream_firmware_path}</P192>
+{if isset($grandstream_firmware_path) && isset($firmware_version)}
+<P192>{$grandstream_firmware_path}/gxp1450/{$firmware_version}</P192>
+{elseif isset($grandstream_firmware_path)}
+<P192>{$grandstream_firmware_path}/gxp1450</P192>
 {else}
 <P192>{$domain_name}{$project_path}/app/provision</P192>
 {/if}

--- a/resources/templates/provision/grandstream/gxp16xx/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp16xx/{$mac}.xml
@@ -1199,7 +1199,7 @@
 <!--  Name -->
 <!--  String -->
 <P507>{$display_name_3}</P507>
-	
+
 <!--  Voice Mail UserID -->
 <!--  String -->
 <P526>*97</P526>
@@ -2045,8 +2045,10 @@
 <P6767>2</P6767>
 <!--  Firmware Server Path -->
 <!--  String -->
-{if isset($grandstream_firmware_path)}
-<P192>{$grandstream_firmware_path}</P192>
+{if isset($grandstream_firmware_path) && isset($firmware_version)}
+<P192>{$grandstream_firmware_path}/gxp16xx/{$firmware_version}</P192>
+{elseif isset($grandstream_firmware_path)}
+<P192>{$grandstream_firmware_path}/gxp16xx</P192>
 {else}
 <P192>{$domain_name}{$project_path}/app/provision</P192>
 {/if}
@@ -3048,4 +3050,3 @@
 <P2986></P2986>
 </config>
 </gs_provision>
-

--- a/resources/templates/provision/grandstream/gxp17xx/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp17xx/{$mac}.xml
@@ -6057,9 +6057,11 @@
 
 <!-- # Firmware Server Path -->
 <!-- # String -->
-    
-{if isset($grandstream_firmware_path)}
-<P192>{$grandstream_firmware_path}</P192>
+
+{if isset($grandstream_firmware_path) && isset($firmware_version)}
+<P192>{$grandstream_firmware_path}/gxp17xx/{$firmware_version}</P192>
+{elseif isset($grandstream_firmware_path)}
+<P192>{$grandstream_firmware_path}/gxp17xx</P192>
 {else}
 <P192>{$domain_name}{$project_path}/app/provision</P192>
 {/if}

--- a/resources/templates/provision/grandstream/gxp20xx/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp20xx/{$mac}.xml
@@ -72,8 +72,10 @@
 
 <!--  Firmware Server Path -->
 
-{if isset($grandstream_firmware_path)}
-<P192>{$grandstream_firmware_path}</P192>
+{if isset($grandstream_firmware_path) && isset($firmware_version)}
+<P192>{$grandstream_firmware_path}/gxp20xx/{$firmware_version}</P192>
+{elseif isset($grandstream_firmware_path)}
+<P192>{$grandstream_firmware_path}/gxp20xx</P192>
 {else}
 <P192>{$domain_name}{$project_path}/app/provision</P192>
 {/if}

--- a/resources/templates/provision/grandstream/gxp2124/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp2124/{$mac}.xml
@@ -1904,13 +1904,15 @@
     <P212>2</P212>
     <!-- Firmware Server Path -->
     <!-- String -->
-    
-    {if isset($grandstream_firmware_path)}
-    <P192>{$grandstream_firmware_path}</P192>
+
+    {if isset($grandstream_firmware_path) && isset($firmware_version)}
+    <P192>{$grandstream_firmware_path}/gxp2124/{$firmware_version}</P192>
+    {elseif isset($grandstream_firmware_path)}
+    <P192>{$grandstream_firmware_path}/gxp2124</P192>
     {else}
     <P192>{$domain_name}{$project_path}/app/provision</P192>
     {/if}
-    
+
     <!-- Config Server Path -->
     <!-- String -->
     <P237>{$domain_name}{$project_path}/app/provision</P237>
@@ -2052,7 +2054,7 @@
     <!-- This is a string of up to 256 characters that should contain a path to the XML file. It MUST be in the host/path format. -->
     <!-- For example: directory.grandstream.com/engineering -->
     <!-- String -->
-    
+
     {if isset($contact_grandstream)}
 <P331>{$grandstream_phonebook_xml_server_path}{$mac}/</P331>
 {elseif isset($grandstream_phonebook_xml_server_path)}

--- a/resources/templates/provision/grandstream/gxp2130/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp2130/{$mac}.xml
@@ -4870,8 +4870,10 @@
 
 <!--  Firmware Server Path Default fm.grandstream.com/gs -->
 <!--  String -->
-{if isset($grandstream_firmware_path)}
-<P192>{$grandstream_firmware_path}</P192>
+{if isset($grandstream_firmware_path) && isset($firmware_version)}
+<P192>{$grandstream_firmware_path}/gxp2130/{$firmware_version}</P192>
+{elseif isset($grandstream_firmware_path)}
+<P192>{$grandstream_firmware_path}/gxp2130</P192>
 {else}
 <P192>{$domain_name}{$project_path}/app/provision</P192>
 {/if}

--- a/resources/templates/provision/grandstream/gxp2135/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp2135/{$mac}.xml
@@ -4870,8 +4870,10 @@
 
 <!--  Firmware Server Path Default fm.grandstream.com/gs -->
 <!--  String -->
-{if isset($grandstream_firmware_path)}
-<P192>{$grandstream_firmware_path}</P192>
+{if isset($grandstream_firmware_path) && isset($firmware_version)}
+<P192>{$grandstream_firmware_path}/gxp2135/{$firmware_version}</P192>
+{elseif isset($grandstream_firmware_path)}
+<P192>{$grandstream_firmware_path}/gxp2135</P192>
 {else}
 <P192>{$domain_name}{$project_path}/app/provision</P192>
 {/if}

--- a/resources/templates/provision/grandstream/gxp2140/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp2140/{$mac}.xml
@@ -4870,8 +4870,10 @@
 
 <!--  Firmware Server Path Default fm.grandstream.com/gs -->
 <!--  String -->
-{if isset($grandstream_firmware_path)}
-<P192>{$grandstream_firmware_path}</P192>
+{if isset($grandstream_firmware_path) && isset($firmware_version)}
+<P192>{$grandstream_firmware_path}/gxp2140/{$firmware_version}</P192>
+{elseif isset($grandstream_firmware_path)}
+<P192>{$grandstream_firmware_path}/gxp2140</P192>
 {else}
 <P192>{$domain_name}{$project_path}/app/provision</P192>
 {/if}

--- a/resources/templates/provision/grandstream/gxp2160/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp2160/{$mac}.xml
@@ -4870,8 +4870,10 @@
 
 <!--  Firmware Server Path Default fm.grandstream.com/gs -->
 <!--  String -->
-{if isset($grandstream_firmware_path)}
-<P192>{$grandstream_firmware_path}</P192>
+{if isset($grandstream_firmware_path) && isset($firmware_version)}
+<P192>{$grandstream_firmware_path}/gxp2160/{$firmware_version}</P192>
+{elseif isset($grandstream_firmware_path)}
+<P192>{$grandstream_firmware_path}/gxp2160</P192>
 {else}
 <P192>{$domain_name}{$project_path}/app/provision</P192>
 {/if}

--- a/resources/templates/provision/grandstream/gxp2170/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp2170/{$mac}.xml
@@ -5514,8 +5514,10 @@
 
 <!-- # Firmware Server Path -->
 <!-- # String -->
-{if isset($grandstream_firmware_path)}
-<P192>{$grandstream_firmware_path}</P192>
+{if isset($grandstream_firmware_path) && isset($firmware_version)}
+<P192>{$grandstream_firmware_path}/gxp2170/{$firmware_version}</P192>
+{elseif isset($grandstream_firmware_path)}
+<P192>{$grandstream_firmware_path}/gxp2170</P192>
 {else}
 <P192>{$domain_name}{$project_path}/app/provision</P192>
 {/if}

--- a/resources/templates/provision/grandstream/gxp21xx/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp21xx/{$mac}.xml
@@ -2695,7 +2695,13 @@
     <!-- Firmware Server Path -->
     <!-- String -->
     <!--<P192>firmware.grandstream.com</P192>-->
+    {if isset($grandstream_firmware_path) && isset($firmware_version)}
+    <P192>{$grandstream_firmware_path}/gxp21xx/{$firmware_version}</P192>
+    {elseif isset($grandstream_firmware_path)}
+    <P192>{$grandstream_firmware_path}/gxp21xx</P192>
+    {else}
     <P192>{$domain_name}{$project_path}/app/provision</P192>
+    {/if}
     <!-- Config Server Path -->
     <!-- String -->
     <P237>{$domain_name}{$project_path}/app/provision</P237>

--- a/resources/templates/provision/grandstream/gxp21xxbk/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp21xxbk/{$mac}.xml
@@ -34,9 +34,10 @@
 
 <!-- Firmware Server Path -->
 <!-- String -->
-
-{if isset($grandstream_firmware_path)}
-<P192>{$grandstream_firmware_path}</P192>
+{if isset($grandstream_firmware_path) && isset($firmware_version)}
+<P192>{$grandstream_firmware_path}/gxp21xx/{$firmware_version}</P192>
+{elseif isset($grandstream_firmware_path)}
+<P192>{$grandstream_firmware_path}/gxp21xx</P192>
 {else}
 <P192>{$domain_name}{$project_path}/app/provision</P192>
 {/if}

--- a/resources/templates/provision/grandstream/gxp2200/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp2200/{$mac}.xml
@@ -3213,9 +3213,11 @@ Account 5 Codec Settings
 <P212>2</P212>
 
 <!-- Firmware Server Path -->
-	
-{if isset($grandstream_firmware_path)}
-<P192>{$grandstream_firmware_path}</P192>
+
+{if isset($grandstream_firmware_path) && isset($firmware_version)}
+<P192>{$grandstream_firmware_path}/gxp2200/{$firmware_version}</P192>
+{elseif isset($grandstream_firmware_path)}
+<P192>{$grandstream_firmware_path}/gxp2200</P192>
 {else}
 <P192>{$domain_name}{$project_path}/app/provision</P192>
 {/if}

--- a/resources/templates/provision/grandstream/gxp3240/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp3240/{$mac}.xml
@@ -3213,9 +3213,10 @@ Account 5 Codec Settings
 <P212>2</P212>
 
 <!-- Firmware Server Path -->
-
-{if isset($grandstream_firmware_path)}
-<P192>{$grandstream_firmware_path}</P192>
+{if isset($grandstream_firmware_path) && isset($firmware_version)}
+<P192>{$grandstream_firmware_path}/gxp3240/{$firmware_version}</P192>
+{elseif isset($grandstream_firmware_path)}
+<P192>{$grandstream_firmware_path}/gxp3240</P192>
 {else}
 <P192>{$domain_name}{$project_path}/app/provision</P192>
 {/if}

--- a/resources/templates/provision/grandstream/gxv300x/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxv300x/{$mac}.xml
@@ -65,13 +65,14 @@
     <!-- Firmware Upgrade. 0 - TFTP Upgrade,  1 - HTTP Upgrade. -->
     <P212>1</P212>
     <!-- Firmware Server Path -->
-    
-    {if isset($grandstream_firmware_path)}
-    <P192>{$grandstream_firmware_path}</P192>
+    {if isset($grandstream_firmware_path) && isset($firmware_version)}
+    <P192>{$grandstream_firmware_path}/gxv300x/{$firmware_version}</P192>
+    {elseif isset($grandstream_firmware_path)}
+    <P192>{$grandstream_firmware_path}/gxv300x</P192>
     {else}
     <P192>{$domain_name}{$project_path}/app/provision</P192>
     {/if}
-    
+
     <!-- Config Server Path -->
     <P237>{$domain_name}{$project_path}/app/provision</P237>
     <!-- Firmware File Prefix -->

--- a/resources/templates/provision/grandstream/gxv3140/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxv3140/{$mac}.xml
@@ -1372,9 +1372,10 @@
 <P1361>{$http_auth_password}</P1361>
 
 <!--  Firmware Server Path, MaxLength 128 -->
-
-{if isset($grandstream_firmware_path)}
-<P192>{$grandstream_firmware_path}</P192>
+{if isset($grandstream_firmware_path) && isset($firmware_version)}
+<P192>{$grandstream_firmware_path}/gxv3140/{$firmware_version}</P192>
+{elseif isset($grandstream_firmware_path)}
+<P192>{$grandstream_firmware_path}/gxv3140</P192>
 {else}
 <P192>{$domain_name}{$project_path}/app/provision</P192>
 {/if}

--- a/resources/templates/provision/grandstream/gxv3175/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxv3175/{$mac}.xml
@@ -1255,7 +1255,6 @@
 <P212>2</P212>
 
 <!-- Firmware Server Path, MaxLength 128 -->
-
 {if isset($grandstream_firmware_path) && isset($firmware_version)}
 <P192>{$grandstream_firmware_path}/gxv3175/{$firmware_version}</P192>
 {elseif isset($grandstream_firmware_path)}

--- a/resources/templates/provision/grandstream/gxv3175/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxv3175/{$mac}.xml
@@ -1256,11 +1256,13 @@
 
 <!-- Firmware Server Path, MaxLength 128 -->
 
-{if isset($grandstream_firmware_path)}
-<P192>{$grandstream_firmware_path}</P192>
+{if isset($grandstream_firmware_path) && isset($firmware_version)}
+<P192>{$grandstream_firmware_path}/gxv3175/{$firmware_version}</P192>
+{elseif isset($grandstream_firmware_path)}
+<P192>{$grandstream_firmware_path}/gxv3175</P192>
 {else}
 <P192>{$domain_name}{$project_path}/app/provision</P192>
-{/if}  
+{/if}
 
 <!-- Config Server Path, MaxLength 128 -->
 <P237>{$domain_name}{$project_path}/app/provision</P237>

--- a/resources/templates/provision/grandstream/gxv3175v2/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxv3175v2/{$mac}.xml
@@ -750,8 +750,9 @@
     <!--  String; between ascii values 33 and 126 -->
     <P1361>{$http_auth_password}</P1361>
 
-    <!-- UPgrade Via: (0 - TFTP,1 - HTTP and 2 - HTTPS) -->
+    <!-- Upgrade Via: (0 - TFTP,1 - HTTP and 2 - HTTPS) -->
     <P212>2</P212>
+
     <!-- Firmware Server Path, MaxLength 128 -->
     {if isset($grandstream_firmware_path) && isset($firmware_version)}
     <P192>{$grandstream_firmware_path}/gxv3175v2/{$firmware_version}</P192>

--- a/resources/templates/provision/grandstream/gxv3175v2/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxv3175v2/{$mac}.xml
@@ -736,7 +736,7 @@
     <P7070>1</P7070>
     <!-- Lock KeyPad UPdate. 0 - No, 1 - Yes -->
     <P88>0</P88>
-    
+
     <!-- XML Config File Password -->
     <!-- String; between ascii values 33 and 126 -->
     <!-- Mandatory -->
@@ -749,17 +749,18 @@
     <!--  HTTP/HTTPS Password -->
     <!--  String; between ascii values 33 and 126 -->
     <P1361>{$http_auth_password}</P1361>
-    
+
     <!-- UPgrade Via: (0 - TFTP,1 - HTTP and 2 - HTTPS) -->
     <P212>2</P212>
     <!-- Firmware Server Path, MaxLength 128 -->
-    
-    {if isset($grandstream_firmware_path)}
-    <P192>{$grandstream_firmware_path}</P192>
+    {if isset($grandstream_firmware_path) && isset($firmware_version)}
+    <P192>{$grandstream_firmware_path}/gxv3175v2/{$firmware_version}</P192>
+    {elseif isset($grandstream_firmware_path)}
+    <P192>{$grandstream_firmware_path}/gxv3175v2</P192>
     {else}
     <P192>{$domain_name}{$project_path}/app/provision</P192>
     {/if}
-    
+
     <!-- Config Server Path, MaxLength 128 -->
     <P237>{$domain_name}{$project_path}/app/provision</P237>
     <!-- Firmware File Prefix, MaxLength 128 -->

--- a/resources/templates/provision/grandstream/gxv3240/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxv3240/{$mac}.xml
@@ -1541,7 +1541,7 @@
 <!-- Check SIP User ID for Incoming INVITE. 0 - No, 1 - Yes. Default value is 0 -->
 <!-- Number: 0, 1 -->
 <P549>0</P549>
- 
+
 <!-- Authenticate Incoming INVITE. 0 - No, 1 - Yes. Default value is 0 -->
 <!-- Number: 0, 1 -->
 <P2546>0 </P2546>
@@ -4758,8 +4758,10 @@
 <P6767>1</P6767>
 
 <!-- Firmware Server Path -->
-{if isset($grandstream_firmware_path)}
-<P192>{$grandstream_firmware_path}</P192>
+{if isset($grandstream_firmware_path) && isset($firmware_version)}
+<P192>{$grandstream_firmware_path}/gxv3240/{$firmware_version}</P192>
+{elseif isset($grandstream_firmware_path)}
+<P192>{$grandstream_firmware_path}/gxv3240</P192>
 {else}
 <P192>{$domain_name}{$project_path}/app/provision</P192>
 {/if}

--- a/resources/templates/provision/grandstream/gxv3275/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxv3275/{$mac}.xml
@@ -3218,8 +3218,10 @@ Account 5 Codec Settings
 <!-- Config Server Path -->
 <P237>{$domain_name}{$project_path}/app/provision</P237>
 
-{if isset($grandstream_firmware_path)}
-<P192>{$grandstream_firmware_path}</P192>
+{if isset($grandstream_firmware_path) && isset($firmware_version)}
+<P192>{$grandstream_firmware_path}/gxv3275/{$firmware_version}</P192>
+{elseif isset($grandstream_firmware_path)}
+<P192>{$grandstream_firmware_path}/gxv3275</P192>
 {else}
 <P192>{$domain_name}{$project_path}/app/provision</P192>
 {/if}

--- a/resources/templates/provision/grandstream/gxv3504/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxv3504/{$mac}.xml
@@ -567,19 +567,15 @@
 <P212>2</P212>
 
 <!-- Firmware Server Path -->
-<P192>{domain_name}/firmware/gs</P192>
-
-<!-- Config Server Path -->
-<P237>{$domain_name}{$project_path}/app/provision</P237>
-
-{if isset($grandstream_firmware_path)}
-<P192>{$grandstream_firmware_path}</P192>
+{if isset($grandstream_firmware_path) && isset($firmware_version)}
+<P192>{$grandstream_firmware_path}/gxv3504/{$firmware_version}</P192>
+{elseif isset($grandstream_firmware_path)}
+<P192>{$grandstream_firmware_path}/gxv3504</P192>
 {else}
 <P192>{$domain_name}{$project_path}/app/provision</P192>
 {/if}
 
 <!-- Config Server Path  -->
-
 <P237>{$domain_name}{$project_path}/app/provision</P237>
 
 <!-- XML Config File Password -->
@@ -1358,7 +1354,3 @@
 
 </config>
 </gs_provision>
-
-
-
-

--- a/resources/templates/provision/grandstream/gxw4004/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxw4004/{$mac}.xml
@@ -12,6 +12,14 @@
 	<!-- Firmware Upgrade -->
 		<!-- Firmware Upgrade and Privisioning. 0 - TFTP Upgrade, 1 - HTTP Upgrade, 2 - HTTPS Upgrade., Number: 0 to 2. Mandatory -->
 		<P212>1</P212>
+		<!-- Firmware Server Path -->
+    {if isset($grandstream_firmware_path) && isset($firmware_version)}
+    <P192>{$grandstream_firmware_path}/gxw4004/{$firmware_version}</P192>
+    {elseif isset($grandstream_firmware_path)}
+    <P192>{$grandstream_firmware_path}/gxw4004</P192>
+    {else}
+    <P192>{$domain_name}{$project_path}/app/provision</P192>
+    {/if}
 		<!-- Config Server Path , String: serveraddress -->
 		<P237>{$domain_name}{$project_path}/app/provision</P237>
 

--- a/resources/templates/provision/grandstream/gxw4008/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxw4008/{$mac}.xml
@@ -12,6 +12,14 @@
 	<!-- Firmware Upgrade -->
 		<!-- Firmware Upgrade and Privisioning. 0 - TFTP Upgrade, 1 - HTTP Upgrade, 2 - HTTPS Upgrade., Number: 0 to 2. Mandatory -->
 		<P212>1</P212>
+		<!-- Firmware Server Path -->
+    {if isset($grandstream_firmware_path) && isset($firmware_version)}
+    <P192>{$grandstream_firmware_path}/gxw4008/{$firmware_version}</P192>
+    {elseif isset($grandstream_firmware_path)}
+    <P192>{$grandstream_firmware_path}/gxw4008</P192>
+    {else}
+    <P192>{$domain_name}{$project_path}/app/provision</P192>
+    {/if}
 		<!-- Config Server Path , String: serveraddress -->
 		<P237>{$domain_name}{$project_path}/app/provision</P237>
 

--- a/resources/templates/provision/grandstream/gxw40xx/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxw40xx/{$mac}.xml
@@ -49,8 +49,11 @@
     <!-- Number: 0 to 2 -->
     <!-- Mandatory -->
     <P212>2</P212>
-    {if isset($grandstream_firmware_path)}
-    <P192>{$grandstream_firmware_path}</P192>
+    <!-- Firmware Server Path -->
+    {if isset($grandstream_firmware_path) && isset($firmware_version)}
+    <P192>{$grandstream_firmware_path}/gxw40xx/{$firmware_version}</P192>
+    {elseif isset($grandstream_firmware_path)}
+    <P192>{$grandstream_firmware_path}/gxw40xx</P192>
     {else}
     <P192>{$domain_name}{$project_path}/app/provision</P192>
     {/if}

--- a/resources/templates/provision/grandstream/gxw410x/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxw410x/{$mac}.xml
@@ -30,8 +30,11 @@
     <!--  Firmware Upgrade -->
     <!--  Firmware Upgrade. 0 - TFTP Upgrade,  1 - HTTP Upgrade. -->
     <P212>1</P212>
-    {if isset($grandstream_firmware_path)}
-    <P192>{$grandstream_firmware_path}</P192>
+    <!-- Firmware Server Path -->
+    {if isset($grandstream_firmware_path) && isset($firmware_version)}
+    <P192>{$grandstream_firmware_path}/gxw410x/{$firmware_version}</P192>
+    {elseif isset($grandstream_firmware_path)}
+    <P192>{$grandstream_firmware_path}/gxw410x</P192>
     {else}
     <P192>{$domain_name}{$project_path}/app/provision</P192>
     {/if}

--- a/resources/templates/provision/grandstream/gxw42xx/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxw42xx/{$mac}.xml
@@ -168,8 +168,11 @@
 <!-- Mandatory -->
 <P212>2</P212>
 
-{if isset($grandstream_firmware_path)}
-<P192>{$grandstream_firmware_path}</P192>
+<!-- Firmware Server Path -->
+{if isset($grandstream_firmware_path) && isset($firmware_version)}
+<P192>{$grandstream_firmware_path}/gxw40xx/{$firmware_version}</P192>
+{elseif isset($grandstream_firmware_path)}
+<P192>{$grandstream_firmware_path}/gxw40xx</P192>
 {else}
 <P192>{$domain_name}{$project_path}/app/provision</P192>
 {/if}

--- a/resources/templates/provision/grandstream/ht502/{$mac}.xml
+++ b/resources/templates/provision/grandstream/ht502/{$mac}.xml
@@ -39,11 +39,14 @@
 	<!-- Firmware Upgrade -->
 		<!-- Firmware Upgrade and Privisioning. 0 - TFTP Upgrade, 1 - HTTP Upgrade, 2 - HTTPS Upgrade. -->
 		<P212>2</P212>
-		{if isset($grandstream_firmware_path)}
-		<P192>{$grandstream_firmware_path}</P192>
-		{else}
-		<P192>{$domain_name}{$project_path}/app/provision</P192>
-		{/if}
+		<!-- Firmware Server Path -->
+    {if isset($grandstream_firmware_path) && isset($firmware_version)}
+    <P192>{$grandstream_firmware_path}/ht502/{$firmware_version}</P192>
+    {elseif isset($grandstream_firmware_path)}
+    <P192>{$grandstream_firmware_path}/ht502</P192>
+    {else}
+    <P192>{$domain_name}{$project_path}/app/provision</P192>
+    {/if}
 		<!-- Config Server Path. Server address -->
 		<P237>{$domain_name}{$project_path}/app/provision</P237>
 		<!-- XML Config File Password. Max Length: 40 characters; between ascii values 33 and 126 -->

--- a/resources/templates/provision/grandstream/ht503/{$mac}.xml
+++ b/resources/templates/provision/grandstream/ht503/{$mac}.xml
@@ -136,8 +136,11 @@
 <!--  Mandatory -->
 <P212>2</P212>
 
-{if isset($grandstream_firmware_path)}
-<P192>{$grandstream_firmware_path}</P192>
+<!-- Firmware Server Path -->
+{if isset($grandstream_firmware_path) && isset($firmware_version)}
+<P192>{$grandstream_firmware_path}/ht503/{$firmware_version}</P192>
+{elseif isset($grandstream_firmware_path)}
+<P192>{$grandstream_firmware_path}/ht503</P192>
 {else}
 <P192>{$domain_name}{$project_path}/app/provision</P192>
 {/if}

--- a/resources/templates/provision/grandstream/ht701/{$mac}.xml
+++ b/resources/templates/provision/grandstream/ht701/{$mac}.xml
@@ -61,9 +61,10 @@
 
 <!-- Firmware Server Path -->
 <!-- Server address -->
-
-{if isset($grandstream_firmware_path)}
-<P192>{$grandstream_firmware_path}</P192>
+{if isset($grandstream_firmware_path) && isset($firmware_version)}
+<P192>{$grandstream_firmware_path}/ht701/{$firmware_version}</P192>
+{elseif isset($grandstream_firmware_path)}
+<P192>{$grandstream_firmware_path}/ht701</P192>
 {else}
 <P192>{$domain_name}{$project_path}/app/provision</P192>
 {/if}

--- a/resources/templates/provision/grandstream/ht702/{$mac}.xml
+++ b/resources/templates/provision/grandstream/ht702/{$mac}.xml
@@ -70,8 +70,12 @@
 <!-- Mandatory -->
 <P212>2</P212>
 
-{if isset($grandstream_firmware_path)}
-<P192>{$grandstream_firmware_path}</P192>
+<!-- Firmware Server Path -->
+<!-- Server address -->
+{if isset($grandstream_firmware_path) && isset($firmware_version)}
+<P192>{$grandstream_firmware_path}/ht702/{$firmware_version}</P192>
+{elseif isset($grandstream_firmware_path)}
+<P192>{$grandstream_firmware_path}/ht702</P192>
 {else}
 <P192>{$domain_name}{$project_path}/app/provision</P192>
 {/if}

--- a/resources/templates/provision/grandstream/ht704/{$mac}.xml
+++ b/resources/templates/provision/grandstream/ht704/{$mac}.xml
@@ -68,8 +68,10 @@
 <P212>2</P212>
 
 <!-- Firmware Server Path -->
-{if isset($grandstream_firmware_path)}
-<P192>{$grandstream_firmware_path}</P192>
+{if isset($grandstream_firmware_path) && isset($firmware_version)}
+<P192>{$grandstream_firmware_path}/ht704/{$firmware_version}</P192>
+{elseif isset($grandstream_firmware_path)}
+<P192>{$grandstream_firmware_path}/ht704</P192>
 {else}
 <P192>{$domain_name}{$project_path}/app/provision</P192>
 {/if}


### PR DESCRIPTION
In this pull request the firmware field in the Devices app in core is used as a way to specify what folder and base URL should be served to a device, so that users can easily test beta firmware on multiple devices, or walk devices like phones through a series of firmware upgrades in cases where a direct upgrade to the latest firmware isn't possible.

There is also a [readme](https://github.com/AccelerateNetworks/fusionpbx/blob/d8736a0efd82a60cc219bf103498cc7dbb2e7d6c/resources/templates/provision/grandstream/README.md) in this pull request to help explain how to use this feature.