### PR TITLE
Update file_cache.lua

### DIFF
--- a/resources/install/scripts/app/servers/resources/file_cache.lua
+++ b/resources/install/scripts/app/servers/resources/file_cache.lua
@@ -79,7 +79,7 @@
 							if (row.method == "curl") then
 								api_command_argument = api_command_argument:gsub(" ", "%%20");
 								url = [[http://]]..row.username..[[:]]..row.password..[[@]]..row.hostname..[[:]]..row.port..[[/webapi/luarun?app/servers/resources/clear_cache.lua%20]]..api_command_argument;
-								os.execute("curl "..url);
+								api:executeString("system curl" .. url  );
 								freeswitch.consoleLog("INFO", "[notice] curl ".. url .. " \n");
 							end
 						end


### PR DESCRIPTION
Run OS command through Freeswitch for better performance. Running OS commands directly from lua can cause RTP timing issues.