### PR TITLE
Fix PHP out of memory error on App Defaults

### DIFF
--- a/app/dialplans/app_defaults.php
+++ b/app/dialplans/app_defaults.php
@@ -91,7 +91,7 @@
 			$sql = "update v_dialplans set dialplan_order = '890' where dialplan_order = '999' and dialplan_name = 'local_extension';\n";
 			$db->query($sql);
 			unset($sql);
-
+		
 		//set empty strings to null
 			$sql = "update v_device_lines set outbound_proxy_primary = null where outbound_proxy_primary = '';\n";
 			$db->query($sql);
@@ -102,12 +102,25 @@
 
 //add xml for each dialplan where the dialplan xml is empty
 	if ($domains_processed == 1) {
+		$sql = "select domain_name ";
+		$sql .= "from v_domains \n";
+		$prep_statement = $this->db->prepare(check_sql($sql));
+		$prep_statement->execute();
+		$results = $prep_statement->fetchAll(PDO::FETCH_NAMED);
+		foreach ($results as $row) {
+			$dialplans = new dialplan;
+			$dialplans->source = "details";
+			$dialplans->destination = "database";
+			$dialplans->context = $row["domain_name"];
+			$dialplans->is_empty = "dialplan_xml";
+			$array = $dialplans->xml();
+			//print_r($array);
+		}
 		$dialplans = new dialplan;
 		$dialplans->source = "details";
 		$dialplans->destination = "database";
 		$dialplans->is_empty = "dialplan_xml";
 		$array = $dialplans->xml();
-		//print_r($array);
 	}
 
 //add not found dialplan to inbound routes


### PR DESCRIPTION
If 400+ domains exist it's not possible to Execute App Defaults without getting PHP out of memory error on line 630 in 'app\dialplan\resources\classes\dialplan.php'.

It would be better to first build XML for each domain_name (context) then for all else.