### PR TITLE
Update {$mac}.cfg

### DIFF
--- a/resources/templates/provision/polycom/5.x/{$mac}.cfg
+++ b/resources/templates/provision/polycom/5.x/{$mac}.cfg
@@ -58,6 +58,8 @@
 	/>
 	<DEVICE_SETTINGS
 		device.set="1"
+                device.baseProfile.set="1"
+                device.baseProfile="Generic"
 		device.sntp.serverName="{$ntp_server_primary}"
 		device.sntp.gmtOffset="{$polycom_gmt_offset}"
 		{if isset($admin_password)}


### PR DESCRIPTION
Added configuration to set the device's base profile to "Generic". This will only affect Polycom phones that come with the Skype4Business license(models ending in "-019"). It sets the profile to the one needed for FusionPBX.