### PR TITLE
Fix queue UUID for Postgres ODBC

### DIFF
--- a/app/call_centers/call_center_queue_edit.php
+++ b/app/call_centers/call_center_queue_edit.php
@@ -193,7 +193,7 @@
 
 		//add the call_center_queue_uuid
 			if (strlen($_POST["call_center_queue_uuid"]) == 0) {
-				$call_center_queue_uuid = uuid();
+				$call_center_queue_uuid = strtoupper(uuid());
 				$_POST["call_center_queue_uuid"] = $call_center_queue_uuid;
 			}
 


### PR DESCRIPTION
ODBC UUID is added lowercase via API call in this script. When doing a callcenter_config queue list, two entries were showing (one lowercase, and one uppercase). Agents would never associate with the lowercase queue UUID.