### PR TITLE
Update {$mac}.cfg

### DIFF
--- a/resources/templates/provision/polycom/5.x/{$mac}.cfg
+++ b/resources/templates/provision/polycom/5.x/{$mac}.cfg
@@ -184,6 +184,7 @@
 		{/if}
 		exchange.server.url="0.0.0.0"
 		up.warningLevel="2"
+		call.defaultTransferType="{$polycom_default_transfer_method}"
 	/>
 	<SOFT_KEYS
 		softkey.1.label="VMTransfer"


### PR DESCRIPTION
Allows transfer type to be set in "Default Settings" with variable polycom_default_transfer_method (already added by Len).