### PR TITLE
Check for directory before trying to create

### DIFF
--- a/app/provision/resources/classes/provision.php
+++ b/app/provision/resources/classes/provision.php
@@ -1419,7 +1419,9 @@ include "root.php";
 												$file_contents = $this->render();
 
 											//write the file
-												mkdir($directory,0777,true);
+												if(!is_dir($directory)) {
+													mkdir($directory,0777,true);
+												}
 												$fh = fopen($dest_path,"w") or die("Unable to write to $directory for provisioning. Make sure the path exists and permissons are set correctly.");
 												fwrite($fh, $file_contents);
 												fclose($fh);


### PR DESCRIPTION
"Warning: mkdir(): File exists in /var/www/fusionpbx/app/provision/resources/classes/provision.php on line 1405

When using tftp an error would be thrown when modifying extensions. This checks for the existence of the directory before creating.