### PR TITLE
Fix cisco 7940/7960 directory.xml enterprise line

### DIFF
--- a/resources/templates/provision/cisco/7940/directory.xml
+++ b/resources/templates/provision/cisco/7940/directory.xml
@@ -11,7 +11,7 @@
 	</MenuItem>
 	<MenuItem>
 		<Name>Enterprise</Name>
-		<URL>http://{$domain_name}/app/provision/?file=directory_enterprise.xml&mac=$mac}</URL>
+		<URL>http://{$domain_name}/app/provision/?file=directory_enterprise.xml&mac={$mac}</URL>
 	</MenuItem>
 	<MenuItem>
 		<Name>Speed Dial</Name>

--- a/resources/templates/provision/cisco/7960/directory.xml
+++ b/resources/templates/provision/cisco/7960/directory.xml
@@ -11,7 +11,7 @@
 	</MenuItem>
 	<MenuItem>
 		<Name>Enterprise</Name>
-		<URL>http://{$domain_name}/app/provision/?file=directory_enterprise.xml&mac=$mac}</URL>
+		<URL>http://{$domain_name}/app/provision/?file=directory_enterprise.xml&mac={$mac}</URL>
 	</MenuItem>
 	<MenuItem>
 		<Name>Speed Dial</Name>


### PR DESCRIPTION
Generated Cisco 7940/7960 templates contained an error for the 'Enterprise' directory. The $mac variable was not expanded in the template engine.

http://$SOMEPBX/app/provision/?file=directory_enterprise.xml&mac=$mac}

{$mac} is now properly wrapped in the source template.