### PR TITLE
Unescape Json before decoding

### DIFF
--- a/app/xml_cdr/xml_cdr_details.php
+++ b/app/xml_cdr/xml_cdr_details.php
@@ -88,6 +88,7 @@
 //parse the xml to get the call detail record info
 	try {
 		if ($format == 'json') {
+			$json_string = stripcslashes($json_string);
 			$array = json_decode($json_string,true);
 		}
 		if ($format == 'xml') {


### PR DESCRIPTION
I have realized since 4.4, json is escaped (\" for example). Some PHP releases fail to decode if that is used.