### PR TITLE
Added check if transcription result is nil

### DIFF
--- a/resources/install/scripts/app/voicemail/resources/functions/record_message.lua
+++ b/resources/install/scripts/app/voicemail/resources/functions/record_message.lua
@@ -81,6 +81,11 @@
 						return ''
 					end
 					local transcribe_json = JSON.decode(transcribe_result);
+					--Trancribe result can be nil
+					if (transcribe_json["results"] == nil) then
+						freeswitch.consoleLog("notice", "[voicemail] TRANSCRIPTION: results = (null) \n");
+						return ''
+					end
 					if (debug["info"]) then
 						if (transcribe_json["results"][1]["name"] == nil) then
 							freeswitch.consoleLog("notice", "[voicemail] TRANSCRIPTION: (null) \n");


### PR DESCRIPTION
If the message is too short then the result is nil.
Error occurs in this case: record_message.lua:97: attempt to index field 'results' (a nil value) 
Added check if transcribe_json["results"] is nil.