### PR TITLE
Selfhosted Transcription Service

### DIFF
--- a/resources/install/scripts/app/voicemail/resources/functions/record_message.lua
+++ b/resources/install/scripts/app/voicemail/resources/functions/record_message.lua
@@ -100,18 +100,18 @@
 					return transcription;
 				end
 			end
-			--start of my section
 			if (transcribe_provider == "selfhosted") then
 				local transcription_server = settings:get('voicemail', 'transcription_server', 'text') or '';
-				freeswitch.consoleLog("notice", "[voicemail] transcription provider: " .. transcription_server .. "\n");
 				local api_key2 = settings:get('voicemail', 'api_key', 'text') or '';
 				if (transcription_server ~= '') then
 					transcribe_cmd = "curl -L " .. transcription_server .. " -F file=@"..file_path
 					local handle = io.popen(transcribe_cmd);
 					local transcribe_result = handle:read("*a");
 					handle:close();
-					freeswitch.consoleLog("notice", "[voicemail] CMD: " .. transcribe_cmd .. "\n");
-					freeswitch.consoleLog("notice", "[voicemail] RESULT: " .. transcribe_result .. "\n");
+					if (debug["info"]) then
+						freeswitch.consoleLog("notice", "[voicemail] CMD: " .. transcribe_cmd .. "\n");
+						freeswitch.consoleLog("notice", "[voicemail] RESULT: " .. transcribe_result .. "\n");
+					end
 					--Trancribe request can fail
 					if (transcribe_result == '') then
 						freeswitch.consoleLog("notice", "[voicemail] TRANSCRIPTION: (null) \n");
@@ -120,7 +120,6 @@
 					return transcribe_result;
 				end
 			end
-			--end of my function
 		else
 			if (debug["info"]) then
 				freeswitch.consoleLog("notice", "[voicemail] message too short for transcription.\n");

--- a/resources/install/scripts/app/voicemail/resources/functions/record_message.lua
+++ b/resources/install/scripts/app/voicemail/resources/functions/record_message.lua
@@ -38,6 +38,22 @@
 		end)
 	end
 
+--define escape function (prevents lua injection attacks)
+	local function esc(x)
+   return (x:gsub('%%', '%%%%')
+            :gsub('^%^', '%%^')
+            :gsub('%$$', '%%$')
+            :gsub('%(', '%%(')
+            :gsub('%)', '%%)')
+            :gsub('%.', '%%.')
+            :gsub('%[', '%%[')
+            :gsub('%]', '%%]')
+            :gsub('%*', '%%*')
+            :gsub('%+', '%%+')
+            :gsub('%-', '%%-')
+            :gsub('%?', '%%?'))
+	end
+
 	local function transcribe(file_path,settings,start_epoch)
 		--transcription variables
 		if (os.time() - start_epoch > 2) then
@@ -106,7 +122,7 @@
 				if (transcription_server ~= '') then
 					transcribe_cmd = "curl -L " .. transcription_server .. " -F file=@"..file_path
 					local handle = io.popen(transcribe_cmd);
-					local transcribe_result = handle:read("*a");
+					local transcribe_result = esc(handle:read("*a"));
 					handle:close();
 					if (debug["info"]) then
 						freeswitch.consoleLog("notice", "[voicemail] CMD: " .. transcribe_cmd .. "\n");


### PR DESCRIPTION
By setting a few variables, one can use any of a variety of self hosted speech to text APIs.

| Variable               | type    | value              |   |
|------------------------|---------|--------------------|---|
| transcribe_enabled     | boolean | true               |   |
| transcription_server   | text    | https://yourserver |   |
| transcription_provider | text    | selfhosted         |   |
| json_enabled | boolean    | true         | Optional  |
| api_key | text    | your_api_key         | Optional  |

One other thing I noted was it appears the particular Bing Speech API used doesn't have documentation that I can find, and Microsoft is deprecating the Bing Speech APIs in favor of their newer Speech Service API. The documentation of this deprecation is [lacking at best](https://github.com/MicrosoftDocs/azure-docs/blob/master/includes/cognitive-services-bing-speech-api-deprecation-note.md) :c

Edit: Microsoft [responded](https://github.com/MicrosoftDocs/azure-docs/issues/18040), here is the [Bing Speech to Speech Services Migration](https://github.com/MicrosoftDocs/azure-docs/blob/master/articles/cognitive-services/Speech-Service/how-to-migrate-from-bing-speech.md) document.