### PR TITLE
HTek Template Changes

### DIFF
--- a/resources/templates/provision/htek/uc903/{$mac}.cfg
+++ b/resources/templates/provision/htek/uc903/{$mac}.cfg
@@ -2356,7 +2356,7 @@
         <P20120 para="RTCPReportCollector" />
         <P20121 para="RTCPReportFormat" />
         <P20155 para="ServerCaType">0</P20155>
-        <P20156 para="TrustedCaType">0</P20156>
+        <P20156 para="TrustedCaType">2</P20156>
         <P20163 para="NetWork.StaticDNS">0</P20163>
         <P20164 para="MulticastPaging.MulticatCodec">0</P20164>
         <P20165 para="FirmwareUpGrade.PnPActive">1</P20165>
@@ -2411,8 +2411,8 @@
         <P23139 para="BwXsiDir.EnableUCOne">0</P23139>
         <P23140 para="Preference.EXPBacklightLevel">8</P23140>
         <P23253 para="Preference.LabelScroll">0</P23253>
-        <P23376 para="TLSCommenNameValidation">0</P23376>
-        <P23377 para="TLSOnlyAcceptTrustCA">0</P23377>
+        <P23376 para="TLSCommenNameValidation">1</P23376>
+        <P23377 para="TLSOnlyAcceptTrustCA">1</P23377>
         <P24015 para="TLSChooseTLSVersion">1</P24015>
         <P20995 para="AutoProvision.SoftkeyLayoutUrl" />
         <P23169 para="Features.Popups.MissedCall">0</P23169>

--- a/resources/templates/provision/htek/uc903/{$mac}.cfg
+++ b/resources/templates/provision/htek/uc903/{$mac}.cfg
@@ -1023,7 +1023,7 @@
         <!--Management/AutoProvision-->
         <P212 para="FirmwareUpGrade.UrgrateMode">3</P212>
         <P192 para="FirmwareUpGrade.FirmwareServerPath">http://h-tek.com/fm</P192>
-        <P237 para="FirmwareUpGrade.ConfigServerPath">http://{$domain_name}/app/provision</P237>
+        <P237 para="FirmwareUpGrade.ConfigServerPath">https://{$domain_name}/app/provision</P237>
         <P1145 para="FirmwareUpGrade.AllowDHCPOption">66</P1145>
         <P145 para="FirmwareUpGrade.ToOverrideServer">1</P145>
         <P194 para="FirmwareUpGrade.AutoUpgrade">1</P194>

--- a/resources/templates/provision/htek/uc923/{$mac}.cfg
+++ b/resources/templates/provision/htek/uc923/{$mac}.cfg
@@ -2356,7 +2356,7 @@
         <P20120 para="RTCPReportCollector" />
         <P20121 para="RTCPReportFormat" />
         <P20155 para="ServerCaType">0</P20155>
-        <P20156 para="TrustedCaType">0</P20156>
+        <P20156 para="TrustedCaType">2</P20156>
         <P20163 para="NetWork.StaticDNS">0</P20163>
         <P20164 para="MulticastPaging.MulticatCodec">0</P20164>
         <P20165 para="FirmwareUpGrade.PnPActive">1</P20165>
@@ -2411,8 +2411,8 @@
         <P23139 para="BwXsiDir.EnableUCOne">0</P23139>
         <P23140 para="Preference.EXPBacklightLevel">8</P23140>
         <P23253 para="Preference.LabelScroll">0</P23253>
-        <P23376 para="TLSCommenNameValidation">0</P23376>
-        <P23377 para="TLSOnlyAcceptTrustCA">0</P23377>
+        <P23376 para="TLSCommenNameValidation">1</P23376>
+        <P23377 para="TLSOnlyAcceptTrustCA">1</P23377>
         <P24015 para="TLSChooseTLSVersion">1</P24015>
         <P20995 para="AutoProvision.SoftkeyLayoutUrl" />
         <P23169 para="Features.Popups.MissedCall">0</P23169>

--- a/resources/templates/provision/htek/uc923/{$mac}.cfg
+++ b/resources/templates/provision/htek/uc923/{$mac}.cfg
@@ -1023,7 +1023,7 @@
         <!--Management/AutoProvision-->
         <P212 para="FirmwareUpGrade.UrgrateMode">3</P212>
         <P192 para="FirmwareUpGrade.FirmwareServerPath">http://h-tek.com/fm</P192>
-        <P237 para="FirmwareUpGrade.ConfigServerPath">http://{$domain_name}/app/provision</P237>
+        <P237 para="FirmwareUpGrade.ConfigServerPath">https://{$domain_name}/app/provision</P237>
         <P1145 para="FirmwareUpGrade.AllowDHCPOption">66</P1145>
         <P145 para="FirmwareUpGrade.ToOverrideServer">1</P145>
         <P194 para="FirmwareUpGrade.AutoUpgrade">1</P194>

--- a/resources/templates/provision/htek/uc924/{$mac}.cfg
+++ b/resources/templates/provision/htek/uc924/{$mac}.cfg
@@ -2356,7 +2356,7 @@
         <P20120 para="RTCPReportCollector" />
         <P20121 para="RTCPReportFormat" />
         <P20155 para="ServerCaType">0</P20155>
-        <P20156 para="TrustedCaType">0</P20156>
+        <P20156 para="TrustedCaType">2</P20156>
         <P20163 para="NetWork.StaticDNS">0</P20163>
         <P20164 para="MulticastPaging.MulticatCodec">0</P20164>
         <P20165 para="FirmwareUpGrade.PnPActive">1</P20165>
@@ -2411,8 +2411,8 @@
         <P23139 para="BwXsiDir.EnableUCOne">0</P23139>
         <P23140 para="Preference.EXPBacklightLevel">8</P23140>
         <P23253 para="Preference.LabelScroll">0</P23253>
-        <P23376 para="TLSCommenNameValidation">0</P23376>
-        <P23377 para="TLSOnlyAcceptTrustCA">0</P23377>
+        <P23376 para="TLSCommenNameValidation">1</P23376>
+        <P23377 para="TLSOnlyAcceptTrustCA">1</P23377>
         <P24015 para="TLSChooseTLSVersion">1</P24015>
         <P20995 para="AutoProvision.SoftkeyLayoutUrl" />
         <P23169 para="Features.Popups.MissedCall">0</P23169>

--- a/resources/templates/provision/htek/uc924/{$mac}.cfg
+++ b/resources/templates/provision/htek/uc924/{$mac}.cfg
@@ -1023,7 +1023,7 @@
         <!--Management/AutoProvision-->
         <P212 para="FirmwareUpGrade.UrgrateMode">3</P212>
         <P192 para="FirmwareUpGrade.FirmwareServerPath">http://h-tek.com/fm</P192>
-        <P237 para="FirmwareUpGrade.ConfigServerPath">http://{$domain_name}/app/provision</P237>
+        <P237 para="FirmwareUpGrade.ConfigServerPath">https://{$domain_name}/app/provision</P237>
         <P1145 para="FirmwareUpGrade.AllowDHCPOption">66</P1145>
         <P145 para="FirmwareUpGrade.ToOverrideServer">1</P145>
         <P194 para="FirmwareUpGrade.AutoUpgrade">1</P194>

--- a/resources/templates/provision/htek/uc926/{$mac}.cfg
+++ b/resources/templates/provision/htek/uc926/{$mac}.cfg
@@ -2356,7 +2356,7 @@
         <P20120 para="RTCPReportCollector" />
         <P20121 para="RTCPReportFormat" />
         <P20155 para="ServerCaType">0</P20155>
-        <P20156 para="TrustedCaType">0</P20156>
+        <P20156 para="TrustedCaType">2</P20156>
         <P20163 para="NetWork.StaticDNS">0</P20163>
         <P20164 para="MulticastPaging.MulticatCodec">0</P20164>
         <P20165 para="FirmwareUpGrade.PnPActive">1</P20165>
@@ -2411,8 +2411,8 @@
         <P23139 para="BwXsiDir.EnableUCOne">0</P23139>
         <P23140 para="Preference.EXPBacklightLevel">8</P23140>
         <P23253 para="Preference.LabelScroll">0</P23253>
-        <P23376 para="TLSCommenNameValidation">0</P23376>
-        <P23377 para="TLSOnlyAcceptTrustCA">0</P23377>
+        <P23376 para="TLSCommenNameValidation">1</P23376>
+        <P23377 para="TLSOnlyAcceptTrustCA">1</P23377>
         <P24015 para="TLSChooseTLSVersion">1</P24015>
         <P20995 para="AutoProvision.SoftkeyLayoutUrl" />
         <P23169 para="Features.Popups.MissedCall">0</P23169>

--- a/resources/templates/provision/htek/uc926/{$mac}.cfg
+++ b/resources/templates/provision/htek/uc926/{$mac}.cfg
@@ -1023,7 +1023,7 @@
         <!--Management/AutoProvision-->
         <P212 para="FirmwareUpGrade.UrgrateMode">3</P212>
         <P192 para="FirmwareUpGrade.FirmwareServerPath">http://h-tek.com/fm</P192>
-        <P237 para="FirmwareUpGrade.ConfigServerPath">http://{$domain_name}/app/provision</P237>
+        <P237 para="FirmwareUpGrade.ConfigServerPath">https://{$domain_name}/app/provision</P237>
         <P1145 para="FirmwareUpGrade.AllowDHCPOption">66</P1145>
         <P145 para="FirmwareUpGrade.ToOverrideServer">1</P145>
         <P194 para="FirmwareUpGrade.AutoUpgrade">1</P194>


### PR DESCRIPTION
Currently in the template, the server config prefix is set to http:// and should be set to https://