### PR TITLE
Add new Advanced SIP Var

### DIFF
--- a/resources/templates/provision/yealink/cp860/y000000000037.cfg
+++ b/resources/templates/provision/yealink/cp860/y000000000037.cfg
@@ -345,6 +345,8 @@ sip.use_out_bound_in_dialog =
 #Configure the registration random time (in seconds). It ranges from 0 (default) to 60.
 sip.reg_surge_prevention =
 
+sip.call_fail_use_reason.enable = {$yealink_sip_call_fail_use_reason_enable}
+
 
 ################################################################
 #                        NAT&ICE                              ##

--- a/resources/templates/provision/yealink/cp920/y000000000000.cfg
+++ b/resources/templates/provision/yealink/cp920/y000000000000.cfg
@@ -345,6 +345,7 @@ sip.use_out_bound_in_dialog =
 #Configure the registration random time (in seconds). It ranges from 0 (default) to 60.
 sip.reg_surge_prevention =
 
+sip.call_fail_use_reason.enable = {$yealink_sip_call_fail_use_reason_enable}
 
 ################################################################
 #                        NAT&ICE                              ##

--- a/resources/templates/provision/yealink/cp960/y000000000000.cfg
+++ b/resources/templates/provision/yealink/cp960/y000000000000.cfg
@@ -345,6 +345,7 @@ sip.use_out_bound_in_dialog =
 #Configure the registration random time (in seconds). It ranges from 0 (default) to 60.
 sip.reg_surge_prevention =
 
+sip.call_fail_use_reason.enable = {$yealink_sip_call_fail_use_reason_enable}
 
 ################################################################
 #                        NAT&ICE                              ##

--- a/resources/templates/provision/yealink/t19p/y000000000053.cfg
+++ b/resources/templates/provision/yealink/t19p/y000000000053.cfg
@@ -1293,3 +1293,9 @@ screen_saver.pic.url = {$yealink_t20p_screen_saver}
 #Require reboot
 web_item_level.url =
 
+#######################################################################################
+##                                   SIP Advanced                                    ##
+#######################################################################################
+
+sip.call_fail_use_reason.enable = {$yealink_sip_call_fail_use_reason_enable}
+

--- a/resources/templates/provision/yealink/t20p/y000000000007.cfg
+++ b/resources/templates/provision/yealink/t20p/y000000000007.cfg
@@ -1293,3 +1293,9 @@ screen_saver.pic.url = {$yealink_t20p_screen_saver}
 #Require reboot
 web_item_level.url =
 
+#######################################################################################
+##                                   SIP Advanced                                    ##
+#######################################################################################
+
+sip.call_fail_use_reason.enable = {$yealink_sip_call_fail_use_reason_enable}
+

--- a/resources/templates/provision/yealink/t21p/y000000000052.cfg
+++ b/resources/templates/provision/yealink/t21p/y000000000052.cfg
@@ -308,6 +308,8 @@ sip.reg_surge_prevention =
 #Configures the local SIP port.  Integer from 1024 to 65535
 {if isset($yealink_sip_listen_port)}sip.listen_port = {$yealink_sip_listen_port}{else}sip.listen_port = 5060{/if}
 
+sip.call_fail_use_reason.enable = {$yealink_sip_call_fail_use_reason_enable}
+
 #######################################################################################
 ##                                   Echo Cancellation                               ##
 #######################################################################################

--- a/resources/templates/provision/yealink/t22p/y000000000005.cfg
+++ b/resources/templates/provision/yealink/t22p/y000000000005.cfg
@@ -1292,3 +1292,9 @@ screen_saver.pic.url = {$yealink_t22p_screen_saver}
 #Configure the access URL for downloading the files for var.
 #Require reboot
 web_item_level.url =
+
+#######################################################################################
+##                                   SIP Advanced                                    ##
+#######################################################################################
+
+sip.call_fail_use_reason.enable = {$yealink_sip_call_fail_use_reason_enable}

--- a/resources/templates/provision/yealink/t23g/y000000000044.cfg
+++ b/resources/templates/provision/yealink/t23g/y000000000044.cfg
@@ -325,6 +325,8 @@ sip.reg_surge_prevention =
 #Configures the local SIP port.  Integer from 1024 to 65535
 {if isset($yealink_sip_listen_port)}sip.listen_port = {$yealink_sip_listen_port}{else}sip.listen_port = 5060{/if}
 
+sip.call_fail_use_reason.enable = {$yealink_sip_call_fail_use_reason_enable}
+
 
 ################################################################
 #                        NAT&ICE                              ##

--- a/resources/templates/provision/yealink/t23p/y000000000044.cfg
+++ b/resources/templates/provision/yealink/t23p/y000000000044.cfg
@@ -326,6 +326,8 @@ sip.reg_surge_prevention =
 #Configures the local SIP port.  Integer from 1024 to 65535
 {if isset($yealink_sip_listen_port)}sip.listen_port = {$yealink_sip_listen_port}{else}sip.listen_port = 5060{/if}
 
+sip.call_fail_use_reason.enable = {$yealink_sip_call_fail_use_reason_enable}
+
 
 ################################################################
 #                        NAT&ICE                              ##

--- a/resources/templates/provision/yealink/t26p/y000000000004.cfg
+++ b/resources/templates/provision/yealink/t26p/y000000000004.cfg
@@ -1293,3 +1293,9 @@ screen_saver.pic.url = {$yealink_t26p_screen_saver}
 #Require reboot
 web_item_level.url =
 
+#######################################################################################
+##                                   SIP Advanced                                    ##
+#######################################################################################
+
+sip.call_fail_use_reason.enable = {$yealink_sip_call_fail_use_reason_enable}
+

--- a/resources/templates/provision/yealink/t27g/y000000000069.cfg
+++ b/resources/templates/provision/yealink/t27g/y000000000069.cfg
@@ -325,6 +325,7 @@ sip.reg_surge_prevention =
 #Configures the local SIP port.  Integer from 1024 to 65535
 {if isset($yealink_sip_listen_port)}sip.listen_port = {$yealink_sip_listen_port}{else}sip.listen_port = 5060{/if}
 
+sip.call_fail_use_reason.enable = {$yealink_sip_call_fail_use_reason_enable}
 
 ################################################################
 #                        NAT&ICE                              ##

--- a/resources/templates/provision/yealink/t27p/y000000000045.cfg
+++ b/resources/templates/provision/yealink/t27p/y000000000045.cfg
@@ -326,6 +326,8 @@ sip.reg_surge_prevention =
 #Configures the local SIP port.  Integer from 1024 to 65535
 {if isset($yealink_sip_listen_port)}sip.listen_port = {$yealink_sip_listen_port}{else}sip.listen_port = 5060{/if}
 
+sip.call_fail_use_reason.enable = {$yealink_sip_call_fail_use_reason_enable}
+
 
 ################################################################
 #                        NAT&ICE                              ##

--- a/resources/templates/provision/yealink/t28p/y000000000000.cfg
+++ b/resources/templates/provision/yealink/t28p/y000000000000.cfg
@@ -1293,3 +1293,8 @@ screen_saver.pic.url = {$yealink_t28p_screen_saver}
 #Require reboot
 web_item_level.url =
 
+#######################################################################################
+##                                   SIP Advanced                                    ##
+#######################################################################################
+
+sip.call_fail_use_reason.enable = {$yealink_sip_call_fail_use_reason_enable}

--- a/resources/templates/provision/yealink/t29g/y000000000046.cfg
+++ b/resources/templates/provision/yealink/t29g/y000000000046.cfg
@@ -326,6 +326,8 @@ sip.reg_surge_prevention =
 #Configures the local SIP port.  Integer from 1024 to 65535
 {if isset($yealink_sip_listen_port)}sip.listen_port = {$yealink_sip_listen_port}{else}sip.listen_port = 5060{/if}
 
+sip.call_fail_use_reason.enable = {$yealink_sip_call_fail_use_reason_enable}
+
 
 ################################################################
 #                        NAT&ICE                              ##

--- a/resources/templates/provision/yealink/t32g/y000000000032.cfg
+++ b/resources/templates/provision/yealink/t32g/y000000000032.cfg
@@ -1290,3 +1290,9 @@ screen_saver.pic.url = {$yealink_t32g_screen_saver}
 #Require reboot
 web_item_level.url =
 
+#######################################################################################
+##                                   SIP Advanced                                    ##
+#######################################################################################
+
+sip.call_fail_use_reason.enable = {$yealink_sip_call_fail_use_reason_enable}
+

--- a/resources/templates/provision/yealink/t38g/y000000000038.cfg
+++ b/resources/templates/provision/yealink/t38g/y000000000038.cfg
@@ -1293,3 +1293,9 @@ screen_saver.pic.url = {$yealink_t38g_screen_saver}
 #Require reboot
 web_item_level.url =
 
+#######################################################################################
+##                                   SIP Advanced                                    ##
+#######################################################################################
+
+sip.call_fail_use_reason.enable = {$yealink_sip_call_fail_use_reason_enable}
+

--- a/resources/templates/provision/yealink/t40g/y000000000076.cfg
+++ b/resources/templates/provision/yealink/t40g/y000000000076.cfg
@@ -326,6 +326,8 @@ sip.reg_surge_prevention =
 #Configures the local SIP port.  Integer from 1024 to 65535
 {if isset($yealink_sip_listen_port)}sip.listen_port = {$yealink_sip_listen_port}{else}sip.listen_port = 5060{/if}
 
+sip.call_fail_use_reason.enable = {$yealink_sip_call_fail_use_reason_enable}
+
 
 ################################################################
 #                        NAT&ICE                              ##

--- a/resources/templates/provision/yealink/t40p/y000000000054.cfg
+++ b/resources/templates/provision/yealink/t40p/y000000000054.cfg
@@ -326,6 +326,8 @@ sip.reg_surge_prevention =
 #Configures the local SIP port.  Integer from 1024 to 65535
 {if isset($yealink_sip_listen_port)}sip.listen_port = {$yealink_sip_listen_port}{else}sip.listen_port = 5060{/if}
 
+sip.call_fail_use_reason.enable = {$yealink_sip_call_fail_use_reason_enable}
+
 
 ################################################################
 #                        NAT&ICE                              ##

--- a/resources/templates/provision/yealink/t41p/y000000000036.cfg
+++ b/resources/templates/provision/yealink/t41p/y000000000036.cfg
@@ -326,6 +326,8 @@ sip.reg_surge_prevention =
 #Configures the local SIP port.  Integer from 1024 to 65535
 {if isset($yealink_sip_listen_port)}sip.listen_port = {$yealink_sip_listen_port}{else}sip.listen_port = 5060{/if}
 
+sip.call_fail_use_reason.enable = {$yealink_sip_call_fail_use_reason_enable}
+
 
 ################################################################
 #                        NAT&ICE                              ##

--- a/resources/templates/provision/yealink/t41s/y000000000068.cfg
+++ b/resources/templates/provision/yealink/t41s/y000000000068.cfg
@@ -595,6 +595,8 @@ sip.disp_incall_to_info=
 features.call_invite_format=
 phone_setting.early_media.rtp_sniffer.timeout=
 
+sip.call_fail_use_reason.enable = {$yealink_sip_call_fail_use_reason_enable}
+
 
 ################################################################
 #                        NAT&ICE                              ##

--- a/resources/templates/provision/yealink/t42g/y000000000029.cfg
+++ b/resources/templates/provision/yealink/t42g/y000000000029.cfg
@@ -326,6 +326,8 @@ sip.reg_surge_prevention =
 #Configures the local SIP port.  Integer from 1024 to 65535
 {if isset($yealink_sip_listen_port)}sip.listen_port = {$yealink_sip_listen_port}{else}sip.listen_port = 5060{/if}
 
+sip.call_fail_use_reason.enable = {$yealink_sip_call_fail_use_reason_enable}
+
 
 ################################################################
 #                        NAT&ICE                              ##

--- a/resources/templates/provision/yealink/t42s/y000000000067.cfg
+++ b/resources/templates/provision/yealink/t42s/y000000000067.cfg
@@ -595,6 +595,8 @@ sip.disp_incall_to_info=
 features.call_invite_format=
 phone_setting.early_media.rtp_sniffer.timeout=
 
+sip.call_fail_use_reason.enable = {$yealink_sip_call_fail_use_reason_enable}
+
 
 ################################################################
 #                        NAT&ICE                              ##

--- a/resources/templates/provision/yealink/t46g/y000000000028.cfg
+++ b/resources/templates/provision/yealink/t46g/y000000000028.cfg
@@ -326,6 +326,8 @@ sip.reg_surge_prevention =
 #Configures the local SIP port.  Integer from 1024 to 65535
 {if isset($yealink_sip_listen_port)}sip.listen_port = {$yealink_sip_listen_port}{else}sip.listen_port = 5060{/if}
 
+sip.call_fail_use_reason.enable = {$yealink_sip_call_fail_use_reason_enable}
+
 
 ################################################################
 #                        NAT&ICE                              ##

--- a/resources/templates/provision/yealink/t46s/y000000000066.cfg
+++ b/resources/templates/provision/yealink/t46s/y000000000066.cfg
@@ -595,6 +595,8 @@ sip.disp_incall_to_info=
 features.call_invite_format=
 phone_setting.early_media.rtp_sniffer.timeout=
 
+sip.call_fail_use_reason.enable = {$yealink_sip_call_fail_use_reason_enable}
+
 
 ################################################################
 #                        NAT&ICE                              ##

--- a/resources/templates/provision/yealink/t48g/y000000000035.cfg
+++ b/resources/templates/provision/yealink/t48g/y000000000035.cfg
@@ -326,6 +326,8 @@ sip.reg_surge_prevention =
 #Configures the local SIP port.  Integer from 1024 to 65535
 {if isset($yealink_sip_listen_port)}sip.listen_port = {$yealink_sip_listen_port}{else}sip.listen_port = 5060{/if}
 
+sip.call_fail_use_reason.enable = {$yealink_sip_call_fail_use_reason_enable}
+
 
 ################################################################
 #                        NAT&ICE                              ##

--- a/resources/templates/provision/yealink/t48s/y000000000065.cfg
+++ b/resources/templates/provision/yealink/t48s/y000000000065.cfg
@@ -595,6 +595,8 @@ sip.disp_incall_to_info=
 features.call_invite_format=
 phone_setting.early_media.rtp_sniffer.timeout=
 
+sip.call_fail_use_reason.enable = {$yealink_sip_call_fail_use_reason_enable}
+
 
 ################################################################
 #                        NAT&ICE                              ##

--- a/resources/templates/provision/yealink/t49g/y000000000051.cfg
+++ b/resources/templates/provision/yealink/t49g/y000000000051.cfg
@@ -308,6 +308,8 @@ sip.reg_surge_prevention =
 #Configures the local SIP port.  Integer from 1024 to 65535
 {if isset($yealink_sip_listen_port)}sip.listen_port = {$yealink_sip_listen_port}{else}sip.listen_port = 5060{/if}
 
+sip.call_fail_use_reason.enable = {$yealink_sip_call_fail_use_reason_enable}
+
 #######################################################################################
 ##                                   Echo Cancellation                               ##
 #######################################################################################

--- a/resources/templates/provision/yealink/t52s/y000000000074.cfg
+++ b/resources/templates/provision/yealink/t52s/y000000000074.cfg
@@ -598,6 +598,8 @@ sip.disp_incall_to_info=
 features.call_invite_format=
 phone_setting.early_media.rtp_sniffer.timeout=
 
+sip.call_fail_use_reason.enable = {$yealink_sip_call_fail_use_reason_enable}
+
 
 ################################################################
 #                        NAT&ICE                              ##

--- a/resources/templates/provision/yealink/t54s/y000000000070.cfg
+++ b/resources/templates/provision/yealink/t54s/y000000000070.cfg
@@ -598,6 +598,8 @@ sip.disp_incall_to_info=
 features.call_invite_format=
 phone_setting.early_media.rtp_sniffer.timeout=
 
+sip.call_fail_use_reason.enable = {$yealink_sip_call_fail_use_reason_enable}
+
 
 ################################################################
 #                        NAT&ICE                              ##

--- a/resources/templates/provision/yealink/t56a/y000000000056.cfg
+++ b/resources/templates/provision/yealink/t56a/y000000000056.cfg
@@ -372,6 +372,8 @@ sip.reserve_characters =
 ##2-the out-contracting ports fixed contact, via carry fix
 sip.tcp_port_random_mode = 
 
+sip.call_fail_use_reason.enable = {$yealink_sip_call_fail_use_reason_enable}
+
 
 #######################################################################################
 ##                                   Echo Cancellation                               ##

--- a/resources/templates/provision/yealink/t58v/y000000000058.cfg
+++ b/resources/templates/provision/yealink/t58v/y000000000058.cfg
@@ -372,6 +372,8 @@ sip.reserve_characters =
 ##2-the out-contracting ports fixed contact, via carry fix
 sip.tcp_port_random_mode = 
 
+sip.call_fail_use_reason.enable = {$yealink_sip_call_fail_use_reason_enable}
+
 
 #######################################################################################
 ##                                   Echo Cancellation                               ##

--- a/resources/templates/provision/yealink/vp530/y000000000023.cfg
+++ b/resources/templates/provision/yealink/vp530/y000000000023.cfg
@@ -1104,3 +1104,9 @@ directory_setting.url = https://{if isset($http_auth_username)}{$http_auth_usern
 #Uploading the settings of the shortcut keys;
 #Require reboot;
 dialing_shortcut.url=
+
+#######################################################################################
+##                                   SIP Advanced                                    ##
+#######################################################################################
+
+sip.call_fail_use_reason.enable = {$yealink_sip_call_fail_use_reason_enable}

--- a/resources/templates/provision/yealink/w52p/y000000000025.cfg
+++ b/resources/templates/provision/yealink/w52p/y000000000025.cfg
@@ -543,3 +543,9 @@ network.snmp.port =
 #Require reboot;
 network.snmp.trust_ip =
 
+
+#######################################################################################
+##                                   SIP Advanced                                    ##
+#######################################################################################
+
+sip.call_fail_use_reason.enable = {$yealink_sip_call_fail_use_reason_enable}

--- a/resources/templates/provision/yealink/w56p/y000000000025.cfg
+++ b/resources/templates/provision/yealink/w56p/y000000000025.cfg
@@ -543,3 +543,9 @@ network.snmp.port =
 #Require reboot;
 network.snmp.trust_ip =
 
+#######################################################################################
+##                                   SIP Advanced                                    ##
+#######################################################################################
+
+sip.call_fail_use_reason.enable = {$yealink_sip_call_fail_use_reason_enable}
+

--- a/resources/templates/provision/yealink/w60b/y000000000077.cfg
+++ b/resources/templates/provision/yealink/w60b/y000000000077.cfg
@@ -597,3 +597,9 @@ network.snmp.port =
 #Require reboot;
 network.snmp.trust_ip =
 
+#######################################################################################
+##                                   SIP Advanced                                    ##
+#######################################################################################
+
+sip.call_fail_use_reason.enable = {$yealink_sip_call_fail_use_reason_enable}
+


### PR DESCRIPTION
Add the following advanced SIP variable. Disabling this allows Yealink phones to display the SIP error reason in the format sent by the carrier rather than Q.850 format e.g. "User Busy" rather than "NORMAL_CLEARING"

sip.call_fail_use_reason.enable = {$yealink_sip_call_fail_use_reason_enable}