### PR TITLE
Update BLF for agents when making changes in the GUI. Also use BLF as a speed dial for login/logout.

### DIFF
--- a/app/call_centers/call_center_agent_status.php
+++ b/app/call_centers/call_center_agent_status.php
@@ -120,8 +120,31 @@
 								$response = event_socket_request($fp, $cmd);
 							}
 							usleep(200);
-					}
+					
+						//set the blf status
+						//get the agents from the database
+							$sql = "select agent_name from v_call_center_agents ";
+							$sql .= "where domain_uuid = '".$_SESSION['domain_uuid']."' ";
+							$sql .= "and call_center_agent_uuid = '".$row['agent_uuid']."' ";
+							$prep_statement = $db->prepare(check_sql($sql));
+							$prep_statement->execute();
+							$agent_name = $prep_statement->fetchAll(PDO::FETCH_NAMED);
 
+							if ($row['agent_status'] == 'Available') {
+								$answer_state = 'confirmed';
+							}
+							else {
+								$answer_state = 'terminated';
+							}
+							
+							$call_center_notify = new call_center_notify;
+							$call_center_notify->domain_name = $_SESSION['domain_name'];
+							$call_center_notify->agent_name = $agent_name[0]['agent_name'];
+							$call_center_notify->answer_state = $answer_state;
+							$call_center_notify->agent_uuid = $row['agent_uuid'];
+							$call_center_notify->send_call_center_notify();
+							unset($call_center_notify);
+					}
 			}
 		}
 	}

--- a/app/conference_centers/resources/classes/call_center_notify.php
+++ b/app/conference_centers/resources/classes/call_center_notify.php
@@ -1,0 +1,63 @@
+<?php
+/*
+	FusionPBX
+	Version: MPL 1.1
+
+	The contents of this file are subject to the Mozilla Public License Version
+	1.1 (the "License"); you may not use this file except in compliance with
+	the License. You may obtain a copy of the License at
+	http://www.mozilla.org/MPL/
+
+	Software distributed under the License is distributed on an "AS IS" basis,
+	WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License
+	for the specific language governing rights and limitations under the
+	License.
+
+	The Original Code is FusionPBX
+
+	The Initial Developer of the Original Code is
+	Mark J Crane <markjcrane@fusionpbx.com>
+	Portions created by the Initial Developer are Copyright (C) 2008-2017
+	the Initial Developer. All Rights Reserved.
+
+	Contributor(s):
+	Mark J Crane <markjcrane@fusionpbx.com>
+	KonradSC <konrd@yahoo.com>
+*/
+include "root.php";
+
+//define the blf_notify class
+	class call_center_notify {
+
+		public $debug;
+		public $domain_name;
+		public $agent_name;
+		public $answer_state;
+		public $agent_uuid;
+
+
+	//feature_event method		
+		public function send_call_center_notify() {
+
+				$fp = event_socket_create($_SESSION['event_socket_ip_address'], $_SESSION['event_socket_port'], $_SESSION['event_socket_password']);
+				if ($fp) {
+					//send the event
+						$event = "sendevent PRESENCE_IN\n";
+						$event .= "proto: agent\n";
+						$event .= "event_type: presence\n";
+						$event .= "alt_event_type: dialog\n";
+						$event .= "Presence-Call-Direction: outbound\n";
+						$event .= "state: Active (1 waiting)\n";
+						$event .= "from: agent+".$this->agent_name."@".$this->domain_name."\n";
+						$event .= "login: agent+".$this->agent_name."@".$this->domain_name."\n";
+						$event .= "unique-id: ".$this->agent_uuid."\n";
+						$event .= "answer-state: ".$this->answer_state."\n";
+						event_socket_request($fp, $event);
+						//echo $event."<br />";
+					fclose($fp);	
+				}
+		} //function
+	
+	} //class
+
+?>

--- a/app/dialplans/resources/switch/conf/dialplan/200_agent_status.xml
+++ b/app/dialplans/resources/switch/conf/dialplan/200_agent_status.xml
@@ -1,6 +1,9 @@
 <context name="{v_context}">
 	<extension name="agent_status" number="*22" continue="false" app_uuid="2eb032c5-c79d-4096-ac90-8a47fe40f411">
-		<condition field="destination_number" expression="^\*22$">
+		<condition field="destination_number" expression="^\*22$" break="never">
+			<action application="set" data="agent_id=${sip_from_user}"/>
+		</condition>
+		<condition field="destination_number" expression="^(agent\+)?(.*)$">
 			<action application="set" data="agent_id=${sip_from_user}"/>
 			<action application="lua" data="app.lua agent_status"/>
 		</condition>


### PR DESCRIPTION
Agent status can be monitored as a BLF line in the format of "agent+_agentname_".

This update adds functionality for using the BLF as a speed dial for login/logout. 

It also adds functionality to update the BLF when changing the agent status on the "app/call_centers/call_center_agent_status.php" page. 