### PR TITLE
Update index.lua

### DIFF
--- a/resources/install/scripts/app/ring_groups/index.lua
+++ b/resources/install/scripts/app/ring_groups/index.lua
@@ -879,6 +879,8 @@
 								if ring_group_timeout_app and #ring_group_timeout_app > 0 then
 									session:execute(ring_group_timeout_app, ring_group_timeout_data);
 								end
+							--check and report missed call
+								missed()
 						end
 					else
 						if (ring_group_timeout_app ~= nil) then


### PR DESCRIPTION
When bridge application ends with "originate_disposition: ALLOTTED_TIMEOUT" for example, the "missed call" feature doesn't work for ring group because of hangup hook isn't called. Should we just avoid using this channel variable or add additional processing at the end? Like for timeout action? I choose to call "missed" at the end of script. But may be we should add it to other places too?