### PR TITLE
To allow recording termination when the extension is entered by menu …

### DIFF
--- a/resources/install/scripts/app/voicemail/index.lua
+++ b/resources/install/scripts/app/voicemail/index.lua
@@ -276,14 +276,15 @@
 						--unset bind meta app
 							session:execute("unbind_meta_app", "");
 
-						--set the callback function
-							if (session:ready()) then
-								session:setVariable("playback_terminators", "#");
-								session:setInputCallback("on_dtmf", "");
-							end
 						end
 				end
 			end
+	end
+
+--set the callback function
+	if (session:ready()) then
+		session:setVariable("playback_terminators", "#");
+		session:setInputCallback("on_dtmf", "");
 	end
 
 --general functions


### PR DESCRIPTION
…(*98)

It was not possible to terminate a recording with a keypress when *98 was used.
*98ext was working.