### PR TITLE
Parent-Child Domain Capability

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,5 +1,9 @@
 RewriteEngine    On
 
+#RewriteCond %{HTTPS} off
+#RewriteCond %{HTTP_HOST} !^127.0.0
+#RewriteRule .* https://%{HTTP_HOST}%{REQUEST_URI} [L,R=301]
+
 #REST api
 RewriteRule ^(.*)/api/(.*)$                                                     $1/api/index.php?rewrite_uri=$2 [QSA]
 

--- a/.htaccess
+++ b/.htaccess
@@ -1,9 +1,5 @@
 RewriteEngine    On
 
-#RewriteCond %{HTTPS} off
-#RewriteCond %{HTTP_HOST} !^127.0.0
-#RewriteRule .* https://%{HTTP_HOST}%{REQUEST_URI} [L,R=301]
-
 #REST api
 RewriteRule ^(.*)/api/(.*)$                                                     $1/api/index.php?rewrite_uri=$2 [QSA]
 

--- a/core/domain_settings/app_languages.php
+++ b/core/domain_settings/app_languages.php
@@ -841,4 +841,44 @@ $text['description-domain-add']['ru-ru'] = "Введите данные доме
 $text['description-domain-add']['sv-se'] = "Ange domändetaljer nedan.";
 $text['description-domain-add']['uk-ua'] = "Введіть дані домену нижче.";
 
+$text['description-child-of']['en-us'] = "child of";
+$text['description-child-of']['ar-eg'] = "";
+$text['description-child-of']['de-at'] = ""; //copied from de-de
+$text['description-child-of']['de-ch'] = ""; //copied from de-de
+$text['description-child-of']['de-de'] = "";
+$text['description-child-of']['es-cl'] = "hijo de";
+$text['description-child-of']['es-mx'] = "hijo de"; //copied from es-cl
+$text['description-child-of']['fr-ca'] = "fils de"; //copied from fr-fr
+$text['description-child-of']['fr-fr'] = "fils de";
+$text['description-child-of']['he-il'] = "";
+$text['description-child-of']['it-it'] = "";
+$text['description-child-of']['nl-nl'] = "";
+$text['description-child-of']['pl-pl'] = "";
+$text['description-child-of']['pt-br'] = "";
+$text['description-child-of']['pt-pt'] = "";
+$text['description-child-of']['ro-ro'] = "";
+$text['description-child-of']['ru-ru'] = "";
+$text['description-child-of']['sv-se'] = "";
+$text['description-child-of']['uk-ua'] = "";
+
+$text['label-child-of']['en-us'] = "Child of";
+$text['label-child-of']['ar-eg'] = "";
+$text['label-child-of']['de-at'] = ""; //copied from de-de
+$text['label-child-of']['de-ch'] = ""; //copied from de-de
+$text['label-child-of']['de-de'] = "";
+$text['label-child-of']['es-cl'] = "Hijo de";
+$text['label-child-of']['es-mx'] = "Hijo de"; //copied from es-cl
+$text['label-child-of']['fr-ca'] = "Fils de"; //copied from fr-fr
+$text['label-child-of']['fr-fr'] = "Fils de";
+$text['label-child-of']['he-il'] = "";
+$text['label-child-of']['it-it'] = "";
+$text['label-child-of']['nl-nl'] = "";
+$text['label-child-of']['pl-pl'] = "";
+$text['label-child-of']['pt-br'] = "";
+$text['label-child-of']['pt-pt'] = "";
+$text['label-child-of']['ro-ro'] = "";
+$text['label-child-of']['ru-ru'] = "";
+$text['label-child-of']['sv-se'] = "";
+$text['label-child-of']['uk-ua'] = "";
+
 ?>

--- a/core/domain_settings/domain_edit.php
+++ b/core/domain_settings/domain_edit.php
@@ -64,6 +64,7 @@
 		$domain_name = check_str($_POST["domain_name"]);
 		$domain_enabled = check_str($_POST["domain_enabled"]);
 		$domain_description = check_str($_POST["domain_description"]);
+		$domain_parent_uuid = check_str($_POST["domain_parent_uuid"]);
 	}
 
 if (count($_POST) > 0 && strlen($_POST["persistformvar"]) == 0) {
@@ -104,14 +105,20 @@ if (count($_POST) > 0 && strlen($_POST["persistformvar"]) == 0) {
 						$sql .= "domain_uuid, ";
 						$sql .= "domain_name, ";
 						$sql .= "domain_enabled, ";
-						$sql .= "domain_description ";
+						$sql .= "domain_description";
+						if (strlen($domain_parent_uuid)){
+							$sql .= ", domain_parent_uuid";
+						}
 						$sql .= ")";
 						$sql .= "values ";
 						$sql .= "(";
 						$sql .= "'".uuid()."', ";
 						$sql .= "'".$domain_name."', ";
 						$sql .= "'".$domain_enabled."', ";
-						$sql .= "'".$domain_description."' ";
+						$sql .= "'".$domain_description."'";
+						if (strlen($domain_parent_uuid)){
+							$sql .= ", '".$domain_parent_uuid."' ";
+						}
 						$sql .= ")";
 						$db->exec(check_sql($sql));
 						unset($sql);
@@ -136,7 +143,10 @@ if (count($_POST) > 0 && strlen($_POST["persistformvar"]) == 0) {
 				$sql = "update v_domains set ";
 				$sql .= "domain_name = '".$domain_name."', ";
 				$sql .= "domain_enabled = '".$domain_enabled."', ";
-				$sql .= "domain_description = '".$domain_description."' ";
+				$sql .= "domain_description = '".$domain_description."'";
+				if ($domain_parent_uuid){
+					$sql .= ", domain_parent_uuid = '".$domain_parent_uuid."' ";
+				}
 				$sql .= "where domain_uuid = '".$domain_uuid."' ";
 				$db->exec(check_sql($sql));
 				unset($sql);
@@ -629,6 +639,7 @@ if (count($_POST) > 0 && strlen($_POST["persistformvar"]) == 0) {
 			$domain_name = strtolower($row["domain_name"]);
 			$domain_enabled = $row["domain_enabled"];
 			$domain_description = $row["domain_description"];
+			$domain_parent_uuid = $row["domain_parent_uuid"];
 		}
 		unset ($prep_statement);
 	}
@@ -761,6 +772,31 @@ if (count($_POST) > 0 && strlen($_POST["persistformvar"]) == 0) {
 	echo "	<input class='formfld' type='text' name='domain_description' maxlength='255' value=\"".escape($domain_description)."\">\n";
 	echo "<br />\n";
 	echo $text['description-description']."\n";
+	echo "</td>\n";
+	echo "</tr>\n";
+
+	echo "<tr>\n";
+	echo "<td class='vncell' valign='top' align='left' nowrap='nowrap'>\n";
+	echo "	".$text['label-child-of']."\n";
+	echo "</td>\n";
+	echo "<td class='vtable' align='left'>\n";
+	$sql = "select domain_uuid, domain_name from v_domains ";
+	$sql .= "where domain_enabled='true' and domain_uuid <> '".$domain_uuid."';";
+	$prep_statement = $db->prepare(check_sql($sql));
+	$prep_statement->execute();
+	$result = $prep_statement->fetchAll(PDO::FETCH_NAMED);
+	echo "  <select class='formfld' name='domain_parent_uuid'>";
+	echo "  <option value=''></option>";
+	foreach ($result as &$row) {
+		$list_domain_name = $row["domain_name"];
+		$list_domain_uuid = $row["domain_uuid"];
+		$list_selected = ($domain_parent_uuid	 == $list_domain_uuid)?" selected='selected' ":'';
+		echo "  <option value='$list_domain_uuid' $list_selected>$list_domain_name</option>";
+	}
+	unset($sql, $prep_statement);
+	echo "  </select>";
+	echo "<br />\n";
+	echo $text['description-child-of']."\n";
 	echo "</td>\n";
 	echo "</tr>\n";
 


### PR DESCRIPTION
Gives admin (not only superadmins) the ability to manage more than one domain. Super admins will still need still to create the domain and link it (child of another domain). When this is done, for example, an admin account under a domain like reseller.mydomain.com will be able to manage customer1.mydomain.com with a single login once the superadmin makes customer1 domain a child of reseller domain.