### PR TITLE
Update y000000000077.cfg

### DIFF
--- a/resources/templates/provision/yealink/w60b/y000000000077.cfg
+++ b/resources/templates/provision/yealink/w60b/y000000000077.cfg
@@ -253,6 +253,7 @@ local_time.offset_time = {$yealink_offset_time}
 
 #Configure the time format; 0-12 Hour, 1-24 Hour (default);
 local_time.time_format = {$yealink_time_format}
+custom.handset.time_format = {$yealink_time_format}
 
 #Configure the date format; 0-WWW MMM DD (default), 1-DD-MMM-YY, 2-YYYY-MM-DD, 3-DD/MM/YYYY, 4-MM/DD/YY, 5-DD MMM YYYY, 6-WWW DD MMM;
 local_time.date_format = {$yealink_date_format}


### PR DESCRIPTION
Added variable custom.handset.time_format which is required to properly set the time format for firmware above 81.  This is probably applicable to other yealink configuration files, but this was only tested with a w60b.