### PR TITLE
Show fax file date in user's timezone

### DIFF
--- a/app/fax/fax_files.php
+++ b/app/fax/fax_files.php
@@ -367,8 +367,10 @@
 			else {
 				echo "&nbsp;\n";
 			}
+			$fax_date = ($_SESSION['domain']['time_format']['text'] == '12h') ? date("F d Y H:i", $row['fax_epoch']) : date("F d Y H:i", $row['fax_epoch']);
+			
 			echo "  </td>\n";
-			echo "	<td valign='top' class='".$row_style[$c]."'>".date("F d Y H:i:s", strtotime(escape($row['fax_date'])))."&nbsp;</td>\n";
+			echo "	<td valign='top' class='".$row_style[$c]."'>".$fax_date."&nbsp;</td>\n";
 			echo "	<td style='width: 25px;' class='list_control_icons'>";
 			if (permission_exists('fax_file_delete')) {
 				echo "<a href='fax_file_delete.php?id=".escape($row['fax_file_uuid'])."' alt='".$text['button-delete']."' onclick=\"return confirm('".$text['confirm-delete']."')\">$v_link_label_delete</a>";


### PR DESCRIPTION
Previously timezone was showing in GMT, this now shows fax time in user's timezone. Code to display timezone was carried over from fax_logs.php page.