### PR TITLE
Fix Ring Group Delay Timing

### DIFF
--- a/resources/install/scripts/app/ring_groups/index.lua
+++ b/resources/install/scripts/app/ring_groups/index.lua
@@ -645,7 +645,7 @@
 				--leg delay settings
 					if (ring_group_strategy == "enterprise") then
 						delay_name = "originate_delay_start";
-						destination_delay = destination_delay * 1000;
+						destination_delay = destination_delay * 500;
 					else
 						delay_name = "leg_delay_start";
 					end


### PR DESCRIPTION
This is going to sound really stupid but I have tested this extensively, submitted a Jira on it months ago (was told FS 1.6.20 was no longer supported) and it's still an issue. Please do not take my word for this and create a ring group to test the delay settings with a stopwatch and you should see the real vs set delay discrepancy.

In FreeSWITCH (both on 1.6.20 and 1.8.5) when sending leg_delay_start values, for whatever reason the actual time is double the value sent. The result of this is that if you send 1000ms as leg_delay_start the actual time the call will be delayed is 2000ms.

Because of this bad behavior, ring group delay settings end up being exactly double what is set. e.g. if you set 10s, you will have to wait 20s for the call to be initiated on leg b.

The easiest way to fix this behavior is to simply multiply leg_delay_start by half as much to get the right "real" delay time. Ugly, I know... I'm not sure if leg_delay_start value is passed elsewhere, I'm thinking this behavior may also be present in find me/follow me. If this gets accepted I will look for other locations where this behavior occurs and submit separate PRs if I find any other instances of this.