### PR TITLE
FreeSWITCH phrases database recordings fix

### DIFF
--- a/app/phrases/phrase_edit.php
+++ b/app/phrases/phrase_edit.php
@@ -147,7 +147,11 @@
 								$sql .= "'".check_str($_POST['phrase_detail_order'])."', ";
 								$sql .= "'".check_str($_POST['phrase_detail_tag'])."', ";
 								$sql .= "'".check_str($_POST['phrase_detail_pattern'])."', ";
-								$sql .= "'".check_str($_POST['phrase_detail_function'])."', ";
+								if ($_SESSION['recordings']['storage_type']['text'] == 'base64') {
+                                                                        $sql .= "'execute', ";
+                                                                } else {
+                                                                        $sql .= "'".check_str($_POST['phrase_detail_function'])."', ";
+                                                                }
 								$sql .= "'".check_str($_POST['phrase_detail_data'])."', ";
 								$sql .= "'".check_str($_POST['phrase_detail_method'])."', ";
 								$sql .= "'".check_str($_POST['phrase_detail_type'])."', ";
@@ -215,7 +219,11 @@
 								$sql .= "'".check_str($_POST['phrase_detail_pattern'])."', ";
 								$sql .= "'".check_str($_POST['phrase_detail_function'])."', ";
 								$sql .= "'".check_str($_POST['phrase_detail_data'])."', ";
-								$sql .= "'".check_str($_POST['phrase_detail_method'])."', ";
+								if ($_SESSION['recordings']['storage_type']['text'] == 'base64') {
+                                                                        $sql .= "'execute', ";
+                                                                } else {
+                                                                        $sql .= "'".check_str($_POST['phrase_detail_function'])."', ";
+                                                                }
 								$sql .= "'".check_str($_POST['phrase_detail_type'])."', ";
 								$sql .= "'".check_str($_POST['phrase_detail_group'])."' ";
 								$sql .= ") ";


### PR DESCRIPTION
The FreeSWITCH phrases module play function is not able to deal with executing a Lua script as is required when recordings are stored in the database, however FusionPBX is storing this as a play-file function in the database. This change forces the phrase_detail_function field to be execute when using database stored recordings as a lua script has to be run in order to extract the recording. After making this change the UI shows the action correctly and FreeSWITCH executes the phrase correctly.