### PR TITLE
Fix typo in switch.conf.xml

### DIFF
--- a/resources/templates/conf/autoload_configs/switch.conf.xml
+++ b/resources/templates/conf/autoload_configs/switch.conf.xml
@@ -116,7 +116,7 @@
 		-->
 		<!--<param name="mailer-app" value="sendmail"/>-->
 		<!--<param name="mailer-app-args" value="-t"/>-->
-		<param name="mailer-app" value="/usr/bin/php /var/www/fusionpbx/secure/v_mailto.php"/>
+		<param name="mailer-app" value="/usr/bin/php /var/www/html/fusionpbx/secure/v_mailto.php"/>
 		<param name="mailer-app-args" value="-t"/>
 		<param name="dump-cores" value="yes"/>
 		<!-- Enable verbose channel events to include every detail about a channel on every event  -->


### PR DESCRIPTION
Minor typo in the path for the mailer.