### PR TITLE
Update {$mac}.cfg

### DIFF
--- a/resources/templates/provision/yealink/t46g/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t46g/{$mac}.cfg
@@ -13,7 +13,7 @@ account.1.enable = 1
 {else}
 account.1.enable = 0
 {/if}
-account.1.label = {$account.1.display_name}
+account.1.label = {$device_label}
 account.1.display_name = {$account.1.display_name}
 account.1.auth_name = {$account.1.auth_id}
 account.1.password = {$account.1.password}


### PR DESCRIPTION
Yealink label setting is not the same as the display name setting, label, is the device label whereas the display name is the account name