### PR TITLE
Bug fix: No answer_stamp in CDR

### DIFF
--- a/app/xml_cdr/resources/classes/xml_cdr.php
+++ b/app/xml_cdr/resources/classes/xml_cdr.php
@@ -535,7 +535,7 @@ if (!class_exists('xml_cdr')) {
 									$array['call_recordings'][$x]['call_recording_name'] = $record_name;
 									$array['call_recordings'][$x]['call_recording_path'] = $record_path;
 									$array['call_recordings'][$x]['call_recording_length'] = $record_length;
-									$array['call_recordings'][$x]['call_recording_date'] =  urldecode($xml->variables->start_stamp);
+									$array['call_recordings'][$x]['call_recording_date'] = urldecode($xml->variables->start_stamp);
 									$array['call_recordings'][$x]['call_direction'] = urldecode($xml->variables->call_direction);
 									//$array['call_recordings'][$x]['call_recording_description']= $row['zzz'];
 									//$array['call_recordings'][$x]['call_recording_base64']= $row['zzz'];

--- a/app/xml_cdr/resources/classes/xml_cdr.php
+++ b/app/xml_cdr/resources/classes/xml_cdr.php
@@ -535,7 +535,7 @@ if (!class_exists('xml_cdr')) {
 									$array['call_recordings'][$x]['call_recording_name'] = $record_name;
 									$array['call_recordings'][$x]['call_recording_path'] = $record_path;
 									$array['call_recordings'][$x]['call_recording_length'] = $record_length;
-									$array['call_recordings'][$x]['call_recording_date'] =  urldecode($xml->variables->answer_stamp);
+									$array['call_recordings'][$x]['call_recording_date'] =  urldecode($xml->variables->start_stamp);
 									$array['call_recordings'][$x]['call_direction'] = urldecode($xml->variables->call_direction);
 									//$array['call_recordings'][$x]['call_recording_description']= $row['zzz'];
 									//$array['call_recordings'][$x]['call_recording_base64']= $row['zzz'];

--- a/app/xml_cdr/v_xml_cdr_import.php
+++ b/app/xml_cdr/v_xml_cdr_import.php
@@ -415,7 +415,7 @@
 						$recordings['call_recordings'][$x]['call_recording_path'] = $record_path;
 						$recordings['call_recordings'][$x]['call_recording_length'] = $record_length;
 						$recordings['call_recordings'][$x]['call_recording_description'] = $record_description;
-						$recordings['call_recordings'][$x]['call_recording_date'] = urldecode($xml->variables->answer_stamp);
+						$recordings['call_recordings'][$x]['call_recording_date'] = urldecode($xml->variables->start_stamp);
 						$recordings['call_recordings'][$x]['call_direction'] = urldecode($xml->variables->call_direction);
 						//$recordings['call_recordings'][$x]['call_recording_description']= $row['zzz'];
 						//$recordings['call_recordings'][$x]['call_recording_base64']= $row['zzz'];


### PR DESCRIPTION
Here's a fun little bug that took me a longer than it should have to figure out. When a person make a call and then cancels the request there is no "answer_stamp" written to the CDR. Because of this, v_call_recordings.call_recording_name gets imported as NULL. This causes all the canceled calls to show up in the Call Recordings app first in the list and with no date set.