### PR TITLE
[4.5] fixes null record_name and record_path fields in v_xml_cdr

### DIFF
--- a/app/xml_cdr/resources/classes/xml_cdr.php
+++ b/app/xml_cdr/resources/classes/xml_cdr.php
@@ -520,7 +520,30 @@ if (!class_exists('xml_cdr')) {
 								$record_length = urldecode($xml->variables->duration);
 							}
 						}
-
+							
+					// Last check
+						 if (!isset($record_name) || is_null ($record_name) || (strlen($record_name) == 0)) {
+							$bridge_uuid = check_str(urldecode($xml->variables->bridge_uuid));
+							$path = $_SESSION['switch']['recordings']['dir'].'/'.$domain_name.'/archive/'.$start_year.'/'.$start_month.'/'.$start_day;
+							if (file_exists($path.'/'.$bridge_uuid.'.wav')) {
+								$record_path = $path;
+								$record_name = $bridge_uuid.'.wav';
+								$record_length = urldecode($xml->variables->duration);
+							} elseif (file_exists($path.'/'.$bridge_uuid.'.mp3')) {
+								$record_path = $path;
+								$record_name = $bridge_uuid.'.mp3';
+								$record_length = urldecode($xml->variables->duration);
+							} elseif (file_exists($path.'/'.$bridge_uuid.'.wav')) {
+								$record_path = $path;
+								$record_name = $bridge_uuid.'.wav';
+								$record_length = urldecode($xml->variables->duration);
+							} elseif (file_exists($path.'/'.$bridge_uuid.'.mp3')) {
+								$record_path = $path;
+								$record_name = $bridge_uuid.'.mp3';
+								$record_length = urldecode($xml->variables->duration);
+							}
+						}
+					
 					//add the call recording
 						if (isset($record_path) && isset($record_name) && file_exists($record_path.'/'.$record_name) && $record_length > 0) {
 							//add to the xml cdr table

--- a/app/xml_cdr/v_xml_cdr_import.php
+++ b/app/xml_cdr/v_xml_cdr_import.php
@@ -370,7 +370,7 @@
 					}
 				}
 			}
-			if (!isset($record_name)) {
+			if (!isset($record_name) || is_null ($record_name) || (strlen($record_name) == 0)) {
 				$bridge_uuid = urldecode($xml->variables->bridge_uuid);
 				$path = $_SESSION['switch']['recordings']['dir'].'/'.$domain_name.'/archive/'.$start_year.'/'.$start_month.'/'.$start_day;
 				if (file_exists($path.'/'.$bridge_uuid.'.wav')) {
@@ -383,7 +383,7 @@
 					$record_length = urldecode($xml->variables->duration);
 				}
 			}
-			if (!isset($record_name)) {
+			if (!isset($record_name) || is_null ($record_name) || (strlen($record_name) == 0)) {
 				$path = $_SESSION['switch']['recordings']['dir'].'/'.$domain_name.'/archive/'.$start_year.'/'.$start_month.'/'.$start_day;
 				if (file_exists($path.'/'.$uuid.'.wav')) {
 					$record_path = $path;


### PR DESCRIPTION
when you carry on some updates from 4.0 to 4.2 and then 4.4, old dialplans do not create all the variables, record_session is created, but record_name (and record_path) are not null, set and lenght zero,  "" in other words.

Then, in the db record, record_name and record_path are empty, regardless if the recording file exists. Therefore, they are not shown in the CDR app.
This fixes this issue.