### PR TITLE
Update {$mac}.cfg

### DIFF
--- a/resources/templates/provision/polycom/5.x/{$mac}.cfg
+++ b/resources/templates/provision/polycom/5.x/{$mac}.cfg
@@ -55,6 +55,9 @@
 		{if isset($row.register_expires)}reg.{$row.line_number}.server.2.expires="{$row.register_expires}"{else}reg.{$row.line_number}.server.2.expires="{$row.register_expires}"{/if}
 
 		{/foreach}
+		
+		sec.TLS.SIP.strictCertCommonNameValidation="0"
+		sec.TLS.customCaCert.5="{$polycom_root_cert}"
 	/>
 	<DEVICE_SETTINGS
 		device.set="1"

--- a/resources/templates/provision/polycom/5.x/{$mac}.cfg
+++ b/resources/templates/provision/polycom/5.x/{$mac}.cfg
@@ -56,8 +56,8 @@
 
 		{/foreach}
 		
-		sec.TLS.SIP.strictCertCommonNameValidation="0"
-		sec.TLS.customCaCert.5="{$polycom_root_cert}"
+		{if isset($polycom_cert_validation)}sec.TLS.SIP.strictCertCommonNameValidation="{$polycom_cert_validation}"{/if}
+		{if isset($polycom_root_cert)}sec.TLS.customCaCert.5="{$polycom_root_cert}"{/if}
 	/>
 	<DEVICE_SETTINGS
 		device.set="1"
@@ -190,7 +190,7 @@
 		{if $analog_headset_option != ''}up.analogHeadsetOption="{$analog_headset_option}"{/if}
 		{if isset($polycom_onetouchvoicemail)}
 			up.oneTouchVoiceMail="{$polycom_onetouchvoicemail}"
-			{else}
+		{else}
 			up.oneTouchVoiceMail="0"
 		{/if}
 		exchange.server.url="0.0.0.0"


### PR DESCRIPTION
Polycom will not support wild  card cert only if you disable strictCertCommonNameValidation

also polycom is missing many root  certs so we need an option to push them via the template 

bot stuff was tested by me in  production and its working fine