### PR TITLE
convert local html characters like &Uuml;

### DIFF
--- a/app/fax/fax_emails.php
+++ b/app/fax/fax_emails.php
@@ -225,7 +225,7 @@ if (sizeof($result) != 0) {
 
 					if ($fax_message != '') {
 						$fax_message = strip_tags($fax_message);
-						$fax_message = str_replace("&nbsp;", "\r\n", $fax_message);
+						$fax_message = html_entity_decode($fax_message);
 						$fax_message = str_replace("\r\n\r\n", "\r\n", $fax_message);
 					}
 


### PR DESCRIPTION
Foreign language html emails were sent as received.
Now all html entities should be converted to there corresponding UTF8 characters.