### PR TITLE
[4.5] Fix the ALTER TABLE

### DIFF
--- a/resources/classes/schema.php
+++ b/resources/classes/schema.php
@@ -648,7 +648,7 @@ if (!class_exists('schema')) {
 																$sql_update .= "ALTER TABLE ".$table_name." ADD ".$field['name']." ".$field_type.";\n";
 															}
 														}
-														else{
+														else {
 															if ($field['exists'] == "false") {
 																$sql_update .= "ALTER TABLE ".$table_name." ADD ".$field['name']["text"]." ".$field_type.";\n";
 															}

--- a/resources/classes/schema.php
+++ b/resources/classes/schema.php
@@ -648,6 +648,11 @@ if (!class_exists('schema')) {
 																$sql_update .= "ALTER TABLE ".$table_name." ADD ".$field['name']." ".$field_type.";\n";
 															}
 														}
+														else{
+															if ($field['exists'] == "false") {
+																$sql_update .= "ALTER TABLE ".$table_name." ADD ".$field['name']["text"]." ".$field_type.";\n";
+															}
+														}
 													}
 												//rename fields where the name has changed
 													if (is_array($field['name'])) {


### PR DESCRIPTION
when $apps[$x]['db'][$y]['fields'][$z]['name'] is an array, you dont try to get the ['text'] index therefore fields such as v_xml_cdr.xml_uuid, v_destinations.destination_type and v_destinations.destination_number wont be created when upgrading.

This patch fixes it