### PR TITLE
fix sip_h_Diversion typo

### DIFF
--- a/app/dialplans/dialplan_detail_edit.php
+++ b/app/dialplans/dialplan_detail_edit.php
@@ -342,7 +342,7 @@ function replace_param(obj){
 		echo "	<option value='\${sip_to_uri}'>\${sip_to_uri}</option>\n";
 		echo "	<option value='\${sip_to_user}'>\${sip_to_user}</option>\n";
 		echo "	<option value='\${sip_to_host}'>\${sip_to_host}</option>\n";
-		echo "  <option value='\${sip_h_Diversion}'>\$sip_h_Diversion}</option>\n";
+		echo "  <option value='\${sip_h_Diversion}'>\${sip_h_Diversion}</option>\n";
 		echo "</optgroup>\n";
 	}
 	if (strlen($dialplan_detail_tag) == 0 || $dialplan_detail_tag == "action" || $dialplan_detail_tag == "anti-action") {

--- a/app/dialplans/dialplan_edit.php
+++ b/app/dialplans/dialplan_edit.php
@@ -705,7 +705,7 @@
 								echo "		<option value='\${sip_to_user}'>\${sip_to_user}</option>\n";
 								echo "		<option value='\${sip_to_host}'>\${sip_to_host}</option>\n";
 								echo "		<option value='\${toll_allow}'>\${toll_allow}</option>\n";
-								echo "		<option value='\${sip_h_Diversion}'>\$sip_h_Diversion}</option>\n";
+								echo "		<option value='\${sip_h_Diversion}'>\${sip_h_Diversion}</option>\n";
 								echo "	</optgroup>\n";
 							//}
 							//if (strlen($dialplan_detail_tag) == 0 || $dialplan_detail_tag == "action" || $dialplan_detail_tag == "anti-action") {


### PR DESCRIPTION
I committed the change to allow using the diversion header as a condition field a year ago and didnt notice this typo.  I apologize!