### PR TITLE
Update xml_cdr.php

### DIFF
--- a/app/xml_cdr/xml_cdr.php
+++ b/app/xml_cdr/xml_cdr.php
@@ -571,6 +571,7 @@
 						$json_string = trim($row["json"]);
 						$array = json_decode($json_string,true);
 						$remove_prefix = false;
+						$prefix = false;
 						if (is_array($array["app_log"]["application"])) {
 							foreach ($array["app_log"]["application"] as $application) {
 								$app_data = urldecode($application["@attributes"]["app_data"]);


### PR DESCRIPTION

$prefix = $prefix = substr($app_data,7); gets set in the for loop once and stays set to that value for the rest of the loop and lets the loop always go into the if ($prefix) block