### PR TITLE
Add support for PostgreSQL TLS

### DIFF
--- a/app/scripts/resources/classes/scripts.php
+++ b/app/scripts/resources/classes/scripts.php
@@ -38,6 +38,8 @@ if (!class_exists('scripts')) {
 		public $db;
 		public $db_type;
 		public $db_name;
+		public $db_secure;
+		public $db_cert_authority;
 		public $db_host;
 		public $db_port;
 		public $db_path;
@@ -61,6 +63,8 @@ if (!class_exists('scripts')) {
 			$this->db_host = $database->host;
 			$this->db_port = $database->port;
 			$this->db_path = $database->path;
+			$this->db_secure = $database->db_secure;
+			$this->db_cert_authority = $database->db_cert_authority;
 			$this->db_username = $database->username;
 			$this->db_password = $database->password;
 		}
@@ -253,8 +257,14 @@ if (!class_exists('scripts')) {
 						}
 						elseif ($this->db_type == "pgsql") {
 							if ($this->db_host == "localhost") { $this->db_host = "127.0.0.1"; }
-							$tmp .= "	database.system = \"pgsql://hostaddr=".$this->db_host." port=".$this->db_port." dbname=".$this->db_name." user=".$this->db_username." password=".$this->db_password." options=''\";\n";
-							$tmp .= "	database.switch = \"pgsql://hostaddr=".$this->db_host." port=".$this->db_port." dbname=freeswitch user=".$this->db_username." password=".$this->db_password." options=''\";\n";
+							if ($this->db_secure == true) {
+								$tmp .= "	database.system = \"pgsql://hostaddr=".$this->db_host." port=".$this->db_port." dbname=".$this->db_name." user=".$this->db_username." password=".$this->db_password." sslmode=verify-ca sslrootcert=".$this->db_cert_authority." options=''\";\n";
+								$tmp .= "	database.switch = \"pgsql://hostaddr=".$this->db_host." port=".$this->db_port." dbname=freeswitch user=".$this->db_username." password=".$this->db_password." sslmode=verify-ca sslrootcert=".$this->db_cert_authority." options=''\";\n";
+							}
+							else {
+								$tmp .= "	database.system = \"pgsql://hostaddr=".$this->db_host." port=".$this->db_port." dbname=".$this->db_name." user=".$this->db_username." password=".$this->db_password." options=''\";\n";
+								$tmp .= "	database.switch = \"pgsql://hostaddr=".$this->db_host." port=".$this->db_port." dbname=freeswitch user=".$this->db_username." password=".$this->db_password." options=''\";\n";
+							}
 						}
 						elseif ($this->db_type == "sqlite") {
 							$tmp .= "	database.system = \"sqlite://".$this->db_path."/".$this->db_name."\";\n";

--- a/resources/classes/config.php
+++ b/resources/classes/config.php
@@ -19,6 +19,8 @@ class config {
 	public $db_host;
 	public $db_path;
 	public $db_port;
+	public $db_secure;
+	public $db_cert_authority;
 	public $config_path;
 
 	/**
@@ -47,6 +49,8 @@ class config {
 	 * @var string $db_host - hostname of the database server
 	 * @var string $db_path - path of the database file
 	 * @var string $db_port - network port to connect to the database
+	 * @var bool $db_secure - whether or not to connect with SSL
+	 * @var string $db_cert_authority - location of certificate authority
 	 */
 	public function get() {
 		$this->find();
@@ -56,6 +60,8 @@ class config {
 			$this->db_name = $db_name;
 			$this->db_username = $db_username;
 			$this->db_password = $db_password;
+			$this->db_secure = $db_secure;
+			$this->db_cert_authority = $db_cert_authority;
 			$this->db_host = $db_host;
 			$this->db_path = $db_path;
 			$this->db_port = $db_port;

--- a/resources/classes/database.php
+++ b/resources/classes/database.php
@@ -35,6 +35,8 @@ include "root.php";
 			public $host;
 			public $port;
 			public $db_name;
+			public $db_secure;
+			public $db_cert_authority;
 			public $username;
 			public $password;
 			public $path;
@@ -107,6 +109,12 @@ include "root.php";
 						if (!isset($this->host) && isset($db_host)) { $this->host = $db_host; }
 						if (!isset($this->port) && isset($db_port)) { $this->port = $db_port; }
 						if (!isset($this->db_name) && isset($db_name)) { $this->db_name = $db_name; }
+						if (!isset($this->db_secure) && isset($db_secure)) {
+							$this->db_secure = $db_secure;
+						}
+						else {
+							$this->db_secure = false;
+						}
 						if (!isset($this->username) && isset($db_username)) { $this->username = $db_username; }
 						if (!isset($this->password) && isset($db_password)) { $this->password = $db_password; }
 						if (!isset($this->path) && isset($db_path)) { $this->path = $db_path; }
@@ -183,7 +191,12 @@ include "root.php";
 					try {
 						if (strlen($this->host) > 0) {
 							if (strlen($this->port) == 0) { $this->port = "5432"; }
-							$this->db = new PDO("pgsql:host=$this->host port=$this->port dbname=$this->db_name user=$this->username password=$this->password");
+							if ($this->db_secure == true) {
+								$this->db = new PDO("pgsql:host=$this->host port=$this->port dbname=$this->db_name user=$this->username password=$this->password sslmode=verify-ca sslrootcert=$this->db_cert_authority");
+							}
+							else {
+								$this->db = new PDO("pgsql:host=$this->host port=$this->port dbname=$this->db_name user=$this->username password=$this->password");
+							}
 						}
 						else {
 							$this->db = new PDO("pgsql:dbname=$this->db_name user=$this->username password=$this->password");

--- a/resources/classes/domains.php
+++ b/resources/classes/domains.php
@@ -222,6 +222,8 @@ if (!class_exists('domains')) {
 				$db_name = $config->db_name;
 				$db_username = $config->db_username;
 				$db_password = $config->db_password;
+				$db_secure = $config->db_secure;
+				$db_cert_authority = $config->db_cert_authority;
 				$db_host = $config->db_host;
 				$db_path = $config->db_path;
 				$db_port = $config->db_port;

--- a/resources/pdo.php
+++ b/resources/pdo.php
@@ -54,6 +54,12 @@
 	if (isset($dbfilename)) {
 		$db_name = $dbfilename;
 	}
+	if (isset($dbsecure)) {
+		$db_secure = $dbsecure;
+	}
+	if (isset($dbcertauthority)) {
+		$db_cert_authority = $dbcertauthority;
+	}
 
 if (!function_exists('get_db_field_names')) {
 	function get_db_field_names($db, $table, $db_name='fusionpbx') {
@@ -240,9 +246,20 @@ if ($db_type == "mysql") {
 if ($db_type == "pgsql") {
 	//database connection
 	try {
+		if (isset($db_secure)) {
+			$dbissecure = $db_secure;
+		}
+		else {
+			$dbissecure = false;
+		}
 		if (strlen($db_host) > 0) {
 			if (strlen($db_port) == 0) { $db_port = "5432"; }
-			$db = new PDO("pgsql:host=$db_host port=$db_port dbname=$db_name user=$db_username password=$db_password");
+			if ($dbissecure == true) {
+				$db = new PDO("pgsql:host=$db_host port=$db_port dbname=$db_name user=$db_username password=$db_password sslmode=verify-ca sslrootcert=$db_cert_authority");
+			}
+			else {
+				$db = new PDO("pgsql:host=$db_host port=$db_port dbname=$db_name user=$db_username password=$db_password");
+			}
 		}
 		else {
 			$db = new PDO("pgsql:dbname=$db_name user=$db_username password=$db_password");


### PR DESCRIPTION
This commit adds support for PostgreSQL TLS communication. This requires /etc/fusionpbx/config.php to have two parameters added:

$db_secure = true;
$db_cert_authority = "/path/to/ca.crt";