### PR TITLE
gives save_var_xml() more tolerance

### DIFF
--- a/resources/switch.php
+++ b/resources/switch.php
@@ -401,6 +401,12 @@ function save_var_xml() {
 
 		//get the hostname
 		$hostname = trim(event_socket_request_cmd('api switchname'));
+		if (strlen($hostname) == 0){
+			$hostname = trim(gethostname());
+		}
+		if (strlen($hostname) == 0){
+			return;
+		}
 
 		//build the xml
 		$sql = "select * from v_vars ";


### PR DESCRIPTION
when there is no local freeswitch running (big cluster deployments where Fusion UI is in another server), sometimes there is no local freeswitch running. this breaks the variables per host.

This patch gives the chance to use the hostname as a fallback option before giving up.