### PR TITLE
Fix custom variables in the CDR importer

### DIFF
--- a/app/xml_cdr/resources/classes/xml_cdr.php
+++ b/app/xml_cdr/resources/classes/xml_cdr.php
@@ -154,7 +154,9 @@ if (!class_exists('xml_cdr')) {
 			$this->fields[] = "sip_hangup_disposition";
 			if (is_array($_SESSION['cdr']['field'])) {
 				foreach ($_SESSION['cdr']['field'] as $field) {
-					$this->fields[] = $field;
+					if (!in_array($field, $this->fields)){
+						$this->fields[] = $field;
+					}
 				}
 			}
 		}
@@ -392,15 +394,19 @@ if (!class_exists('xml_cdr')) {
 							foreach ($_SESSION['cdr']['field'] as $field) {
 								$fields = explode(",", $field);
 								$field_name = end($fields);
-								$this->fields[] = $field_name;
+								if (!in_array($field_name, $this->fields))
+									$this->fields[] = $field_name;
 								if (count($fields) == 1) {
-									$this->array[$key][$field_name] = urldecode($xml->variables->$fields[0]);
+									if (is_null($this->array[$key][$field_name]))
+										$this->array[$key][$field_name] = urldecode($xml->variables->$fields[0]);
 								}
 								if (count($fields) == 2) {
-									$this->array[$key][$field_name] = urldecode($xml->$fields[0]->$fields[1]);
+									if (is_null($this->array[$key][$field_name]))
+										$this->array[$key][$field_name] = urldecode($xml->$fields[0]->$fields[1]);
 								}
 								if (count($fields) == 3) {
-									$this->array[$key][$field_name] = urldecode($xml->$fields[0]->$fields[1]->$fields[2]);
+									if (is_null($this->array[$key][$field_name]))
+										$this->array[$key][$field_name] = urldecode($xml->$fields[0]->$fields[1]->$fields[2]);
 								}
 							}
 						}

--- a/app/xml_cdr/v_xml_cdr_import.php
+++ b/app/xml_cdr/v_xml_cdr_import.php
@@ -279,19 +279,24 @@
 					$fields = explode(",", $field);
 					$field_name = end($fields);
 					if (count($fields) == 1) {
-						$database->fields[$field_name] = urldecode($array['variables'][$fields[0]]);
+						if (is_null($database->fields[$field_name]))
+							$database->fields[$field_name] = urldecode($array['variables'][$fields[0]]);
 					}
 					if (count($fields) == 2) {
-						$database->fields[$field_name] = urldecode($array[$fields[0]][$fields[1]]);
+						if (is_null($database->fields[$field_name]))
+							$database->fields[$field_name] = urldecode($array[$fields[0]][$fields[1]]);
 					}
 					if (count($fields) == 3) {
-						$database->fields[$field_name] = urldecode($array[$fields[0]][0][$fields[1]][$fields[2]]);
+						if (is_null($database->fields[$field_name]))
+							$database->fields[$field_name] = urldecode($array[$fields[0]][0][$fields[1]][$fields[2]]);
 					}
 					if (count($fields) == 4) {
-						$database->fields[$field_name] = urldecode($array[$fields[0]][$fields[1]][$fields[2]][$fields[3]]);
+						if (is_null($database->fields[$field_name]))
+							$database->fields[$field_name] = urldecode($array[$fields[0]][$fields[1]][$fields[2]][$fields[3]]);
 					}
 					if (count($fields) == 5) {
-						$database->fields[$field_name] = urldecode($array[$fields[0]][$fields[1]][$fields[2]][$fields[3]][$fields[4]]);
+						if (is_null($database->fields[$field_name]))
+							$database->fields[$field_name] = urldecode($array[$fields[0]][$fields[1]][$fields[2]][$fields[3]][$fields[4]]);
 					}
 				}
 			}


### PR DESCRIPTION
If you specify a custom column in $_SESSION['cdr']['field'], and the :;array variable is set somewhere else (class heritance?), the variable doesn't exist in the JSON, but it is already specified in the ::field and in the ::array variables.

This patch prevents the reset of those variables if they already exist.