### PR TITLE
Database Class Support for "...ies" Table Names

### DIFF
--- a/resources/classes/database.php
+++ b/resources/classes/database.php
@@ -1813,6 +1813,9 @@ include "root.php";
 			private function singular($word) {
 				//"-es" is used for words that end in "-x", "-s", "-z", "-sh", "-ch" in which case you add
 				if (substr($word, -2) == "es") {
+					if (substr($word, -3) == "ies") {
+						return substr($word,0,-3)."y";
+					}
 					if (substr($word, -3, 1) == "x") {
 						return substr($word,0,-2);
 					}


### PR DESCRIPTION
Currently, the permission checks within the class try to singularize the table name, then check for permissions based on the result.  This PR modifies the private singular() function to support table names that end in "...ies", where an _add or _edit permission likely uses a 'y' instead.  An example would be where inserting records into v_event_categories, the class should probably look for an "event_category_add" permission, instead of "event_categorie_add".  Likewise for update queries.  

This proposed change isn't foolproof, obviously. In the case of inserting or updating records in a table named v_pies, it would fail to suffice.  You're welcome to integrate a better solution, if one exists.