### PR TITLE
Update {$mac}.cfg

### DIFF
--- a/resources/templates/provision/polycom/5.x/{$mac}.cfg
+++ b/resources/templates/provision/polycom/5.x/{$mac}.cfg
@@ -171,8 +171,8 @@
 		{/if}
 		nat.keepalive.interval="30"
 		voIpProt.SIP.specialEvent.checkSync.alwaysReboot="1"
-		voIpProt.SIP.requestValidation.1.request="INVITE" 
-		voIpProt.SIP.requestValidation.1.method="source"
+		voIpProt.SIP.requestValidation.1.request={$polycom_request_validation_request}
+		voIpProt.SIP.requestValidation.1.method={$polycom_request_validation_method}
 
 		voIpProt.server.1.failOver.reRegisterOn="1"
 		voIpProt.server.1.failOver.failRegistrationOn="1"


### PR DESCRIPTION
I have experienced issues with these settings when using the server1 server2 setup with Polycom, as the phone tried to validate the server name from the INVITE that contains the tenant's domain name and it fails as the server address and the tenant's domain name are not the same IP. so my only solution was to disable  these parameters  So would be nice to control these parameters with the default settings