### PR TITLE
Little Optimization

### DIFF
--- a/core/authentication/resources/classes/authentication.php
+++ b/core/authentication/resources/classes/authentication.php
@@ -44,18 +44,28 @@ class authentication {
 	public function validate() {
 
 		//set the default authentication method to the database
-			if (!is_array($_SESSION['authentication']['methods'])) {
+			if (!is_array($_SESSION['authentication']['methods']) || !isset($_SESSION['authentication']['methods'])) {
 				$_SESSION['authentication']['methods'][]  = 'database';	
+			}
+			else {
+				// This protects against $_SESSION['authentication']['methods']['text'] and any simillar which is wrong set.
+				// It must be an array.
+				$do_fix = false;
+				foreach ($_SESSION['authentication']['methods'] as $i){
+					if (is_array($i)){
+						$do_fix = true;
+						break;
+					}
+				}
+				if ($do_fix){
+					unset($_SESSION['authentication']['methods']);
+					$_SESSION['authentication']['methods'][]  = 'database';	
+				}
 			}
 
 		//get the domain_name and domain_uuid
 			if (!isset($this->domain_name) || !isset($this->domain_uuid)) {
 				$this->get_domain();
-			}
-
-		//set the database as the default plugin
-			if (!isset($_SESSION['authentication']['methods'])) {
-				$_SESSION['authentication']['methods'][] = 'database';
 			}
 
 		//use the authentication plugins


### PR DESCRIPTION
I was doing the following test, which is similar to the authentication methods array.
<?php
$a['authentication']['something']['text'] = 'abc';
if (!is_array($a['authentication']['methods'])) {
        print 'no array'.PHP_EOL;
        $a['authentication']['methods'][] = 'database';
}
if (!isset($a['authentication']['methods'])) {
        print 'not set'.PHP_EOL;
        $a['authentication']['methods'][] = 'database';
}

print_r ($a);

The output was:
PHP Notice:  Undefined index: methods in /tmp/t.php on line 7
no array
Array
(
    [authentication] => Array
        (
            [something] => Array
                (
                    [text] => abc
                )

            [methods] => Array
                (
                    [0] => database
                )

        )

)

Therefore, no need to verify twice, a simple OR should do the same.
Also this patch protects against wront default settings, lets say someone put $_SESSION['authentication']['methods']['boolean'] = true