### PR TITLE
Duplicate uuid

### DIFF
--- a/app/yealink/app_config.php
+++ b/app/yealink/app_config.php
@@ -566,7 +566,7 @@
 		$apps[$x]['default_settings'][$y]['default_setting_enabled'] = "false";
 		$apps[$x]['default_settings'][$y]['default_setting_description'] = "Text to map the keywords contained in the Alert-info header.";
 		$y++;
-		$apps[$x]['default_settings'][$y]['default_setting_uuid'] = "f2985575-04ed-47d0-b301-059caff3bba1";
+		$apps[$x]['default_settings'][$y]['default_setting_uuid'] = "f2985575-04ed-47d0-b301-059caff3bba2";
 		$apps[$x]['default_settings'][$y]['default_setting_category'] = "provision";
 		$apps[$x]['default_settings'][$y]['default_setting_subcategory'] = "yealink_ring_text_6";
 		$apps[$x]['default_settings'][$y]['default_setting_name'] = "text";

--- a/app/yealink/app_config.php
+++ b/app/yealink/app_config.php
@@ -566,7 +566,7 @@
 		$apps[$x]['default_settings'][$y]['default_setting_enabled'] = "false";
 		$apps[$x]['default_settings'][$y]['default_setting_description'] = "Text to map the keywords contained in the Alert-info header.";
 		$y++;
-		$apps[$x]['default_settings'][$y]['default_setting_uuid'] = "f2985575-04ed-47d0-b301-059caff3bba2";
+		$apps[$x]['default_settings'][$y]['default_setting_uuid'] = "0b02df63-256c-46ed-a6e4-8099addf2af0";
 		$apps[$x]['default_settings'][$y]['default_setting_category'] = "provision";
 		$apps[$x]['default_settings'][$y]['default_setting_subcategory'] = "yealink_ring_text_6";
 		$apps[$x]['default_settings'][$y]['default_setting_name'] = "text";


### PR DESCRIPTION
The duplicate uuid of ring_text_5 and _6 produces a lot of errors in postgres log file.
Also ring_text_6 is not available in the settings.