### PR TITLE
Check for null uuid's

### DIFF
--- a/app/xml_cdr/resources/classes/xml_cdr.php
+++ b/app/xml_cdr/resources/classes/xml_cdr.php
@@ -266,7 +266,7 @@ if (!class_exists('xml_cdr')) {
 				}
 
 			//process data if the call detail record is not a duplicate
-				if ($duplicate_uuid == false) {
+				if ($duplicate_uuid == false && $uuid != null) {
 					//get the destination number
 						if ($xml->variables->current_application == "bridge") {
 							$current_application_data = urldecode($xml->variables->current_application_data);


### PR DESCRIPTION
Null UUID's are not very kind. They will sneak into your CDR's when you aren't looking and break an otherwise very nice database INSERT statement. We cannot tolerate that sort of behavior.