### PR TITLE
IBM Watson voicemail transcription

### DIFF
--- a/resources/install/scripts/app/voicemail/resources/functions/record_message.lua
+++ b/resources/install/scripts/app/voicemail/resources/functions/record_message.lua
@@ -210,6 +210,74 @@
 			        end
 			end
 
+		--Watson
+                        if (transcribe_provider == "watson") then
+                                local api_key = settings:get('voicemail', 'api_key', 'text') or '';
+                                local transcription_server = settings:get('voicemail', 'transcription_server', 'text') or '';
+                                if (api_key ~= '') then
+                                        transcribe_cmd = [[ curl -X POST -u "apikey:]]..api_key..[[" --header "Content-type: audio/wav" --data-binary @]]..file_path..[[ "]]..transcription_server..[[" ]]
+                                        local handle = io.popen(transcribe_cmd);
+                                        local transcribe_result = handle:read("*a");
+                                        handle:close();
+                                        if (debug["info"]) then
+                                                freeswitch.consoleLog("notice", "[voicemail] CMD: " .. transcribe_cmd .. "\n");
+                                                freeswitch.consoleLog("notice", "[voicemail] RESULT: " .. transcribe_result .. "\n");
+                                        end
+										
+									--Trancribe request can fail
+										if (transcribe_result == '') then
+											freeswitch.consoleLog("notice", "[voicemail] TRANSCRIPTION: (null) \n");
+											return ''
+										else
+                                        	status, transcribe_json = pcall(JSON.decode, transcribe_result);
+
+   											if not status then
+												if (debug["info"]) then
+													freeswitch.consoleLog("notice", "[voicemail] error decoding watson json\n");
+												end
+												return '';
+											end 
+										end
+
+									
+									if (transcribe_json["results"] ~= nil) then
+										--Transcription	
+											if (transcribe_json["results"][1]["alternatives"][1]["transcript"] ~= nil) then
+												transcription = '';
+												for key, row in pairs(transcribe_json["results"]) do 
+													transcription = transcription .. row["alternatives"][1]["transcript"];
+												end
+												if (debug["info"]) then
+													freeswitch.consoleLog("notice", "[voicemail] TRANSCRIPTION: " .. transcription .. "\n");
+												end
+											else
+												if (debug["info"]) then
+													freeswitch.consoleLog("notice", "[voicemail] TRANSCRIPTION: (null) \n");
+												end
+												return '';
+											end
+										--Confidence
+											if (transcribe_json["results"][1]["alternatives"][1]["confidence"]) then
+												if (debug["info"]) then
+													freeswitch.consoleLog("notice", "[voicemail] CONFIDENCE: " .. transcribe_json["results"][1]["alternatives"][1]["confidence"] .. "\n");
+												end											
+												confidence = transcribe_json["results"][1]["alternatives"][1]["confidence"];
+											else
+												if (debug["info"]) then
+													freeswitch.consoleLog("notice", "[voicemail] CONFIDENCE: (null) \n");
+												end
+											end
+											
+	                                        return transcription;
+									else
+										if (debug["info"]) then
+											freeswitch.consoleLog("notice", "[voicemail] TRANSCRIPTION: json error \n");
+										end
+										return '';	
+									end
+                                end
+                        end
+		
 			if (transcribe_provider == "custom") then
 				local transcription_server = settings:get('voicemail', 'transcription_server', 'text') or '';
 				local api_key = settings:get('voicemail', 'api_key', 'text') or '';

--- a/resources/install/scripts/app/voicemail/resources/functions/send_email.lua
+++ b/resources/install/scripts/app/voicemail/resources/functions/send_email.lua
@@ -180,6 +180,7 @@
 					body = body:gsub("${caller_id_number}", caller_id_number);
 					body = body:gsub("${message_date}", message_date);
 					if (transcription ~= nil) then
+						transcription = transcription:gsub("%%", "*");
 						body = body:gsub("${message_text}", transcription);
 					end
 					body = body:gsub("${message_duration}", message_length_formatted);


### PR DESCRIPTION
First, a big shout out to bcmike over at pbxforums for doing the bulk of the work on this code. Nice work!

The following PR is for voicemail transcription using IBM Watson.
https://cloud.ibm.com/catalog/services/speech-to-text

The following values need to be configured in Default Settings: 

Category: Voicemail
Subcategory: api_key 
type: text 
Value: [Your Watson api key ]

Category: Voicemail
Subcategory: json_enabled 
type: boolean 
Value: true

Category: Voicemail
Subcategory: transcibe_language 
type: text 
Value: en-US

Category: Voicemail
Subcategory: transcribe_provider 
type: text 
Value: watson

Category: Voicemail
Subcategory: transcription_server 
type: text 
Value: https://stream.watsonplatform.net/speech-to-text/api/v1/recognize?model=en-US_NarrowbandModel

Reload Default Settings. I Flushed Cache and Reloaded XML just for good measure. 

Also make sure transcription is set to TRUE in your voicemail box.