### PR TITLE
FollowMe external number timeout fix

### DIFF
--- a/app/calls/resources/classes/follow_me.php
+++ b/app/calls/resources/classes/follow_me.php
@@ -442,15 +442,17 @@ include "root.php";
 							}
 							elseif ($_SESSION['domain']['bridge']['text'] == "loopback") {
 								$variables[] = "is_follow_me_loopback=true";
+								$sleep_time = "sleep:".($row["follow_me_delay"] * 1000);
 								//$dial_string .= "loopback/".$row["follow_me_destination"]."/".$this->domain_name;
-								$dial_string .= "loopback/export:".implode("\,export:", $variables)."\,transfer:".$row["follow_me_destination"]."/".$this->domain_name."/inline";
+								$dial_string .= "loopback/".$sleep_time."\,export:".implode("\,export:", $variables)."\,transfer:".$row["follow_me_destination"]."/".$this->domain_name."/inline";
 							}
 							elseif ($_SESSION['domain']['bridge']['text'] == "lcr") {
 								$dial_string .= "[".implode(",", $variables)."]lcr/".$_SESSION['lcr']['profile']['text']."/".$this->domain_name."/".$row["follow_me_destination"];
 							}
 							else {
 								//$dial_string .= "loopback/".$row["follow_me_destination"]."/".$this->domain_name;
-								$dial_string .= "loopback/export:".implode("\,export:", $variables)."\,transfer:".$row["follow_me_destination"]."/".$this->domain_name."/inline";
+								$sleep_time = "sleep:".($row["follow_me_delay"] * 1000);
+								$dial_string .= "loopback/".$sleep_time."\,export:".implode("\,export:", $variables)."\,transfer:".$row["follow_me_destination"]."/".$this->domain_name."/inline";
 							}
 						}
 						else {


### PR DESCRIPTION
In a case of FollowMe external number, sleep is not treated as a command, but just set as variable named 'sleep'. This fix explicitly set `sleep` in loopback inline dialplan.