### PR TITLE
Unset Call_timeout

### DIFF
--- a/app/dialplans/resources/switch/conf/dialplan/500_follow-me-destinations.xml
+++ b/app/dialplans/resources/switch/conf/dialplan/500_follow-me-destinations.xml
@@ -2,6 +2,7 @@
 <extension name="follow-me-destinations" continue="false" app_uuid="846bbc43-683b-49e9-b697-c4714b17c528" global="true">
 	<condition field="${user_exists}" expression="^true$"/>
 	<condition field="${follow_me_enabled}" expression="^true$">
+		<action application="unset" data="call_timeout" inline="true"/>
 		<action application="lua" data="app.lua follow_me"/>
 	</condition>
 </extension>


### PR DESCRIPTION
I believe that call_timeout from the original destination should be unset, so that call_timeouts of the various follow-me destinations can work properly.