### PR TITLE
Fix delay for external follow-me calls

### DIFF
--- a/resources/install/scripts/app/ring_groups/index.lua
+++ b/resources/install/scripts/app/ring_groups/index.lua
@@ -753,6 +753,9 @@
 						dial_string = "[sip_invite_domain="..domain_name..",call_direction="..call_direction..","..group_confirm.."leg_timeout="..destination_timeout..","..delay_name.."="..destination_delay.."]" .. row.destination_number;
 					else
 						--external number
+							-- have to double destination_delay here due a FS bug requiring a 50% delay value for internal externsions, but not external calls. 
+							destination_delay = destination_delay * 2;
+							
 							route_bridge = 'loopback/'..destination_number;
 							if (extension_toll_allow ~= nil) then
 								toll_allow = extension_toll_allow:gsub(",", ":");


### PR DESCRIPTION
This is related to https://github.com/fusionpbx/fusionpbx/commit/9dcaddd81422bb46d940a2a3105112b30debcafa#diff-b1f5588538149bd825603176ff81d714.

For internal calls the delay needs to be "Delay In Seconds * 500".
For external calls the delay needs to be "Delay In Seconds * 10000". 

For external calls I'm am just doubling the value set prior in the script.