### PR TITLE
Calculate timeout for Follow-me

### DIFF
--- a/resources/install/scripts/app/ring_groups/index.lua
+++ b/resources/install/scripts/app/ring_groups/index.lua
@@ -546,7 +546,10 @@
 								else
 									new_key = #destinations + 1;
 								end
-
+								
+								--Calculate the destination_timeout for follow-me destinations.
+								--The call should honor ring group timeouts with rg delays, follow-me timeouts and follow-me delays factored in.
+								--Destinations with a timeout of 0 or negative numbers should be ignored. 
 								if (tonumber(field.destination_timeout) < (tonumber(row.destination_timeout) - tonumber(field.destination_delay))) then
 									new_destination_timeout = field.destination_timeout;
 								else

--- a/resources/install/scripts/app/ring_groups/index.lua
+++ b/resources/install/scripts/app/ring_groups/index.lua
@@ -547,6 +547,12 @@
 									new_key = #destinations + 1;
 								end
 
+								if (tonumber(field.destination_timeout) < (tonumber(row.destination_timeout) - tonumber(field.destination_delay))) then
+									new_destination_timeout = field.destination_timeout;
+								else
+									new_destination_timeout = row.destination_timeout - field.destination_delay;
+								end
+
 								--add to the destinations array
 								destinations[new_key] = {}
 								destinations[new_key]['ring_group_strategy'] = row.ring_group_strategy;
@@ -561,11 +567,7 @@
 								destinations[new_key]['domain_name'] = field.domain_name;
 								destinations[new_key]['destination_number'] = field.destination_number;
 								destinations[new_key]['destination_delay'] = field.destination_delay + row.destination_delay;
-								if (tonumber(field.destination_timeout) < (tonumber(row.destination_timeout) - tonumber(field.destination_delay))) then
-									destinations[new_key]['destination_timeout'] = field.destination_timeout;
-								else
-									destinations[new_key]['destination_timeout'] = row.destination_timeout - field.destination_delay;
-								end
+								destinations[new_key]['destination_timeout'] = new_destination_timeout;
 								destinations[new_key]['destination_prompt'] = field.destination_prompt;
 								destinations[new_key]['group_confirm_key'] = row.group_confirm_key;
 								destinations[new_key]['group_confirm_file'] = row.group_confirm_file;


### PR DESCRIPTION
Need to calculate the timeout for Enterprise RG members that have extensions with follow-me. 

The RG timeout should always take precedence over a follow-me timeout value. What we do is take the delay of the follow-me destination and subtract that from the ring group timeout to give us the total timeout of the destination. 

Example: 
RG 1: x1000 (Delay=0, Timeout=10)
RG 2: x2000 (Delay=10, Timeout=10)

x2000 has follow-me enabled
FM 1: x2000 (Delay=0, Timeout=15)
FM 2: x3000 (Delay=5, Timeout=20)

In this example we would want x2000 ring for 10 seconds and x3000 to ring for 5 seconds. 

What if we changed this... FM 2: x3000 (Delay 15, Timeout=20)

In this example we wouldn't want x3000 to ring at all because it would start to ring after the RG timeout has expired. Our calculated value would be a negative value, -5. These negative values don't work as leg_timeouts in the dialstring, so we need to test for them.