### PR TITLE
Update do_not_disturb.lua

### DIFF
--- a/resources/install/scripts/do_not_disturb.lua
+++ b/resources/install/scripts/do_not_disturb.lua
@@ -177,7 +177,7 @@
 		sql = sql .. "do_not_disturb = 'true', ";
 		sql = sql .. "forward_all_enabled = 'false' ";
 	else
-		sql = sql .. "dial_string = :dial_string, ";
+		sql = sql .. "dial_string = null, ";
 		sql = sql .. "do_not_disturb = 'false' ";
 	end
 	sql = sql .. "where domain_uuid = :domain_uuid ";


### PR DESCRIPTION
The SQL query was broken it always set the dial_string to error/user_busy should be null when disabling DND