### PR TITLE
default setting to remove prefix on cdr page

### DIFF
--- a/app/xml_cdr/app_config.php
+++ b/app/xml_cdr/app_config.php
@@ -135,6 +135,14 @@
 		$apps[$x]['default_settings'][$y]['default_setting_enabled'] = "true";
 		$apps[$x]['default_settings'][$y]['default_setting_description'] = "";
 		$y++;
+		$apps[$x]['default_settings'][$y]['default_setting_uuid'] = "53c56ddb-bd20-4fbd-b646-1ca9f8d2af11";
+		$apps[$x]['default_settings'][$y]['default_setting_category'] = "cdr";
+		$apps[$x]['default_settings'][$y]['default_setting_subcategory'] = "cut_prefix";
+		$apps[$x]['default_settings'][$y]['default_setting_name'] = "text";
+		$apps[$x]['default_settings'][$y]['default_setting_value'] = "false";
+		$apps[$x]['default_settings'][$y]['default_setting_enabled'] = "false";
+		$apps[$x]['default_settings'][$y]['default_setting_description'] = "Cuts outbound calls prefix on cdr page";
+		$y++;
 		$apps[$x]['default_settings'][$y]['default_setting_uuid'] = "cdb19dda-234b-407a-9eda-e8af74597d4b";
 		$apps[$x]['default_settings'][$y]['default_setting_category'] = "cdr";
 		$apps[$x]['default_settings'][$y]['default_setting_subcategory'] = "limit";

--- a/app/xml_cdr/app_config.php
+++ b/app/xml_cdr/app_config.php
@@ -138,10 +138,10 @@
 		$apps[$x]['default_settings'][$y]['default_setting_uuid'] = "53c56ddb-bd20-4fbd-b646-1ca9f8d2af11";
 		$apps[$x]['default_settings'][$y]['default_setting_category'] = "cdr";
 		$apps[$x]['default_settings'][$y]['default_setting_subcategory'] = "remove_prefix";
-		$apps[$x]['default_settings'][$y]['default_setting_name'] = "text";
+		$apps[$x]['default_settings'][$y]['default_setting_name'] = "boolean";
 		$apps[$x]['default_settings'][$y]['default_setting_value'] = "false";
 		$apps[$x]['default_settings'][$y]['default_setting_enabled'] = "false";
-		$apps[$x]['default_settings'][$y]['default_setting_description'] = "Cuts outbound calls prefix on cdr page";
+		$apps[$x]['default_settings'][$y]['default_setting_description'] = "Remove outbound prefix in the call detail records.";
 		$y++;
 		$apps[$x]['default_settings'][$y]['default_setting_uuid'] = "cdb19dda-234b-407a-9eda-e8af74597d4b";
 		$apps[$x]['default_settings'][$y]['default_setting_category'] = "cdr";

--- a/app/xml_cdr/app_config.php
+++ b/app/xml_cdr/app_config.php
@@ -137,7 +137,7 @@
 		$y++;
 		$apps[$x]['default_settings'][$y]['default_setting_uuid'] = "53c56ddb-bd20-4fbd-b646-1ca9f8d2af11";
 		$apps[$x]['default_settings'][$y]['default_setting_category'] = "cdr";
-		$apps[$x]['default_settings'][$y]['default_setting_subcategory'] = "cut_prefix";
+		$apps[$x]['default_settings'][$y]['default_setting_subcategory'] = "remove_prefix";
 		$apps[$x]['default_settings'][$y]['default_setting_name'] = "text";
 		$apps[$x]['default_settings'][$y]['default_setting_value'] = "false";
 		$apps[$x]['default_settings'][$y]['default_setting_enabled'] = "false";


### PR DESCRIPTION
There was added a feature a while ago that removes outbound calls prefix on the CDR page, but people don't know about it because the setting was never added to the default settings