### PR TITLE
Update {$mac}.cfg

### DIFF
--- a/resources/templates/provision/polycom/5.x/{$mac}.cfg
+++ b/resources/templates/provision/polycom/5.x/{$mac}.cfg
@@ -69,7 +69,7 @@
 		{if isset($dns_server_secondary)}device.dns.altSrvAddress="{$dns_server_secondary}"{/if}
 		{if isset($polycom_provision_url)}
 		device.prov.serverName.set="1"
-		device.prov.serverName="{$polycom_provision_url}"
+		device.prov.serverName="{$domain_name}{$polycom_provision_url}"
 		device.prov.serverType.set="1"
 		device.prov.serverType="{$polycom_server_type}"
 		device.prov.user.set="1"
@@ -77,8 +77,6 @@
 		device.prov.password.set="1"
 		device.prov.password="{$http_auth_password}"
 		device.prov.tagSerialNo="1"
-		{else}
-		device.prov.serverName="{$domain_name}"
 		{/if}
 		{if isset($polycom_syslog_server)}
 		device.syslog.serverName.set="1"


### PR DESCRIPTION
removed {else} as this is a dead function if no device set=1 is also added.

also added {$domain_name} to provisioning url to simplify new domain setups