### PR TITLE
Update {$mac}.cfg

### DIFF
--- a/resources/templates/provision/polycom/5.x/{$mac}.cfg
+++ b/resources/templates/provision/polycom/5.x/{$mac}.cfg
@@ -78,7 +78,15 @@
 		device.prov.password="{$http_auth_password}"
 		device.prov.tagSerialNo="1"
 		{else}
-		device.prov.serverName="{$domain_name}"
+		device.prov.serverName.set="1"
+		device.prov.serverName="{$domain_name}/app/provision/"
+		device.prov.serverType.set="1"
+		device.prov.serverType="{$polycom_server_type}"
+		device.prov.user.set="1"
+		device.prov.user="{$http_auth_username}"
+		device.prov.password.set="1"
+		device.prov.password="{$http_auth_password}"
+		device.prov.tagSerialNo="1"
 		{/if}
 		{if isset($polycom_syslog_server)}
 		device.syslog.serverName.set="1"


### PR DESCRIPTION
this should satisfy exsisting using polycom_provision_url and allow to have it global so each domain does not need to have a path attached to it.