### PR TITLE
Update {$mac}.cfg

### DIFF
--- a/resources/templates/provision/polycom/5.x/{$mac}.cfg
+++ b/resources/templates/provision/polycom/5.x/{$mac}.cfg
@@ -74,7 +74,6 @@
 		device.prov.serverName.set="1"
 		device.prov.serverName="{$domain_name}/app/provision/"
 		{/if}
-		device.prov.serverName="{$polycom_provision_url}"
 		device.prov.serverType.set="1"
 		device.prov.serverType="{$polycom_server_type}"
 		device.prov.user.set="1"

--- a/resources/templates/provision/polycom/5.x/{$mac}.cfg
+++ b/resources/templates/provision/polycom/5.x/{$mac}.cfg
@@ -70,6 +70,11 @@
 		{if isset($polycom_provision_url)}
 		device.prov.serverName.set="1"
 		device.prov.serverName="{$polycom_provision_url}"
+		{else}
+		device.prov.serverName.set="1"
+		device.prov.serverName="{$domain_name}/app/provision/"
+		{/if}
+		device.prov.serverName="{$polycom_provision_url}"
 		device.prov.serverType.set="1"
 		device.prov.serverType="{$polycom_server_type}"
 		device.prov.user.set="1"
@@ -77,9 +82,6 @@
 		device.prov.password.set="1"
 		device.prov.password="{$http_auth_password}"
 		device.prov.tagSerialNo="1"
-		{else}
-		device.prov.serverName="{$domain_name}"
-		{/if}
 		{if isset($polycom_syslog_server)}
 		device.syslog.serverName.set="1"
 		device.syslog.serverName="{$polycom_syslog_server}"


### PR DESCRIPTION
this should satisfy exsisting pbx setups using polycom_provision_url and allow to have it global so each domain does not need to have a path attached to it. (this method is the same being used in most other templates)