### PR TITLE
Registrations page: Parse for LAN IP in "Contact" field

### DIFF
--- a/app/registrations/resources/classes/registrations.php
+++ b/app/registrations/resources/classes/registrations.php
@@ -54,8 +54,8 @@ if (!class_exists('registrations')) {
 							if ($xml_response == "Invalid Profile!") { $xml_response = "<error_msg>".$text['label-message']."</error_msg>"; }
 							$xml_response = str_replace("<profile-info>", "<profile_info>", $xml_response);
 							$xml_response = str_replace("</profile-info>", "</profile_info>", $xml_response);
-                            $xml_response = str_replace("&lt;", "", $xml_response);
-                            $xml_response = str_replace("&gt;", "", $xml_response);
+							$xml_response = str_replace("&lt;", "", $xml_response);
+							$xml_response = str_replace("&gt;", "", $xml_response);
 							if (strlen($xml_response) > 101) {
 								try {
 									$xml = new SimpleXMLElement($xml_response);
@@ -119,10 +119,10 @@ if (!class_exists('registrations')) {
 																}
 											$registrations[$id]['lan-ip'] = $lan_ip;
 										}
-                                        else if (preg_match('/\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}/', $row['contact'], $ip_match)) {
-                                            $lan_ip = preg_replace('/_/', '.', $ip_match[0]);
-                                            $registrations[$id]['lan-ip'] = "$lan_ip";
-                                        }
+										else if (preg_match('/\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}/', $row['contact'], $ip_match)) {
+										    $lan_ip = preg_replace('/_/', '.', $ip_match[0]);
+										    $registrations[$id]['lan-ip'] = "$lan_ip";
+										}
 										else {
 											$registrations[$id]['lan-ip'] = '';
 										}

--- a/app/registrations/resources/classes/registrations.php
+++ b/app/registrations/resources/classes/registrations.php
@@ -54,6 +54,8 @@ if (!class_exists('registrations')) {
 							if ($xml_response == "Invalid Profile!") { $xml_response = "<error_msg>".$text['label-message']."</error_msg>"; }
 							$xml_response = str_replace("<profile-info>", "<profile_info>", $xml_response);
 							$xml_response = str_replace("</profile-info>", "</profile_info>", $xml_response);
+                            $xml_response = str_replace("&lt;", "", $xml_response);
+                            $xml_response = str_replace("&gt;", "", $xml_response);
 							if (strlen($xml_response) > 101) {
 								try {
 									$xml = new SimpleXMLElement($xml_response);
@@ -117,6 +119,10 @@ if (!class_exists('registrations')) {
 																}
 											$registrations[$id]['lan-ip'] = $lan_ip;
 										}
+                                        else if (preg_match('/\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}/', $row['contact'], $ip_match)) {
+                                            $lan_ip = preg_replace('/_/', '.', $ip_match[0]);
+                                            $registrations[$id]['lan-ip'] = "$lan_ip";
+                                        }
 										else {
 											$registrations[$id]['lan-ip'] = '';
 										}


### PR DESCRIPTION
1. Registrations XML from Freeswitch contains invalid characters '&gt' and '&lt' in the contact field; stripped. 
2. Registrations does not parse the Freeswitch 'Contact' field for a Yealink (or other) LAN IP address; added condition.