### PR TITLE
Match mixed case in "from" address

### DIFF
--- a/app/fax/fax_edit.php
+++ b/app/fax/fax_edit.php
@@ -246,7 +246,7 @@
 						foreach ($fax_email_outbound_authorized_senders as $sender_num => $sender) {
 							if ($sender == '' || !valid_email($sender)) { unset($fax_email_outbound_authorized_senders[$sender_num]); }
 						}
-						$fax_email_outbound_authorized_senders = implode(',', $fax_email_outbound_authorized_senders);
+						$fax_email_outbound_authorized_senders = strtolower(implode(',', $fax_email_outbound_authorized_senders));
 					}
 
 				if ($action == "add" && permission_exists('fax_extension_add')) {


### PR DESCRIPTION
RFC's do not specify addresses must be converted lower case by email servers. If a sender has set their "from" address set to a mixed case string, the fax send will not match the authorized senders. This ensures newly entered authorized senders are now stored as lower case.