### PR TITLE
[4.4] Fix the confirmation

### DIFF
--- a/app/calls/resources/classes/follow_me.php
+++ b/app/calls/resources/classes/follow_me.php
@@ -311,7 +311,7 @@ include "root.php";
 				$x = 0;
 				if (is_array($result)) foreach ($result as &$row) {
 					if ($x > 0) {
-						$dial_string .= ",";
+						$dial_string .= ":_:";
 					}
 
 					//determine if the destination is a local sip user


### PR DESCRIPTION
When the confirmation number is not a local extension (aka cellphone), you need to use enterprise in order to make the confirm to work, otherwise, it will answer right away (no prompt)


I think you have these already fixed in 4.5, I was reading you are using enterprise. I am not sure if you switch to the enterprise mode when you find an external number.