### PR TITLE
Devices Page - Show only Assigned Devices to User Level

### DIFF
--- a/app/devices/app_config.php
+++ b/app/devices/app_config.php
@@ -193,6 +193,10 @@
 		$apps[$x]['permissions'][$y]['name'] = "device_all";
 		$apps[$x]['permissions'][$y]['groups'][] = "superadmin";
 		$y++;
+		$apps[$x]['permissions'][$y]['name'] = "device_domain_all";
+		$apps[$x]['permissions'][$y]['groups'][] = "superadmin";
+		$apps[$x]['permissions'][$y]['groups'][] = "admin";
+		$y++;
 		$apps[$x]['permissions'][$y]['name'] = "device_vendor";
 		$apps[$x]['permissions'][$y]['groups'][] = "superadmin";
 		$apps[$x]['permissions'][$y]['groups'][] = "admin";

--- a/app/devices/devices.php
+++ b/app/devices/devices.php
@@ -54,13 +54,14 @@
 	$sql = "select count(*) from v_devices ";
 	$sql .= "where domain_uuid = :domain_uuid ";
 	if (!permission_exists('device_all') && !permission_exists('device_domain_all')) {
-		$sql .= "and device_user_uuid ='".$_SESSION['user_uuid']."' ";
+		$sql .= "and device_user_uuid = :user_uuid ";
+		$parameters['user_uuid'] = $_SESSION['user_uuid'];
 	}
 	$parameters['domain_uuid'] = $_SESSION['domain_uuid'];
 	$database = new database;
 	$total_devices = $database->select($sql, $parameters, 'column');
 	unset($sql, $parameters);
-	
+
 //get the devices profiles
 	$sql = "select * from v_device_profiles ";
 	$sql .= "where domain_uuid = :domain_uuid ";
@@ -137,7 +138,8 @@
 		$parameters['domain_uuid'] = $domain_uuid;
 	}
 	if (!permission_exists('device_all') && !permission_exists('device_domain_all')) {
-		$sql .= "and d.device_user_uuid ='{$_SESSION['user_uuid']}' ";
+		$sql .= "and d.device_user_uuid = :user_uuid ";
+		$parameters['user_uuid'] = $_SESSION['user_uuid'];
 	}
 	if (strlen($search) > 0) {
 		$sql .= "and (";

--- a/app/devices/devices.php
+++ b/app/devices/devices.php
@@ -53,11 +53,14 @@
 //get total devices count from the database
 	$sql = "select count(*) from v_devices ";
 	$sql .= "where domain_uuid = :domain_uuid ";
+	if (!permission_exists('device_all') && !permission_exists('device_domain_all')) {
+		$sql .= "and device_user_uuid ='".$_SESSION['user_uuid']."' ";
+	}
 	$parameters['domain_uuid'] = $_SESSION['domain_uuid'];
 	$database = new database;
 	$total_devices = $database->select($sql, $parameters, 'column');
 	unset($sql, $parameters);
-
+	
 //get the devices profiles
 	$sql = "select * from v_device_profiles ";
 	$sql .= "where domain_uuid = :domain_uuid ";
@@ -133,6 +136,9 @@
 		$sql .= ") ";
 		$parameters['domain_uuid'] = $domain_uuid;
 	}
+	if (!permission_exists('device_all') && !permission_exists('device_domain_all')) {
+		$sql .= "and d.device_user_uuid ='{$_SESSION['user_uuid']}' ";
+	}
 	if (strlen($search) > 0) {
 		$sql .= "and (";
 		$sql .= "	lower(d.device_mac_address) like :search ";
@@ -170,7 +176,7 @@
 	echo "<table width='100%' cellpadding='0' cellspacing='0' border='0'>\n";
 	echo "	<tr>\n";
 	echo "		<td width='100%' align='left' valign='top'>\n";
-	echo "			<b>".$text['header-devices']." (".$num_rows.")</b>\n";
+	echo "			<b>".$text['header-devices']." (".$total_devices.")</b>\n";
 	echo "		</td>\n";
 	echo "		<td align='right' nowrap='nowrap' valign='top'>\n";
 	echo "			<form method='get' action=''>\n";


### PR DESCRIPTION
This makes a permission change on the devices page to list only devices assigned to a particular user if they do not have device_all or device_domain_all permissions.

Note that device_domain_all is a new permission that has been added. The concept is that this permission could be assigned to admins which would allow them to see all devices on their particular domain, without having access to the "Show all" button.

To see how this works, assign device_view and device_edit permissions to a user-level user that has an extension assigned to them. They will now be able to see their assigned devices on the devices.php page and no other user's devices.