### PR TITLE
Update record_message.lua

### DIFF
--- a/resources/install/scripts/app/voicemail/resources/functions/record_message.lua
+++ b/resources/install/scripts/app/voicemail/resources/functions/record_message.lua
@@ -466,7 +466,7 @@
 				mkdir(voicemail_dir.."/"..voicemail_id);
 				if (vm_message_ext == "mp3") then
 					shout_exists = trim(api:execute("module_exists", "mod_shout"));
-					if (shout_exists == "true" and transcribe_enabled == "false") or (shout_exists == "true" and transcribe_enabled == "true" and voicemail_transcription_enabled == "false") then
+					if (shout_exists == "true" and transcribe_enabled == "false") or (shout_exists == "true" and transcribe_enabled == "true" and voicemail_transcription_enabled ~= "true") then
 						freeswitch.consoleLog("notice", "using mod_shout for mp3 encoding\n");
 						--record in mp3 directly
 							result = session:recordFile(voicemail_dir.."/"..voicemail_id.."/msg_"..uuid..".mp3", message_max_length, message_silence_threshold, message_silence_seconds);


### PR DESCRIPTION
When we have MP3 enabled we want ALL voicemails to be MP3 EXCEPT the ones that need to be transcribed, which will be WAV.

When transcribe_enabled is set to true, ALL voicemails currently become WAV even when MP3 is set.

This change ensures that ALL voicemails remain MP3 except the extensions that have voicemail_transcription_enabled set to true.

Note: The reason this was not working is because setting transcribe_enabled to true also sets voicemail_transcription_enabled to false for ALL extensions BUT it is not written into the database. Therefore a SAVE is required for ALL voicemails to ensure this field is written to the database. Changing to ~=true gets around this problem.