### PR TITLE
We do not need PROJECT_PATH

### DIFF
--- a/core/domains/domain_edit.php
+++ b/core/domains/domain_edit.php
@@ -650,7 +650,7 @@
 
 	if ($action == "update" && permission_exists('domain_setting_view')) {
 		echo "<br />\n";
-		require PROJECT_PATH."core/domain_settings/domain_settings.php";
+		require "core/domain_settings/domain_settings.php";
 	}
 
 //include the footer


### PR DESCRIPTION
Since the project update the include_path variable PHP, adding here PROJECT_PATH creates an error:

Sun Oct 27 04:39:31.464973 2019] [:error] [pid 3472] [client 104.222.127.252:40696] PHP Fatal error:  require(): Failed opening required '/fusionpbxcore/domain_settings/domain_settings.php' (include_path='.:/usr/share/pear:/usr/share/php:/var/www/html/fusionpbx') in /var/www/html/fusionpbx/core/domains/domain_edit.php on line 698, referer: http://208.167.253.86/fusionpbx/core/domains/domain_edit.p

/fusionpbx/core/..../domain_settings.php could not be found.