### PR TITLE
Update destination_edit.php

### DIFF
--- a/app/destinations/destination_edit.php
+++ b/app/destinations/destination_edit.php
@@ -154,8 +154,14 @@
 			if ($destination_type == 'inbound' && $destination_number != $db_destination_number) {
 				$sql = "select count(*) from v_destinations ";
 				$sql .= "where (destination_number = :destination_number or destination_prefix || destination_number = :destination_number) ";
+				if ($action == "update") {
+					$sql .= "and destination_uuid != :destination_uuid ";
+				}
 				$sql .= "and destination_type = 'inbound' ";
 				$parameters['destination_number'] = $destination_number;
+				if ($action == "update") {
+					$parameters['destination_uuid'] = $destination_uuid;
+				}
 				$database = new database;
 				$num_rows = $database->select($sql, $parameters, 'column');
 				if ($num_rows > 0) {


### PR DESCRIPTION
when removing the prefix from the prefix field and putting it to the destination field causes a duplicate error because the sql query counts existing destinations in the database that matches the destination number and includes the destination that it tries to update in the count . fixed by omitting the  destination that's being updated from getting counted in the sql