### PR TITLE
Dashboards disk usage ability to choose partition

### DIFF
--- a/core/default_settings/app_config.php
+++ b/core/default_settings/app_config.php
@@ -429,6 +429,14 @@
 		$apps[$x]['default_settings'][$y]['default_setting_enabled'] = "true";
 		$apps[$x]['default_settings'][$y]['default_setting_description'] = "Enable Dashboard Call Center Agent Status block for users in the agent group.";
 		$y++;
+		$apps[$x]['default_settings'][$y]['default_setting_uuid'] = "5da8cd79-7d3d-4842-97a9-40e91f96f34b";
+		$apps[$x]['default_settings'][$y]['default_setting_category'] = "dashboard";
+		$apps[$x]['default_settings'][$y]['default_setting_subcategory'] = "";
+		$apps[$x]['default_settings'][$y]['default_setting_name'] = "disk_usage_partition";
+		$apps[$x]['default_settings'][$y]['default_setting_value'] = "/home";
+		$apps[$x]['default_settings'][$y]['default_setting_enabled'] = "false";
+		$apps[$x]['default_settings'][$y]['default_setting_description'] = "Sets the partition to show  for disk usage.";
+		$y++;
 		$apps[$x]['default_settings'][$y]['default_setting_uuid'] = "85d79c4e-4689-4d8e-b87d-5edd5b1574b1";
 		$apps[$x]['default_settings'][$y]['default_setting_category'] = "cache";
 		$apps[$x]['default_settings'][$y]['default_setting_subcategory'] = "method";

--- a/core/user_settings/user_dashboard.php
+++ b/core/user_settings/user_dashboard.php
@@ -964,7 +964,12 @@
 
 			//disk usage
 			if (PHP_OS == 'FreeBSD' || PHP_OS == 'Linux') {
-				$tmp = shell_exec("df /home 2>&1");
+				if ($_SESSION['dashboard']['disk_usage_partition']['text']) {
+					$disk_usage_partition = $_SESSION['dashboard']['disk_usage_partition']['text'];
+				} else {
+					$disk_usage_partition = "/home";
+				}
+				$tmp = shell_exec("df ".$disk_usage_partition." 2>&1");
 				$tmp = explode("\n", $tmp);
 				$tmp = preg_replace('!\s+!', ' ', $tmp[1]); // multiple > single space
 				$tmp = explode(' ', $tmp);


### PR DESCRIPTION
Disk usage currently hard coded to use the ```/home``` partition. On some systems the home partition resides on a separate partition than the root so would be nice to be able to choose