### PR TITLE
SMS bugfix

### DIFF
--- a/app/voicemails/app_config.php
+++ b/app/voicemails/app_config.php
@@ -92,6 +92,10 @@
 		$apps[$x]['permissions'][$y]['groups'][] = "superadmin";
 		$apps[$x]['permissions'][$y]['groups'][] = "admin";
 		$y++;
+		$apps[$x]['permissions'][$y]['name'] = "voicemail_sms_edit";
+		$apps[$x]['permissions'][$y]['groups'][] = "superadmin";
+		$apps[$x]['permissions'][$y]['groups'][] = "admin";
+		$y++;
 		$apps[$x]['permissions'][$y]['name'] = "voicemail_local_after_email";
 		$apps[$x]['permissions'][$y]['groups'][] = "superadmin";
 		$apps[$x]['permissions'][$y]['groups'][] = "admin";

--- a/app/voicemails/voicemail_edit.php
+++ b/app/voicemails/voicemail_edit.php
@@ -553,7 +553,7 @@
 	echo "</td>\n";
 	echo "</tr>\n";
 
-	if (permission_exists('sms_edit')) {
+	if (permission_exists('voicemail_sms_edit')) {
 		echo "<tr>\n";
 		echo "<td class='vncell' valign='top' align='left' nowrap='nowrap'>\n";
 		echo "	".$text['label-voicemail_sms_to']."\n";

--- a/resources/install/scripts/app/voicemail/resources/functions/send_sms.lua
+++ b/resources/install/scripts/app/voicemail/resources/functions/send_sms.lua
@@ -77,7 +77,9 @@
 					message_length_formatted = format_seconds(message_length);
 					if (debug["info"]) then
 						freeswitch.consoleLog("notice", "[voicemail-sms] message length: " .. message_length .. "\n");
-						freeswitch.consoleLog("notice", "[voicemail-sms] transcription: " .. transcription .. "\n");
+						if (transcription ~= nil) then
+							freeswitch.consoleLog("notice", "[voicemail-sms] transcription: " .. transcription .. "\n");
+						end
 						freeswitch.consoleLog("notice", "[voicemail-sms] domain_name: " .. domain_name .. "\n");
 					end
 					local message_date = os.date("%A, %d %b %Y %I:%M %p", created_epoch)


### PR DESCRIPTION
This SMS bugfix works out two issues:
* SMS permissions were not properly included. This causes SMS functionality to be inaccessible if the system implementor works out a Lua SMS implementation
* If voicemail transcription doesn't exist for the voicemail the send_sms.lua script crashes. Added a nil check to prevent this.