### PR TITLE
Fix SQL in cidlookup script.

### DIFF
--- a/resources/install/scripts/cidlookup.lua
+++ b/resources/install/scripts/cidlookup.lua
@@ -87,7 +87,6 @@
 		sql = "SELECT v_contacts.contact_name_given || ' ' || v_contacts.contact_name_family AS name FROM v_contacts ";
 	end
 	sql = sql .. "INNER JOIN v_contact_phones ON v_contact_phones.contact_uuid = v_contacts.contact_uuid ";
-	sql = sql .. "INNER JOIN v_destinations ON v_destinations.domain_uuid = v_contacts.domain_uuid AND v_destinations.destination_number = :caller";
 	
 	local params;
 	if ((not domain_uuid) or (domain_uuid == "")) then


### PR DESCRIPTION
1. There should be a space at the end of line. Otherwise, resulting SQL has "callerWHERE" error.
sql = sql .. "INNER JOIN v_destinations ON v_destinations.domain_uuid = v_contacts.domain_uuid AND v_destinations.destination_number = :caller";
2. Destination number will never match with caller's number. The result will be nil.
        v_destinations.destination_number = :caller
3. There is no reason to join destination table at all. It just multiplies the number of rows in the result.