### PR TITLE
Update {$mac}.cfg

### DIFF
--- a/resources/templates/provision/htek/uc924/{$mac}.cfg
+++ b/resources/templates/provision/htek/uc924/{$mac}.cfg
@@ -816,8 +816,8 @@
         <P1401 para="Preference.AlertGroupText" />
         <P1404 para="Preference.AlertGroupText">0</P1404>
         <P20017 para="Preference.RefreshCallerIdViaContact">0</P20017>
-        <P20019 para="Preference.HeadSetPriority">0</P20019>
-        <P20020 para="Preference.RingerDeviceForHeadSet">0</P20020>
+        <P20019 para="Preference.HeadSetPriority"></P20019>
+        <P20020 para="Preference.RingerDeviceForHeadSet"></P20020>
         <P8621 para="Preference.LcdLanguage">0</P8621>
         <P56203 para="Preference.BusyToneTimer">4</P56203>
         <P23126 para="Preference.Autologouttime">6</P23126>


### PR DESCRIPTION
These settings are for EHS/HEADSETS.  The template has them set to 0 (Disabled).. So when they get enabled, they end up going back to disabled once phone provisions. I deleted the 0 and left it blank.