### PR TITLE
Allow permission to export devices and extensions to be assigned to groups

### DIFF
--- a/app/devices/app_config.php
+++ b/app/devices/app_config.php
@@ -320,6 +320,9 @@
 		$apps[$x]['permissions'][$y]['name'] = 'device_profile_setting_all';
 		$apps[$x]['permissions'][$y]['groups'][] = 'superadmin';
 		$y++;
+		$apps[$x]['permissions'][$y]['name'] = 'device_export';
+		$apps[$x]['permissions'][$y]['groups'][] = 'superadmin';
+		$y++;
 
 	//default settings
 		$y = 0;

--- a/app/devices/device_download.php
+++ b/app/devices/device_download.php
@@ -31,13 +31,13 @@
 	require_once "resources/paging.php";
 
 //check permissions
-	if (if_group("superadmin")) {
-		//access granted
-	}
-	else {
-		echo "access denied";
-		exit;
-	}
+        if (permission_exists('device_export')) {
+                //access granted
+        }
+        else {
+                echo "access denied";
+                exit;
+        }
 
 //add multi-lingual support
 	$language = new text;

--- a/app/extensions/app_config.php
+++ b/app/extensions/app_config.php
@@ -187,6 +187,9 @@
 		$y++;
 		$apps[$x]['permissions'][$y]['name'] = "extension_copy";
 		$apps[$x]['permissions'][$y]['groups'][] = "superadmin";
+		$y++;
+		$apps[$x]['permissions'][$y]['name'] = "extension_export";
+		$apps[$x]['permissions'][$y]['groups'][] = "superadmin";
 
 	//default settings
 		$y=0;

--- a/app/extensions/extension_download.php
+++ b/app/extensions/extension_download.php
@@ -31,13 +31,13 @@
 	require_once "resources/paging.php";
 
 //check permissions
-	if (if_group("superadmin")) {
-		//access granted
-	}
-	else {
-		echo "access denied";
-		exit;
-	}
+        if (permission_exists('extension_export')) {
+                //access granted
+        }
+        else {
+                echo "access denied";
+                exit;
+        }
 
 //add multi-lingual support
 	$language = new text;


### PR DESCRIPTION
Add new permissions extension_export and device_export which may be assigned under group manager. Default only allows superadmin.