### PR TITLE
Incorrect SQL query in groups

### DIFF
--- a/core/groups/groups.php
+++ b/core/groups/groups.php
@@ -92,7 +92,7 @@
 	}
 
 //get the count
-	$sql = "select count(*) from view_groups ";
+	$sql = "select count(*) from v_groups ";
 	if ($_GET['show'] == "all" && permission_exists('group_all')) {
 		if (isset($sql_search)) {
 			$sql .= "where ".$sql_search;


### PR DESCRIPTION
view_groups does not exist, changing this to v_groups resolves the issue of no groups showing in the group manager