### PR TITLE
fix the limit call

### DIFF
--- a/app/dialplans/resources/switch/conf/dialplan/020_call_direction.xml
+++ b/app/dialplans/resources/switch/conf/dialplan/020_call_direction.xml
@@ -1,7 +1,16 @@
 <context name="{v_context}">
 	<extension name="call-direction" number="" continue="true" app_uuid="3780f814-5543-4350-b65d-563512d1fe71" enabled="true">
+		<condition field="context" expression="^(public$|outbound@)" break="on-true">
+			<action application="set" data="call_direction=inbound" inline="true"/>
+		</condition>
+		<condition field="destination_number" expression="^([\d\D]{1,6})$" break="on-true">
+			<action application="set" data="call_direction=local" inline="true"/>
+		</condition>
+		<condition field="destination_number" expression="^([\d\D]{7,})$" break="on-true">
+			<action application="set" data="call_direction=outbound" inline="true"/>
+		</condition>
 		<condition field="${call_direction}" expression="^(inbound|outbound|local)$" break="never">
-			<anti-action application="export" data="call_direction=local" inline="true"/>
+			<anti-action application="set" data="call_direction=local" inline="true"/>
 		</condition>
 	</extension>
 </context>

--- a/app/dialplans/resources/switch/conf/dialplan/020_variables.xml
+++ b/app/dialplans/resources/switch/conf/dialplan/020_variables.xml
@@ -3,6 +3,7 @@
 		<condition>
 			<action application="export" data="origination_callee_id_name=${destination_number}"/>
 			<action application="set" data="RFC2822_DATE=${strftime(%a, %d %b %Y %T %z)}"/>
+			<action application="set" data="max_calls=-1"/>
 		</condition>
 	</extension>
 </context>

--- a/app/dialplans/resources/switch/conf/dialplan/020_variables.xml
+++ b/app/dialplans/resources/switch/conf/dialplan/020_variables.xml
@@ -3,7 +3,10 @@
 		<condition>
 			<action application="export" data="origination_callee_id_name=${destination_number}"/>
 			<action application="set" data="RFC2822_DATE=${strftime(%a, %d %b %Y %T %z)}"/>
-			<action application="set" data="max_calls=-1"/>
+			<action application="set" data="max_calls=-1" inline="true"/>
+		</condition>
+		<condition field="${limit_max}" expression="^$">
+			<action application="set" data="limit_max=-1" inline="true"/>
 		</condition>
 	</extension>
 </context>

--- a/app/dialplans/resources/switch/conf/dialplan/025_call_limit.xml
+++ b/app/dialplans/resources/switch/conf/dialplan/025_call_limit.xml
@@ -1,6 +1,7 @@
 <context name="{v_context}">
 	<extension name="call-limit" number="" continue="true" app_uuid="4670c44c-45dd-4bae-97ba-b0dfe0aca639" enabled="false">
 		<condition field="${call_direction}" expression="^(inbound|outbound)$">
+			<action application="limit" data="hash inbound ${extension_uuid} ${limit_max} !USER_BUSY"/>
 			<action application="limit" data="hash inbound ${domain_uuid} ${max_calls} !USER_BUSY"/>
 		</condition>
 	</extension>


### PR DESCRIPTION
The call limit seems to be broken in many ways, first the call direction was not detected correctly. I copy the logic from ${scripts_dir}/app/dialplan/index.lua to a dialplan which seems to work very well.

The call-limit dialplan has undeclared variables. Also, it doesn't evaluate the limit per extension.  A null variable for the limit app is 0 (no calls allowed)

My fix makes evaluation by domain and by extension. Also, if the variable is not set, it is set to -1 which allows all the calls.