### PR TITLE
Update {$mac}.cfg

### DIFF
--- a/resources/templates/provision/htek/uc924/{$mac}.cfg
+++ b/resources/templates/provision/htek/uc924/{$mac}.cfg
@@ -808,7 +808,7 @@
         <P8680 para="Preference.WatchDogEnable">1</P8680>
         <P2532 para="Preference.DisplayMode">1</P2532>
         <P8660 para="Preference.WallPaper">1</P8660>
-        <P20018 para="Preference.DialFirstDigit">0</P20018>
+        <P20018 para="Preference.DialFirstDigit">1</P20018>
         <P1399 para="Preference.AlertInternalText" />
         <P1402 para="Preference.AlertInternalRinger">0</P1402>
         <P1400 para="Preference.AlertExternalText" />


### PR DESCRIPTION
Dial first digit was set to 0 which meant, it would only wake up the screen but not dial the digit. In setting to 1, it will wake
up screensaver and dial.