### PR TITLE
Fix the CDR Archive

### DIFF
--- a/app/xml_cdr/app_config.php
+++ b/app/xml_cdr/app_config.php
@@ -88,6 +88,9 @@
 		$apps[$x]['permissions'][$y]['name'] = "caller_destination";
 		$apps[$x]['permissions'][$y]['groups'][] = "admin";
 		$apps[$x]['permissions'][$y]['groups'][] = "superadmin";
+                $y++;
+                $apps[$x]['permissions'][$y]['name'] = "xml_cdr_archive";
+                //$apps[$x]['permissions'][$y]['groups'][] = "superadmin";
 
 	//default settings
 		$y=0;

--- a/app/xml_cdr/app_languages.php
+++ b/app/xml_cdr/app_languages.php
@@ -2501,4 +2501,23 @@ $text['button-advanced_search']['ru-ru'] = "Расширенный поиск";
 $text['button-advanced_search']['sv-se'] = "Avancerad Sökning";
 $text['button-advanced_search']['uk-ua'] = "";
 
+$text['button-archive']['en-us'] = "Archive";
+$text['button-archive']['ar-eg'] = "";
+$text['button-archive']['de-at'] = "Archiv"; //copied from de-de
+$text['button-archive']['de-ch'] = "Archiv"; //copied from de-de
+$text['button-archive']['de-de'] = "Archiv";
+$text['button-archive']['es-cl'] = "Archivo";
+$text['button-archive']['es-mx'] = "Archivo"; //copied from es-cl
+$text['button-archive']['fr-ca'] = "Archiver"; //copied from fr-fr
+$text['button-archive']['fr-fr'] = "Archiver";
+$text['button-archive']['he-il'] = "";
+$text['button-archive']['it-it'] = "Archivio";
+$text['button-archive']['nl-nl'] = "";
+$text['button-archive']['pl-pl'] = "Archiwum";
+$text['button-archive']['pt-br'] = "Archiwum";
+$text['button-archive']['pt-pt'] = "Arquivo";
+$text['button-archive']['ro-ro'] = "";
+$text['button-archive']['ru-ru'] = "архив";
+$text['button-archive']['sv-se'] = "archív";
+$text['button-archive']['uk-ua'] = "архів";
 ?>

--- a/app/xml_cdr/xml_cdr.php
+++ b/app/xml_cdr/xml_cdr.php
@@ -49,6 +49,9 @@
 
 //xml cdr include
 	$rows_per_page = ($_SESSION['domain']['paging']['numeric'] != '') ? $_SESSION['domain']['paging']['numeric'] : 50;
+	if ($_REQUEST['show'] == 'archive') {
+		$archive_request = 'true';
+	}
 	require_once "xml_cdr_inc.php";
 
 //javascript function: send_cmd
@@ -146,9 +149,7 @@
 	}
 	echo "				<input type='button' class='btn' value='".$text['button-statistics']."' onclick=\"document.location.href='xml_cdr_statistics.php';\">\n";
 	if (permission_exists('xml_cdr_archive')) {
-		if ($_REQUEST['show'] == 'all') {
-			$query_string = "show=all";
-		}
+		$query_string = "show=all";
 		echo "			<input type='button' class='btn' value='".$text['button-archive']."' onclick=\"window.location='xml_cdr_archive.php?".escape($query_string)."';\">\n";
 	}
 	echo "				<input type='button' class='btn' value='".$text['button-export']."' onclick=\"toggle_select('export_format');\">\n";


### PR DESCRIPTION
The archive works almost out of the works, but it is missing some little things:
- xml_cdr_archive permission is never defined
- button-archive is never defined
- variable $archive_request is never defined (but evaluated).

This patch enables de "archive" button, and then it allows us to use the DB specified in the ['cdr']['archive_database'] default settings set.

No SQL modifications are required.