### PR TITLE
Backwards compatibility

### DIFF
--- a/resources/functions.php
+++ b/resources/functions.php
@@ -28,18 +28,21 @@
 	// Deprecated, backwards compatibility. This functions will be gone in 4.7+
         if (!function_exists('software_version')) {
                 function software_version() {
+			print 'software_version() is deprecated, use software::version() instead';
                         return software::version();
                 }
         }
 
         if (!function_exists('version')) {
                 function version() {
+			print 'version() is deprecated, use software::version() instead';
                         return software::version();
                 }
         }
 
         if (!function_exists('numeric_version')) {
                 function numeric_version() {
+			print 'numeric_version() is deprecated, use software::numeric_version() instead';
                         return software::numeric_version();
                 }
         }

--- a/resources/functions.php
+++ b/resources/functions.php
@@ -25,6 +25,25 @@
 	Luis Daniel Lucio Quiroz <dlucio@okay.com.mx>
 */
 
+	// Deprecated, backwards compatibility. This functions will be gone in 4.7+
+        if (!function_exists('software_version')) {
+                function software_version() {
+                        return software::version();
+                }
+        }
+
+        if (!function_exists('version')) {
+                function version() {
+                        return software::version();
+                }
+        }
+
+        if (!function_exists('numeric_version')) {
+                function numeric_version() {
+                        return software::numeric_version();
+                }
+        }
+
 	if (!function_exists('mb_strtoupper')) {
 		function mb_strtoupper($string) {
 			return strtoupper($string);


### PR DESCRIPTION
The right way to take out a function is first deprecating it in one release (4.6?) and eliminating it in the next stable.