### PR TITLE
E.164 Inbound caller ID fix

### DIFF
--- a/app/xml_cdr/v_xml_cdr_import.php
+++ b/app/xml_cdr/v_xml_cdr_import.php
@@ -209,7 +209,11 @@
 
 		//get the caller details
 			$database->fields['caller_id_name'] = urldecode($xml->variables->effective_caller_id_name);
-			$database->fields['caller_id_number'] = urldecode($xml->variables->effective_caller_id_number);
+			if ($xml->variables->call_direction == 'inbound' ){
+				$database->fields['caller_id_number'] = urldecode($xml->variables->caller_id_number);
+			} else {
+				$database->fields['caller_id_number'] = urldecode($xml->variables->effective_caller_id_number);
+			}
 
 		//get the values from the callflow.
 			$i = 0;


### PR DESCRIPTION
When an inbound call has E.164 caller ID format (eg Skyetel), the + is being stripped from the caller_id_number variable before storing in the v_xml_cdr database table. If we then try and block this CDR in the Call Block application it adds the number BUT without the + so it never matches future calls.
This proposed change ensures that the + is not stripped for INBOUND calls when written to v_xml_cdr and therefore when blocking the CDR it works correctly (i.e. it includes the + which then matches the call next time and blocks it).