### PR TITLE
Add Option for Background Radial Gradient

### DIFF
--- a/themes/default/css.php
+++ b/themes/default/css.php
@@ -151,6 +151,11 @@ $default_login = ($_REQUEST['login'] == 'default') ? true : false;
 		else if ($background_colors[0] == '' && $background_colors[1] != '') { // use color 2
 			$background_color = "background: ".$background_colors[1].";";
 		}
+		else if ($background_colors[0] != '' && $background_colors[1] != '' && isset($_SESSION['theme']['background_radial_gradient']['text'])) { // radial gradient
+			$background_color = "background: ".$background_colors[0].";\n";
+			$background_color .= "background: -ms-radial-gradient(center, circle, ".$background_colors[0]." 0%, ".$background_colors[1]." 100%);\n";
+			$background_color .= "background: radial-gradient(circle at center, ".$background_colors[0]." 0%, ".$background_colors[1]." 100%);\n";
+		}
 		else if ($background_colors[0] != '' && $background_colors[1] != '') { // vertical gradient
 			$background_color = "background: ".$background_colors[0].";\n";
 			$background_color .= "background: -ms-linear-gradient(top, ".$background_colors[0]." 0%, ".$background_colors[1]." 100%);\n";


### PR DESCRIPTION
Adds ability to set the background to be a centered circular radial gradient

If the following is set: theme > background_radial_gradient > text

Then the radial gradient will be enabled. If not set, it will use linear gradient to preserve previous behavior.