### PR TITLE
[4.4] Fix Click To Call

### DIFF
--- a/app/click_to_call/click_to_call.php
+++ b/app/click_to_call/click_to_call.php
@@ -69,7 +69,7 @@
 			$context = $_SESSION['context'];
 
 		//clean up variable values
-			$src = str_replace(array('.','(',')','-',' '), '', $src);
+			$src = str_replace(array('(',')',' '), '', $src);
 			$dest = (strpbrk($dest, '@') != FALSE) ? str_replace(array('(',')',' '), '', $dest) : str_replace(array('.','(',')','-',' '), '', $dest); //don't strip periods or dashes in sip-uri calls, only phone numbers
 
 		//adjust variable values
@@ -149,13 +149,14 @@
 				$source_common .= ",record_name='".$record_name."'";
 			}
 
-			if (strlen($src) < 7) {
+			if (user_exists($src)) {
 				//source is a local extension
 				$source = $source_common.$sip_auto_answer.
 					",domain_uuid=".$domain_uuid.
 					",domain_name=".$_SESSION['domains'][$domain_uuid]['domain_name']."}user/".$src."@".$_SESSION['domains'][$domain_uuid]['domain_name'];
 			}
 			else {
+				$src = str_replace(array('.','-'), '', $src);
 				//source is an external number
 				$bridge_array = outbound_route_to_bridge($_SESSION['domain_uuid'], $src);
 				$source = $source_common."}".$bridge_array[0];
@@ -164,7 +165,7 @@
 
 		//define b leg - set destination to display the defined caller id name and number
 			$destination_common = " &bridge({origination_caller_id_name='".$dest_cid_name."',origination_caller_id_number=".$dest_cid_number;
-			if (strlen($dest) < 7) {
+			if (user_exists($dest)) {
 				//destination is a local extension
 				if (strpbrk($dest, '@') != FALSE) { //sip-uri
 					$switch_cmd = $destination_common.",call_direction=outbound}sofia/external/".$dest.")";

--- a/app/click_to_call/click_to_call.php
+++ b/app/click_to_call/click_to_call.php
@@ -176,7 +176,7 @@
 			}
 			else {
 				//local extension (source) > external number (destination)
-				if (strlen($src) < 7 && strlen($dest_cid_number) == 0) {
+				if (user_exists($src)&& strlen($dest_cid_number) == 0) {
 					//retrieve outbound caller id from the (source) extension
 					$sql = "select outbound_caller_id_name, outbound_caller_id_number from v_extensions where domain_uuid = '".$_SESSION['domain_uuid']."' and extension = '".$src."' ";
 					$prep_statement = $db->prepare(check_sql($sql));

--- a/resources/functions.php
+++ b/resources/functions.php
@@ -2004,4 +2004,27 @@ function number_pad($number,$n) {
 		}
 	}
 
+// User exists
+        if (!function_exists('user_exists')){
+                function user_exists($login, $domain_name = null){
+                //connect to fs
+                        $fp = event_socket_create($_SESSION['event_socket_ip_address'], $_SESSION['event_socket_port'], $_SESSION['event_socket_password']);
+                        if (!$fp) {
+                                return false;
+                        }
+                //send the user_exists command to freeswitch
+                        if ($fp) {
+                                //build and send the mkdir command to freeswitch
+                                        if (is_null($domain_name)){
+                                                $domain_name = $_SESSION['domain_name'];
+                                        }
+                                        $switch_cmd = "user_exists id '$login' '$domain_name'";
+                                        $switch_result = event_socket_request($fp, 'api '.$switch_cmd);
+                                        fclose($fp);
+                                        return ($switch_result == 'true'?true:false);
+                        }
+                //can not create directory
+                        return null;
+                }
+        }
 ?>


### PR DESCRIPTION
Click to call doesn't work if sip extension has - or . (which it is allowed by the naming rules).

Also, we have agreed in another PR discussion that detecting local extensions by the condition strlen < 7 is not an option. I have created user_exists() as a way to verify any extension regardless of its naming.