### PR TITLE
Allow user with only contact_view permission to click on contact record to view numbers etc.

### DIFF
--- a/app/contacts/contact_edit.php
+++ b/app/contacts/contact_edit.php
@@ -495,7 +495,9 @@
 			}
 		}
 	}
-	echo button::create(['type'=>'button','label'=>$text['button-save'],'icon'=>$_SESSION['theme']['button_icon_save'],'style'=>($action != 'update' ?: 'margin-left: 15px;'),'collapse'=>'hide-sm-dn','onclick'=>"document.getElementById('frm').submit();"]);
+	if (permission_exists('contact_edit') || permission_exists('contact_add')) {
+		echo button::create(['type'=>'button','label'=>$text['button-save'],'icon'=>$_SESSION['theme']['button_icon_save'],'style'=>($action != 'update' ?: 'margin-left: 15px;'),'collapse'=>'hide-sm-dn','onclick'=>"document.getElementById('frm').submit();"]);
+	}
 	echo "	</div>\n";
 	echo "	<div style='clear: both;'></div>\n";
 	echo "</div>\n";

--- a/app/contacts/contacts.php
+++ b/app/contacts/contacts.php
@@ -305,7 +305,7 @@
 	if (is_array($contacts) && @sizeof($contacts) != 0) {
 		$x = 0;
 		foreach($contacts as $row) {
-			if (permission_exists('contact_edit')) {
+			if (permission_exists('contact_edit') || permission_exists('contact_view')) {
 				$list_row_url = "contact_edit.php?id=".urlencode($row['contact_uuid'])."&query_string=".urlencode($_SERVER["QUERY_STRING"]);
 			}
 			echo "<tr class='list-row' href='".$list_row_url."'>\n";


### PR DESCRIPTION
A user with only contact_view permissions is unable to click on the contact record to view the numbers and addresses etc.

By add allowing contact_view to have the contact_edit.php link they can now view the numbers etc.

Only showing the save button for users with contact_edit and contact_add permissions reinforces the fact that a user with contact_view only cannot edit the contact.