### PR TITLE
Remove hard-coded sounds path

### DIFF
--- a/app/dialplans/resources/switch/conf/dialplan/370_tone_stream.xml
+++ b/app/dialplans/resources/switch/conf/dialplan/370_tone_stream.xml
@@ -2,7 +2,7 @@
 	<extension name="tone_stream" number="*9198" continue="false" app_uuid="98ccdb0b-c074-4f74-b28a-9528372faa7d">
 		<condition field="destination_number" expression="^\*9198$">
 			<action application="answer"/>
-			<action application="playback" data="{loops=10}tone_stream://path=${conf_dir}/conf/tetris.ttml"/>
+			<action application="playback" data="{loops=10}tone_stream://path=${conf_dir}/tetris.ttml"/>
 		</condition>
 	</extension>
 </context>

--- a/app/dialplans/resources/switch/conf/dialplan/370_tone_stream.xml
+++ b/app/dialplans/resources/switch/conf/dialplan/370_tone_stream.xml
@@ -2,7 +2,7 @@
 	<extension name="tone_stream" number="*9198" continue="false" app_uuid="98ccdb0b-c074-4f74-b28a-9528372faa7d">
 		<condition field="destination_number" expression="^\*9198$">
 			<action application="answer"/>
-			<action application="playback" data="{loops=10}tone_stream://path=${base_dir}/conf/tetris.ttml"/>
+			<action application="playback" data="{loops=10}tone_stream://path=${conf_dir}/conf/tetris.ttml"/>
 		</condition>
 	</extension>
 </context>

--- a/resources/classes/file.php
+++ b/resources/classes/file.php
@@ -66,7 +66,7 @@ class file {
 	 * Get the sounds list of search as a relative path without the rate
 	 */
 	public function sounds() {
-		$dir = $_SESSION['switch']['sounds']['dir'].'/en/us/callie';
+		$dir = $_SESSION['switch']['sound_prefix']['dir'];
 		$rate = '8000';
 		$files = $this->glob($dir.'/*/'.$rate, true);
 		foreach($files as $file) {


### PR DESCRIPTION
There should be a way of reading the sound_prefix path from the switch variables, so this is a bit of a hack. Better way needed.

It appears there are more places en/us/callie is hard-coded too:
https://github.com/fusionpbx/fusionpbx/search?q=%2Fen%2Fus%2Fcallie&type=Code