### PR TITLE
Setting a conference room sounds=false

### DIFF
--- a/app/scripts/resources/scripts/app/conference_center/index.lua
+++ b/app/scripts/resources/scripts/app/conference_center/index.lua
@@ -670,6 +670,9 @@
 				--set the exit sound
 					if (sounds == "true") then
 						session:execute("set","conference_exit_sound="..exit_sound);
+					else
+						session:execute("set","conference_enter_sound=none");
+						session:execute("set","conference_exit_sound=none");
 					end
 
 				--set flags and moderator controls


### PR DESCRIPTION
Right now settings a conference room's to 'sounds=false' doesn't do anything. This fixes that bug. 

Additional updates to the script most likely need to be made after this so that conference_enter_sound and conference_exit_sound honor the value specified in the conference profile. I didn't see any code referencing the conference profile values for sounds.