### PR TITLE
Remove hard coded setting for moderator conf ctls

### DIFF
--- a/app/scripts/resources/scripts/app/conference_center/index.lua
+++ b/app/scripts/resources/scripts/app/conference_center/index.lua
@@ -692,7 +692,7 @@
 						--when the moderator leaves end the conference
 							--flags = flags .. "|endconf";
 						--set the moderator controls
-							session:execute("set","conference_controls=moderator");
+							--session:execute("set","conference_controls=moderator");
 					end
 
 				--get the conference xml_list


### PR DESCRIPTION
Conference Controls for moderators are hard coded. Because of this you cannot use the Conference Controls app in the web interface to create a new set of moderator controls and set them in the Conference Profile.