### PR TITLE
Specify table for Accountcode Search

### DIFF
--- a/app/xml_cdr/xml_cdr_inc.php
+++ b/app/xml_cdr/xml_cdr_inc.php
@@ -457,7 +457,7 @@
 		$parameters['bleg_uuid'] = $bleg_uuid;
 	}
 	if (strlen($accountcode) > 0) {
-		$sql .= "and accountcode = :accountcode ";
+		$sql .= "and c.accountcode = :accountcode ";
 		$parameters['accountcode'] = $accountcode;
 	}
 	if (strlen($read_codec) > 0) {


### PR DESCRIPTION
I had to add "c." in order for accountcode CDR searches to work under Advanced CDR Search. 

I suspect there may be more that require this, but I haven't checked every field under advanced search.