### PR TITLE
Fix is_local 

### DIFF
--- a/app/scripts/resources/scripts/app/is_local/index.lua
+++ b/app/scripts/resources/scripts/app/is_local/index.lua
@@ -108,7 +108,7 @@
 		--define the array/table and variables
 			local var = {}
 			local key = "";
-			local value = "";
+			local value = value;
 
 		--parse the cache
 			key_pairs = explode("&", value);


### PR DESCRIPTION
line 111 emptied the  cache ```value``` variable that was set on line 51