### PR TITLE
Attach PDF on Sent Fax Email Instead of TIF

### DIFF
--- a/app/scripts/resources/scripts/fax_retry.lua
+++ b/app/scripts/resources/scripts/fax_retry.lua
@@ -648,7 +648,7 @@
 				email_address,
 				"To: "..email_address.."\nFrom: "..from_address.."\nSubject: "..email_subject_success_default.."\n"..x_headers,
 				email_body_success_default,
-				fax_file
+				fax_file:gsub(".tif",".pdf",x)
 			);
 
 		if (settings['fax']['keep_local']['boolean'] ~= "nil") then


### PR DESCRIPTION
Small change that attaches a pdf copy of the sent fax rather than the tif by replacing the extension in the file path.

PDF files are dramatically smaller and more user friendly than TIF files.