### PR TITLE
Remove duplicate declaration of P2916

### DIFF
--- a/resources/templates/provision/grandstream/gxp2135/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp2135/{$mac}.xml
@@ -8099,7 +8099,8 @@
     <!-- # Wallpaper Source. 0 - Default, 1 - Download, 2-USB(for GXP2140/2160/2170 only), 3 - Uploaded, 4 - Color Background -->
     <!-- # Number: 0-4 -->
     <!-- # Mandatory -->
-    <P2916>0</P2916>
+    <!-- # This is defined in if/else statement below. Commented out here to avoid duplicate declaration -->
+    <!-- <P2916>0</P2916> -->
 
     <!-- # Wallpaper Server Path -->
     <!-- # String  -->


### PR DESCRIPTION
P2916 (wallpaper source) is defined twice in the file: once statically and then again immediately after in an if/else statement. The latter is correct. Having it defined twice causes the phone to ignore the second declaration.