### PR TITLE
Checking returnvalue of PDO::execute for errors in database->save()

### DIFF
--- a/resources/classes/database.php
+++ b/resources/classes/database.php
@@ -1227,10 +1227,23 @@ include "root.php";
 									if ($prep_statement) {
 										//get the data
 											try {
-												$prep_statement->execute();
+												$res_exec = $prep_statement->execute();
+												if ($res_exec === false) {
+													$errInfo = $prep_statement->errorInfo();
+													if (isset($errInfo[2])) {
+														throw new RuntimeException($errInfo[2]);
+													} else {
+														throw new RuntimeException("Error executing SQL statement");
+													}
+												}
 												$result = $prep_statement->fetchAll(PDO::FETCH_ASSOC);
 											}
 											catch(PDOException $e) {
+												echo 'Caught exception: ',  $e->getMessage(), "<br/><br/>\n";
+												echo $sql;
+												exit;
+											}
+											catch(RuntimeException $e) {
 												echo 'Caught exception: ',  $e->getMessage(), "<br/><br/>\n";
 												echo $sql;
 												exit;


### PR DESCRIPTION
Caught this while importing extensions csv with first line that contained column headers while leaving the "from_row" to 1.
In that case, saving the first row generates a sql error, because of an invalid value for the extension_uuid column (value not being a uuid). This causes execute() to return false which is not handled/checked.
Saving the second row generates a PDOException because of an invalid transaction state, which is displayed to the user.
I throw and catch a RuntimeException, which doubles the catch clause, because I did not want to misuse the PDOException

There are more cases where execute() is used and the return value is not checked. Some, if not all, could be dealt with in similar fashion.