### PR TITLE
Update {$mac}.cfg for plycom 4.x

### DIFF
--- a/resources/templates/provision/polycom/4.x/{$mac}.cfg
+++ b/resources/templates/provision/polycom/4.x/{$mac}.cfg
@@ -3,7 +3,7 @@
 	<REGISTRATION
 
 		{foreach $lines as $row}reg.{$row.line_number}.displayName="{$row.display_name}"
-		reg.{$row.line_number}.address="{$row.user_id}"
+		reg.{$row.line_number}.address="{$row.user_id}@{$row.server_address}"
 		reg.{$row.line_number}.label="{$row.display_name}"
 
 		reg.{$row.line_number}.serverFeatureControl.cf="{$polycom_feature_key_sync}"


### PR DESCRIPTION
added server address to address line instead of just the user id got issue when doing server1 server2 setup