### PR TITLE
Rogue Apostrophe in SQL statement

### DIFF
--- a/core/upgrade/app_defaults.php
+++ b/core/upgrade/app_defaults.php
@@ -52,7 +52,7 @@ if ($domains_processed == 1) {
 			$sql .= "'login', ";
 			$sql .= "'message', ";
 			$sql .= "'text', ";
-			$sql .= "':default_setting_value, ";
+			$sql .= ":default_setting_value, ";
 			$sql .= "'true', ";
 			$sql .= "'' ";
 			$sql .= ")";


### PR DESCRIPTION
Remove rogue apostrophe in SQL statement for `:default_setting_value`.