### PR TITLE
[4.4] Use INT instead of NUMERIC

### DIFF
--- a/app/devices/device_copy.php
+++ b/app/devices/device_copy.php
@@ -99,7 +99,7 @@
 	$sql .= "WHEN 'programmable' THEN 3 ";
 	$sql .= "WHEN 'expansion' THEN 4 ";
 	$sql .= "ELSE 100 END, ";
-	$sql .= "cast(device_key_id as numeric) asc ";
+	$sql .= "cast(device_key_id as int) asc ";
 	$prep_statement = $db->prepare(check_sql($sql));
 	$prep_statement->execute();
 	$device_keys = $prep_statement->fetchAll(PDO::FETCH_NAMED);


### PR DESCRIPTION
Since the field is an integer, INT is a common type on Postgresql and MariaDB, Numeric is not (yet).

This fixes copy_device.php