### PR TITLE
add missing quotes surrounding extension_advanced

### DIFF
--- a/app/extensions/extension_edit.php
+++ b/app/extensions/extension_edit.php
@@ -1733,7 +1733,7 @@
 
 	//--- begin: show_advanced -----------------------
 
-	if (permission_exists(extension_advanced)) {
+	if (permission_exists("extension_advanced")) {
 		echo "<tr>\n";
 		echo "<td style='padding: 0px;' colspan='2' class='' valign='top' align='left' nowrap>\n";
 


### PR DESCRIPTION
Add missing quotes surrounding extension_advanced permission so it is interpreted as text.