### PR TITLE
Fix disa caller_id

### DIFF
--- a/app/scripts/resources/scripts/disa.lua
+++ b/app/scripts/resources/scripts/disa.lua
@@ -47,8 +47,8 @@
 		sound_extension = session:getVariable("sound_extension");
 		pin_number = session:getVariable("pin_number");
 		sounds_dir = session:getVariable("sounds_dir");
-		caller_id_name = session:getVariable("caller_id_name");
-		caller_id_number = session:getVariable("caller_id_number");
+		disa_caller_id_name = session:getVariable("disa_caller_id_name");
+		disa_caller_id_number = session:getVariable("disa_caller_id_number");
 		predefined_destination = session:getVariable("predefined_destination");
 		fallback_destination = session:getVariable("fallback_destination");
 		digit_min_length = session:getVariable("digit_min_length");
@@ -155,26 +155,26 @@
 		cmd = "user_exists id ".. destination_number .." "..context;
 		user_exists = trim(api:executeString(cmd));
 		if (user_exists == "true") then
-			if (caller_id_name) then
+			if (disa_caller_id_name) then
 				--caller id name provided do nothing
 			else
-			        caller_id_number = session:getVariable("effective_caller_id_number");
+			        disa_caller_id_number = session:getVariable("effective_caller_id_number");
 			end
-			if (caller_id_number) then
+			if (disa_caller_id_number) then
 				--caller id number provided do nothing
 			else
-				caller_id_number = session:getVariable("effective_caller_id_number");
+				disa_caller_id_number = session:getVariable("effective_caller_id_number");
 			end
 		else
-			if (caller_id_name) then
+			if (disa_caller_id_name) then
 				--caller id name provided do nothing
 			else
-				caller_id_number = session:getVariable("outbound_caller_id_number");
+				disa_caller_id_name = session:getVariable("outbound_caller_id_name");
 			end
-			if (caller_id_number) then
+			if (disa_caller_id_number) then
 				--caller id number provided do nothing
 			else
-				caller_id_number = session:getVariable("outbound_caller_id_number");
+				disa_caller_id_number = session:getVariable("outbound_caller_id_number");
 			end
 		end
 	end
@@ -198,15 +198,15 @@
 			session:execute("transfer", destination_number .. " XML " .. context);
 		else
 			--external call
-			if (caller_id_name) then
-				session:execute("set", "outbound_caller_id_name="..caller_id_name);
-				session:execute("set", "effective_caller_id_name="..caller_id_name);
+			if (disa_caller_id_name) then
+				session:execute("set", "outbound_caller_id_name="..disa_caller_id_name);
+				session:execute("set", "effective_caller_id_name="..disa_caller_id_name);
 			end
 			if (caller_id_number) then
-				session:execute("set", "outbound_caller_id_number="..caller_id_number);
-				session:execute("set", "effective_caller_id_number="..caller_id_number);
+				session:execute("set", "outbound_caller_id_number="..disa_caller_id_number);
+				session:execute("set", "effective_caller_id_number="..disa_caller_id_number);
 			end
-                        session:execute("set","disa_outbound=true");
+            		session:execute("set","disa_outbound=true");
 			session:execute("transfer", destination_number .. " XML " .. context);
 		end
 	end

--- a/app/scripts/resources/scripts/disa.lua
+++ b/app/scripts/resources/scripts/disa.lua
@@ -202,7 +202,7 @@
 				session:execute("set", "outbound_caller_id_name="..disa_caller_id_name);
 				session:execute("set", "effective_caller_id_name="..disa_caller_id_name);
 			end
-			if (caller_id_number) then
+			if (disa_caller_id_number) then
 				session:execute("set", "outbound_caller_id_number="..disa_caller_id_number);
 				session:execute("set", "effective_caller_id_number="..disa_caller_id_number);
 			end


### PR DESCRIPTION
disa.lua was checking if ``caller_id_name`` and ``caller_id_number`` variables are set. These 2 variables are read-only variables set by FreeSWITCH on every call it always has the values of the caller causing disa to always call out with original caller id