### PR TITLE
Update phrases.php

### DIFF
--- a/app/phrases/phrases.php
+++ b/app/phrases/phrases.php
@@ -29,7 +29,7 @@
 	require_once "resources/require.php";
 	require_once "resources/check_auth.php";
 	require_once "resources/paging.php";
-	require_once "resources/functions/save_phrases_xml.php";
+
 
 //check the permission
 	if (!permission_exists('phrase_view')) {


### PR DESCRIPTION
Fix: 
Fatal error: require_once(): Failed opening required 'resources/functions/save_phrases_xml.php' (include_path='.:/usr/share/php:/var/www/fusionpbx') in /var/www/fusionpbx/app/phrases/phrases.php on line 32