### PR TITLE
Update app_config.php

### DIFF
--- a/app/yealink/app_config.php
+++ b/app/yealink/app_config.php
@@ -109,7 +109,7 @@
 		$apps[$x]['default_settings'][$y]['default_setting_name'] = "numeric";
 		$apps[$x]['default_settings'][$y]['default_setting_value'] = "0";
 		$apps[$x]['default_settings'][$y]['default_setting_enabled'] = "true";
-		$apps[$x]['default_settings'][$y]['default_setting_description'] = "0-Disabled;1-Optional;2-Compulsory";
+		$apps[$x]['default_settings'][$y]['default_setting_description'] = "0=Disabled, 1=Optional, 2=Compulsory";
 		$y++;
 		$apps[$x]['default_settings'][$y]['default_setting_uuid'] = "f0704072-c3d9-48df-b89b-2aea6035b3c4";
 		$apps[$x]['default_settings'][$y]['default_setting_category'] = "provision";

--- a/app/yealink/app_config.php
+++ b/app/yealink/app_config.php
@@ -109,7 +109,7 @@
 		$apps[$x]['default_settings'][$y]['default_setting_name'] = "numeric";
 		$apps[$x]['default_settings'][$y]['default_setting_value'] = "0";
 		$apps[$x]['default_settings'][$y]['default_setting_enabled'] = "true";
-		$apps[$x]['default_settings'][$y]['default_setting_description'] = "0-Disabled (default), 1-Forced, 2-Negotiate";
+		$apps[$x]['default_settings'][$y]['default_setting_description'] = "0-Disabled;1-Optional;2-Compulsory";
 		$y++;
 		$apps[$x]['default_settings'][$y]['default_setting_uuid'] = "f0704072-c3d9-48df-b89b-2aea6035b3c4";
 		$apps[$x]['default_settings'][$y]['default_setting_category'] = "provision";


### PR DESCRIPTION
Description:
1.It configures whether to use audio encryption service.
CFG Configuration:
account.x.srtp_encryption
Valid Value:
(0-Disabled;1-Optional;2-Compulsory)
Optional: the phone will negotiate with the other phone what type of encryption to use for the session.
Compulsory: the phone must use SRTP during a call.