### PR TITLE
Add samesite=strict to session cookie

### DIFF
--- a/core/install/install.php
+++ b/core/install/install.php
@@ -41,6 +41,9 @@
 
 //start the session
 	//ini_set("session.cookie_httponly", True);
+	if(version_compare(phpversion(), '7.3', '>=')) {
+		session_set_cookie_params(["samesite" => "strict"]);
+	}
 	session_start();
 
 //set the default domain_uuid

--- a/index.php
+++ b/index.php
@@ -28,7 +28,12 @@
 
 // start the session
 	ini_set("session.cookie_httponly", True);
-	if (!isset($_SESSION)) { session_start(); }
+	if (!isset($_SESSION)) { 
+		if(version_compare(phpversion(), '7.3', '>=')) {
+			session_set_cookie_params(["samesite" => "strict"]);
+		}
+		session_start(); 
+	}
 
 //if config.php file does not exist then redirect to the install page
 	if (file_exists($_SERVER["PROJECT_ROOT"]."/resources/config.php")) {

--- a/resources/check_auth.php
+++ b/resources/check_auth.php
@@ -36,7 +36,12 @@
 	}
 
 //start the session
-	if (!isset($_SESSION)) { session_start(); }
+	if (!isset($_SESSION)) { 
+		if(version_compare(phpversion(), '7.3', '>=')) {
+			session_set_cookie_params(["samesite" => "strict"]);
+		}
+		session_start(); 
+	}
 
 //define variables
 	if (!isset($_SESSION['template_content'])) { $_SESSION["template_content"] = null; }

--- a/resources/php.php
+++ b/resources/php.php
@@ -28,6 +28,9 @@
 	//start the session
 		if (function_exists('session_start')) { 
 			if (!isset($_SESSION)) {
+				if(version_compare(phpversion(), '7.3', '>=')) {
+					session_set_cookie_params(["samesite" => "strict"]);
+				}
 				session_start();
 			}
 		}


### PR DESCRIPTION
* Additional security layer for CSRF attacks is to use the same-site attribute in the cookie
more info can be at found https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html#samesite-cookie-attribute

* It's only supported in PHP version 7.3 and up