### PR TITLE
Order SIP Profiles by Name by Default

### DIFF
--- a/app/sip_profiles/sip_profiles.php
+++ b/app/sip_profiles/sip_profiles.php
@@ -71,7 +71,12 @@
 	}
 
 //get order and order by
-	$order_by = $_GET["order_by"];
+	if (isset($_GET["order_by"])) {
+		$order_by = $_GET["order_by"];
+	}
+	else {
+		$order_by = 'sip_profile_name';
+	}
 	$order = $_GET["order"];
 
 //add the search string


### PR DESCRIPTION
SIP profiles were unordered unless $_GET["order_by"] was set. Now if unset, it will order by sip_profile_name by default for nicer ordering.