### PR TITLE
feature add mask/unmask recordings in real time. white space cleanup.

### DIFF
--- a/app/dialplans/resources/switch/conf/dialplan/050_user_record.xml
+++ b/app/dialplans/resources/switch/conf/dialplan/050_user_record.xml
@@ -46,6 +46,8 @@
 			<action application="set" data="record_name=${uuid}.${record_ext}" inline="true"/>
 			<!--<action application="set" data="record_name=${destination_number}-${caller_id_number}_${strftime(%Y-%m-%d %H:%M)}.${record_ext}" inline="true"/>-->
 			<action application="set" data="recording_follow_transfer=true" inline="true"/>
+			<action application="bind_digit_action" data="local,*5,api:uuid_record,${uuid} mask ${recordings_dir}/${domain_name}/archive/${strftime(%Y)}/${strftime(%b)}/${strftime(%d)}/${uuid}.${record_ext},${bind_target}"/>
+			<action application="bind_digit_action" data="local,*6,api:uuid_record,${uuid} unmask ${recordings_dir}/${domain_name}/archive/${strftime(%Y)}/${strftime(%b)}/${strftime(%d)}/${uuid}.${record_ext},${bind_target}"/>
 			<action application="set" data="record_append=true" inline="true"/>
 			<action application="set" data="record_in_progress=true" inline="true"/>
 			<action application="set" data="${uuid_record ${uuid} start ${record_path}/${record_name}}" inline="false"/>

--- a/app/scripts/resources/scripts/app/ring_groups/index.lua
+++ b/app/scripts/resources/scripts/app/ring_groups/index.lua
@@ -25,6 +25,7 @@
 --
 --	Contributor(s):
 --	Mark J Crane <markjcrane@fusionpbx.com>
+--  Gill Abada <gill.abada@gmail.com>
 
 --include the log
 	log = require "resources.functions.log".ring_group
@@ -580,7 +581,7 @@
 
 								--Calculate the destination_timeout for follow-me destinations.
 								--The call should honor ring group timeouts with rg delays, follow-me timeouts and follow-me delays factored in.
-								--Destinations with a timeout of 0 or negative numbers should be ignored. 
+								--Destinations with a timeout of 0 or negative numbers should be ignored.
 								if (tonumber(field.destination_timeout) < (tonumber(row.destination_timeout) - tonumber(field.destination_delay))) then
 									new_destination_timeout = field.destination_timeout;
 								else
@@ -879,12 +880,14 @@
 					-- end
 
 				--set bind digit action
-					local bind_target = 'peer'
+					local bind_target = 'local'
 					if session:getVariable("sip_authorized") == "true" then
-						bind_target = 'both';
+						bind_target = 'peer';
 					end
 					local bindings = {
 						"local,*2,exec:record_session," .. record_path .. "/" .. record_name,
+						"local,*5,api:uuid_record," .. uuid .. " mask " .. record_path .. "/" .. record_name,
+						"local,*6,api:uuid_record," .. uuid .. " unmask " .. record_path .. "/" .. record_name,
 						-- "local,*0,exec:execute_extension,conf_xfer_from_dialplan XML conf-xfer@" .. context
 					}
 					for _, str in ipairs(bindings) do
@@ -920,7 +923,7 @@
 
 							--if the timeout was reached exit the loop and go to the timeout action
 								if (tonumber(ring_group_call_timeout) == timeout) then
-									break;	
+									break;
 								end
 
 							--send the call to the destination


### PR DESCRIPTION
This is a feature for PCI compliance when taking credit card numbers or any personal information over a recorded phone call.
This allows the user to dial *5 before taking the personal information to play white noise instead of recording and then *6 after the information is taken to start recording the conversation again.

This solution is better than pausing and unpausing the recording because you can tell how long it took the user to gather the personal information. The recording is still in progress but white noise is being recorded instead of the conversation.

These changes allow recording masking/unmasking on inbound, outbound, and ring group calls.

1 bug is that if you dial a DID the outside party can mask/unmask but I think its a nonissue since its an obscure binding and the callee would have to know about it.

I also removed some white space in index.lua of ring groups.

NOTE: This change does not affect call center.