### PR TITLE
Allow Variable to Manually set Agent Status

### DIFF
--- a/app/scripts/resources/scripts/app/agent_status/index.lua
+++ b/app/scripts/resources/scripts/app/agent_status/index.lua
@@ -39,6 +39,7 @@
 			context = session:getVariable("context");
 			uuid = session:get_uuid();
 			agent_authorized = session:getVariable("agent_authorized");
+			agent_action = session:getVariable("agent_action");
 			agent_id = session:getVariable("agent_id");
 			agent_password = session:getVariable("agent_password");
 
@@ -116,12 +117,20 @@
 			user_status = trim(api:executeString(cmd));
 
 		--get the user info
-			if (user_status == "Available") then
-				action = "logout";
-				status = 'Logged Out';
-			else
-				action = "login";
-				status = 'Available';
+			if (agent_action == nil) then
+				if (user_status == "Available") then
+					action = "logout";
+					status = 'Logged Out';
+				else
+					action = "login";
+					status = 'Available';
+				end
+			elseif (agent_action == "login") then
+					action = "login";
+					status = 'Available';
+			elseif (agent_action == "logout") then
+					action = "logout";
+					status = 'Logged Out';
 			end
 
 		--send a login or logout to mod_callcenter


### PR DESCRIPTION
Adds a bit of additional logic to allow the following variable to be set in dialplan:

agent_action

When set to login, this script will always log the agent in regardless of current state.
When set to logout, this script will always log the agent out regardless of current state.
When unset, original behavior is preserved.

The reason for adding this code is to allow us to create a dialplan that puts a user on DND at the same time as logging out the agent, and vice-versa.