### PR TITLE
Updated snom templates to work with newer firmware

### DIFF
--- a/resources/templates/provision/snom/D120/{$mac}.xml
+++ b/resources/templates/provision/snom/D120/{$mac}.xml
@@ -29,6 +29,8 @@
     <mwi_dialtone perm="">stutter</mwi_dialtone>
     <enable_rport_rfc3581 perm="RW">on</enable_rport_rfc3581>
     <privacy_in perm="">off</privacy_in>
+    <quick_transfer perm="">blind</quick_transfer>
+    <call_screen_fkeys_on_connected perm="">F_HOLD F_TRANSFER F_CONFERENCE</call_screen_fkeys_on_connected>
     <!-- Updates -->
     <update_policy perm="">auto_update</update_policy>
     <setting_server perm="RW">https://{if isset($http_auth_enabled) && $http_auth_enabled == true}{$http_auth_username}:{$http_auth_password}@{/if}{$domain_name}{$project_path}/app/provision/index.php?mac={$mac}</setting_server>

--- a/resources/templates/provision/snom/D315/{$mac}.xml
+++ b/resources/templates/provision/snom/D315/{$mac}.xml
@@ -29,6 +29,8 @@
     <mwi_dialtone perm="">stutter</mwi_dialtone>
     <enable_rport_rfc3581 perm="RW">on</enable_rport_rfc3581>
     <privacy_in perm="">off</privacy_in>
+    <quick_transfer perm="">blind</quick_transfer>
+    <call_screen_fkeys_on_connected perm="">F_HOLD F_TRANSFER F_CONFERENCE</call_screen_fkeys_on_connected>
     <!-- Updates -->
     <update_policy perm="">auto_update</update_policy>
     <setting_server perm="RW">https://{if isset($http_auth_enabled) && $http_auth_enabled == true}{$http_auth_username}:{$http_auth_password}@{/if}{$domain_name}{$project_path}/app/provision/index.php?mac={$mac}</setting_server>

--- a/resources/templates/provision/snom/D345/{$mac}.xml
+++ b/resources/templates/provision/snom/D345/{$mac}.xml
@@ -29,6 +29,8 @@
     <mwi_dialtone perm="">stutter</mwi_dialtone>
     <enable_rport_rfc3581 perm="RW">on</enable_rport_rfc3581>
     <privacy_in perm="">off</privacy_in>
+    <quick_transfer perm="">blind</quick_transfer>
+    <call_screen_fkeys_on_connected perm="">F_HOLD F_TRANSFER F_CONFERENCE</call_screen_fkeys_on_connected>
     <!-- Updates -->
     <update_policy perm="">auto_update</update_policy>
     <setting_server perm="RW">https://{if isset($http_auth_enabled) && $http_auth_enabled == true}{$http_auth_username}:{$http_auth_password}@{/if}{$domain_name}{$project_path}/app/provision/index.php?mac={$mac}</setting_server>

--- a/resources/templates/provision/snom/D375/{$mac}.xml
+++ b/resources/templates/provision/snom/D375/{$mac}.xml
@@ -29,6 +29,8 @@
     <mwi_dialtone perm="">stutter</mwi_dialtone>
     <enable_rport_rfc3581 perm="RW">on</enable_rport_rfc3581>
     <privacy_in perm="">off</privacy_in>
+    <quick_transfer perm="">blind</quick_transfer>
+    <call_screen_fkeys_on_connected perm="">F_HOLD F_TRANSFER F_CONFERENCE</call_screen_fkeys_on_connected>
     <!-- Updates -->
     <update_policy perm="">auto_update</update_policy>
     <setting_server perm="RW">https://{if isset($http_auth_enabled) && $http_auth_enabled == true}{$http_auth_username}:{$http_auth_password}@{/if}{$domain_name}{$project_path}/app/provision/index.php?mac={$mac}</setting_server>

--- a/resources/templates/provision/snom/D385/{$mac}.xml
+++ b/resources/templates/provision/snom/D385/{$mac}.xml
@@ -29,6 +29,8 @@
     <mwi_dialtone perm="">stutter</mwi_dialtone>
     <enable_rport_rfc3581 perm="RW">on</enable_rport_rfc3581>
     <privacy_in perm="">off</privacy_in>
+    <quick_transfer perm="">blind</quick_transfer>
+    <call_screen_fkeys_on_connected perm="">F_HOLD F_TRANSFER F_CONFERENCE</call_screen_fkeys_on_connected>
     <!-- Updates -->
     <update_policy perm="">auto_update</update_policy>
     <setting_server perm="RW">https://{if isset($http_auth_enabled) && $http_auth_enabled == true}{$http_auth_username}:{$http_auth_password}@{/if}{$domain_name}{$project_path}/app/provision/index.php?mac={$mac}</setting_server>

--- a/resources/templates/provision/snom/D712/{$mac}.xml
+++ b/resources/templates/provision/snom/D712/{$mac}.xml
@@ -29,6 +29,8 @@
     <mwi_dialtone perm="">stutter</mwi_dialtone>
     <enable_rport_rfc3581 perm="RW">on</enable_rport_rfc3581>
     <privacy_in perm="">off</privacy_in>
+    <quick_transfer perm="">blind</quick_transfer>
+    <call_screen_fkeys_on_connected perm="">F_HOLD F_TRANSFER F_CONFERENCE</call_screen_fkeys_on_connected>
     <!-- Updates -->
     <update_policy perm="">auto_update</update_policy>
     <setting_server perm="RW">https://{if isset($http_auth_enabled) && $http_auth_enabled == true}{$http_auth_username}:{$http_auth_password}@{/if}{$domain_name}{$project_path}/app/provision/index.php?mac={$mac}</setting_server>

--- a/resources/templates/provision/snom/D715/{$mac}.xml
+++ b/resources/templates/provision/snom/D715/{$mac}.xml
@@ -29,6 +29,8 @@
     <mwi_dialtone perm="">stutter</mwi_dialtone>
     <enable_rport_rfc3581 perm="RW">on</enable_rport_rfc3581>
     <privacy_in perm="">off</privacy_in>
+    <quick_transfer perm="">blind</quick_transfer>
+    <call_screen_fkeys_on_connected perm="">F_HOLD F_TRANSFER F_CONFERENCE</call_screen_fkeys_on_connected>
     <!-- Updates -->
     <update_policy perm="">auto_update</update_policy>
     <setting_server perm="RW">https://{if isset($http_auth_enabled) && $http_auth_enabled == true}{$http_auth_username}:{$http_auth_password}@{/if}{$domain_name}{$project_path}/app/provision/index.php?mac={$mac}</setting_server>

--- a/resources/templates/provision/snom/D717/{$mac}.xml
+++ b/resources/templates/provision/snom/D717/{$mac}.xml
@@ -29,6 +29,8 @@
     <mwi_dialtone perm="">stutter</mwi_dialtone>
     <enable_rport_rfc3581 perm="RW">on</enable_rport_rfc3581>
     <privacy_in perm="">off</privacy_in>
+    <quick_transfer perm="">blind</quick_transfer>
+    <call_screen_fkeys_on_connected perm="">F_HOLD F_TRANSFER F_CONFERENCE</call_screen_fkeys_on_connected>
     <!-- Updates -->
     <update_policy perm="">auto_update</update_policy>
     <setting_server perm="RW">https://{if isset($http_auth_enabled) && $http_auth_enabled == true}{$http_auth_username}:{$http_auth_password}@{/if}{$domain_name}{$project_path}/app/provision/index.php?mac={$mac}</setting_server>

--- a/resources/templates/provision/snom/D725/{$mac}.xml
+++ b/resources/templates/provision/snom/D725/{$mac}.xml
@@ -29,6 +29,8 @@
     <mwi_dialtone perm="">stutter</mwi_dialtone>
     <enable_rport_rfc3581 perm="RW">on</enable_rport_rfc3581>
     <privacy_in perm="">off</privacy_in>
+    <quick_transfer perm="">blind</quick_transfer>
+    <call_screen_fkeys_on_connected perm="">F_HOLD F_TRANSFER F_CONFERENCE</call_screen_fkeys_on_connected>
     <!-- Updates -->
     <update_policy perm="">auto_update</update_policy>
     <setting_server perm="RW">https://{if isset($http_auth_enabled) && $http_auth_enabled == true}{$http_auth_username}:{$http_auth_password}@{/if}{$domain_name}{$project_path}/app/provision/index.php?mac={$mac}</setting_server>

--- a/resources/templates/provision/snom/D735/{$mac}.xml
+++ b/resources/templates/provision/snom/D735/{$mac}.xml
@@ -29,6 +29,8 @@
     <mwi_dialtone perm="">stutter</mwi_dialtone>
     <enable_rport_rfc3581 perm="RW">on</enable_rport_rfc3581>
     <privacy_in perm="">off</privacy_in>
+    <quick_transfer perm="">blind</quick_transfer>
+    <call_screen_fkeys_on_connected perm="">F_HOLD F_TRANSFER F_CONFERENCE</call_screen_fkeys_on_connected>
     <!-- Updates -->
     <update_policy perm="">auto_update</update_policy>
     <setting_server perm="RW">https://{if isset($http_auth_enabled) && $http_auth_enabled == true}{$http_auth_username}:{$http_auth_password}@{/if}{$domain_name}{$project_path}/app/provision/index.php?mac={$mac}</setting_server>

--- a/resources/templates/provision/snom/D745/{$mac}.xml
+++ b/resources/templates/provision/snom/D745/{$mac}.xml
@@ -29,6 +29,8 @@
     <mwi_dialtone perm="">stutter</mwi_dialtone>
     <enable_rport_rfc3581 perm="RW">on</enable_rport_rfc3581>
     <privacy_in perm="">off</privacy_in>
+    <quick_transfer perm="">blind</quick_transfer>
+    <call_screen_fkeys_on_connected perm="">F_HOLD F_TRANSFER F_CONFERENCE</call_screen_fkeys_on_connected>
     <!-- Updates -->
     <update_policy perm="">auto_update</update_policy>
     <setting_server perm="RW">https://{if isset($http_auth_enabled) && $http_auth_enabled == true}{$http_auth_username}:{$http_auth_password}@{/if}{$domain_name}{$project_path}/app/provision/index.php?mac={$mac}</setting_server>

--- a/resources/templates/provision/snom/D765/{$mac}.xml
+++ b/resources/templates/provision/snom/D765/{$mac}.xml
@@ -29,6 +29,8 @@
     <mwi_dialtone perm="">stutter</mwi_dialtone>
     <enable_rport_rfc3581 perm="RW">on</enable_rport_rfc3581>
     <privacy_in perm="">off</privacy_in>
+    <quick_transfer perm="">blind</quick_transfer>
+    <call_screen_fkeys_on_connected perm="">F_HOLD F_TRANSFER F_CONFERENCE</call_screen_fkeys_on_connected>
     <!-- Updates -->
     <update_policy perm="">auto_update</update_policy>
     <setting_server perm="RW">https://{if isset($http_auth_enabled) && $http_auth_enabled == true}{$http_auth_username}:{$http_auth_password}@{/if}{$domain_name}{$project_path}/app/provision/index.php?mac={$mac}</setting_server>

--- a/resources/templates/provision/snom/D785/{$mac}.xml
+++ b/resources/templates/provision/snom/D785/{$mac}.xml
@@ -29,6 +29,8 @@
     <mwi_dialtone perm="">stutter</mwi_dialtone>
     <enable_rport_rfc3581 perm="RW">on</enable_rport_rfc3581>
     <privacy_in perm="">off</privacy_in>
+    <quick_transfer perm="">blind</quick_transfer>
+    <call_screen_fkeys_on_connected perm="">F_HOLD F_TRANSFER F_CONFERENCE</call_screen_fkeys_on_connected>
     <!-- Updates -->
     <update_policy perm="">auto_update</update_policy>
     <setting_server perm="RW">https://{if isset($http_auth_enabled) && $http_auth_enabled == true}{$http_auth_username}:{$http_auth_password}@{/if}{$domain_name}{$project_path}/app/provision/index.php?mac={$mac}</setting_server>


### PR DESCRIPTION
The most recent firmware adds a setting on how to handle BLF key presses while on a call, as well as options to display certain function keys while in various call states. I set some sensible defaults for those.