### PR TITLE
Add TLS settings to enable working with LetsEncrypt wildcard

### DIFF
--- a/resources/templates/provision/polycom/4.x/{$mac}.cfg
+++ b/resources/templates/provision/polycom/4.x/{$mac}.cfg
@@ -61,10 +61,12 @@
 		sec.srtp.enable="{$polycom_srtp_enable}"
 		sec.srtp.offer="{$polycom_srtp_offer}"
 		sec.srtp.require="{$polycom_srtp_require}"
+		sec.TLS.SIP.strictCertCommonNameValidation="0"
 	/>
 	<DEVICE_SETTINGS
 		device.set="1"
 		device.sntp.serverName="{$ntp_server_primary}"
+		{if isset($polycom_gmt_offset)}device.sntp.gmtOffset.set="1"{/if}
 		device.sntp.gmtOffset="{$polycom_gmt_offset}"
 		device.prov.upgradeServer.set="1"
 		device.prov.upgradeServer="{$polycom_firmware_url}"
@@ -91,6 +93,11 @@
 		device.prov.tagSerialNo="1"
 		{else}
 		device.prov.serverName="{$domain_name}"
+		{/if}
+		{if isset($polycom_gmt_offset)}
+		device.sntp.gmtOffset.set="1"
+		device.sec.TLS.customCaCert1.set="1"
+		device.sec.TLS.customCaCert1="{$polycom_root_cert}"
 		{/if}
 	/>
 	<SNTP


### PR DESCRIPTION
I added variables to allow loading a root TLS certificate authority and time settings. The variables that have been added are the same as in the Polycom 5.x branch.