### PR TITLE
[4.5] Gives IVR Loopback support 1/2

### DIFF
--- a/app/extensions/app_config.php
+++ b/app/extensions/app_config.php
@@ -47,7 +47,7 @@
 		$y++;
 		$apps[$x]['destinations'][$y]['type'] = "sql";
 		$apps[$x]['destinations'][$y]['label'] = "loopback";
-		$apps[$x]['destinations'][$y]['name'] = "extensions";
+		$apps[$x]['destinations'][$y]['name'] = "loopback_extensions";
 		$apps[$x]['destinations'][$y]['sql'] = "select extension, number_alias, user_context as context, description from v_extensions ";
 		$apps[$x]['destinations'][$y]['where'] = "where domain_uuid = '\${domain_uuid}' and enabled = 'true' ";
 		$apps[$x]['destinations'][$y]['order_by'] = "number_alias, extension asc";
@@ -55,7 +55,8 @@
 		$apps[$x]['destinations'][$y]['field']['context'] = "user_context";
 		$apps[$x]['destinations'][$y]['field']['description'] = "description";
 		$apps[$x]['destinations'][$y]['select_value']['user_contact'] = "loopback/\${destination}/\${context}";
-		$apps[$x]['destinations'][$y]['select_label'] = "\${destination} \${description}";
+		$apps[$x]['destinations'][$y]['select_value']['ivr'] = "loopback/\${destination}/\${context}";
+		$apps[$x]['destinations'][$y]['select_label'] = "\${destination} \${description} (loopback)";
 		$y++;
 		$apps[$x]['destinations'][$y]['type'] = "sql";
 		$apps[$x]['destinations'][$y]['label'] = "call_groups";
@@ -206,6 +207,11 @@
 		$apps[$x]['permissions'][$y]['groups'][] = "superadmin";
 		$y++;
 		$apps[$x]['permissions'][$y]['name'] = "extension_destinations";
+		$apps[$x]['permissions'][$y]['groups'][] = "superadmin";
+		$apps[$x]['permissions'][$y]['groups'][] = "admin";
+		$apps[$x]['permissions'][$y]['groups'][] = "user";
+		$y++;
+		$apps[$x]['permissions'][$y]['name'] = "loopback_extension_destinations";
 		$apps[$x]['permissions'][$y]['groups'][] = "superadmin";
 		$apps[$x]['permissions'][$y]['groups'][] = "admin";
 		$apps[$x]['permissions'][$y]['groups'][] = "user";

--- a/app/extensions/app_languages.php
+++ b/app/extensions/app_languages.php
@@ -22,6 +22,27 @@ $text['title-extensions']['ru-ru'] = "";
 $text['title-extensions']['sv-se'] = "Anknytningar";
 $text['title-extensions']['uk-ua'] = "Розширення";
 
+$text['title-loopback']['en-us'] = "Extensions (loopback)";
+$text['title-loopback']['en-gb'] = "Extensions (loopback)";
+$text['title-loopback']['ar-eg'] = "الأرقام الداخلية";
+$text['title-loopback']['de-at'] = "Nebenstellen"; //copied from de-de
+$text['title-loopback']['de-ch'] = "Nebenstellen"; //copied from de-de
+$text['title-loopback']['de-de'] = "Nebenstellen";
+$text['title-loopback']['es-cl'] = "Extensiones";
+$text['title-loopback']['es-mx'] = "Extensiones"; //copied from es-cl
+$text['title-loopback']['fr-ca'] = "Extensions"; //copied from fr-fr
+$text['title-loopback']['fr-fr'] = "Extensions";
+$text['title-loopback']['he-il'] = "שלוחות";
+$text['title-loopback']['it-it'] = "Interni";
+$text['title-loopback']['nl-nl'] = "Toestellen";
+$text['title-loopback']['pl-pl'] = "Numery wewnętrzne";
+$text['title-loopback']['pt-br'] = "Ramais"; //copied from pt-pt
+$text['title-loopback']['pt-pt'] = "Extensões";
+$text['title-loopback']['ro-ro'] = "";
+$text['title-loopback']['ru-ru'] = "";
+$text['title-loopback']['sv-se'] = "Anknytningar";
+$text['title-loopback']['uk-ua'] = "Розширення";
+
 $text['title-extension_import']['en-us'] = "Extension Import";
 $text['title-extension_import']['en-gb'] = "Extension Import";
 $text['title-extension_import']['ar-eg'] = "";


### PR DESCRIPTION
After reading the destinations class, I found that you have an issue comparing against $apps[$x]['destinations'][$y]['name'] (method destination::select()), this is the root cause why loopback is not shown although you already have the definition in extensions/app_config.php.

'name' index needs to be different so users can have both options, direct transfer and loopback bridge.

Also, the 'ivr' index was missing (just copy and paste).

This patch allows a user to have the option of selecting a direct transfer or loopback bridge when adding a menu option.