### PR TITLE
[4.5] Allow changing the direct dial digits regex for IVRs

### DIFF
--- a/app/ivr_menus/app_config.php
+++ b/app/ivr_menus/app_config.php
@@ -140,6 +140,14 @@
 		$apps[$x]['default_settings'][$y]['default_setting_enabled'] = "true";
 		$apps[$x]['default_settings'][$y]['default_setting_description'] = "";
 		$y++;
+		$apps[$x]['default_settings'][$y]['default_setting_uuid'] = "ac4ff01d-51a2-433f-9243-be9b6dd8ba9c";
+		$apps[$x]['default_settings'][$y]['default_setting_category'] = "ivr_menu";
+		$apps[$x]['default_settings'][$y]['default_setting_subcategory'] = "direct_dial_digits";
+		$apps[$x]['default_settings'][$y]['default_setting_name'] = "text";
+		$apps[$x]['default_settings'][$y]['default_setting_value'] = "/^(\d{2,11})$/";
+		$apps[$x]['default_settings'][$y]['default_setting_enabled'] = "false";
+		$apps[$x]['default_settings'][$y]['default_setting_description'] = "";
+		$y++;
 		$apps[$x]['default_settings'][$y]['default_setting_uuid'] = "26984efd-2445-4ac9-b459-bb7bda4217c6";
 		$apps[$x]['default_settings'][$y]['default_setting_category'] = "limit";
 		$apps[$x]['default_settings'][$y]['default_setting_subcategory'] = "ivr_menus";

--- a/app/scripts/resources/scripts/app/xml_handler/resources/scripts/configuration/ivr.conf.lua
+++ b/app/scripts/resources/scripts/app/xml_handler/resources/scripts/configuration/ivr.conf.lua
@@ -114,8 +114,16 @@
 					ivr_menu_cid_prefix = row["ivr_menu_cid_prefix"];
 					ivr_menu_description = row["ivr_menu_description"];
 
-				--set the storage path
+
+				--set variables from settings
 					local settings = Settings.new(dbh, domain_name, domain_uuid)
+				
+				--direct dial regex
+					direct_dial_digits = settings:get('ivr_menu', 'direct_dial_digits', 'text')
+					if (direct_dial_digits == nil or direct_dial == '') then
+						direct_dial_digits = '/^(\d{2,11})$/'
+					end
+				--storage path
 					local storage_type = settings:get('recordings', 'storage_type', 'text')
 					local storage_path = settings:get('recordings', 'storage_path', 'text')
 					if (storage_path ~= nil) then
@@ -272,11 +280,11 @@
 
 				--direct dial
 					if (ivr_menu_direct_dial == "true") then
-						table.insert(xml, [[					<entry action="menu-exec-app" digits="/^(\d{2,11})$/" param="set ${cond(${user_exists id $1 ]]..domain_name..[[} == true ? user_exists=true : user_exists=false)}" description="direct dial"/>\n]]);
-						table.insert(xml, [[					<entry action="menu-exec-app" digits="/^(\d{2,11})$/" param="set ${cond(${user_exists} == true ? user_exists=true : ivr_max_failures=${system(expr ${ivr_max_failures} + 1)})}" description="increment max failures"/>\n]]);
-						table.insert(xml, [[					<entry action="menu-exec-app" digits="/^(\d{2,11})$/" param="playback ${cond(${user_exists} == true ? ]]..sound_prefix..[[ivr/ivr-call_being_transferred.wav : ]]..sound_prefix..[[ivr/ivr-that_was_an_invalid_entry.wav)}" description="play sound"/>\n]]);
-						table.insert(xml, [[					<entry action="menu-exec-app" digits="/^(\d{2,11})$/" param="transfer ${cond(${ivr_max_failures} == ]]..ivr_menu_max_failures..[[ ? ]]..ivr_menu_exit_data..[[)}" description="max fail transfer"/>\n]]);
-						table.insert(xml, [[					<entry action="menu-exec-app" digits="/^(\d{2,11})$/" param="transfer ${cond(${user_exists} == true ? $1 XML ]]..domain_name..[[)}" description="direct dial transfer"/>\n]]);
+						table.insert(xml, [[					<entry action="menu-exec-app" digits="]]..direct_dial_digits..[[" param="set ${cond(${user_exists id $1 ]]..domain_name..[[} == true ? user_exists=true : user_exists=false)}" description="direct dial"/>\n]]);
+						table.insert(xml, [[					<entry action="menu-exec-app" digits="]]..direct_dial_digits..[[" param="set ${cond(${user_exists} == true ? user_exists=true : ivr_max_failures=${system(expr ${ivr_max_failures} + 1)})}" description="increment max failures"/>\n]]);
+						table.insert(xml, [[					<entry action="menu-exec-app" digits="]]..direct_dial_digits..[[" param="playback ${cond(${user_exists} == true ? ]]..sound_prefix..[[ivr/ivr-call_being_transferred.wav : ]]..sound_prefix..[[ivr/ivr-that_was_an_invalid_entry.wav)}" description="play sound"/>\n]]);
+						table.insert(xml, [[					<entry action="menu-exec-app" digits="]]..direct_dial_digits..[[" param="transfer ${cond(${ivr_max_failures} == ]]..ivr_menu_max_failures..[[ ? ]]..ivr_menu_exit_data..[[)}" description="max fail transfer"/>\n]]);
+						table.insert(xml, [[					<entry action="menu-exec-app" digits="]]..direct_dial_digits..[[" param="transfer ${cond(${user_exists} == true ? $1 XML ]]..domain_name..[[)}" description="direct dial transfer"/>\n]]);
 					end
 
 				--close the extension tag if it was left open


### PR DESCRIPTION
# Context
In one of our production systems we have IVR options that are three digits and we also have direct dial enabled. I do not believe this was a supported configuration to begin with but it operated okay until this commit 2e8f5d1f00a45d445f281fd47c0b412412aa130e. This merge request adds in the ability to change the direct dial digits regex from the default settings to allow more granular matching.

# Overview
* Add a new default setting in ivr_menus called direct_dial_digits to allow changing the behavior of the direct dial IVR feature
* Modify ivr.conf.lua to attempt to load that setting, if the setting does not exist or is blank default back to the normal regex pattern for direct_dial