### PR TITLE
Fix follow me originate_delay for external numbers

### DIFF
--- a/app/scripts/resources/scripts/app/follow_me/index.lua
+++ b/app/scripts/resources/scripts/app/follow_me/index.lua
@@ -384,7 +384,7 @@
 					end
 
 				--set the destination dial string
-					-- have to double destination_delay here due a FS bug requiring a 50% delay value for internal externsions, but not external calls. 
+					-- have to double destination_delay here due a FS bug requiring a 50% delay value for internal extensions, but not external calls. 
 					destination_delay = destination_delay * 2;
 					dial_string = "[ignore_early_media=true,toll_allow=".. toll_allow ..",".. caller_id ..",sip_invite_domain="..domain_name..",domain_uuid="..domain_uuid..",call_direction="..call_direction..","..group_confirm..","..timeout_name.."="..destination_timeout..","..delay_name.."="..destination_delay.."]"..route_bridge
 			end

--- a/app/scripts/resources/scripts/app/follow_me/index.lua
+++ b/app/scripts/resources/scripts/app/follow_me/index.lua
@@ -384,6 +384,8 @@
 					end
 
 				--set the destination dial string
+					-- have to double destination_delay here due a FS bug requiring a 50% delay value for internal externsions, but not external calls. 
+					destination_delay = destination_delay * 2;
 					dial_string = "[ignore_early_media=true,toll_allow=".. toll_allow ..",".. caller_id ..",sip_invite_domain="..domain_name..",domain_uuid="..domain_uuid..",call_direction="..call_direction..","..group_confirm..","..timeout_name.."="..destination_timeout..","..delay_name.."="..destination_delay.."]"..route_bridge
 			end
 


### PR DESCRIPTION
internal numbers were set to half of the time due to a FreeSWITCH bug but need to be set back for external numbers (ring groups was already fixed)