### PR TITLE
Hide global dialplans. Show to superadmin group that has dialplan_all permission

### DIFF
--- a/app/dialplans/dialplans.php
+++ b/app/dialplans/dialplans.php
@@ -140,9 +140,11 @@
 		$sql .= "where true ";
 	}
 	else {
-		$sql .= "where (domain_uuid = :domain_uuid) ";
 		if (if_group("superadmin")) {
-			$sql .= " or (domain_uuid is null)";
+			$sql .= "where (domain_uuid = :domain_uuid or domain_uuid is null) ";
+		}
+		else {
+			$sql .= "where (domain_uuid = :domain_uuid) ";
 		}
 		$parameters['domain_uuid'] = $domain_uuid;
 	}

--- a/app/dialplans/dialplans.php
+++ b/app/dialplans/dialplans.php
@@ -140,7 +140,10 @@
 		$sql .= "where true ";
 	}
 	else {
-		$sql .= "where (domain_uuid = :domain_uuid or domain_uuid is null) ";
+		$sql .= "where (domain_uuid = :domain_uuid) ";
+		if (if_group("superadmin")) {
+			$sql .= " or (domain_uuid is null)";
+		}
 		$parameters['domain_uuid'] = $domain_uuid;
 	}
 	if (!is_uuid($app_uuid)) {

--- a/app/dialplans/dialplans.php
+++ b/app/dialplans/dialplans.php
@@ -140,12 +140,7 @@
 		$sql .= "where true ";
 	}
 	else {
-		if (if_group("superadmin")) {
-			$sql .= "where (domain_uuid = :domain_uuid or domain_uuid is null) ";
-		}
-		else {
-			$sql .= "where (domain_uuid = :domain_uuid) ";
-		}
+		$sql .= "where domain_uuid = :domain_uuid ";
 		$parameters['domain_uuid'] = $domain_uuid;
 	}
 	if (!is_uuid($app_uuid)) {


### PR DESCRIPTION
If permissions to dialplans is given to anyone other than superadmin then they should not be able to see GLOBAL dialpans unless they have dialplan_all permission as well.