### PR TITLE
[4.5] Fix show own extensions only

### DIFF
--- a/app/xml_cdr/xml_cdr_statistics_inc.php
+++ b/app/xml_cdr/xml_cdr_statistics_inc.php
@@ -321,6 +321,9 @@
 					}
 				}
 			}
+                       foreach ($_SESSION['user']['extension'] as $row) {
+                                $sql_where_ors[] = "extension_uuid = '".$row['extension_uuid']."'";
+                        }
 			// concatenate the 'or's array, then add to the 'and's array
 			if (sizeof($sql_where_ors) > 0) {
 				$sql_where_ands[] = "( ".implode(" or ", $sql_where_ors)." )";


### PR DESCRIPTION
When you log as a non-admin user, and if you are using non-numeric extensions it won't show data. Adding extension_uuid actually fixes this issue.