### PR TITLE
Add new grandstream_onhook_dial_barging & grandstream_history_dialpla…

### DIFF
--- a/resources/templates/provision/grandstream/gxp2130/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp2130/{$mac}.xml
@@ -7330,7 +7330,9 @@
     <!-- # Onhook Dial Barging. 0 - Disabled, 1 - Enabled. Default is 1 -->
     <!-- # Number: 0, 1 -->
     <!-- # Mandatory -->
-    <P8397>1</P8397>
+    {if isset($grandstream_onhook_dial_barging)}
+      <P8397>{$grandstream_onhook_dial_barging}</P8397>
+    {/if}
 
     <!-- # Off-hook Auto Dial -->
     <!-- # String -->
@@ -7373,7 +7375,9 @@
     <!-- # Bypass Dial Plan Through Call History and Directories. 0 - No, 1 - Yes. Default is 0 -->
     <!-- # Number: 0, 1 -->
     <!-- # Mandatory -->
-    <P6758>0</P6758>
+    {if isset($grandstream_history_dialplan_bypass)}
+      <P6758>{$grandstream_history_dialplan_bypass}</P6758>
+    {/if}
 
     <!-- # Disable Call Waiting. 0 - No, 1 - Yes. Default is 0 -->
     <!-- # Number: 0, 1 -->


### PR DESCRIPTION
…n_bypass variables

Enable the option to prevent incoming calls from interrupting outbound dialing (a commonly requested functionality)
Enable the option to bypass Grandstream phone's dialplan when dialing from call history (to prevent errors on calls that contained a + in front of them)