### PR TITLE
Follow me add ability to use internal caller id when calling out to external numbers  

### DIFF
--- a/app/scripts/resources/scripts/app/follow_me/index.lua
+++ b/app/scripts/resources/scripts/app/follow_me/index.lua
@@ -364,7 +364,8 @@
 					end
 
 				--set the outbound caller id
-					if (session:ready() and caller_is_local) then
+					ignore_outbound_caller_id = session:getVariable("follow_me_ignore_outbound_caller_id");
+					if (session:ready() and caller_is_local and ignore_outbound_caller_id ~= "true") then
 						if (outbound_caller_id_name ~= nil) then
 							caller_id_name = outbound_caller_id_name;
 						end


### PR DESCRIPTION
There are some cases where people want to use their internal extension caller id  when calling out to external numbers