### PR TITLE
Update app_config.php

### DIFF
--- a/app/yealink/app_config.php
+++ b/app/yealink/app_config.php
@@ -859,7 +859,7 @@
 		$apps[$x]['default_settings'][$y]['default_setting_category'] = "provision";
 		$apps[$x]['default_settings'][$y]['default_setting_subcategory'] = "yealink_trust_certificates";
 		$apps[$x]['default_settings'][$y]['default_setting_name'] = "text";
-		$apps[$x]['default_settings'][$y]['default_setting_value'] = "true";
+		$apps[$x]['default_settings'][$y]['default_setting_value'] = "false";
 		$apps[$x]['default_settings'][$y]['default_setting_enabled'] = "true";
 		$apps[$x]['default_settings'][$y]['default_setting_description'] = "Required trusted certificate for provisioning.";
 		$y++;


### PR DESCRIPTION
yealink_trust_certificates should always be default FALSE. This messes up provisioning.