### PR TITLE
Voicemail : Not Found Extension (ability to transfer to a destination (extension/ivr/etc) when extension is unavailable and no voicemail is configured

### DIFF
--- a/app/scripts/resources/scripts/app/voicemail/index.lua
+++ b/app/scripts/resources/scripts/app/voicemail/index.lua
@@ -219,6 +219,13 @@
 					end
 				end
 
+				not_found_extension = '';
+				if (settings['voicemail']['not_found_extension'] ~= nil) then
+					if (settings['voicemail']['not_found_extension']['text'] ~= nil) then
+						not_found_extension = settings['voicemail']['not_found_extension']['text'];
+					end
+				end
+
 			end
 
 			if (settings['voicemail']) then
@@ -645,6 +652,10 @@
 								session:answer();
 								session:execute("sleep", "1000");
 								session:execute("playback", sounds_dir.."/"..default_language.."/"..default_dialect.."/"..default_voice.."/voicemail/vm-no_answer_no_vm.wav");
+							end
+							if (not_found_extension ~= "") then
+								session:transfer(not_found_extension, "XML", context);
+							else
 								session:hangup();
 							end
 						end


### PR DESCRIPTION
Voicemail : Not Found Extension

When an extension is unavailable and no voicemail is configured, there is an option to transfer the caller to a defined destination (extension/ivr/etc).

To enable/disable this, add a default setting of type: text, named (subcategory) not_found_extension in Advanced > Default Settings > Voicemail category and set the value field to the destination to suit your needs.

This setting can be used in conjunction with not_found_message if desired.