### PR TITLE
Update {$mac}.xml

### DIFF
--- a/resources/templates/provision/grandstream/gxp2170/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp2170/{$mac}.xml
@@ -8256,7 +8256,7 @@
     <!-- # Speaker Ring Volume -->
     <!-- # Number: 0-7. Default is 5. -->
     <!-- # Mandatory -->
-    <P8352>5</P8352>
+    <!-- <P8352>5</P8352> -->
 
     <!-- # Notification Tone Volume -->
     <!-- # Number: 0-7. Default is 5. -->


### PR DESCRIPTION
    <!-- # Speaker Ring Volume -->
    <!-- # Number: 0-7. Default is 5. -->
    <!-- # Mandatory -->
   <P8352>5</P8352>

When this is set, it will override the users choice of ring volume. My customer sets some phones to low by pressing the - volume button. By next morning, the volume is back to loud because the provision file sets <P8352>5</P8352> thus overwriting the users choice of volume.