### PR TITLE
Fix Config URLs for unconfigured Grandstream Phones

### DIFF
--- a/resources/templates/provision/grandstream/dp715.sm/{$mac}.xml
+++ b/resources/templates/provision/grandstream/dp715.sm/{$mac}.xml
@@ -80,7 +80,7 @@
 <P237></P237>
 {elseif isset($grandstream_config_server_path)}
 <P237>{$grandstream_config_server_path}</P237>
-{else}
+{elseif isset($domain_name)}
 <P237>{$domain_name}{$project_path}/app/provision</P237>
 {/if}
 

--- a/resources/templates/provision/grandstream/dp715/{$mac}.xml
+++ b/resources/templates/provision/grandstream/dp715/{$mac}.xml
@@ -42,7 +42,7 @@
                 <P237></P237>
                 {elseif isset($grandstream_config_server_path)}
                 <P237>{$grandstream_config_server_path}</P237>
-                {else}
+                {elseif isset($domain_name)}
                 <P237>{$domain_name}{$project_path}/app/provision</P237>
                 {/if}
 	

--- a/resources/templates/provision/grandstream/dp750/{$mac}.xml
+++ b/resources/templates/provision/grandstream/dp750/{$mac}.xml
@@ -2921,7 +2921,7 @@
 <P237></P237>
 {elseif isset($grandstream_config_server_path)}
 <P237>{$grandstream_config_server_path}</P237>
-{else}
+{elseif isset($domain_name)}
 <P237>{$domain_name}{$project_path}/app/provision</P237>
 {/if}
 

--- a/resources/templates/provision/grandstream/gac2500/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gac2500/{$mac}.xml
@@ -4168,7 +4168,7 @@
 	<P237></P237>
 	{elseif isset($grandstream_config_server_path)}
 	<P237>{$grandstream_config_server_path}</P237>
-	{else}
+	{elseif isset($domain_name)}
 	<P237>{$domain_name}{$project_path}/app/provision</P237>
 	{/if}
 

--- a/resources/templates/provision/grandstream/gds3705/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gds3705/{$mac}.xml
@@ -690,7 +690,7 @@
     <P237></P237>
     {elseif isset($grandstream_config_server_path)}
     <P237>{$grandstream_config_server_path}</P237>
-    {else}
+    {elseif isset($domain_name)}
     <P237>{$domain_name}{$project_path}/app/provision</P237>
     {/if}
     <!-- HTTP/HTTPS User Name -->

--- a/resources/templates/provision/grandstream/gds3710/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gds3710/{$mac}.xml
@@ -743,7 +743,7 @@ E0Fw0O5Kx31JPa+aSBLDMZAG1+SZ/zfxRYQe7VH8p1g=
     <P237></P237>
     {elseif isset($grandstream_config_server_path)}
     <P237>{$grandstream_config_server_path}</P237>
-    {else}
+    {elseif isset($domain_name)}
     <P237>{$domain_name}{$project_path}/app/provision</P237>
     {/if}
     <!-- Config HTTP/HTTPS User Name -->

--- a/resources/templates/provision/grandstream/grp2612/{$mac}.xml
+++ b/resources/templates/provision/grandstream/grp2612/{$mac}.xml
@@ -2451,7 +2451,7 @@
     <P237></P237>
 {elseif isset($grandstream_config_server_path)}
     <P237>{$grandstream_config_server_path}</P237>
-{else}
+{elseif isset($domain_name)}
     <P237>{$domain_name}{$project_path}/app/provision</P237>
 {/if}
 

--- a/resources/templates/provision/grandstream/grp2612w/{$mac}.xml
+++ b/resources/templates/provision/grandstream/grp2612w/{$mac}.xml
@@ -2545,7 +2545,7 @@
     <P237></P237>
 {elseif isset($grandstream_config_server_path)}
     <P237>{$grandstream_config_server_path}</P237>
-{else}
+{elseif isset($domain_name)}
     <P237>{$domain_name}{$project_path}/app/provision</P237>
 {/if}
 

--- a/resources/templates/provision/grandstream/grp2613/{$mac}.xml
+++ b/resources/templates/provision/grandstream/grp2613/{$mac}.xml
@@ -3277,7 +3277,7 @@
     <P237></P237>
 {elseif isset($grandstream_config_server_path)}
     <P237>{$grandstream_config_server_path}</P237>
-{else}
+{elseif isset($domain_name)}
     <P237>{$domain_name}{$project_path}/app/provision</P237>
 {/if}
 

--- a/resources/templates/provision/grandstream/grp2614/{$mac}.xml
+++ b/resources/templates/provision/grandstream/grp2614/{$mac}.xml
@@ -4483,7 +4483,7 @@
     <P237></P237>
 {elseif isset($grandstream_config_server_path)}
     <P237>{$grandstream_config_server_path}</P237>
-{else}
+{elseif isset($domain_name)}
     <P237>{$domain_name}{$project_path}/app/provision</P237>
 {/if}
 

--- a/resources/templates/provision/grandstream/grp2615/{$mac}.xml
+++ b/resources/templates/provision/grandstream/grp2615/{$mac}.xml
@@ -5430,7 +5430,7 @@
     <P237></P237>
 {elseif isset($grandstream_config_server_path)}
     <P237>{$grandstream_config_server_path}</P237>
-{else}
+{elseif isset($domain_name)}
     <P237>{$domain_name}{$project_path}/app/provision</P237>
 {/if}
 

--- a/resources/templates/provision/grandstream/grp2616/{$mac}.xml
+++ b/resources/templates/provision/grandstream/grp2616/{$mac}.xml
@@ -6381,7 +6381,7 @@
     <P237></P237>
 {elseif isset($grandstream_config_server_path)}
     <P237>{$grandstream_config_server_path}</P237>
-{else}
+{elseif isset($domain_name)}
     <P237>{$domain_name}{$project_path}/app/provision</P237>
 {/if}
 

--- a/resources/templates/provision/grandstream/grp26xx/{$mac}.xml
+++ b/resources/templates/provision/grandstream/grp26xx/{$mac}.xml
@@ -5746,7 +5746,7 @@
     <P237></P237>
 {elseif isset($grandstream_config_server_path)}
     <P237>{$grandstream_config_server_path}</P237>
-{else}
+{elseif isset($domain_name)}
     <P237>{$domain_name}{$project_path}/app/provision</P237>
 {/if}
 

--- a/resources/templates/provision/grandstream/gxp110x/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp110x/{$mac}.xml
@@ -940,7 +940,7 @@
 <P237></P237>
 {elseif isset($grandstream_config_server_path)}
 <P237>{$grandstream_config_server_path}</P237>
-{else}
+{elseif isset($domain_name)}
 <P237>{$domain_name}{$project_path}/app/provision</P237>
 {/if}
 

--- a/resources/templates/provision/grandstream/gxp116x/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp116x/{$mac}.xml
@@ -814,7 +814,7 @@
 <P237></P237>
 {elseif isset($grandstream_config_server_path)}
 <P237>{$grandstream_config_server_path}</P237>
-{else}
+{elseif isset($domain_name)}
 <P237>{$domain_name}{$project_path}/app/provision</P237>
 {/if}
 

--- a/resources/templates/provision/grandstream/gxp140x/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp140x/{$mac}.xml
@@ -1186,7 +1186,7 @@
     <P237></P237>
     {elseif isset($grandstream_config_server_path)}
     <P237>{$grandstream_config_server_path}</P237>
-    {else}
+    {elseif isset($domain_name)}
     <P237>{$domain_name}{$project_path}/app/provision</P237>
     {/if}
     

--- a/resources/templates/provision/grandstream/gxp140xbk/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp140xbk/{$mac}.xml
@@ -1186,7 +1186,7 @@
     <P237></P237>
     {elseif isset($grandstream_config_server_path)}
     <P237>{$grandstream_config_server_path}</P237>
-    {else}
+    {elseif isset($domain_name)}
     <P237>{$domain_name}{$project_path}/app/provision</P237>
     {/if}
     

--- a/resources/templates/provision/grandstream/gxp1450/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp1450/{$mac}.xml
@@ -1569,7 +1569,7 @@
 <P237></P237>
 {elseif isset($grandstream_config_server_path)}
 <P237>{$grandstream_config_server_path}</P237>
-{else}
+{elseif isset($domain_name)}
 <P237>{$domain_name}{$project_path}/app/provision</P237>
 {/if}
 

--- a/resources/templates/provision/grandstream/gxp1450bk/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp1450bk/{$mac}.xml
@@ -1376,7 +1376,7 @@
 <P237></P237>
 {elseif isset($grandstream_config_server_path)}
 <P237>{$grandstream_config_server_path}</P237>
-{else}
+{elseif isset($domain_name)}
 <P237>{$domain_name}{$project_path}/app/provision</P237>
 {/if}
 

--- a/resources/templates/provision/grandstream/gxp16xx/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp16xx/{$mac}.xml
@@ -2073,7 +2073,7 @@
 <P237></P237>
 {elseif isset($grandstream_config_server_path)}
 <P237>{$grandstream_config_server_path}</P237>
-{else}
+{elseif isset($domain_name)}
 <P237>{$domain_name}{$project_path}/app/provision</P237>
 {/if}
 <!--  Config HTTP/HTTPS User Name -->

--- a/resources/templates/provision/grandstream/gxp17xx/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp17xx/{$mac}.xml
@@ -6039,7 +6039,7 @@
 <P237></P237>
 {elseif isset($grandstream_config_server_path)}
 <P237>{$grandstream_config_server_path}</P237>
-{else}
+{elseif isset($domain_name)}
 <P237>{$domain_name}{$project_path}/app/provision</P237>
 {/if}
 

--- a/resources/templates/provision/grandstream/gxp20xx/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp20xx/{$mac}.xml
@@ -85,7 +85,7 @@
 <P237></P237>
 {elseif isset($grandstream_config_server_path)}
 <P237>{$grandstream_config_server_path}</P237>
-{else}
+{elseif isset($domain_name)}
 <P237>{$domain_name}{$project_path}/app/provision</P237>
 {/if}
 

--- a/resources/templates/provision/grandstream/gxp2100/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp2100/{$mac}.xml
@@ -2809,7 +2809,7 @@
 <P237></P237>
 {elseif isset($grandstream_config_server_path)}
 <P237>{$grandstream_config_server_path}</P237>
-{else}
+{elseif isset($domain_name)}
 <P237>{$domain_name}{$project_path}/app/provision</P237>
 {/if}
 

--- a/resources/templates/provision/grandstream/gxp2124/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp2124/{$mac}.xml
@@ -1925,7 +1925,7 @@
     <P237></P237>
     {elseif isset($grandstream_config_server_path)}
     <P237>{$grandstream_config_server_path}</P237>
-    {else}
+    {elseif isset($domain_name)}
     <P237>{$domain_name}{$project_path}/app/provision</P237>
     {/if}
     

--- a/resources/templates/provision/grandstream/gxp2130/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp2130/{$mac}.xml
@@ -6305,7 +6305,7 @@
     <P237></P237>
 {elseif isset($grandstream_config_server_path)}
     <P237>{$grandstream_config_server_path}</P237>
-{else}
+{elseif isset($domain_name)}
     <P237>{$domain_name}{$project_path}/app/provision</P237>
 {/if}
 

--- a/resources/templates/provision/grandstream/gxp2135/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp2135/{$mac}.xml
@@ -6305,7 +6305,7 @@
     <P237></P237>
 {elseif isset($grandstream_config_server_path)}
     <P237>{$grandstream_config_server_path}</P237>
-{else}
+{elseif isset($domain_name)}
     <P237>{$domain_name}{$project_path}/app/provision</P237>
 {/if}
 

--- a/resources/templates/provision/grandstream/gxp2140/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp2140/{$mac}.xml
@@ -6305,7 +6305,7 @@
     <P237></P237>
 {elseif isset($grandstream_config_server_path)}
     <P237>{$grandstream_config_server_path}</P237>
-{else}
+{elseif isset($domain_name)}
     <P237>{$domain_name}{$project_path}/app/provision</P237>
 {/if}
 

--- a/resources/templates/provision/grandstream/gxp2160/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp2160/{$mac}.xml
@@ -6305,7 +6305,7 @@
     <P237></P237>
 {elseif isset($grandstream_config_server_path)}
     <P237>{$grandstream_config_server_path}</P237>
-{else}
+{elseif isset($domain_name)}
     <P237>{$domain_name}{$project_path}/app/provision</P237>
 {/if}
 

--- a/resources/templates/provision/grandstream/gxp2170/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp2170/{$mac}.xml
@@ -6305,7 +6305,7 @@
     <P237></P237>
 {elseif isset($grandstream_config_server_path)}
     <P237>{$grandstream_config_server_path}</P237>
-{else}
+{elseif isset($domain_name)}
     <P237>{$domain_name}{$project_path}/app/provision</P237>
 {/if}
 

--- a/resources/templates/provision/grandstream/gxp21xx/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp21xx/{$mac}.xml
@@ -2714,7 +2714,7 @@
     <P237></P237>
     {elseif isset($grandstream_config_server_path)}
     <P237>{$grandstream_config_server_path}</P237>
-    {else}
+    {elseif isset($domain_name)}
     <P237>{$domain_name}{$project_path}/app/provision</P237>
     {/if}
     

--- a/resources/templates/provision/grandstream/gxp21xxbk/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp21xxbk/{$mac}.xml
@@ -48,7 +48,7 @@
 <P237></P237>
 {elseif isset($grandstream_config_server_path)}
 <P237>{$grandstream_config_server_path}</P237>
-{else}
+{elseif isset($domain_name)}
 <P237>{$domain_name}{$project_path}/app/provision</P237>
 {/if}
 

--- a/resources/templates/provision/grandstream/gxp2200/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp2200/{$mac}.xml
@@ -3016,7 +3016,7 @@ Account 5 Codec Settings
 <P237></P237>
 {elseif isset($grandstream_config_server_path)}
 <P237>{$grandstream_config_server_path}</P237>
-{else}
+{elseif isset($domain_name)}
 <P237>{$domain_name}{$project_path}/app/provision</P237>
 {/if}
 

--- a/resources/templates/provision/grandstream/gxp3240/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp3240/{$mac}.xml
@@ -3226,7 +3226,7 @@ Account 5 Codec Settings
 <P237></P237>
 {elseif isset($grandstream_config_server_path)}
 <P237>{$grandstream_config_server_path}</P237>
-{else}
+{elseif isset($domain_name)}
 <P237>{$domain_name}{$project_path}/app/provision</P237>
 {/if}
 

--- a/resources/templates/provision/grandstream/gxv300x/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxv300x/{$mac}.xml
@@ -78,7 +78,7 @@
     <P237></P237>
     {elseif isset($grandstream_config_server_path)}
     <P237>{$grandstream_config_server_path}</P237>
-    {else}
+    {elseif isset($domain_name)}
     <P237>{$domain_name}{$project_path}/app/provision</P237>
     {/if}
     

--- a/resources/templates/provision/grandstream/gxv3140/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxv3140/{$mac}.xml
@@ -1385,7 +1385,7 @@
 <P237></P237>
 {elseif isset($grandstream_config_server_path)}
 <P237>{$grandstream_config_server_path}</P237>
-{else}
+{elseif isset($domain_name)}
 <P237>{$domain_name}{$project_path}/app/provision</P237>
 {/if}
 

--- a/resources/templates/provision/grandstream/gxv3175/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxv3175/{$mac}.xml
@@ -1268,7 +1268,7 @@
 <P237></P237>
 {elseif isset($grandstream_config_server_path)}
 <P237>{$grandstream_config_server_path}</P237>
-{else}
+{elseif isset($domain_name)}
 <P237>{$domain_name}{$project_path}/app/provision</P237>
 {/if}
 

--- a/resources/templates/provision/grandstream/gxv3175v2/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxv3175v2/{$mac}.xml
@@ -767,7 +767,7 @@
     <P237></P237>
     {elseif isset($grandstream_config_server_path)}
     <P237>{$grandstream_config_server_path}</P237>
-    {else}
+    {elseif isset($domain_name)}
     <P237>{$domain_name}{$project_path}/app/provision</P237>
     {/if}
     

--- a/resources/templates/provision/grandstream/gxv3240/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxv3240/{$mac}.xml
@@ -4820,7 +4820,7 @@
 <P237></P237>
 {elseif isset($grandstream_config_server_path)}
 <P237>{$grandstream_config_server_path}</P237>
-{else}
+{elseif isset($domain_name)}
 <P237>{$domain_name}{$project_path}/app/provision</P237>
 {/if}
 

--- a/resources/templates/provision/grandstream/gxv3275/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxv3275/{$mac}.xml
@@ -3225,7 +3225,7 @@ Account 5 Codec Settings
 <P237></P237>
 {elseif isset($grandstream_config_server_path)}
 <P237>{$grandstream_config_server_path}</P237>
-{else}
+{elseif isset($domain_name)}
 <P237>{$domain_name}{$project_path}/app/provision</P237>
 {/if}
 

--- a/resources/templates/provision/grandstream/gxv3504/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxv3504/{$mac}.xml
@@ -580,7 +580,7 @@
 <P237></P237>
 {elseif isset($grandstream_config_server_path)}
 <P237>{$grandstream_config_server_path}</P237>
-{else}
+{elseif isset($domain_name)}
 <P237>{$domain_name}{$project_path}/app/provision</P237>
 {/if}
 

--- a/resources/templates/provision/grandstream/gxw4004/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxw4004/{$mac}.xml
@@ -26,7 +26,7 @@
                 <P237></P237>
                 {elseif isset($grandstream_config_server_path)}
                 <P237>{$grandstream_config_server_path}</P237>
-                {else}
+                {elseif isset($domain_name)}
                 <P237>{$domain_name}{$project_path}/app/provision</P237>
                 {/if}
 

--- a/resources/templates/provision/grandstream/gxw4008/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxw4008/{$mac}.xml
@@ -26,7 +26,7 @@
                 <P237></P237>
                 {elseif isset($grandstream_config_server_path)}
                 <P237>{$grandstream_config_server_path}</P237>
-                {else}
+                {elseif isset($domain_name)}
                 <P237>{$domain_name}{$project_path}/app/provision</P237>
                 {/if}
 

--- a/resources/templates/provision/grandstream/gxw40xx/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxw40xx/{$mac}.xml
@@ -63,7 +63,7 @@
     <P237></P237>
     {elseif isset($grandstream_config_server_path)}
     <P237>{$grandstream_config_server_path}</P237>
-    {else}
+    {elseif isset($domain_name)}
     <P237>{$domain_name}{$project_path}/app/provision</P237>
     {/if}
     

--- a/resources/templates/provision/grandstream/gxw410x/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxw410x/{$mac}.xml
@@ -43,7 +43,7 @@
     <P237></P237>
     {elseif isset($grandstream_config_server_path)}
     <P237>{$grandstream_config_server_path}</P237>
-    {else}
+    {elseif isset($domain_name)}
     <P237>{$domain_name}{$project_path}/app/provision</P237>
     {/if}
     

--- a/resources/templates/provision/grandstream/gxw42xx/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxw42xx/{$mac}.xml
@@ -171,7 +171,7 @@
 <P237></P237>
 {elseif isset($grandstream_config_server_path)}
 <P237>{$grandstream_config_server_path}</P237>
-{else}
+{elseif isset($domain_name)}
 <P237>{$domain_name}{$project_path}/app/provision</P237>
 {/if}
 

--- a/resources/templates/provision/grandstream/ht502/{$mac}.xml
+++ b/resources/templates/provision/grandstream/ht502/{$mac}.xml
@@ -53,7 +53,7 @@
                 <P237></P237>
                 {elseif isset($grandstream_config_server_path)}
                 <P237>{$grandstream_config_server_path}</P237>
-                {else}
+                {elseif isset($domain_name)}
                 <P237>{$domain_name}{$project_path}/app/provision</P237>
                 {/if}
 		

--- a/resources/templates/provision/grandstream/ht503/{$mac}.xml
+++ b/resources/templates/provision/grandstream/ht503/{$mac}.xml
@@ -150,7 +150,7 @@
 <P237></P237>
 {elseif isset($grandstream_config_server_path)}
 <P237>{$grandstream_config_server_path}</P237>
-{else}
+{elseif isset($domain_name)}
 <P237>{$domain_name}{$project_path}/app/provision</P237>
 {/if}
 

--- a/resources/templates/provision/grandstream/ht701/{$mac}.xml
+++ b/resources/templates/provision/grandstream/ht701/{$mac}.xml
@@ -75,7 +75,7 @@
 <P237></P237>
 {elseif isset($grandstream_config_server_path)}
 <P237>{$grandstream_config_server_path}</P237>
-{else}
+{elseif isset($domain_name)}
 <P237>{$domain_name}{$project_path}/app/provision</P237>
 {/if}
 

--- a/resources/templates/provision/grandstream/ht702/{$mac}.xml
+++ b/resources/templates/provision/grandstream/ht702/{$mac}.xml
@@ -86,7 +86,7 @@
 <P237></P237>
 {elseif isset($grandstream_config_server_path)}
 <P237>{$grandstream_config_server_path}</P237>
-{else}
+{elseif isset($domain_name)}
 <P237>{$domain_name}{$project_path}/app/provision</P237>
 {/if}
 

--- a/resources/templates/provision/grandstream/ht704/{$mac}.xml
+++ b/resources/templates/provision/grandstream/ht704/{$mac}.xml
@@ -81,7 +81,7 @@
 <P237></P237>
 {elseif isset($grandstream_config_server_path)}
 <P237>{$grandstream_config_server_path}</P237>
-{else}
+{elseif isset($domain_name)}
 <P237>{$domain_name}{$project_path}/app/provision</P237>
 {/if}
 

--- a/resources/templates/provision/grandstream/ht802/{$mac}.xml
+++ b/resources/templates/provision/grandstream/ht802/{$mac}.xml
@@ -105,7 +105,7 @@
     <P237></P237>
     {elseif isset($grandstream_config_server_path)}
     <P237>{$grandstream_config_server_path}</P237>
-    {else}
+    {elseif isset($domain_name)}
     <P237>{$domain_name}{$project_path}/app/provision</P237>
     {/if}
 

--- a/resources/templates/provision/grandstream/ht818/{$mac}.xml
+++ b/resources/templates/provision/grandstream/ht818/{$mac}.xml
@@ -94,7 +94,7 @@
     <P237></P237>
     {elseif isset($grandstream_config_server_path)}
     <P237>{$grandstream_config_server_path}</P237>
-    {else}
+    {elseif isset($domain_name)}
     <P237>{$domain_name}{$project_path}/app/provision</P237>
     {/if}
 

--- a/resources/templates/provision/grandstream/htx86/{$mac}.xml
+++ b/resources/templates/provision/grandstream/htx86/{$mac}.xml
@@ -57,7 +57,7 @@
     <P237></P237>
     {elseif isset($grandstream_config_server_path)}
     <P237>{$grandstream_config_server_path}</P237>
-    {else}
+    {elseif isset($domain_name)}
     <P237>{$domain_name}{$project_path}/app/provision</P237>
     {/if}
 

--- a/resources/templates/provision/grandstream/wp820/{$mac}.xml
+++ b/resources/templates/provision/grandstream/wp820/{$mac}.xml
@@ -2235,7 +2235,7 @@
 <P237></P237>
 {elseif isset($grandstream_config_server_path)}
 <P237>{$grandstream_config_server_path}</P237>
-{else}
+{elseif isset($domain_name)}
 <P237>{$domain_name}{$project_path}/app/provision</P237>
 {/if}
 


### PR DESCRIPTION
Fix config URL so that the phones don't get an invalid URL when $domain_name is unset. They would previously receive `/app/provision` with no domain/ip included, which makes the phone unable to provision again once they have been added to the Devices page without manually re-setting the config URL or factory defaulting the device.

The alternative solution is that the PHP code could always ensure that the $domain_name variable is set, even if the device doesn't exist yet in the Devices page. My suggestion is to see if it can be set to the same domain/IP as the request used. I don't know how to do that, so I fixed it in the template itself for now.