### PR TITLE
Set the domain_name even if the device doesn't exist

### DIFF
--- a/app/provision/index.php
+++ b/app/provision/index.php
@@ -154,7 +154,11 @@
 
 		//get the domain name
 			$domain_name = $_SESSION['domains'][$domain_uuid]['domain_name'];
-
+		//previous value only set if the device exists in the database already. Backup method to get the domain name
+			if (strlen($domain_name) == 0) {
+				$domain_array = explode(":", $_SERVER["HTTP_HOST"]);
+				$domain_name = $domain_array[0];
+			}
 		//get the default settings
 			$sql = "select * from v_default_settings ";
 			$sql .= "where default_setting_enabled = 'true' ";


### PR DESCRIPTION
Sets the domain name variable even if the device doesn't exist. Setting it here ensures that the default settings for the specific domain are loaded. It can also be set just in the render function of provision.php if we want to skip loading domain settings for unconfigured devices, we just need to make sure that the domain_name isn't empty by the time the configuration is generated.

This fix is more elegant than #5543 which just modifies the template to compensate for an empty domain_name variable. That being said, the 2 are not mutually exclusive and #5543 will ensure that the phones won't get a broken configuration if $domain_name is empty.