### PR TITLE
Fix displaying array order for settings of type array in multiple settings pages

### DIFF
--- a/core/default_settings/default_setting_edit.php
+++ b/core/default_settings/default_setting_edit.php
@@ -211,7 +211,7 @@
 //pre-populate the form
 	if (count($_GET) > 0 && $_POST["persistformvar"] != "true") {
 		$default_setting_uuid = $_GET["id"];
-		$sql = "select default_setting_uuid, default_setting_category, default_setting_subcategory, default_setting_name, default_setting_value, cast(default_setting_enabled as text), default_setting_description ";
+		$sql = "select default_setting_uuid, default_setting_category, default_setting_subcategory, default_setting_name, default_setting_value, default_setting_order, cast(default_setting_enabled as text), default_setting_description ";
 		$sql .= "from v_default_settings ";
 		$sql .= "where default_setting_uuid = :default_setting_uuid ";
 		$parameters['default_setting_uuid'] = $default_setting_uuid;

--- a/core/domain_settings/domain_setting_edit.php
+++ b/core/domain_settings/domain_setting_edit.php
@@ -325,7 +325,7 @@ if (count($_POST) > 0 && strlen($_POST["persistformvar"]) == 0) {
 //pre-populate the form
 	if (count($_GET)>0 && $_POST["persistformvar"] != "true" && is_uuid($_GET["id"])) {
 		$domain_setting_uuid = $_GET["id"];
-		$sql = "select domain_setting_uuid, domain_setting_category, domain_setting_subcategory, domain_setting_name, domain_setting_value, cast(domain_setting_enabled as text), domain_setting_description ";
+		$sql = "select domain_setting_uuid, domain_setting_category, domain_setting_subcategory, domain_setting_name, domain_setting_value, domain_setting_order, cast(domain_setting_enabled as text), domain_setting_description ";
 		$sql .= "from v_domain_settings ";
 		$sql .= "where domain_uuid = :domain_uuid ";
 		$sql .= "and domain_setting_uuid = :domain_setting_uuid ";

--- a/core/user_settings/user_setting_edit.php
+++ b/core/user_settings/user_setting_edit.php
@@ -319,7 +319,7 @@ if (count($_POST) > 0 && strlen($_POST["persistformvar"]) == 0) {
 //pre-populate the form
 	if (is_uuid($_GET["id"]) && count($_GET) > 0 && $_POST["persistformvar"] != "true") {
 		$user_setting_uuid = $_GET["id"];
-		$sql = "select user_setting_category, user_setting_subcategory, user_setting_name, user_setting_value, cast(user_setting_enabled as text), user_setting_description ";
+		$sql = "select user_setting_category, user_setting_subcategory, user_setting_name, user_setting_value, user_setting_order, cast(user_setting_enabled as text), user_setting_description ";
 		$sql .= "from v_user_settings ";
 		$sql .= "where user_setting_uuid = :user_setting_uuid ";
 		$sql .= "and user_uuid = :user_uuid ";


### PR DESCRIPTION
the _setting_order was missing from the SELECT queries for all 3 places I could find that use this mechanism. The device settings don't seem to use it.