### PR TITLE
Update dialplan_outbound_add.php

### DIFF
--- a/app/dialplan_outbound/dialplan_outbound_add.php
+++ b/app/dialplan_outbound/dialplan_outbound_add.php
@@ -729,7 +729,7 @@
 	$sql = "select * from v_gateways ";
 	$sql .= "where enabled = 'true' ";
 	if (permission_exists('outbound_route_any_gateway')) {
-		$sql .= "order by domain_uuid, gateway ";
+		$sql .= "order by domain_uuid = '$domain_uuid' DESC, gateway ";
 	}
 	else {
 		$sql .= "and domain_uuid = :domain_uuid ";


### PR DESCRIPTION
Make the gateway select order the gateways with the current domain first. This is a behaviour change on the older versions where the selected gateway was at the end of the list but much better than current with none.