### PR TITLE
Prevent users from overriding user_context

### DIFF
--- a/app/extensions/extension_edit.php
+++ b/app/extensions/extension_edit.php
@@ -398,7 +398,7 @@
 									}
 									else {
 										if ($action == "add") {
-											$user_context = $_SESSION['domain_name'];
+											$array["extensions"][$i]["user_context"] = $_SESSION['domain_name'];
 										}
 									}
 									if (permission_exists('extension_missed_call')) {

--- a/app/extensions/extension_edit.php
+++ b/app/extensions/extension_edit.php
@@ -267,15 +267,6 @@
 				return;
 			}
 
-		//set the default user context
-			if (permission_exists("extension_user_context")) {
-				//allow a user assigned to super admin to change the user_context
-			}
-			else {
-				//if the user_context was not set then set the default value
-				$user_context = $_SESSION['domain_name'];
-			}
-
 		//prevent users from bypassing extension limit by using range
 			if ($_SESSION['limit']['extensions']['numeric'] != '') {
 				if ($total_extensions + $range > $_SESSION['limit']['extensions']['numeric']){
@@ -402,7 +393,14 @@
 									$array["extensions"][$i]["directory_exten_visible"] = $directory_exten_visible;
 									$array["extensions"][$i]["limit_max"] = $limit_max;
 									$array["extensions"][$i]["limit_destination"] = $limit_destination;
-									$array["extensions"][$i]["user_context"] = $user_context;
+									if (permission_exists("extension_user_context")) {
+										$array["extensions"][$i]["user_context"] = $user_context;
+									}
+									else {
+										if ($action == "add") {
+											$user_context = $_SESSION['domain_name'];
+										}
+									}
 									if (permission_exists('extension_missed_call')) {
 										$array["extensions"][$i]["missed_call_app"] = $missed_call_app;
 										$array["extensions"][$i]["missed_call_data"] = $missed_call_data;


### PR DESCRIPTION
if the user_context is set to something other than the default domain_name users with edit permission were overriding the context to the default domain_name when saving extensions