### PR TITLE
Fix Device Provisioning and Feature Sync across SIP Profiles

### DIFF
--- a/app/devices/device_edit.php
+++ b/app/devices/device_edit.php
@@ -625,20 +625,6 @@
 		}
 	}
 
-//get the sip profile name
-	$fp = event_socket_create($_SESSION['event_socket_ip_address'], $_SESSION['event_socket_port'], $_SESSION['event_socket_password']);
-	if ($fp) {
-		$command = "sofia_contact */".$user_id."@".$server_address;
-		$contact_string = event_socket_request($fp, "api ".$command);
-		if (substr($contact_string, 0, 5) == "sofia") {
-			$contact_array = explode("/", $contact_string);
-			$sip_profile_name = $contact_array[1];
-		}
-		else {
-			$sip_profile_name = 'internal';
-		}
-	}
-
 //create token
 	$object = new token;
 	$token = $object->create($_SERVER['PHP_SELF']);
@@ -816,7 +802,7 @@
 			echo button::create(['type'=>'button','label'=>$text['button-qr_code'],'icon'=>'qrcode','style'=>$button_margin,'onclick'=>"$('#qr_code_container').fadeIn(400);"]);
 			unset($button_margin);
 		}
-		echo button::create(['type'=>'button','label'=>$text['button-provision'],'icon'=>'fax','style'=>$button_margin,'link'=>PROJECT_PATH."/app/devices/cmd.php?cmd=check_sync&profile=".urlencode($sip_profile_name)."&user=".urlencode($user_id)."@".urlencode($server_address)."&domain=".urlencode($server_address)."&agent=".urlencode($device_vendor)]);
+		echo button::create(['type'=>'button','label'=>$text['button-provision'],'icon'=>'fax','style'=>$button_margin,'link'=>PROJECT_PATH."/app/devices/cmd.php?cmd=check_sync"."&user=".urlencode($user_id)."@".urlencode($server_address)."&domain=".urlencode($server_address)."&agent=".urlencode($device_vendor)]);
 		unset($button_margin);
 		if (permission_exists("device_files")) {
 			//get the template directory

--- a/app/scripts/resources/scripts/app/feature_event/index.lua
+++ b/app/scripts/resources/scripts/app/feature_event/index.lua
@@ -72,7 +72,7 @@
 	end
 
 --get the events
-	--if (user == nil) then 
+	--if (user == nil) then
 		--serialize the data for the console
 			--freeswitch.consoleLog("notice","[events] " .. event:serialize("xml") .. "\n");
 			--freeswitch.consoleLog("notice","[evnts] " .. event:serialize("json") .. "\n");
@@ -115,13 +115,13 @@
 
 	--get sip profile
 		if (user ~= nil and host ~= nil) then
-			sip_profile = notify.get_profile(user, host);
+			sip_profiles = notify.get_profiles(user, host);
 		end
 
 	--DND
-
+		if (sip_profiles ~= nil) then
 		--DND enabled
-			if (feature_action == "SetDoNotDisturb" and feature_enabled == "true" and sip_profile ~= nil) then
+			if (feature_action == "SetDoNotDisturb" and feature_enabled == "true") then
 				--set a variable
 					dial_string = "error/user_busy";
 					do_not_disturb = "true";
@@ -155,11 +155,11 @@
 					end
 
 				--send notify to the phone
-					notify.dnd(user, host, sip_profile, do_not_disturb);	
+					notify.dnd(user, host, sip_profiles, do_not_disturb);
 			end
 
 		--DND disabled
-			if (feature_action == "SetDoNotDisturb" and feature_enabled == "false" and sip_profile ~= nil ) then
+			if (feature_action == "SetDoNotDisturb" and feature_enabled == "false") then
 					--set a variable
 						do_not_disturb = "false";
 
@@ -177,14 +177,14 @@
 						dbh:query(sql, params);
 
 				--send notify to the phone
-					notify.dnd(user, host, sip_profile, do_not_disturb);	
+					notify.dnd(user, host, sip_profiles, do_not_disturb);
 
 			end
 
 	--Call Forward
 
 		--Call Formward All enabled
-			if (feature_action == "SetCallForward" and feature_enabled == "true" and action_name == "forward_immediate" and sip_profile ~= nil) then
+			if (feature_action == "SetCallForward" and feature_enabled == "true" and action_name == "forward_immediate") then
 				--set a variable
 					forward_all_destination = action_value;
 					forward_all_enabled = "true";
@@ -247,11 +247,11 @@
 					end
 
 				--send notify to the phone
-					notify.forward_immediate(user, host, sip_profile, forward_immediate_enabled, forward_immediate_destination);
+					notify.forward_immediate(user, host, sip_profiles, forward_immediate_enabled, forward_immediate_destination);
 			end
 
 		--Call Formward All disable
-			if (feature_action == "SetCallForward" and feature_enabled == "false" and action_name == "forward_immediate" and sip_profile ~= nil) then
+			if (feature_action == "SetCallForward" and feature_enabled == "false" and action_name == "forward_immediate") then
 				--set a variable				
 					forward_all_destination = action_value;
 					forward_all_enabled = "false";
@@ -277,14 +277,14 @@
 					dbh:query(sql, params);
 
 				--send notify to the phone
-					if (forward_immediate_destination == nil) then 
+					if (forward_immediate_destination == nil) then
 						forward_immediate_destination = " ";
 					end
-					notify.forward_immediate(user, host, sip_profile, forward_immediate_enabled, forward_immediate_destination);
+					notify.forward_immediate(user, host, sip_profiles, forward_immediate_enabled, forward_immediate_destination);
 			end
 
 		--Call Formward BUSY enable
-			if (feature_action == "SetCallForward" and feature_enabled == "true" and action_name == "forward_busy" and sip_profile ~= nil) then
+			if (feature_action == "SetCallForward" and feature_enabled == "true" and action_name == "forward_busy") then
 				--set a variable
 					forward_busy_destination = action_value;
 					forward_busy_enabled = "true";
@@ -303,11 +303,11 @@
 					dbh:query(sql, params);
 
 				--send notify to the phone
-					notify.forward_busy(user, host, sip_profile, forward_busy_enabled, forward_busy_destination);
+					notify.forward_busy(user, host, sip_profiles, forward_busy_enabled, forward_busy_destination);
 			end
 
 		--Call Formward BUSY disable
-			if (feature_action == "SetCallForward" and feature_enabled == "false" and action_name == "forward_busy" and sip_profile ~= nil) then
+			if (feature_action == "SetCallForward" and feature_enabled == "false" and action_name == "forward_busy") then
 				--set a variable
 					forward_busy_destination = action_value;
 					forward_busy_enabled = "false";
@@ -330,11 +330,11 @@
 					dbh:query(sql, params);
 
 				--send notify to the phone
-					notify.forward_busy(user, host, sip_profile, forward_busy_enabled, forward_busy_destination);					
+					notify.forward_busy(user, host, sip_profiles, forward_busy_enabled, forward_busy_destination);
 			end
 
 		--Call Formward NO ANSWER enable
-			if (feature_action == "SetCallForward" and feature_enabled == "true" and action_name == "forward_no_answer" and sip_profile ~= nil) then
+			if (feature_action == "SetCallForward" and feature_enabled == "true" and action_name == "forward_no_answer") then
 				--set a variable
 					forward_no_answer_destination = action_value;
 					forward_no_answer_enabled = "true";
@@ -355,11 +355,11 @@
 					dbh:query(sql, params);
 
 				--send notify to the phone
-					notify.forward_no_answer(user, host, sip_profile, forward_no_answer_enabled, forward_no_answer_destination, ring_count);
+					notify.forward_no_answer(user, host, sip_profiles, forward_no_answer_enabled, forward_no_answer_destination, ring_count);
 			end
 
 		--Call Formward NO ANSWER disable
-			if (feature_action == "SetCallForward" and feature_enabled == "false" and action_name == "forward_no_answer" and sip_profile ~= nil) then
+			if (feature_action == "SetCallForward" and feature_enabled == "false" and action_name == "forward_no_answer") then
 				--set a variable
 					forward_no_answer_destination = action_value;
 					forward_no_answer_enabled = "false";
@@ -382,28 +382,28 @@
 					dbh:query(sql, params);
 
 				--send notify to the phone
-					notify.forward_no_answer(user, host, sip_profile, forward_no_answer_enabled, forward_no_answer_destination, ring_count);					
+					notify.forward_no_answer(user, host, sip_profiles, forward_no_answer_enabled, forward_no_answer_destination, ring_count);
 			end			
 	
 	--No feature event (phone boots): Send all values
 		if (feature_enabled == nil) then
 			--Do Not Disturb
-				--notify.dnd(user, host, sip_profile, do_not_disturb);
+				--notify.dnd(user, host, sip_profiles, do_not_disturb);
 
 			--Forward all
 				forward_immediate_enabled = forward_all_enabled;
 				forward_immediate_destination = forward_all_destination;
-				--notify.forward_immediate(user, host, sip_profile, forward_immediate_enabled, forward_immediate_destination);
+				--notify.forward_immediate(user, host, sip_profiles, forward_immediate_enabled, forward_immediate_destination);
 
 			--Forward busy
-				--notify.forward_busy(user, host, sip_profile, forward_busy_enabled, forward_busy_destination);
+				--notify.forward_busy(user, host, sip_profiles, forward_busy_enabled, forward_busy_destination);
 
 			--Forward No Answer
 				ring_count = math.ceil (call_timeout / 6);
-				--notify.forward_no_answer(user, host, sip_profile, forward_no_answer_enabled, forward_no_answer_destination, ring_count);
+				--notify.forward_no_answer(user, host, sip_profiles, forward_no_answer_enabled, forward_no_answer_destination, ring_count);
 			notify.init(user, 
 				host, 
-				sip_profile, 
+				sip_profiles,
 				forward_immediate_enabled, 
 				forward_immediate_destination, 
 				forward_busy_enabled, 
@@ -414,8 +414,8 @@
 				do_not_disturb);
 		end
 
---		feature_event_notify.init(user, host, sip_profile, forward_immediate_enabled, forward_immediate_destination, forward_busy_enabled, forward_busy_destination, forward_no_answer_enabled, forward_no_answer_destination, ring_count, do_not_disturb)
-
+--		feature_event_notify.init(user, host, sip_profiles, forward_immediate_enabled, forward_immediate_destination, forward_busy_enabled, forward_busy_destination, forward_no_answer_enabled, forward_no_answer_destination, ring_count, do_not_disturb)
+	end
 	--clear the cache
 		if (feature_enabled ~= nil) then
 			cache.del("directory:"..user.."@"..host)

--- a/app/scripts/resources/scripts/app/feature_event/resources/functions/feature_event_notify.lua
+++ b/app/scripts/resources/scripts/app/feature_event/resources/functions/feature_event_notify.lua
@@ -56,35 +56,50 @@ function feature_event_notify.get_db_values(user, domain_name)
 			return do_not_disturb, forward_all_enabled, forward_all_destination, forward_busy_enabled, forward_busy_destination, forward_no_answer_enabled, forward_no_answer_destination, call_timeout
 end
 
-function feature_event_notify.get_profile(user, host)		
+---@return table, nil
+function feature_event_notify.get_profiles(user, domain)
 		--includes
-		require "resources.functions.explode"
 		require "resources.functions.trim"
-		
-		local account = user.."@"..host
+
+		local account = user.."@"..domain
 		--create the api object
 		api = freeswitch.API();
 		local sofia_contact = trim(api:executeString("sofia_contact */"..account));
-		local array = explode("/", sofia_contact);
-		local sip_profile = array[2];
-		return sip_profile
+		--get all profiles for the user account
+		local profile_iterator = string.gmatch(sofia_contact, "sofia/([^,]+)/[^,]+");
+
+		--remove any duplicates and check if we have any profiles
+		local unique_profiles = {}
+		local has_profile = false
+		for profile in profile_iterator do
+			has_profile = true
+			unique_profiles[profile] = 1
+		end
+
+		-- return nil if we have no profiles
+		if not has_profile then return nil end
+
+		return unique_profiles
 end
 
-function feature_event_notify.dnd(user, host, sip_profile, do_not_disturb)
-		--set the event and send it
-		local event = freeswitch.Event("SWITCH_EVENT_PHONE_FEATURE")
-		event:addHeader("profile", sip_profile)
-		event:addHeader("user", user)
-		event:addHeader("host", host)
-		event:addHeader("device", "")
-		event:addHeader("Feature-Event", "DoNotDisturbEvent")
-		event:addHeader("doNotDisturbOn", do_not_disturb)
-		--freeswitch.consoleLog("notice","[events] " .. event:serialize("xml") .. "\n");
-		event:fire()
+function feature_event_notify.dnd(user, host, sip_profiles, do_not_disturb)
+		--set the event and send it to each profile
+		for sip_profile, _ in pairs(sip_profiles) do
+			local event = freeswitch.Event("SWITCH_EVENT_PHONE_FEATURE")
+			event:addHeader("profile", sip_profile)
+			event:addHeader("user", user)
+			event:addHeader("host", host)
+			event:addHeader("device", "")
+			event:addHeader("Feature-Event", "DoNotDisturbEvent")
+			event:addHeader("doNotDisturbOn", do_not_disturb)
+			--freeswitch.consoleLog("notice","[events] " .. event:serialize("xml") .. "\n");
+			event:fire()
+		end
 end
 
-function feature_event_notify.forward_immediate(user, host, sip_profile, forward_immediate_enabled, forward_immediate_destination)
-		--set the event and send it
+function feature_event_notify.forward_immediate(user, host, sip_profiles, forward_immediate_enabled, forward_immediate_destination)
+	--set the event and send it to each profile
+	for sip_profile, _ in pairs(sip_profiles) do
 		local event = freeswitch.Event("SWITCH_EVENT_PHONE_FEATURE")
 		event:addHeader("profile", sip_profile)
 		event:addHeader("user", user)
@@ -95,10 +110,12 @@ function feature_event_notify.forward_immediate(user, host, sip_profile, forward
 		event:addHeader("forward_immediate", forward_immediate_destination);
 		freeswitch.consoleLog("notice","[events] " .. event:serialize("xml") .. "\n");
 		event:fire()
+	end
 end
 
-function feature_event_notify.forward_busy(user, host, sip_profile, forward_busy_enabled, forward_busy_destination)
-		--set the event and send it
+function feature_event_notify.forward_busy(user, host, sip_profiles, forward_busy_enabled, forward_busy_destination)
+	--set the event and send it to each profile
+	for sip_profile, _ in pairs(sip_profiles) do
 		local event = freeswitch.Event("SWITCH_EVENT_PHONE_FEATURE")
 		event:addHeader("profile", sip_profile)
 		event:addHeader("user", user)
@@ -108,10 +125,12 @@ function feature_event_notify.forward_busy(user, host, sip_profile, forward_busy
 		event:addHeader("forward_busy", forward_busy_destination)
 		event:addHeader("forward_busy_enabled", forward_busy_enabled)
 		event:fire()
+	end
 end
 
-function feature_event_notify.forward_no_answer(user, host, sip_profile, forward_no_answer_enabled, forward_no_answer_destination, ring_count)
-		--set the event and send it
+function feature_event_notify.forward_no_answer(user, host, sip_profiles, forward_no_answer_enabled, forward_no_answer_destination, ring_count)
+	--set the event and send it to each profile
+	for sip_profile, _ in pairs(sip_profiles) do
 		local event = freeswitch.Event("SWITCH_EVENT_PHONE_FEATURE")
 		event:addHeader("profile", sip_profile)
 		event:addHeader("user", user)
@@ -122,10 +141,12 @@ function feature_event_notify.forward_no_answer(user, host, sip_profile, forward
 		event:addHeader("forward_no_answer_enabled", forward_no_answer_enabled)
 		event:addHeader("ringCount", ring_count)
 		event:fire()
+	end
 end
 
-function feature_event_notify.init(user, host, sip_profile, forward_immediate_enabled, forward_immediate_destination, forward_busy_enabled, forward_busy_destination, forward_no_answer_enabled, forward_no_answer_destination, ring_count, do_not_disturb)
-		--set the event and send it
+function feature_event_notify.init(user, host, sip_profiles, forward_immediate_enabled, forward_immediate_destination, forward_busy_enabled, forward_busy_destination, forward_no_answer_enabled, forward_no_answer_destination, ring_count, do_not_disturb)
+	--set the event and send it to each profile
+	for sip_profile, _ in pairs(sip_profiles) do
 		local event = freeswitch.Event("SWITCH_EVENT_PHONE_FEATURE")
 		event:addHeader("profile", sip_profile)
 		event:addHeader("user", user)
@@ -143,6 +164,7 @@ function feature_event_notify.init(user, host, sip_profile, forward_immediate_en
 		event:addHeader("Feature-Event", "DoNotDisturbEvent")
 		event:addHeader("doNotDisturbOn", do_not_disturb)
 		event:fire()
+	end
 end
 
 return feature_event_notify

--- a/app/scripts/resources/scripts/call_forward.lua
+++ b/app/scripts/resources/scripts/call_forward.lua
@@ -262,14 +262,14 @@
 
 		-- Get the sip_profile
 			if (extension ~= nil and domain_name ~= nil) then
-				sip_profile = notify.get_profile(extension, domain_name);
+				sip_profiles = notify.get_profiles(extension, domain_name);
 			end
 
-		if (sip_profile ~= nil) then 
+		if (sip_profiles ~= nil) then
 				freeswitch.consoleLog("NOTICE", "[feature_event] SIP NOTIFY: CFWD set to "..forward_all_enabled.."\n");
 
 			--Do Not Disturb
-				notify.dnd(extension, domain_name, sip_profile, do_not_disturb);
+				notify.dnd(extension, domain_name, sip_profiles, do_not_disturb);
 
 			--Forward all
 				forward_immediate_enabled = forward_all_enabled;
@@ -281,7 +281,7 @@
 					end
 
 				freeswitch.consoleLog("NOTICE", "[feature_event] forward_immediate_destination "..forward_immediate_destination.."\n");
-				notify.forward_immediate(extension, domain_name, sip_profile, forward_immediate_enabled, forward_immediate_destination);
+				notify.forward_immediate(extension, domain_name, sip_profiles, forward_immediate_enabled, forward_immediate_destination);
 
 			--Forward busy
 				--workaround for freeswitch not sending NOTIFY when destination values are nil. Send 0.
@@ -290,7 +290,7 @@
 					end
 
 				freeswitch.consoleLog("NOTICE", "[feature_event] forward_busy_destination "..forward_busy_destination.."\n");
-				notify.forward_busy(extension, domain_name, sip_profile, forward_busy_enabled, forward_busy_destination);
+				notify.forward_busy(extension, domain_name, sip_profiles, forward_busy_enabled, forward_busy_destination);
 
 			--Forward No Answer
 				ring_count = math.ceil (call_timeout / 6);
@@ -300,7 +300,7 @@
 					end
 
 				freeswitch.consoleLog("NOTICE", "[feature_event] forward_no_answer_destination "..forward_no_answer_destination.."\n");
-				notify.forward_no_answer(extension, domain_name, sip_profile, forward_no_answer_enabled, forward_no_answer_destination, ring_count);
+				notify.forward_no_answer(extension, domain_name, sip_profiles, forward_no_answer_enabled, forward_no_answer_destination, ring_count);
 		end
 	end
 

--- a/app/scripts/resources/scripts/do_not_disturb.lua
+++ b/app/scripts/resources/scripts/do_not_disturb.lua
@@ -227,15 +227,15 @@
 
 		-- Get the sip_profile
 		if (extension ~= nil and domain_name ~= nil) then
-			sip_profile = notify.get_profile(extension, domain_name);
+			sip_profiles = notify.get_profiles(extension, domain_name);
 		end
 
 		-- check if not nil
-		if (sip_profile ~= nil) then 
+		if (sip_profiles ~= nil) then
 				freeswitch.consoleLog("NOTICE", "[feature_event] SIP NOTIFY: CFWD set to "..forward_all_enabled.."\n");
 
 			--Do Not Disturb
-				notify.dnd(extension, domain_name, sip_profile, do_not_disturb);
+				notify.dnd(extension, domain_name, sip_profiles, do_not_disturb);
 
 			--Forward all
 				forward_immediate_enabled = forward_all_enabled;
@@ -246,7 +246,7 @@
 						forward_immediate_destination = '0';
 					end
 
-				notify.forward_immediate(extension, domain_name, sip_profile, forward_immediate_enabled, forward_immediate_destination);
+				notify.forward_immediate(extension, domain_name, sip_profiles, forward_immediate_enabled, forward_immediate_destination);
 
 			--Forward busy
 				--workaround for freeswitch not sending NOTIFY when destination values are nil. Send 0.
@@ -254,7 +254,7 @@
 						forward_busy_destination = '0';
 					end
 
-				notify.forward_busy(extension, domain_name, sip_profile, forward_busy_enabled, forward_busy_destination);
+				notify.forward_busy(extension, domain_name, sip_profiles, forward_busy_enabled, forward_busy_destination);
 
 			--Forward No Answer
 				ring_count = math.ceil (call_timeout / 6);
@@ -263,7 +263,7 @@
 						forward_no_answer_destination = '0';
 					end
 
-				notify.forward_no_answer(extension, domain_name, sip_profile, forward_no_answer_enabled, forward_no_answer_destination, ring_count);
+				notify.forward_no_answer(extension, domain_name, sip_profiles, forward_no_answer_enabled, forward_no_answer_destination, ring_count);
 		end
 	end
 


### PR DESCRIPTION
# Context
If you have multiple registrations that are also across SIP profiles the provision button under the `device_edit.php` page and the feature syncing will not work since it calls `sofia_contact` and only uses the first profile found. This causes the feature keys to not sync or devices to not re-provision in some cases.

# Overview
- Modify `send_notify` in `feature_event_notify.php` to use `preg_match_all` to grab all of the profiles and loop the event sending for each unique profile.
- Move the profile code to `cmd.php` in the devices app and like what was completed in `feature_event_notify.php` loop over each unique profile and send the command.
  - Also removes the newly unused code from `device_edit.php`
- Renames `get_profile` to `get_profiles` in `feature_event_notify.lua` which either returns nil for no profiles or a array of unique profiles.
- Each lua function that used to take the single sip_profile was updated to take this array and send events to each profile the user is part of.