### PR TITLE
Minify Provisioning XML

### DIFF
--- a/app/devices/device_edit.php
+++ b/app/devices/device_edit.php
@@ -683,7 +683,7 @@
 			if ($_SERVER['HTTPS'] == 'on') { $_SERVER['HTTP_PROTOCOL'] = 'https'; }
 			if ($_SERVER['SERVER_PORT'] == '443') { $_SERVER['HTTP_PROTOCOL'] = 'https'; }
 		}
-		echo "		window.location = '".$_SERVER['HTTP_PROTOCOL']."://".$domain_name.PROJECT_PATH."/app/provision/index.php?mac=".escape($device_mac_address)."&file=' + d + '&content_type=application/octet-stream';\n";
+		echo "		window.location = '".$_SERVER['HTTP_PROTOCOL']."://".$domain_name.PROJECT_PATH."/app/provision/index.php?pretty=true&mac=".escape($device_mac_address)."&file=' + d + '&content_type=application/octet-stream';\n";
 		echo "	}\n";
 
 		echo "\n";

--- a/app/provision/app_config.php
+++ b/app/provision/app_config.php
@@ -487,5 +487,13 @@
 		$apps[$x]['default_settings'][$y]['default_setting_enabled'] = "true";
 		$apps[$x]['default_settings'][$y]['default_setting_description'] = "SPA upgrade firmware enable Yes or No Default No.";
 		$y++;
+		$apps[$x]['default_settings'][$y]['default_setting_uuid'] = "0e9edca0-51ed-43ca-96b4-b0af9055e497";
+		$apps[$x]['default_settings'][$y]['default_setting_category'] = "provision";
+		$apps[$x]['default_settings'][$y]['default_setting_subcategory'] = "minify_xml";
+		$apps[$x]['default_settings'][$y]['default_setting_name'] = "boolean";
+		$apps[$x]['default_settings'][$y]['default_setting_value'] = "true";
+		$apps[$x]['default_settings'][$y]['default_setting_enabled'] = "true";
+		$apps[$x]['default_settings'][$y]['default_setting_description'] = "Strip whitespace and comments from well formatted XML configuration files. Default true.";
+		$y++;
 
 ?>

--- a/app/provision/index.php
+++ b/app/provision/index.php
@@ -42,6 +42,7 @@
 	$mac = $_REQUEST['mac'];
 	$file = $_REQUEST['file'];
 	$ext = $_REQUEST['ext'];
+	$pretty = $_REQUEST['pretty'];
 	//if (strlen($_REQUEST['template']) > 0) {
 	//	$device_template = $_REQUEST['template'];
 	//}
@@ -426,6 +427,21 @@
 	$prov->mac = $mac;
 	$prov->file = $file;
 	$file_contents = $prov->render();
+
+	// Remove all comments and whitespace if valid XML and if $pretty is empty
+	if (empty($pretty)) {
+		$dom = new DOMDocument;
+		$dom->preserveWhiteSpace = false;
+		$dom->formatOutput = false;
+		if ($dom->loadXML($file_contents) === true) {
+			$xpath = new DOMXPath($dom);
+			// Iterate backwards over the XML file
+			for ($els = $xpath->query('//comment()'), $i = $els->length - 1; $i >= 0; $i--) {
+				$els->item($i)->parentNode->removeChild($els->item($i));
+			}
+			$file_contents = $dom->saveXML();
+		}
+	}
 
 //deliver the customized config over HTTP/HTTPS
 	//need to make sure content-type is correct

--- a/app/provision/index.php
+++ b/app/provision/index.php
@@ -432,8 +432,8 @@
 	$dom->preserveWhiteSpace = false;
 	$dom->formatOutput = false;
 	$isXML = $dom->loadXML($file_contents, LIBXML_NOERROR|LIBXML_ERR_FATAL|LIBXML_ERR_NONE);
-	// Remove all comments and whitespace if valid XML and if $pretty is empty
-	if ($isXML === true && empty($pretty)) {
+	// Remove all comments and whitespace if valid XML, $pretty is empty, and enabled in settings
+	if ($isXML === true && empty($pretty) && $provision["minify_xml"] == "true") {
 		$xpath = new DOMXPath($dom);
 		// Iterate backwards over the XML file
 		for ($els = $xpath->query('//comment()'), $i = $els->length - 1; $i >= 0; $i--) {


### PR DESCRIPTION
# Context
For device provisioning templates that are valid XML there can be a substantial size reduction by removing all whitespace and comments from served XML files.

## Example in size reduction
GRP2613 Template (8% of original):
- Before: ‘index.html?mac=000b82354b51&pretty=true’ saved [168157/168157]
- After: ‘index.html?mac=000b82354b51’ saved [14837/14837]

Custom Template (42% of original):
- Before: ‘index.html?mac=c074ad288040&pretty=true’ saved [426295/426295]
- After: ‘index.html?mac=c074ad288040.2’ saved [178341/178341]

# Overview
- Add a new request parameter of `pretty` and if it is not empty do not minify output
- Add a new setting called `minify_xml` to allow disabling this behavior.
- Using DOMDocument parse the output of the provisioning template and minify the XML if requested and was parsed as valid XML.
- Remove the call to `simplexml_load_string` for determining the Content-Type and use the result of the `loadXML` call.