### PR TITLE
Ensure new lines respect proxy and address default settings.

### DIFF
--- a/app/devices/device_edit.php
+++ b/app/devices/device_edit.php
@@ -283,11 +283,13 @@
 						$y = 0;
 						foreach ($device_lines as $row) {
 							if (strlen($row['line_number']) > 0) {
+								$new_line = false;
 								if (is_uuid($row["device_line_uuid"])) {
 									$device_line_uuid = $row["device_line_uuid"];
 								}
 								else {
 									$device_line_uuid = uuid();
+									$new_line = true;
 								}
 								$array['devices'][0]['device_lines'][$y]['domain_uuid'] = $domain_uuid;
 								$array['devices'][0]['device_lines'][$y]['device_uuid'] = $device_uuid;
@@ -296,15 +298,23 @@
 								$array['devices'][0]['device_lines'][$y]['server_address'] = $row["server_address"];
 								if (permission_exists('device_line_outbound_proxy_primary')) {
 									$array['devices'][0]['device_lines'][$y]['outbound_proxy_primary'] = $row["outbound_proxy_primary"];
+								} else if ($new_line && isset($_SESSION['provision']['outbound_proxy_primary'])) {
+									$array['devices'][0]['device_lines'][$y]['outbound_proxy_primary'] = $_SESSION['provision']['outbound_proxy_primary']['text'];
 								}
 								if (permission_exists('device_line_outbound_proxy_secondary')) {
 									$array['devices'][0]['device_lines'][$y]['outbound_proxy_secondary'] = $row["outbound_proxy_secondary"];
+								} else if ($new_line && isset($_SESSION['provision']['outbound_proxy_secondary'])) {
+									$array['devices'][0]['device_lines'][$y]['outbound_proxy_secondary'] = $_SESSION['provision']['outbound_proxy_secondary']['text'];
 								}
 								if (permission_exists('device_line_server_address_primary')) {
 									$array['devices'][0]['device_lines'][$y]['server_address_primary'] = $row["server_address_primary"];
+								} else if ($new_line && isset($_SESSION['provision']['server_address_primary'])) {
+									$array['devices'][0]['device_lines'][$y]['server_address_primary'] = $_SESSION['provision']['server_address_primary']['text'];
 								}
 								if (permission_exists('device_line_server_address_secondary')) {
 									$array['devices'][0]['device_lines'][$y]['server_address_secondary'] = $row["server_address_secondary"];
+								} else if ($new_line && isset($_SESSION['provision']['server_address_secondary'])) {
+									$array['devices'][0]['device_lines'][$y]['server_address_secondary'] = $_SESSION['provision']['server_address_secondary']['text'];
 								}
 								$array['devices'][0]['device_lines'][$y]['display_name'] = $row["display_name"];
 								$array['devices'][0]['device_lines'][$y]['user_id'] = $row["user_id"];


### PR DESCRIPTION
# Context
It appears that no group by default has the permissions device_line_outbound_proxy_primary/secondary or device_line_server_address_primary/secondary. They appear commented out for superadmin and admin in the app_config.php This causes any new lines/devices that are setup for provisioning to not respect the global outbound_proxy_primary/secondary and server_address_primary/secondary settings.

This change helps ensure that device configurations are not broken for some multi-tenant configurations where the domain isn't a real domain or isn't routed to the server. In this configuration the server_address always refers to the domain but the outbound proxy is set to the actual routable address.

This could be operating 100% as intended and I just need to always enable those permissions when working in a multi-tenant environment. In that case this MR would just ensure that anyone that forgets to enable those permissions will have phones that correctly register the first time around.

# Overview
- If there is no uuid provided, the line must be a new one and set the settings from their value stored in $_SESSION

# Drawbacks
- The lines will not respect any changes to the global settings. This is true for many of the settings in devices as it stands currently.