### PR TITLE
Add new_messages variable in VM Email template

### DIFF
--- a/app/scripts/resources/scripts/app/voicemail/resources/functions/send_email.lua
+++ b/app/scripts/resources/scripts/app/voicemail/resources/functions/send_email.lua
@@ -184,6 +184,7 @@
 					subject = subject:gsub("${voicemail_description}", voicemail_description);
 					subject = subject:gsub("${voicemail_name_formatted}", voicemail_name_formatted);
 					subject = subject:gsub("${domain_name}", domain_name);
+					subject = subject:gsub("${new_messages}", new_messages);
 					subject = trim(subject);
 					subject = '=?utf-8?B?'..base64.encode(subject)..'?=';
 


### PR DESCRIPTION
Ability to use ${new_messages} as a variable in the subject for voicemail to email template. Specifically useful for users who are migrating from asterisk and freepbx