### PR TITLE
[4.4] Deprecated syntax of JOIN

### DIFF
--- a/resources/php.php
+++ b/resources/php.php
@@ -45,7 +45,7 @@
 			}
 
 	//get the document_root parent directory
-		$document_root_parent = join(array_slice(explode("\\",realpath($_SERVER["DOCUMENT_ROOT"])),0,-1), '/');
+		$document_root_parent = join('/', array_slice(explode("\\",realpath($_SERVER["DOCUMENT_ROOT"])),0,-1));
 
 	//if magic quotes is enabled remove the slashes
 		if (get_magic_quotes_gpc()) {


### PR DESCRIPTION
I saw this variable is stripped in 4.5, but I think it is used somewhere in 4.4.