### PR TITLE
Only send MWI notifications for enabled voicemail boxes.

### DIFF
--- a/app/scripts/resources/scripts/app/voicemail/resources/scripts/mwi.lua
+++ b/app/scripts/resources/scripts/app/voicemail/resources/scripts/mwi.lua
@@ -76,6 +76,7 @@
 				FROM v_voicemail_messages as m, v_voicemails as v, v_domains as d
 				WHERE v.voicemail_uuid = m.voicemail_uuid
 				AND v.domain_uuid = d.domain_uuid
+				AND v.voicemail_enabled = 'true'
 				GROUP BY v.voicemail_id, v.voicemail_uuid, v.domain_uuid, d.domain_name;]];
 			if (debug["sql"]) then
 				freeswitch.consoleLog("notice", "[voicemail] SQL: " .. sql .. "\n");


### PR DESCRIPTION
# Context
FusionPBX would continue replying to `MESSAGE_QUERY` events or send `MESSAGE_WAITING` events periodically even when voicemail boxes were disabled. This can also cause issues if you have another system responding to MESSAGE_QUERY events for the extensions that have their voicemail boxes disabled.

# Overview
- For the main MWI notifier that just sends notifications every X seconds add an extra clause to check that `v.voicemail_enabled = 'true'`
- For the MWI subscription responder add the same check in the UUID lookup.
- Modify the logic and SQL to instead of embedding the uuid lookup SQL as a subquery to just use the value queried earlier.
  - This is needed otherwise the `(SELECT COUNT(*) ...) AS ...` statements would return a valid row with zeros for even a disabled voicemail account causing the `MESSAGE_WAITING` event to be sent to FreeSWITCH.