### PR TITLE
Fixed Issue with extension limits preventing Extension Search

### DIFF
--- a/app/extensions/extensions.php
+++ b/app/extensions/extensions.php
@@ -79,6 +79,16 @@
 	$order_by = $_GET["order_by"];
 	$order = $_GET["order"];
 
+//get total extension count for domain
+if (is_numeric($_SESSION['limit']['extensions']['numeric'])) {
+	$sql = "select count(*) from v_extensions ";
+	$sql .= "where domain_uuid = :domain_uuid ";
+	$parameters['domain_uuid'] = $_SESSION['domain_uuid'];
+	$database = new database;
+	$total_extensions = $database->select($sql, $parameters, 'column');
+	unset($sql, $parameters);
+}
+
 //add the search term
 	$search = strtolower($_GET["search"]);
 	if (strlen($search) > 0) {
@@ -101,15 +111,7 @@
 		$parameters['search'] = '%'.$search.'%';
 	}
 
-//get total extension count for domain
-	if (is_numeric($_SESSION['limit']['extensions']['numeric'])) {
-		$sql = "select count(*) from v_extensions ";
-		$sql .= "where domain_uuid = :domain_uuid ";
-		$parameters['domain_uuid'] = $_SESSION['domain_uuid'];
-		$database = new database;
-		$total_extensions = $database->select($sql, $parameters, 'column');
-		unset($sql, $parameters);
-	}
+
 
 //get total extension count
 	$sql = "select count(*) from v_extensions where true ";


### PR DESCRIPTION
Extension searches would fail if an extension limit was set. This is because the `unset($parameters)` that was used at the end of the query that counts the extensions is also unsetting the "search" parameter that was set previously and needed later. I moved the `//get total extension count for domain` query to happen before the search parameter is added to fix it.