### PR TITLE
Fix the valet auto-in parking dialplan to allow BLF presence monitoring.

### DIFF
--- a/app/dialplans/resources/switch/conf/dialplan/470_valet_park_in.xml
+++ b/app/dialplans/resources/switch/conf/dialplan/470_valet_park_in.xml
@@ -1,7 +1,7 @@
 <context name="{v_context}">
 	<extension name="valet_park_in" number="park+*5900" continue="false" app_uuid="c192ee50-084d-40d8-8d9a-6959369382c8" enabled="false" order="470">
-		<condition field="destination_number" expression="^(park\+)?(\*5900)$">
+		<condition field="destination_number" expression="^(?:(?:park\+\*?)|(?:\*))(5900)$">
 			<action application="valet_park" data="park@${domain_name} auto in 5901 5999"/>
 		</condition>
- </extension>
+	</extension>
 </context>

--- a/app/dialplans/resources/switch/conf/dialplan/475_valet_park_out.xml
+++ b/app/dialplans/resources/switch/conf/dialplan/475_valet_park_out.xml
@@ -1,8 +1,8 @@
 <context name="{v_context}">
 	<extension name="valet_park_out" number="park+*5901-*5999" continue="false" app_uuid="242130d4-61d6-4daf-9dd1-b139a2b3b166" enabled="false" order="475">
-		<condition field="destination_number" expression="^(park\+)?\*(59[0-9][0-9])$">
+		<condition field="destination_number" expression="^(?:(?:park\+\*?)|(?:\*))(59[0-9][0-9])$">
 			<action application="answer"/>
-			<action application="valet_park" data="park@${domain_name} $2"/>
+			<action application="valet_park" data="park@${domain_name} $1"/>
 		</condition>
- </extension>
+	</extension>
 </context>


### PR DESCRIPTION
# Context

BLF Presence support was not working with the valet parking dialplan since the parking lots were being created without the * in the parking lot name. This adds allowing park+5900-5999 to match the dialplan so we can use that to monitor the parking lot presence.

https://regex101.com/r/KBNVEj/2

# Overview
- Switched the extension Regex to `^(?:(?:park\+\*?)|(?:\*))(5900)$` and `^(?:(?:park\+\*?)|(?:\*))(59[0-9][0-9])$` in `470_valet_park_in.xml` and `475_valet_park_out.xml` respectively.
- Update `475_valet_park_out.xml` to use $1 since the new Regex used non-capture groups now so the lot is in the first group.
- Fix some whitespace inconsistencies.

## Original attempt at a fix that was not correct
- I originally wanted to add the asterisk prefix in front of the parking lot names to match the default parking dialplan. However this does not work with auto in since the parking lot range has to be numbers it seems like for FreeSWITCH to accept it.

