### PR TITLE
Allow park+x in the Grandstream Dialplan

### DIFF
--- a/app/grandstream/app_config.php
+++ b/app/grandstream/app_config.php
@@ -282,7 +282,7 @@
 		$apps[$x]['default_settings'][$y]['default_setting_category'] = "provision";
 		$apps[$x]['default_settings'][$y]['default_setting_subcategory'] = "grandstream_dial_plan";
 		$apps[$x]['default_settings'][$y]['default_setting_name'] = "text";
-		$apps[$x]['default_settings'][$y]['default_setting_value'] = '{\+x+|x+|*x+|*++||\p\a\r\k\+*x+|\f\l\o\w\+*x+|**x+}';
+		$apps[$x]['default_settings'][$y]['default_setting_value'] = '{\+x+|x+|*x+|*++||\p\a\r\k\+*x+|\p\a\r\k\+x+|\f\l\o\w\+*x+|**x+}';
 		$apps[$x]['default_settings'][$y]['default_setting_enabled'] = "true";
 		$apps[$x]['default_settings'][$y]['default_setting_description'] = "Define the digits that are allowed to be called.";
 		$y++;

--- a/resources/templates/provision/grandstream/dp715.sm/{$mac}.xml
+++ b/resources/templates/provision/grandstream/dp715.sm/{$mac}.xml
@@ -377,7 +377,7 @@
 {if isset($grandstream_dial_plan) }
 <P4200>{$grandstream_dial_plan}</P4200>
 {else}
-<P4200>{literal}{x+|*x+|*++|\p\a\r\k\+*x+| \f\l\o\w\+*x+}{/literal}</P4200>
+<P4200>{literal}{x+|*x+|*++|\p\a\r\k\+*x+|\p\a\r\k\+x+|\f\l\o\w\+*x+}{/literal}</P4200>
 {/if}
 
 <!-- SUBSCRIBE for MWI. 0 - No, 1 - Yes -->

--- a/resources/templates/provision/grandstream/dp715/{$mac}.xml
+++ b/resources/templates/provision/grandstream/dp715/{$mac}.xml
@@ -243,7 +243,7 @@
 		{if isset($grandstream_dial_plan) }
 		<P4200>{$grandstream_dial_plan}</P4200>
 		{else}
-		<P4200>{literal}{x+|*x+|*++|\p\a\r\k\+*x+| \f\l\o\w\+*x+}{/literal}</P4200>
+		<P4200>{literal}{x+|*x+|*++|\p\a\r\k\+*x+|\p\a\r\k\+x+|\f\l\o\w\+*x+}{/literal}</P4200>
 		{/if}
 		
 		<!-- SUBSCRIBE for MWI. 0 - No, 1 - Yes -->

--- a/resources/templates/provision/grandstream/dp750/{$mac}.xml
+++ b/resources/templates/provision/grandstream/dp750/{$mac}.xml
@@ -489,10 +489,10 @@
 {if isset($grandstream_dial_plan) }
 <P4200>{$grandstream_dial_plan}</P4200>
 {else}
-<P4200>{literal}{x+|*x+|*++|\p\a\r\k\+*x+| \f\l\o\w\+*x+}{/literal}</P4200>
+<P4200>{literal}{x+|*x+|*++|\p\a\r\k\+*x+|\p\a\r\k\+x+|\f\l\o\w\+*x+}{/literal}</P4200>
 {/if}
   
-<!-- <P4200>{ x+ | *x+ | *xx | *xxx | *xxxx | *xxxxx | *xxxxxx | **xx | **xxx | **xxxx | **xxxxx | **xxxxxx | **xxxxxxx | **xxxxxxxx | *xx*x+ | \+x+ | \p\a\r\k\+*x+ }</P4200> -->
+<!-- <P4200>{ x+ | *x+ | *xx | *xxx | *xxxx | *xxxxx | *xxxxxx | **xx | **xxx | **xxxx | **xxxxx | **xxxxxx | **xxxxxxx | **xxxxxxxx | *xx*x+ | \+x+ | \p\a\r\k\+*x+ | \p\a\r\k\+x+ }</P4200> -->
 
 <!-- Use #as Dial Key (if set to Yes, "#" will function as the "(Re-)Dial" key). 0 - no, 1 - yes -->
 <!-- Number: 0,1 -->
@@ -1022,7 +1022,7 @@
 <!-- Dial Plan  -->
 <!-- String Max Length: 1024 -->
 <P4201>{ x+ | *x+ | *xx | *xxx | *xxxx | *xxxxx | *xxxxxx | **xx | **xxx | **xxxx | **xxxxx | **xxxxxx | **xxxxxxx | **xxxxxxxx | *xx*x+ }</P4201>
-<!-- <P4201>{ x+ | *x+ | *xx | *xxx | *xxxx | *xxxxx | *xxxxxx | **xx | **xxx | **xxxx | **xxxxx | **xxxxxx | **xxxxxxx | **xxxxxxxx | *xx*x+ | \+x+ | \p\a\r\k\+*x+ }</P4201> -->
+<!-- <P4201>{ x+ | *x+ | *xx | *xxx | *xxxx | *xxxxx | *xxxxxx | **xx | **xxx | **xxxx | **xxxxx | **xxxxxx | **xxxxxxx | **xxxxxxxx | *xx*x+ | \+x+ | \p\a\r\k\+*x+ | \p\a\r\k\+x+ }</P4201> -->
 
 <!-- Use #as Dial Key (if set to Yes, "#" will function as the "(Re-)Dial" key). 0 - no, 1 - yes -->
 <!-- Number: 0,1 -->
@@ -1551,7 +1551,7 @@
 <!-- Dial Plan  -->
 <!-- String Max Length: 1024 -->
 <P4202>{ x+ | *x+ | *xx | *xxx | *xxxx | *xxxxx | *xxxxxx | **xx | **xxx | **xxxx | **xxxxx | **xxxxxx | **xxxxxxx | **xxxxxxxx | *xx*x+ }</P4202>
-<!-- <P4202>{ x+ | *x+ | *xx | *xxx | *xxxx | *xxxxx | *xxxxxx | **xx | **xxx | **xxxx | **xxxxx | **xxxxxx | **xxxxxxx | **xxxxxxxx | *xx*x+ | \+x+ | \p\a\r\k\+*x+ }</P4202> -->
+<!-- <P4202>{ x+ | *x+ | *xx | *xxx | *xxxx | *xxxxx | *xxxxxx | **xx | **xxx | **xxxx | **xxxxx | **xxxxxx | **xxxxxxx | **xxxxxxxx | *xx*x+ | \+x+ | \p\a\r\k\+*x+ | \p\a\r\k\+x+ }</P4202> -->
 
 <!-- Use #as Dial Key (if set to Yes, "#" will function as the "(Re-)Dial" key). 0 - no, 1 - yes -->
 <!-- Number: 0,1 -->
@@ -2081,7 +2081,7 @@
 <!-- Dial Plan  -->
 <!-- String Max Length: 1024 -->
 <P4203>{ x+ | *x+ | *xx | *xxx | *xxxx | *xxxxx | *xxxxxx | **xx | **xxx | **xxxx | **xxxxx | **xxxxxx | **xxxxxxx | **xxxxxxxx | *xx*x+ }</P4203>
-<!-- <P4203>{ x+ | *x+ | *xx | *xxx | *xxxx | *xxxxx | *xxxxxx | **xx | **xxx | **xxxx | **xxxxx | **xxxxxx | **xxxxxxx | **xxxxxxxx | *xx*x+ | \+x+ | \p\a\r\k\+*x+ }</P4203> -->
+<!-- <P4203>{ x+ | *x+ | *xx | *xxx | *xxxx | *xxxxx | *xxxxxx | **xx | **xxx | **xxxx | **xxxxx | **xxxxxx | **xxxxxxx | **xxxxxxxx | *xx*x+ | \+x+ | \p\a\r\k\+*x+ | \p\a\r\k\+x+ }</P4203> -->
 
 <!-- Use #as Dial Key (if set to Yes, "#" will function as the "(Re-)Dial" key). 0 - no, 1 - yes -->
 <!-- Number: 0,1 -->

--- a/resources/templates/provision/grandstream/gac2500/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gac2500/{$mac}.xml
@@ -410,7 +410,7 @@
 	{if isset($grandstream_dial_plan) }
 	<P290>{$grandstream_dial_plan}</P290>
 	{else}
-	<P290>{literal}{x+|*x+|*++|\p\a\r\k\+*x+| \f\l\o\w\+*x+}{/literal}</P290>
+	<P290>{literal}{x+|*x+|*++|\p\a\r\k\+*x+|\p\a\r\k\+x+|\f\l\o\w\+*x+}{/literal}</P290>
 	{/if}
     <!-- # Refer-To Use Target Contact. 0 - No, 1 - Yes. Default value is 0 -->
     <!-- # Number: 0, 1 -->
@@ -981,7 +981,7 @@
     {if isset($grandstream_dial_plan) }
     <P459>{$grandstream_dial_plan}</P459>
     {else}
-    <P459>{literal}{x+|*x+|*++|\p\a\r\k\+*x+| \f\l\o\w\+*x+}{/literal}</P459>
+    <P459>{literal}{x+|*x+|*++|\p\a\r\k\+*x+|\p\a\r\k\+x+|\f\l\o\w\+*x+}{/literal}</P459>
     {/if}
 
     <!-- # Refer-To Use Target Contact. 0 - No, 1 - Yes. Default value is 0 -->
@@ -1549,7 +1549,7 @@
     {if isset($grandstream_dial_plan) }
     <P559>{$grandstream_dial_plan}</P559>
     {else}
-    <P559>{literal}{x+|*x+|*++|\p\a\r\k\+*x+| \f\l\o\w\+*x+}{/literal}</P559>
+    <P559>{literal}{x+|*x+|*++|\p\a\r\k\+*x+|\p\a\r\k\+x+|\f\l\o\w\+*x+}{/literal}</P559>
     {/if}
 
     <!-- # Refer-To Use Target Contact. 0 - No, 1 - Yes. Default value is 0 -->
@@ -2118,7 +2118,7 @@
     {if isset($grandstream_dial_plan) }
     <P659>{$grandstream_dial_plan}</P659>
     {else}
-    <P659>{literal}{x+|*x+|*++|\p\a\r\k\+*x+| \f\l\o\w\+*x+}{/literal}</P659>
+    <P659>{literal}{x+|*x+|*++|\p\a\r\k\+*x+|\p\a\r\k\+x+|\f\l\o\w\+*x+}{/literal}</P659>
     {/if}
 
     <!-- # Refer-To Use Target Contact. 0 - No, 1 - Yes. Default value is 0 -->
@@ -2689,7 +2689,7 @@
     {if isset($grandstream_dial_plan) }
     <P1759>{$grandstream_dial_plan}</P1759>
     {else}
-    <P1759>{literal}{x+|*x+|*++|\p\a\r\k\+*x+| \f\l\o\w\+*x+}{/literal}</P1759>
+    <P1759>{literal}{x+|*x+|*++|\p\a\r\k\+*x+|\p\a\r\k\+x+|\f\l\o\w\+*x+}{/literal}</P1759>
     {/if}
 
     <!-- # Refer-To Use Target Contact. 0 - No, 1 - Yes. Default value is 0 -->
@@ -3260,7 +3260,7 @@
     {if isset($grandstream_dial_plan) }
     <P1859>{$grandstream_dial_plan}</P1859>
     {else}
-    <P1859>{literal}{x+|*x+|*++|\p\a\r\k\+*x+| \f\l\o\w\+*x+}{/literal}</P1859>
+    <P1859>{literal}{x+|*x+|*++|\p\a\r\k\+*x+|\p\a\r\k\+x+|\f\l\o\w\+*x+}{/literal}</P1859>
     {/if}
 
     <!-- # Refer-To Use Target Contact. 0 - No, 1 - Yes. Default value is 0 -->

--- a/resources/templates/provision/grandstream/grp2612/{$mac}.xml
+++ b/resources/templates/provision/grandstream/grp2612/{$mac}.xml
@@ -697,7 +697,7 @@
 {if isset($grandstream_dial_plan) }
     <P290>{$grandstream_dial_plan}</P290>
 {else}
-    <P290>{literal}{x+|*x+|*++|\p\a\r\k\+*x+| \f\l\o\w\+*x+}{/literal}</P290>
+    <P290>{literal}{x+|*x+|*++|\p\a\r\k\+*x+|\p\a\r\k\+x+|\f\l\o\w\+*x+}{/literal}</P290>
 {/if}
 
     <!-- # Bypass Dial Plan -->
@@ -1647,7 +1647,7 @@
 {if isset($grandstream_dial_plan) }
     <P459>{$grandstream_dial_plan}</P459>
 {else}
-    <P459>{literal}{x+|*x+|*++|\p\a\r\k\+*x+| \f\l\o\w\+*x+}{/literal}</P459>
+    <P459>{literal}{x+|*x+|*++|\p\a\r\k\+*x+|\p\a\r\k\+x+|\f\l\o\w\+*x+}{/literal}</P459>
 {/if}
 
     <!-- # Bypass Dial Plan -->

--- a/resources/templates/provision/grandstream/grp2612w/{$mac}.xml
+++ b/resources/templates/provision/grandstream/grp2612w/{$mac}.xml
@@ -697,7 +697,7 @@
 {if isset($grandstream_dial_plan) }
     <P290>{$grandstream_dial_plan}</P290>
 {else}
-    <P290>{literal}{x+|*x+|*++|\p\a\r\k\+*x+| \f\l\o\w\+*x+}{/literal}</P290>
+    <P290>{literal}{x+|*x+|*++|\p\a\r\k\+*x+|\p\a\r\k\+x+|\f\l\o\w\+*x+}{/literal}</P290>
 {/if}
 
     <!-- # Bypass Dial Plan -->
@@ -1647,7 +1647,7 @@
 {if isset($grandstream_dial_plan) }
     <P459>{$grandstream_dial_plan}</P459>
 {else}
-    <P459>{literal}{x+|*x+|*++|\p\a\r\k\+*x+| \f\l\o\w\+*x+}{/literal}</P459>
+    <P459>{literal}{x+|*x+|*++|\p\a\r\k\+*x+|\p\a\r\k\+x+|\f\l\o\w\+*x+}{/literal}</P459>
 {/if}
 
     <!-- # Bypass Dial Plan -->

--- a/resources/templates/provision/grandstream/grp2613/{$mac}.xml
+++ b/resources/templates/provision/grandstream/grp2613/{$mac}.xml
@@ -697,7 +697,7 @@
 {if isset($grandstream_dial_plan) }
     <P290>{$grandstream_dial_plan}</P290>
 {else}
-    <P290>{literal}{x+|*x+|*++|\p\a\r\k\+*x+| \f\l\o\w\+*x+}{/literal}</P290>
+    <P290>{literal}{x+|*x+|*++|\p\a\r\k\+*x+|\p\a\r\k\+x+|\f\l\o\w\+*x+}{/literal}</P290>
 {/if}
 
     <!-- # Bypass Dial Plan -->
@@ -1647,7 +1647,7 @@
 {if isset($grandstream_dial_plan) }
     <P459>{$grandstream_dial_plan}</P459>
 {else}
-    <P459>{literal}{x+|*x+|*++|\p\a\r\k\+*x+| \f\l\o\w\+*x+}{/literal}</P459>
+    <P459>{literal}{x+|*x+|*++|\p\a\r\k\+*x+|\p\a\r\k\+x+|\f\l\o\w\+*x+}{/literal}</P459>
 {/if}
 
     <!-- # Bypass Dial Plan -->
@@ -2594,7 +2594,7 @@
 {if isset($grandstream_dial_plan) }
     <P559>{$grandstream_dial_plan}</P559>
 {else}
-    <P559>{literal}{x+|*x+|*++|\p\a\r\k\+*x+| \f\l\o\w\+*x+}{/literal}</P559>
+    <P559>{literal}{x+|*x+|*++|\p\a\r\k\+*x+|\p\a\r\k\+x+|\f\l\o\w\+*x+}{/literal}</P559>
 {/if}
 
     <!-- # Bypass Dial Plan -->

--- a/resources/templates/provision/grandstream/grp2614/{$mac}.xml
+++ b/resources/templates/provision/grandstream/grp2614/{$mac}.xml
@@ -697,7 +697,7 @@
 {if isset($grandstream_dial_plan) }
     <P290>{$grandstream_dial_plan}</P290>
 {else}
-    <P290>{literal}{x+|*x+|*++|\p\a\r\k\+*x+| \f\l\o\w\+*x+}{/literal}</P290>
+    <P290>{literal}{x+|*x+|*++|\p\a\r\k\+*x+|\p\a\r\k\+x+|\f\l\o\w\+*x+}{/literal}</P290>
 {/if}
 
     <!-- # Bypass Dial Plan -->
@@ -1647,7 +1647,7 @@
 {if isset($grandstream_dial_plan) }
     <P459>{$grandstream_dial_plan}</P459>
 {else}
-    <P459>{literal}{x+|*x+|*++|\p\a\r\k\+*x+| \f\l\o\w\+*x+}{/literal}</P459>
+    <P459>{literal}{x+|*x+|*++|\p\a\r\k\+*x+|\p\a\r\k\+x+|\f\l\o\w\+*x+}{/literal}</P459>
 {/if}
 
     <!-- # Bypass Dial Plan -->
@@ -2594,7 +2594,7 @@
 {if isset($grandstream_dial_plan) }
     <P559>{$grandstream_dial_plan}</P559>
 {else}
-    <P559>{literal}{x+|*x+|*++|\p\a\r\k\+*x+| \f\l\o\w\+*x+}{/literal}</P559>
+    <P559>{literal}{x+|*x+|*++|\p\a\r\k\+*x+|\p\a\r\k\+x+|\f\l\o\w\+*x+}{/literal}</P559>
 {/if}
 
     <!-- # Bypass Dial Plan -->
@@ -3545,7 +3545,7 @@
 {if isset($grandstream_dial_plan) }
     <P659>{$grandstream_dial_plan}</P659>
 {else}
-    <P659>{literal}{x+|*x+|*++|\p\a\r\k\+*x+| \f\l\o\w\+*x+}{/literal}</P659>
+    <P659>{literal}{x+|*x+|*++|\p\a\r\k\+*x+|\p\a\r\k\+x+|\f\l\o\w\+*x+}{/literal}</P659>
 {/if}
 
     <!-- # Bypass Dial Plan -->

--- a/resources/templates/provision/grandstream/grp2615/{$mac}.xml
+++ b/resources/templates/provision/grandstream/grp2615/{$mac}.xml
@@ -697,7 +697,7 @@
 {if isset($grandstream_dial_plan) }
     <P290>{$grandstream_dial_plan}</P290>
 {else}
-    <P290>{literal}{x+|*x+|*++|\p\a\r\k\+*x+| \f\l\o\w\+*x+}{/literal}</P290>
+    <P290>{literal}{x+|*x+|*++|\p\a\r\k\+*x+|\p\a\r\k\+x+|\f\l\o\w\+*x+}{/literal}</P290>
 {/if}
 
     <!-- # Bypass Dial Plan -->
@@ -1647,7 +1647,7 @@
 {if isset($grandstream_dial_plan) }
     <P459>{$grandstream_dial_plan}</P459>
 {else}
-    <P459>{literal}{x+|*x+|*++|\p\a\r\k\+*x+| \f\l\o\w\+*x+}{/literal}</P459>
+    <P459>{literal}{x+|*x+|*++|\p\a\r\k\+*x+|\p\a\r\k\+x+|\f\l\o\w\+*x+}{/literal}</P459>
 {/if}
 
     <!-- # Bypass Dial Plan -->
@@ -2594,7 +2594,7 @@
 {if isset($grandstream_dial_plan) }
     <P559>{$grandstream_dial_plan}</P559>
 {else}
-    <P559>{literal}{x+|*x+|*++|\p\a\r\k\+*x+| \f\l\o\w\+*x+}{/literal}</P559>
+    <P559>{literal}{x+|*x+|*++|\p\a\r\k\+*x+|\p\a\r\k\+x+|\f\l\o\w\+*x+}{/literal}</P559>
 {/if}
 
     <!-- # Bypass Dial Plan -->
@@ -3545,7 +3545,7 @@
 {if isset($grandstream_dial_plan) }
     <P659>{$grandstream_dial_plan}</P659>
 {else}
-    <P659>{literal}{x+|*x+|*++|\p\a\r\k\+*x+| \f\l\o\w\+*x+}{/literal}</P659>
+    <P659>{literal}{x+|*x+|*++|\p\a\r\k\+*x+|\p\a\r\k\+x+|\f\l\o\w\+*x+}{/literal}</P659>
 {/if}
 
     <!-- # Bypass Dial Plan -->
@@ -4493,7 +4493,7 @@
 {if isset($grandstream_dial_plan) }
     <P1759>{$grandstream_dial_plan}</P1759>
 {else}
-    <P1759>{literal}{x+|*x+|*++|\p\a\r\k\+*x+| \f\l\o\w\+*x+}{/literal}</P1759>
+    <P1759>{literal}{x+|*x+|*++|\p\a\r\k\+*x+|\p\a\r\k\+x+|\f\l\o\w\+*x+}{/literal}</P1759>
 {/if}
 
     <!-- # Bypass Dial Plan -->

--- a/resources/templates/provision/grandstream/grp2616/{$mac}.xml
+++ b/resources/templates/provision/grandstream/grp2616/{$mac}.xml
@@ -697,7 +697,7 @@
 {if isset($grandstream_dial_plan) }
     <P290>{$grandstream_dial_plan}</P290>
 {else}
-    <P290>{literal}{x+|*x+|*++|\p\a\r\k\+*x+| \f\l\o\w\+*x+}{/literal}</P290>
+    <P290>{literal}{x+|*x+|*++|\p\a\r\k\+*x+|\p\a\r\k\+x+|\f\l\o\w\+*x+}{/literal}</P290>
 {/if}
 
     <!-- # Bypass Dial Plan -->
@@ -1647,7 +1647,7 @@
 {if isset($grandstream_dial_plan) }
     <P459>{$grandstream_dial_plan}</P459>
 {else}
-    <P459>{literal}{x+|*x+|*++|\p\a\r\k\+*x+| \f\l\o\w\+*x+}{/literal}</P459>
+    <P459>{literal}{x+|*x+|*++|\p\a\r\k\+*x+|\p\a\r\k\+x+|\f\l\o\w\+*x+}{/literal}</P459>
 {/if}
 
     <!-- # Bypass Dial Plan -->
@@ -2594,7 +2594,7 @@
 {if isset($grandstream_dial_plan) }
     <P559>{$grandstream_dial_plan}</P559>
 {else}
-    <P559>{literal}{x+|*x+|*++|\p\a\r\k\+*x+| \f\l\o\w\+*x+}{/literal}</P559>
+    <P559>{literal}{x+|*x+|*++|\p\a\r\k\+*x+|\p\a\r\k\+x+|\f\l\o\w\+*x+}{/literal}</P559>
 {/if}
 
     <!-- # Bypass Dial Plan -->
@@ -3545,7 +3545,7 @@
 {if isset($grandstream_dial_plan) }
     <P659>{$grandstream_dial_plan}</P659>
 {else}
-    <P659>{literal}{x+|*x+|*++|\p\a\r\k\+*x+| \f\l\o\w\+*x+}{/literal}</P659>
+    <P659>{literal}{x+|*x+|*++|\p\a\r\k\+*x+|\p\a\r\k\+x+|\f\l\o\w\+*x+}{/literal}</P659>
 {/if}
 
     <!-- # Bypass Dial Plan -->
@@ -4493,7 +4493,7 @@
 {if isset($grandstream_dial_plan) }
     <P1759>{$grandstream_dial_plan}</P1759>
 {else}
-    <P1759>{literal}{x+|*x+|*++|\p\a\r\k\+*x+| \f\l\o\w\+*x+}{/literal}</P1759>
+    <P1759>{literal}{x+|*x+|*++|\p\a\r\k\+*x+|\p\a\r\k\+x+|\f\l\o\w\+*x+}{/literal}</P1759>
 {/if}
 
     <!-- # Bypass Dial Plan -->
@@ -5445,7 +5445,7 @@
 {if isset($grandstream_dial_plan) }
     <P1859>{$grandstream_dial_plan}</P1859>
 {else}
-    <P1859>{literal}{x+|*x+|*++|\p\a\r\k\+*x+| \f\l\o\w\+*x+}{/literal}</P1859>
+    <P1859>{literal}{x+|*x+|*++|\p\a\r\k\+*x+|\p\a\r\k\+x+|\f\l\o\w\+*x+}{/literal}</P1859>
 {/if}
 
     <!-- # Bypass Dial Plan -->

--- a/resources/templates/provision/grandstream/grp26xx/{$mac}.xml
+++ b/resources/templates/provision/grandstream/grp26xx/{$mac}.xml
@@ -706,7 +706,7 @@
 {if isset($grandstream_dial_plan) }
     <P290>{$grandstream_dial_plan}</P290>
 {else}
-    <P290>{literal}{x+|*x+|*++|\p\a\r\k\+*x+| \f\l\o\w\+*x+}{/literal}</P290>
+    <P290>{literal}{x+|*x+|*++|\p\a\r\k\+*x+|\p\a\r\k\+x+|\f\l\o\w\+*x+}{/literal}</P290>
 {/if}
 
     <!-- # Bypass Dial Plan -->
@@ -1675,7 +1675,7 @@
 {if isset($grandstream_dial_plan) }
     <P459>{$grandstream_dial_plan}</P459>
 {else}
-    <P459>{literal}{x+|*x+|*++|\p\a\r\k\+*x+| \f\l\o\w\+*x+}{/literal}</P459>
+    <P459>{literal}{x+|*x+|*++|\p\a\r\k\+*x+|\p\a\r\k\+x+|\f\l\o\w\+*x+}{/literal}</P459>
 {/if}
 
     <!-- # Bypass Dial Plan -->
@@ -2644,7 +2644,7 @@
 {if isset($grandstream_dial_plan) }
     <P559>{$grandstream_dial_plan}</P559>
 {else}
-    <P559>{literal}{x+|*x+|*++|\p\a\r\k\+*x+| \f\l\o\w\+*x+}{/literal}</P559>
+    <P559>{literal}{x+|*x+|*++|\p\a\r\k\+*x+|\p\a\r\k\+x+|\f\l\o\w\+*x+}{/literal}</P559>
 {/if}
 
     <!-- # Bypass Dial Plan -->
@@ -3615,7 +3615,7 @@
 {if isset($grandstream_dial_plan) }
     <P659>{$grandstream_dial_plan}</P659>
 {else}
-    <P659>{literal}{x+|*x+|*++|\p\a\r\k\+*x+| \f\l\o\w\+*x+}{/literal}</P659>
+    <P659>{literal}{x+|*x+|*++|\p\a\r\k\+*x+|\p\a\r\k\+x+|\f\l\o\w\+*x+}{/literal}</P659>
 {/if}
 
     <!-- # Bypass Dial Plan -->
@@ -4586,7 +4586,7 @@
 {if isset($grandstream_dial_plan) }
     <P1759>{$grandstream_dial_plan}</P1759>
 {else}
-    <P1759>{literal}{x+|*x+|*++|\p\a\r\k\+*x+| \f\l\o\w\+*x+}{/literal}</P1759>
+    <P1759>{literal}{x+|*x+|*++|\p\a\r\k\+*x+|\p\a\r\k\+x+|\f\l\o\w\+*x+}{/literal}</P1759>
 {/if}
 
     <!-- # Bypass Dial Plan -->

--- a/resources/templates/provision/grandstream/gxp110x/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp110x/{$mac}.xml
@@ -584,7 +584,7 @@
 {if isset($grandstream_dial_plan) }
 <P290>{$grandstream_dial_plan}</P290>
 {else}
-<P290>{literal}{x+|*x+|*++|\p\a\r\k\+*x+| \f\l\o\w\+*x+}{/literal}</P290>
+<P290>{literal}{x+|*x+|*++|\p\a\r\k\+*x+|\p\a\r\k\+x+|\f\l\o\w\+*x+}{/literal}</P290>
 {/if}
     
 <!-- Delayed Call Forward Wait Time (in seconds). Default is 20 -->

--- a/resources/templates/provision/grandstream/gxp116x/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp116x/{$mac}.xml
@@ -453,7 +453,7 @@
 {if isset($grandstream_dial_plan) }
 <P290>{$grandstream_dial_plan}</P290>
 {else}
-<P290>{literal}{x+|*x+|*++|\p\a\r\k\+*x+| \f\l\o\w\+*x+}{/literal}</P290>
+<P290>{literal}{x+|*x+|*++|\p\a\r\k\+*x+|\p\a\r\k\+x+|\f\l\o\w\+*x+}{/literal}</P290>
 {/if}
 
 <!--  Delayed Call Forward Wait Time (in seconds). Default is 20 -->

--- a/resources/templates/provision/grandstream/gxp140x/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp140x/{$mac}.xml
@@ -483,7 +483,7 @@
     {if isset($grandstream_dial_plan) }
     <P290>{$grandstream_dial_plan}</P290>
     {else}
-    <P290>{literal}{x+|*x+|*++|\p\a\r\k\+*x+| \f\l\o\w\+*x+}{/literal}</P290>
+    <P290>{literal}{x+|*x+|*++|\p\a\r\k\+*x+|\p\a\r\k\+x+|\f\l\o\w\+*x+}{/literal}</P290>
     {/if}
     
     <!--  Delayed Call Forward Wait Time (in seconds). Default is 20 -->

--- a/resources/templates/provision/grandstream/gxp140xbk/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp140xbk/{$mac}.xml
@@ -483,7 +483,7 @@
     {if isset($grandstream_dial_plan) }
     <P290>{$grandstream_dial_plan}</P290>
     {else}
-    <P290>{literal}{x+|*x+|*++|\p\a\r\k\+*x+| \f\l\o\w\+*x+}{/literal}</P290>
+    <P290>{literal}{x+|*x+|*++|\p\a\r\k\+*x+|\p\a\r\k\+x+|\f\l\o\w\+*x+}{/literal}</P290>
     {/if}
     
     <!--  Delayed Call Forward Wait Time (in seconds). Default is 20 -->

--- a/resources/templates/provision/grandstream/gxp1450/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp1450/{$mac}.xml
@@ -648,7 +648,7 @@
 {if isset($grandstream_dial_plan) }
 <P290>{$grandstream_dial_plan}</P290>
 {else}
-<P290>{literal}{x+|*x+|*++|\p\a\r\k\+*x+| \f\l\o\w\+*x+}{/literal}</P290>
+<P290>{literal}{x+|*x+|*++|\p\a\r\k\+*x+|\p\a\r\k\+x+|\f\l\o\w\+*x+}{/literal}</P290>
 {/if}
 
 <!-- Delayed Call Forward Wait Time (in seconds). Default is 20 -->

--- a/resources/templates/provision/grandstream/gxp1450bk/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp1450bk/{$mac}.xml
@@ -457,7 +457,7 @@
 {if isset($grandstream_dial_plan) }
 <P290>{$grandstream_dial_plan}</P290>
 {else}
-<P290>{literal}{x+|*x+|*++|\p\a\r\k\+*x+| \f\l\o\w\+*x+}{/literal}</P290>
+<P290>{literal}{x+|*x+|*++|\p\a\r\k\+*x+|\p\a\r\k\+x+|\f\l\o\w\+*x+}{/literal}</P290>
 {/if}
 
 <!-- Delayed Call Forward Wait Time (in seconds). Default is 20 -->

--- a/resources/templates/provision/grandstream/gxp16xx/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp16xx/{$mac}.xml
@@ -482,10 +482,10 @@
 {if isset($grandstream_dial_plan) }
 <P290>{$grandstream_dial_plan}</P290>
 {else}
-<P290>{literal}{x+|*x+|*++|\p\a\r\k\+*x+| \f\l\o\w\+*x+}{/literal}</P290>
+<P290>{literal}{x+|*x+|*++|\p\a\r\k\+*x+|\p\a\r\k\+x+|\f\l\o\w\+*x+}{/literal}</P290>
 {/if}
 
-<!-- <P290>{ x+ | *x+ | *xx | *xxx | *xxxx | *xxxxx | *xxxxxx | **xx | **xxx | **xxxx | **xxxxx | **xxxxxx | **xxxxxxx | **xxxxxxxx | *xx*x+ | \+x+ | \p\a\r\k\+*x+ }</P290> -->
+<!-- <P290>{ x+ | *x+ | *xx | *xxx | *xxxx | *xxxxx | *xxxxxx | **xx | **xxx | **xxxx | **xxxxx | **xxxxxx | **xxxxxxx | **xxxxxxxx | *xx*x+ | \+x+ | \p\a\r\k\+*x+ | \p\a\r\k\+x+ }</P290> -->
 <!--  Delayed Call Forward Wait Time (in seconds). Default is 20 -->
 <!--  Number: 1 - 120 -->
 <!--  Mandatory -->
@@ -1087,7 +1087,7 @@
 <!--  String -->
 <!--  Mandatory -->
 <P459>{ x+ | *x+ | *xx | *xxx | *xxxx | *xxxxx | *xxxxxx | **xx | **xxx | **xxxx | **xxxxx | **xxxxxx | **xxxxxxx | **xxxxxxxx | *xx*x+ }</P459>
-<!-- <P459>{ x+ | *x+ | *xx | *xxx | *xxxx | *xxxxx | *xxxxxx | **xx | **xxx | **xxxx | **xxxxx | **xxxxxx | **xxxxxxx | **xxxxxxxx | *xx*x+ | \+x+ | \p\a\r\k\+*x+ }</P459> -->
+<!-- <P459>{ x+ | *x+ | *xx | *xxx | *xxxx | *xxxxx | *xxxxxx | **xx | **xxx | **xxxx | **xxxxx | **xxxxxx | **xxxxxxx | **xxxxxxxx | *xx*x+ | \+x+ | \p\a\r\k\+*x+ | \p\a\r\k\+x+ }</P459> -->
 <!--  Delayed Call Forward Wait Time (in seconds). Default is 20 -->
 <!--  Number: 1 - 120 -->
 <!--  Mandatory -->
@@ -1667,7 +1667,7 @@
 <!--  String -->
 <!--  Mandatory -->
 <P559>{ x+ | *x+ | *xx | *xxx | *xxxx | *xxxxx | *xxxxxx | **xx | **xxx | **xxxx | **xxxxx | **xxxxxx | **xxxxxxx | **xxxxxxxx | *xx*x+ }</P559>
-<!-- <P559>{ x+ | *x+ | *xx | *xxx | *xxxx | *xxxxx | *xxxxxx | **xx | **xxx | **xxxx | **xxxxx | **xxxxxx | **xxxxxxx | **xxxxxxxx | *xx*x+ | \+x+ | \p\a\r\k\+*x+ }</P559> -->
+<!-- <P559>{ x+ | *x+ | *xx | *xxx | *xxxx | *xxxxx | *xxxxxx | **xx | **xxx | **xxxx | **xxxxx | **xxxxxx | **xxxxxxx | **xxxxxxxx | *xx*x+ | \+x+ | \p\a\r\k\+*x+ | \p\a\r\k\+x+ }</P559> -->
 <!--  Delayed Call Forward Wait Time (in seconds). Default is 20 -->
 <!--  Number: 1 - 120 -->
 <!--  Mandatory -->

--- a/resources/templates/provision/grandstream/gxp17xx/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp17xx/{$mac}.xml
@@ -1346,7 +1346,7 @@
 {if isset($grandstream_dial_plan) }
 <P290>{$grandstream_dial_plan}</P290>
 {else}
-<P290>{literal}{x+|*x+|*++|\p\a\r\k\+*x+| \f\l\o\w\+*x+}{/literal}</P290>
+<P290>{literal}{x+|*x+|*++|\p\a\r\k\+*x+|\p\a\r\k\+x+|\f\l\o\w\+*x+}{/literal}</P290>
 {/if}
 
 <!-- # Call Log. 0 - Log All Calls, 1 - Log Incoming/Outgoing only (missed calls NOT recorded), 2 - Disable Call Log. Default is 0 -->

--- a/resources/templates/provision/grandstream/gxp2100/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp2100/{$mac}.xml
@@ -515,7 +515,7 @@
 {if isset($grandstream_dial_plan) }
 <P290>{$grandstream_dial_plan}</P290>
 {else}
-<P290>{literal}{x+|*x+|*++|\p\a\r\k\+*x+| \f\l\o\w\+*x+}{/literal}</P290>
+<P290>{literal}{x+|*x+|*++|\p\a\r\k\+*x+|\p\a\r\k\+x+|\f\l\o\w\+*x+}{/literal}</P290>
 {/if}
 
 <!--# Delayed Call Forward Wait Time (in seconds). Default is 20-->

--- a/resources/templates/provision/grandstream/gxp2124/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp2124/{$mac}.xml
@@ -359,7 +359,7 @@
     {if isset($grandstream_dial_plan) }
     <P290>{$grandstream_dial_plan}</P290>
     {else}
-    <P290>{literal}{x+|*x+|*++|\p\a\r\k\+*x+| \f\l\o\w\+*x+}{/literal}</P290>
+    <P290>{literal}{x+|*x+|*++|\p\a\r\k\+*x+|\p\a\r\k\+x+|\f\l\o\w\+*x+}{/literal}</P290>
     {/if}
     
     <!-- Delayed Call Forward Wait Time (in seconds). Default is 20-->

--- a/resources/templates/provision/grandstream/gxp2130/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp2130/{$mac}.xml
@@ -697,7 +697,7 @@
 {if isset($grandstream_dial_plan) }
     <P290>{$grandstream_dial_plan}</P290>
 {else}
-    <P290>{literal}{x+|*x+|*++|\p\a\r\k\+*x+| \f\l\o\w\+*x+}{/literal}</P290>
+    <P290>{literal}{x+|*x+|*++|\p\a\r\k\+*x+|\p\a\r\k\+x+|\f\l\o\w\+*x+}{/literal}</P290>
 {/if}
 
     <!-- # Bypass Dial Plan -->
@@ -1647,7 +1647,7 @@
 {if isset($grandstream_dial_plan) }
     <P459>{$grandstream_dial_plan}</P459>
 {else}
-    <P459>{literal}{x+|*x+|*++|\p\a\r\k\+*x+| \f\l\o\w\+*x+}{/literal}</P459>
+    <P459>{literal}{x+|*x+|*++|\p\a\r\k\+*x+|\p\a\r\k\+x+|\f\l\o\w\+*x+}{/literal}</P459>
 {/if}
 
     <!-- # Bypass Dial Plan -->
@@ -2594,7 +2594,7 @@
 {if isset($grandstream_dial_plan) }
     <P559>{$grandstream_dial_plan}</P559>
 {else}
-    <P559>{literal}{x+|*x+|*++|\p\a\r\k\+*x+| \f\l\o\w\+*x+}{/literal}</P559>
+    <P559>{literal}{x+|*x+|*++|\p\a\r\k\+*x+|\p\a\r\k\+x+|\f\l\o\w\+*x+}{/literal}</P559>
 {/if}
 
     <!-- # Bypass Dial Plan -->
@@ -3545,7 +3545,7 @@
 {if isset($grandstream_dial_plan) }
     <P659>{$grandstream_dial_plan}</P659>
 {else}
-    <P659>{literal}{x+|*x+|*++|\p\a\r\k\+*x+| \f\l\o\w\+*x+}{/literal}</P659>
+    <P659>{literal}{x+|*x+|*++|\p\a\r\k\+*x+|\p\a\r\k\+x+|\f\l\o\w\+*x+}{/literal}</P659>
 {/if}
 
     <!-- # Bypass Dial Plan -->
@@ -4493,7 +4493,7 @@
 {if isset($grandstream_dial_plan) }
     <P1759>{$grandstream_dial_plan}</P1759>
 {else}
-    <P1759>{literal}{x+|*x+|*++|\p\a\r\k\+*x+| \f\l\o\w\+*x+}{/literal}</P1759>
+    <P1759>{literal}{x+|*x+|*++|\p\a\r\k\+*x+|\p\a\r\k\+x+|\f\l\o\w\+*x+}{/literal}</P1759>
 {/if}
 
     <!-- # Bypass Dial Plan -->
@@ -5445,7 +5445,7 @@
 {if isset($grandstream_dial_plan) }
     <P1859>{$grandstream_dial_plan}</P1859>
 {else}
-    <P1859>{literal}{x+|*x+|*++|\p\a\r\k\+*x+| \f\l\o\w\+*x+}{/literal}</P1859>
+    <P1859>{literal}{x+|*x+|*++|\p\a\r\k\+*x+|\p\a\r\k\+x+|\f\l\o\w\+*x+}{/literal}</P1859>
 {/if}
 
     <!-- # Bypass Dial Plan -->

--- a/resources/templates/provision/grandstream/gxp2135/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp2135/{$mac}.xml
@@ -697,7 +697,7 @@
 {if isset($grandstream_dial_plan) }
     <P290>{$grandstream_dial_plan}</P290>
 {else}
-    <P290>{literal}{x+|*x+|*++|\p\a\r\k\+*x+| \f\l\o\w\+*x+}{/literal}</P290>
+    <P290>{literal}{x+|*x+|*++|\p\a\r\k\+*x+|\p\a\r\k\+x+|\f\l\o\w\+*x+}{/literal}</P290>
 {/if}
 
     <!-- # Bypass Dial Plan -->
@@ -1647,7 +1647,7 @@
 {if isset($grandstream_dial_plan) }
     <P459>{$grandstream_dial_plan}</P459>
 {else}
-    <P459>{literal}{x+|*x+|*++|\p\a\r\k\+*x+| \f\l\o\w\+*x+}{/literal}</P459>
+    <P459>{literal}{x+|*x+|*++|\p\a\r\k\+*x+|\p\a\r\k\+x+|\f\l\o\w\+*x+}{/literal}</P459>
 {/if}
 
     <!-- # Bypass Dial Plan -->
@@ -2594,7 +2594,7 @@
 {if isset($grandstream_dial_plan) }
     <P559>{$grandstream_dial_plan}</P559>
 {else}
-    <P559>{literal}{x+|*x+|*++|\p\a\r\k\+*x+| \f\l\o\w\+*x+}{/literal}</P559>
+    <P559>{literal}{x+|*x+|*++|\p\a\r\k\+*x+|\p\a\r\k\+x+|\f\l\o\w\+*x+}{/literal}</P559>
 {/if}
 
     <!-- # Bypass Dial Plan -->
@@ -3545,7 +3545,7 @@
 {if isset($grandstream_dial_plan) }
     <P659>{$grandstream_dial_plan}</P659>
 {else}
-    <P659>{literal}{x+|*x+|*++|\p\a\r\k\+*x+| \f\l\o\w\+*x+}{/literal}</P659>
+    <P659>{literal}{x+|*x+|*++|\p\a\r\k\+*x+|\p\a\r\k\+x+|\f\l\o\w\+*x+}{/literal}</P659>
 {/if}
 
     <!-- # Bypass Dial Plan -->
@@ -4493,7 +4493,7 @@
 {if isset($grandstream_dial_plan) }
     <P1759>{$grandstream_dial_plan}</P1759>
 {else}
-    <P1759>{literal}{x+|*x+|*++|\p\a\r\k\+*x+| \f\l\o\w\+*x+}{/literal}</P1759>
+    <P1759>{literal}{x+|*x+|*++|\p\a\r\k\+*x+|\p\a\r\k\+x+|\f\l\o\w\+*x+}{/literal}</P1759>
 {/if}
 
     <!-- # Bypass Dial Plan -->
@@ -5445,7 +5445,7 @@
 {if isset($grandstream_dial_plan) }
     <P1859>{$grandstream_dial_plan}</P1859>
 {else}
-    <P1859>{literal}{x+|*x+|*++|\p\a\r\k\+*x+| \f\l\o\w\+*x+}{/literal}</P1859>
+    <P1859>{literal}{x+|*x+|*++|\p\a\r\k\+*x+|\p\a\r\k\+x+|\f\l\o\w\+*x+}{/literal}</P1859>
 {/if}
 
     <!-- # Bypass Dial Plan -->

--- a/resources/templates/provision/grandstream/gxp2140/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp2140/{$mac}.xml
@@ -697,7 +697,7 @@
 {if isset($grandstream_dial_plan) }
     <P290>{$grandstream_dial_plan}</P290>
 {else}
-    <P290>{literal}{x+|*x+|*++|\p\a\r\k\+*x+| \f\l\o\w\+*x+}{/literal}</P290>
+    <P290>{literal}{x+|*x+|*++|\p\a\r\k\+*x+|\p\a\r\k\+x+|\f\l\o\w\+*x+}{/literal}</P290>
 {/if}
 
     <!-- # Bypass Dial Plan -->
@@ -1647,7 +1647,7 @@
 {if isset($grandstream_dial_plan) }
     <P459>{$grandstream_dial_plan}</P459>
 {else}
-    <P459>{literal}{x+|*x+|*++|\p\a\r\k\+*x+| \f\l\o\w\+*x+}{/literal}</P459>
+    <P459>{literal}{x+|*x+|*++|\p\a\r\k\+*x+|\p\a\r\k\+x+|\f\l\o\w\+*x+}{/literal}</P459>
 {/if}
 
     <!-- # Bypass Dial Plan -->
@@ -2594,7 +2594,7 @@
 {if isset($grandstream_dial_plan) }
     <P559>{$grandstream_dial_plan}</P559>
 {else}
-    <P559>{literal}{x+|*x+|*++|\p\a\r\k\+*x+| \f\l\o\w\+*x+}{/literal}</P559>
+    <P559>{literal}{x+|*x+|*++|\p\a\r\k\+*x+|\p\a\r\k\+x+|\f\l\o\w\+*x+}{/literal}</P559>
 {/if}
 
     <!-- # Bypass Dial Plan -->
@@ -3545,7 +3545,7 @@
 {if isset($grandstream_dial_plan) }
     <P659>{$grandstream_dial_plan}</P659>
 {else}
-    <P659>{literal}{x+|*x+|*++|\p\a\r\k\+*x+| \f\l\o\w\+*x+}{/literal}</P659>
+    <P659>{literal}{x+|*x+|*++|\p\a\r\k\+*x+|\p\a\r\k\+x+|\f\l\o\w\+*x+}{/literal}</P659>
 {/if}
 
     <!-- # Bypass Dial Plan -->
@@ -4493,7 +4493,7 @@
 {if isset($grandstream_dial_plan) }
     <P1759>{$grandstream_dial_plan}</P1759>
 {else}
-    <P1759>{literal}{x+|*x+|*++|\p\a\r\k\+*x+| \f\l\o\w\+*x+}{/literal}</P1759>
+    <P1759>{literal}{x+|*x+|*++|\p\a\r\k\+*x+|\p\a\r\k\+x+|\f\l\o\w\+*x+}{/literal}</P1759>
 {/if}
 
     <!-- # Bypass Dial Plan -->
@@ -5445,7 +5445,7 @@
 {if isset($grandstream_dial_plan) }
     <P1859>{$grandstream_dial_plan}</P1859>
 {else}
-    <P1859>{literal}{x+|*x+|*++|\p\a\r\k\+*x+| \f\l\o\w\+*x+}{/literal}</P1859>
+    <P1859>{literal}{x+|*x+|*++|\p\a\r\k\+*x+|\p\a\r\k\+x+|\f\l\o\w\+*x+}{/literal}</P1859>
 {/if}
 
     <!-- # Bypass Dial Plan -->

--- a/resources/templates/provision/grandstream/gxp2160/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp2160/{$mac}.xml
@@ -697,7 +697,7 @@
 {if isset($grandstream_dial_plan) }
     <P290>{$grandstream_dial_plan}</P290>
 {else}
-    <P290>{literal}{x+|*x+|*++|\p\a\r\k\+*x+| \f\l\o\w\+*x+}{/literal}</P290>
+    <P290>{literal}{x+|*x+|*++|\p\a\r\k\+*x+|\p\a\r\k\+x+|\f\l\o\w\+*x+}{/literal}</P290>
 {/if}
 
     <!-- # Bypass Dial Plan -->
@@ -1647,7 +1647,7 @@
 {if isset($grandstream_dial_plan) }
     <P459>{$grandstream_dial_plan}</P459>
 {else}
-    <P459>{literal}{x+|*x+|*++|\p\a\r\k\+*x+| \f\l\o\w\+*x+}{/literal}</P459>
+    <P459>{literal}{x+|*x+|*++|\p\a\r\k\+*x+|\p\a\r\k\+x+|\f\l\o\w\+*x+}{/literal}</P459>
 {/if}
 
     <!-- # Bypass Dial Plan -->
@@ -2594,7 +2594,7 @@
 {if isset($grandstream_dial_plan) }
     <P559>{$grandstream_dial_plan}</P559>
 {else}
-    <P559>{literal}{x+|*x+|*++|\p\a\r\k\+*x+| \f\l\o\w\+*x+}{/literal}</P559>
+    <P559>{literal}{x+|*x+|*++|\p\a\r\k\+*x+|\p\a\r\k\+x+|\f\l\o\w\+*x+}{/literal}</P559>
 {/if}
 
     <!-- # Bypass Dial Plan -->
@@ -3545,7 +3545,7 @@
 {if isset($grandstream_dial_plan) }
     <P659>{$grandstream_dial_plan}</P659>
 {else}
-    <P659>{literal}{x+|*x+|*++|\p\a\r\k\+*x+| \f\l\o\w\+*x+}{/literal}</P659>
+    <P659>{literal}{x+|*x+|*++|\p\a\r\k\+*x+|\p\a\r\k\+x+|\f\l\o\w\+*x+}{/literal}</P659>
 {/if}
 
     <!-- # Bypass Dial Plan -->
@@ -4493,7 +4493,7 @@
 {if isset($grandstream_dial_plan) }
     <P1759>{$grandstream_dial_plan}</P1759>
 {else}
-    <P1759>{literal}{x+|*x+|*++|\p\a\r\k\+*x+| \f\l\o\w\+*x+}{/literal}</P1759>
+    <P1759>{literal}{x+|*x+|*++|\p\a\r\k\+*x+|\p\a\r\k\+x+|\f\l\o\w\+*x+}{/literal}</P1759>
 {/if}
 
     <!-- # Bypass Dial Plan -->
@@ -5445,7 +5445,7 @@
 {if isset($grandstream_dial_plan) }
     <P1859>{$grandstream_dial_plan}</P1859>
 {else}
-    <P1859>{literal}{x+|*x+|*++|\p\a\r\k\+*x+| \f\l\o\w\+*x+}{/literal}</P1859>
+    <P1859>{literal}{x+|*x+|*++|\p\a\r\k\+*x+|\p\a\r\k\+x+|\f\l\o\w\+*x+}{/literal}</P1859>
 {/if}
 
     <!-- # Bypass Dial Plan -->

--- a/resources/templates/provision/grandstream/gxp2170/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp2170/{$mac}.xml
@@ -697,7 +697,7 @@
 {if isset($grandstream_dial_plan) }
     <P290>{$grandstream_dial_plan}</P290>
 {else}
-    <P290>{literal}{x+|*x+|*++|\p\a\r\k\+*x+| \f\l\o\w\+*x+}{/literal}</P290>
+    <P290>{literal}{x+|*x+|*++|\p\a\r\k\+*x+|\p\a\r\k\+x+|\f\l\o\w\+*x+}{/literal}</P290>
 {/if}
 
     <!-- # Bypass Dial Plan -->
@@ -1647,7 +1647,7 @@
 {if isset($grandstream_dial_plan) }
     <P459>{$grandstream_dial_plan}</P459>
 {else}
-    <P459>{literal}{x+|*x+|*++|\p\a\r\k\+*x+| \f\l\o\w\+*x+}{/literal}</P459>
+    <P459>{literal}{x+|*x+|*++|\p\a\r\k\+*x+|\p\a\r\k\+x+|\f\l\o\w\+*x+}{/literal}</P459>
 {/if}
 
     <!-- # Bypass Dial Plan -->
@@ -2594,7 +2594,7 @@
 {if isset($grandstream_dial_plan) }
     <P559>{$grandstream_dial_plan}</P559>
 {else}
-    <P559>{literal}{x+|*x+|*++|\p\a\r\k\+*x+| \f\l\o\w\+*x+}{/literal}</P559>
+    <P559>{literal}{x+|*x+|*++|\p\a\r\k\+*x+|\p\a\r\k\+x+|\f\l\o\w\+*x+}{/literal}</P559>
 {/if}
 
     <!-- # Bypass Dial Plan -->
@@ -3545,7 +3545,7 @@
 {if isset($grandstream_dial_plan) }
     <P659>{$grandstream_dial_plan}</P659>
 {else}
-    <P659>{literal}{x+|*x+|*++|\p\a\r\k\+*x+| \f\l\o\w\+*x+}{/literal}</P659>
+    <P659>{literal}{x+|*x+|*++|\p\a\r\k\+*x+|\p\a\r\k\+x+|\f\l\o\w\+*x+}{/literal}</P659>
 {/if}
 
     <!-- # Bypass Dial Plan -->
@@ -4493,7 +4493,7 @@
 {if isset($grandstream_dial_plan) }
     <P1759>{$grandstream_dial_plan}</P1759>
 {else}
-    <P1759>{literal}{x+|*x+|*++|\p\a\r\k\+*x+| \f\l\o\w\+*x+}{/literal}</P1759>
+    <P1759>{literal}{x+|*x+|*++|\p\a\r\k\+*x+|\p\a\r\k\+x+|\f\l\o\w\+*x+}{/literal}</P1759>
 {/if}
 
     <!-- # Bypass Dial Plan -->
@@ -5445,7 +5445,7 @@
 {if isset($grandstream_dial_plan) }
     <P1859>{$grandstream_dial_plan}</P1859>
 {else}
-    <P1859>{literal}{x+|*x+|*++|\p\a\r\k\+*x+| \f\l\o\w\+*x+}{/literal}</P1859>
+    <P1859>{literal}{x+|*x+|*++|\p\a\r\k\+*x+|\p\a\r\k\+x+|\f\l\o\w\+*x+}{/literal}</P1859>
 {/if}
 
     <!-- # Bypass Dial Plan -->

--- a/resources/templates/provision/grandstream/gxp21xx/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp21xx/{$mac}.xml
@@ -303,7 +303,7 @@
     {if isset($grandstream_dial_plan) }
     <P290>{$grandstream_dial_plan}</P290>
     {else}
-    <P290>{literal}{x+|*x+|*++|\p\a\r\k\+*x+| \f\l\o\w\+*x+}{/literal}</P290>
+    <P290>{literal}{x+|*x+|*++|\p\a\r\k\+*x+|\p\a\r\k\+x+|\f\l\o\w\+*x+}{/literal}</P290>
     {/if}
     
     <!-- Delayed Call Forward Wait Time (in seconds). Default is 20 -->

--- a/resources/templates/provision/grandstream/gxp21xxbk/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp21xxbk/{$mac}.xml
@@ -503,7 +503,7 @@
 {if isset($grandstream_dial_plan) }
 <P290>{$grandstream_dial_plan}</P290>
 {else}
-<P290>{literal}{x+|*x+|*++|\p\a\r\k\+*x+| \f\l\o\w\+*x+}{/literal}</P290>
+<P290>{literal}{x+|*x+|*++|\p\a\r\k\+*x+|\p\a\r\k\+x+|\f\l\o\w\+*x+}{/literal}</P290>
 {/if}
 
 
@@ -1067,7 +1067,7 @@
 {if isset($grandstream_dial_plan) }
 <P459>{$grandstream_dial_plan}</P459>
 {else}
-<P459>{literal}{x+|*x+|*++|\p\a\r\k\+*x+| \f\l\o\w\+*x+}{/literal}</P459>
+<P459>{literal}{x+|*x+|*++|\p\a\r\k\+*x+|\p\a\r\k\+x+|\f\l\o\w\+*x+}{/literal}</P459>
 {/if}  
 
 <!-- Delayed Call Forward Wait Time (in seconds). Default 20 -->

--- a/resources/templates/provision/grandstream/gxv300x/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxv300x/{$mac}.xml
@@ -251,7 +251,7 @@
     <!-- Dial Plan Prefix (dial plan prefix string) -->
     <P66></P66>
     <!-- Dial Plan. Maxlength = 128 character. Defalut is allow all  -->
-    <P290>{literal}{x+|*x+|*++|\p\a\r\k\+*x+| \f\l\o\w\+*x+}{/literal}</P290>
+    <P290>{literal}{x+|*x+|*++|\p\a\r\k\+*x+|\p\a\r\k\+x+|\f\l\o\w\+*x+}{/literal}</P290>
     <!-- Delayed Call Forward Wait Time. Default is 20 seconds, maxlength = 5  -->
     <P139>20</P139>
     <!-- Enable Call Features.  0 - no, 1 - yes -->

--- a/resources/templates/provision/grandstream/gxv3175/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxv3175/{$mac}.xml
@@ -248,7 +248,7 @@
 <P66></P66>
 
 <!-- Dial Plan Maxlength: unlimited, default is allow all  -->
-<P290>{literal}{x+|*x+|*++|\p\a\r\k\+*x+| \f\l\o\w\+*x+}{/literal}</P290>
+<P290>{literal}{x+|*x+|*++|\p\a\r\k\+*x+|\p\a\r\k\+x+|\f\l\o\w\+*x+}{/literal}</P290>
 
 <!-- Early Dial. 0 - No, 1 - Yes. -->
 <P29>0</P29>

--- a/resources/templates/provision/grandstream/gxv3175v2/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxv3175v2/{$mac}.xml
@@ -208,7 +208,7 @@
     <!-- Dial Plan Prefix, MaxLength 32 -->
     <P66></P66>
     <!-- Dial Plan Maxlength = unlimited, default is allow all  -->
-    <P290>{literal}{x+|*x+|*++|\p\a\r\k\+*x+| \f\l\o\w\+*x+}{/literal}</P290>
+    <P290>{literal}{x+|*x+|*++|\p\a\r\k\+*x+|\p\a\r\k\+x+|\f\l\o\w\+*x+}{/literal}</P290>
     <!-- Early Dial. 0 - No, 1 - Yes -->
     <P29>0</P29>
     <!-- Refer-To Use Target Contact. 0 - No, 1 - Yes -->

--- a/resources/templates/provision/grandstream/gxv3240/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxv3240/{$mac}.xml
@@ -1183,7 +1183,7 @@
 <P2482>0</P2482>
 
 <!-- Dial Plan. Default value is { x+ | \+x+ | *x+ | *xx*x+ } -->
-<P459>{ x+ | *x+ | *xx | *xxx | *xxxx | *xxxxx | *xxxxxx | **xx | **xxx | **xxxx | **xxxxx | **xxxxxx | **xxxxxxx | **xxxxxxxx | *xx*x+ | \+x+ | \p\a\r\k\+*x+ }</P459>
+<P459>{ x+ | *x+ | *xx | *xxx | *xxxx | *xxxxx | *xxxxxx | **xx | **xxx | **xxxx | **xxxxx | **xxxxxx | **xxxxxxx | **xxxxxxxx | *xx*x+ | \+x+ | \p\a\r\k\+*x+ | \p\a\r\k\+x+ }</P459>
 
 <!-- Refer-To Use Target Contact. 0 - No, 1 - Yes. Default value is 0 -->
 <!-- Number: 0, 1 -->
@@ -1821,7 +1821,7 @@
 <P2582>0</P2582>
 
 <!-- Dial Plan. Default value is { x+ | \+x+ | *x+ | *xx*x+ } -->
-<P559>{ x+ | *x+ | *xx | *xxx | *xxxx | *xxxxx | *xxxxxx | **xx | **xxx | **xxxx | **xxxxx | **xxxxxx | **xxxxxxx | **xxxxxxxx | *xx*x+ | \+x+ | \p\a\r\k\+*x+ }</P559>
+<P559>{ x+ | *x+ | *xx | *xxx | *xxxx | *xxxxx | *xxxxxx | **xx | **xxx | **xxxx | **xxxxx | **xxxxxx | **xxxxxxx | **xxxxxxxx | *xx*x+ | \+x+ | \p\a\r\k\+*x+ | \p\a\r\k\+x+ }</P559>
 
 <!-- Refer-To Use Target Contact. 0 - No, 1 - Yes. Default value is 0 -->
 <!-- Number: 0, 1 -->
@@ -2462,7 +2462,7 @@
 <P2682>0</P2682>
 
 <!-- Dial Plan. Default value is { x+ | \+x+ | *x+ | *xx*x+ } -->
-<P659>{ x+ | *x+ | *xx | *xxx | *xxxx | *xxxxx | *xxxxxx | **xx | **xxx | **xxxx | **xxxxx | **xxxxxx | **xxxxxxx | **xxxxxxxx | *xx*x+ | \+x+ | \p\a\r\k\+*x+ }</P659>
+<P659>{ x+ | *x+ | *xx | *xxx | *xxxx | *xxxxx | *xxxxxx | **xx | **xxx | **xxxx | **xxxxx | **xxxxxx | **xxxxxxx | **xxxxxxxx | *xx*x+ | \+x+ | \p\a\r\k\+*x+ | \p\a\r\k\+x+ }</P659>
 
 <!-- Refer-To Use Target Contact. 0 - No, 1 - Yes. Default value is 0 -->
 <!-- Number: 0, 1 -->
@@ -3101,7 +3101,7 @@
 <P2782>0</P2782>
 
 <!-- Dial Plan Maxlength: unlimited, default is allow all { x+ | *x+ | *xx*x+ } -->
-<P1759>{ x+ | *x+ | *xx | *xxx | *xxxx | *xxxxx | *xxxxxx | **xx | **xxx | **xxxx | **xxxxx | **xxxxxx | **xxxxxxx | **xxxxxxxx | *xx*x+ | \+x+ | \p\a\r\k\+*x+ }</P1759>
+<P1759>{ x+ | *x+ | *xx | *xxx | *xxxx | *xxxxx | *xxxxxx | **xx | **xxx | **xxxx | **xxxxx | **xxxxxx | **xxxxxxx | **xxxxxxxx | *xx*x+ | \+x+ | \p\a\r\k\+*x+ | \p\a\r\k\+x+ }</P1759>
 
 <!-- Refer-To Use Target Contact. 0 - No, 1 - Yes. Default value is 0 -->
 <!-- Number: 0, 1 -->
@@ -3742,7 +3742,7 @@
 <P2882>0</P2882>
 
 <!-- Dial Plan. Default value is { x+ | \+x+ | *x+ | *xx*x+ } -->
-<P1859>{ x+ | *x+ | *xx | *xxx | *xxxx | *xxxxx | *xxxxxx | **xx | **xxx | **xxxx | **xxxxx | **xxxxxx | **xxxxxxx | **xxxxxxxx | *xx*x+ | \+x+ | \p\a\r\k\+*x+ }</P1859>
+<P1859>{ x+ | *x+ | *xx | *xxx | *xxxx | *xxxxx | *xxxxxx | **xx | **xxx | **xxxx | **xxxxx | **xxxxxx | **xxxxxxx | **xxxxxxxx | *xx*x+ | \+x+ | \p\a\r\k\+*x+ | \p\a\r\k\+x+ }</P1859>
 
 <!-- Refer-To Use Target Contact. 0 - No, 1 - Yes. Default value is 0 -->
 <!-- Number: 0, 1 -->

--- a/resources/templates/provision/grandstream/gxw40xx/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxw40xx/{$mac}.xml
@@ -539,7 +539,7 @@
     {if isset($grandstream_dial_plan) }
     <P4200>{$grandstream_dial_plan}</P4200>
     {else}
-    <P4200>{literal}{x+|*x+|*++|\p\a\r\k\+*x+| \f\l\o\w\+*x+}{/literal}</P4200>
+    <P4200>{literal}{x+|*x+|*++|\p\a\r\k\+*x+|\p\a\r\k\+x+|\f\l\o\w\+*x+}{/literal}</P4200>
     {/if}
     
     <!-- SUBSCRIBE for MWI. 0 - No, 1 - Yes. -->

--- a/resources/templates/provision/grandstream/gxw410x/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxw410x/{$mac}.xml
@@ -567,7 +567,7 @@
     {if isset($grandstream_dial_plan) }
     <P3331>{$grandstream_dial_plan}</P3331>
     {else}
-    <P3331>{literal}{x+|*x+|*++|\p\a\r\k\+*x+| \f\l\o\w\+*x+}{/literal}</P3331>
+    <P3331>{literal}{x+|*x+|*++|\p\a\r\k\+*x+|\p\a\r\k\+x+|\f\l\o\w\+*x+}{/literal}</P3331>
     {/if}
     
     <!--  Hookflash Duration (X10ms). Default 60. -->

--- a/resources/templates/provision/grandstream/gxw42xx/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxw42xx/{$mac}.xml
@@ -1021,7 +1021,7 @@
 {if isset($grandstream_dial_plan) }
 <P4200>{$grandstream_dial_plan}</P4200>
 {else}
-<P4200>{literal}{x+|*x+|*++|\p\a\r\k\+*x+| \f\l\o\w\+*x+}{/literal}</P4200>
+<P4200>{literal}{x+|*x+|*++|\p\a\r\k\+*x+|\p\a\r\k\+x+|\f\l\o\w\+*x+}{/literal}</P4200>
 {/if}
 
 <!-- Use # as Dial Key (if set to Yes, "#" will function as the "(Re-)Dial" key). 0 - no, 1 - yes -->

--- a/resources/templates/provision/grandstream/ht502/{$mac}.xml
+++ b/resources/templates/provision/grandstream/ht502/{$mac}.xml
@@ -334,7 +334,7 @@
 		{if isset($grandstream_dial_plan) }
 		<P4200>{$grandstream_dial_plan}</P4200>
 		{else}
-		<P4200>{literal}{x+|*x+|*++|\p\a\r\k\+*x+| \f\l\o\w\+*x+}{/literal}</P4200>
+		<P4200>{literal}{x+|*x+|*++|\p\a\r\k\+*x+|\p\a\r\k\+x+|\f\l\o\w\+*x+}{/literal}</P4200>
 		{/if}
 		
 		<!-- SUBSCRIBE for MWI. 0 - No, 1 - Yes -->

--- a/resources/templates/provision/grandstream/ht503/{$mac}.xml
+++ b/resources/templates/provision/grandstream/ht503/{$mac}.xml
@@ -693,7 +693,7 @@
 {if isset($grandstream_dial_plan) }
 <P4200>{$grandstream_dial_plan}</P4200>
 {else}
-<P4200>{literal}{x+|*x+|*++|\p\a\r\k\+*x+| \f\l\o\w\+*x+}{/literal}</P4200>
+<P4200>{literal}{x+|*x+|*++|\p\a\r\k\+*x+|\p\a\r\k\+x+|\f\l\o\w\+*x+}{/literal}</P4200>
 {/if}
 
 <!--  SUBSCRIBE for MWI. 0 - No, 1 - Yes -->

--- a/resources/templates/provision/grandstream/ht701/{$mac}.xml
+++ b/resources/templates/provision/grandstream/ht701/{$mac}.xml
@@ -620,7 +620,7 @@
 {if isset($grandstream_dial_plan) }
 <P4200>{$grandstream_dial_plan}</P4200>
 {else}
-<P4200>{literal}{x+|*x+|*++|\p\a\r\k\+*x+| \f\l\o\w\+*x+}{/literal}</P4200>
+<P4200>{literal}{x+|*x+|*++|\p\a\r\k\+*x+|\p\a\r\k\+x+|\f\l\o\w\+*x+}{/literal}</P4200>
 {/if}
 
 <!-- SUBSCRIBE for MWI. 0 - No, 1 - Yes -->

--- a/resources/templates/provision/grandstream/ht702/{$mac}.xml
+++ b/resources/templates/provision/grandstream/ht702/{$mac}.xml
@@ -612,7 +612,7 @@
 {if isset($grandstream_dial_plan) }
 <P4200>{$grandstream_dial_plan}</P4200>
 {else}
-<P4200>{literal}{x+|*x+|*++|\p\a\r\k\+*x+| \f\l\o\w\+*x+}{/literal}</P4200>
+<P4200>{literal}{x+|*x+|*++|\p\a\r\k\+*x+|\p\a\r\k\+x+|\f\l\o\w\+*x+}{/literal}</P4200>
 {/if}
 
 <!-- SUBSCRIBE for MWI. 0 - No, 1 - Yes -->

--- a/resources/templates/provision/grandstream/ht704/{$mac}.xml
+++ b/resources/templates/provision/grandstream/ht704/{$mac}.xml
@@ -666,7 +666,7 @@
 {if isset($grandstream_dial_plan) }
 <P4200>{$grandstream_dial_plan}</P4200>
 {else}
-<P4200>{literal}{x+|*x+|*++|\p\a\r\k\+*x+| \f\l\o\w\+*x+}{/literal}</P4200>
+<P4200>{literal}{x+|*x+|*++|\p\a\r\k\+*x+|\p\a\r\k\+x+|\f\l\o\w\+*x+}{/literal}</P4200>
 {/if}
 
 <!-- SUBSCRIBE for MWI. 0 - No, 1 - Yes -->

--- a/resources/templates/provision/grandstream/ht802/{$mac}.xml
+++ b/resources/templates/provision/grandstream/ht802/{$mac}.xml
@@ -1019,7 +1019,7 @@
 {if isset($grandstream_dial_plan) }
     <P4200>{$grandstream_dial_plan}</P4200>
 {else}
-    <P4200>{literal}{x+|*x+|*++|\p\a\r\k\+*x+| \f\l\o\w\+*x+}{/literal}</P4200>
+    <P4200>{literal}{x+|*x+|*++|\p\a\r\k\+*x+|\p\a\r\k\+x+|\f\l\o\w\+*x+}{/literal}</P4200>
 {/if}
 
     <!-- # SUBSCRIBE for MWI. 0 - No, 1 - Yes -->
@@ -1900,7 +1900,7 @@
 {if isset($grandstream_dial_plan) }
     <P4201>{$grandstream_dial_plan}</P4201>
 {else}
-    <P4201>{literal}{x+|*x+|*++|\p\a\r\k\+*x+| \f\l\o\w\+*x+}{/literal}</P4201>
+    <P4201>{literal}{x+|*x+|*++|\p\a\r\k\+*x+|\p\a\r\k\+x+|\f\l\o\w\+*x+}{/literal}</P4201>
 {/if}	  
 
     <!-- # SUBSCRIBE for MWI. 0 - No, 1 - Yes -->


### PR DESCRIPTION
# Context

To go along with #5606 this merge request ensures that Grandstream phones with their dialplans can dial park+5900-5999.

# Overview
- Update the default value for `grandstream_dial_plan` to `{\+x+|x+|*x+|*++||\p\a\r\k\+*x+|\p\a\r\k\+x+|\f\l\o\w\+*x+|**x+}`
- A mass search and replace in all XML to replace `|\p\a\r\k\+*x+|` with `|\p\a\r\k\+*x+|\p\a\r\k\+x+|`