### PR TITLE
Update the valet park dialplan to allow matching park+5901-5999

### DIFF
--- a/app/dialplans/resources/switch/conf/dialplan/470_valet_park.xml
+++ b/app/dialplans/resources/switch/conf/dialplan/470_valet_park.xml
@@ -7,7 +7,6 @@
 		<condition field="destination_number" expression="^(?:(?:park\+\*?)|(?:\*))((?:590[1-9])|(?:59[1-9][0-9]))$" break="never">
 			<action application="set" data="park_in_use=false" inline="true"/>
 			<action application="set" data="park_lot=$1" inline="true"/>
-			<action application="info" data=""/>
 		</condition>
 		<condition field="destination_number" expression="^(?:(?:park\+\*?)|(?:\*))((?:590[1-9])|(?:59[1-9][0-9]))$"/>
 		<condition field="${referred_by_user}" expression="^.+$" break="never">

--- a/app/dialplans/resources/switch/conf/dialplan/470_valet_park.xml
+++ b/app/dialplans/resources/switch/conf/dialplan/470_valet_park.xml
@@ -1,18 +1,18 @@
 <context name="{v_context}">
-	<extension name="valet_park" number="park+*5901-*5999" continue="false" app_uuid="3cc8363d-5ce3-48aa-8ac1-143cf297c4f7" enabled="true" order="470">
-		<condition field="destination_number" expression="^(park\+)?\*(59[0-9][0-9])$" break="never"/>
+	<extension name="valet_park" number="park+5901-5999" continue="false" app_uuid="3cc8363d-5ce3-48aa-8ac1-143cf297c4f7" enabled="true" order="470">
+		<condition field="destination_number" expression="^(?:(?:park\+\*?)|(?:\*))((?:590[1-9])|(?:59[1-9][0-9]))$" break="never"/>
 		<condition field="${sip_h_Referred-By}" expression="sip:(.*)@.*" break="never">
 			<action application="set" data="referred_by_user=$1" inline="true"/>
 		</condition>
-		<condition field="destination_number" expression="^(park\+)?\*(59[0-9][0-9])$" break="never">
+		<condition field="destination_number" expression="^(?:(?:park\+\*?)|(?:\*))((?:590[1-9])|(?:59[1-9][0-9]))$" break="never">
 			<action application="set" data="park_in_use=false" inline="true"/>
-			<action application="set" data="park_lot=$2" inline="true"/>
+			<action application="set" data="park_lot=$1" inline="true"/>
 			<action application="info" data=""/>
 		</condition>
-		<condition field="destination_number" expression="^(park\+)?\*(59[0-9][0-9])$"/>
+		<condition field="destination_number" expression="^(?:(?:park\+\*?)|(?:\*))((?:590[1-9])|(?:59[1-9][0-9]))$"/>
 		<condition field="${referred_by_user}" expression="^.+$" break="never">
-			<action application="set" data="valet_info_park=${valet_info park@${domain_name}}|\*${park_lot}" inline="true"/>
-			<action application="set" data="park_in_use=${regex ${valet_info park@${domain_name}}|\*${park_lot}}" inline="true"/>
+			<action application="set" data="valet_info_park=${valet_info 5900@${domain_name}}|${park_lot}" inline="true"/>
+			<action application="set" data="park_in_use=${regex ${valet_info 5900@${domain_name}}|${park_lot}}" inline="true"/>
 		</condition>
 		<condition field="${park_in_use}" expression="true" break="never">
 			<action application="transfer" data="${referred_by_user} XML ${context}"/>
@@ -20,7 +20,7 @@
 			<anti-action application="set" data="valet_parking_timeout=180"/>
 			<anti-action application="set" data="valet_hold_music=${hold_music}"/>
 			<anti-action application="set" data="valet_parking_orbit_exten=${referred_by_user}"/>
-			<anti-action application="valet_park" data="park@${domain_name} *${park_lot}"/>
+			<anti-action application="valet_park" data="5900@${domain_name} ${park_lot}"/>
 		</condition>
 	</extension>
 </context>


### PR DESCRIPTION
# Context
This updates the main valet_park diaplan to match the changes done in #5606. This allows the diaplan to work with park+5901-5999 without the asterisk prefixed and fixes the lot names to match.

# Overview
- Parking lots are no longer directly prefixed with *. But for backwards compatibility can be called that way still.
- Parking lot name changed from `park` to `5900` to allow monitoring the whole parking lot with a BLF if desired.
  - https://freeswitch.org/confluence/display/FREESWITCH/mod_valet_parking#mod_valet_parking-UsingPresence
- Fix regex from matching 5900 to allow this dialplan to work with the valet_park_auto if enabled.