### PR TITLE
Improve the valet_park_auto dialplan to support auto out and whole lot BLF monitoring

### DIFF
--- a/app/dialplans/resources/switch/conf/dialplan/470_valet_park_auto.xml
+++ b/app/dialplans/resources/switch/conf/dialplan/470_valet_park_auto.xml
@@ -1,0 +1,9 @@
+<context name="{v_context}">
+	<extension name="valet_park_auto" number="park+5900" continue="false" app_uuid="c192ee50-084d-40d8-8d9a-6959369382c8" enabled="false" order="470">
+		<condition field="destination_number" expression="^(?:(?:park\+\*?)|(?:\*))(5900)$"/>
+		<condition field="${sip_h_Referred-By}" expression="sip:(.*)@.*" break="never">
+			<action application="valet_park" data="5900@${domain_name} auto in 5901 5999"/>
+			<anti-action application="valet_park" data="5900@${domain_name} auto out 5901 5999"/>
+		</condition>
+	</extension>
+</context>

--- a/app/dialplans/resources/switch/conf/dialplan/470_valet_park_in.xml
+++ b/app/dialplans/resources/switch/conf/dialplan/470_valet_park_in.xml
@@ -1,7 +1,0 @@
-<context name="{v_context}">
-	<extension name="valet_park_in" number="park+*5900" continue="false" app_uuid="c192ee50-084d-40d8-8d9a-6959369382c8" enabled="false" order="470">
-		<condition field="destination_number" expression="^(?:(?:park\+\*?)|(?:\*))(5900)$">
-			<action application="valet_park" data="park@${domain_name} auto in 5901 5999"/>
-		</condition>
-	</extension>
-</context>

--- a/app/dialplans/resources/switch/conf/dialplan/475_valet_park_out.xml
+++ b/app/dialplans/resources/switch/conf/dialplan/475_valet_park_out.xml
@@ -1,8 +1,8 @@
 <context name="{v_context}">
-	<extension name="valet_park_out" number="park+*5901-*5999" continue="false" app_uuid="242130d4-61d6-4daf-9dd1-b139a2b3b166" enabled="false" order="475">
+	<extension name="valet_park_out" number="park+5901-5999" continue="false" app_uuid="242130d4-61d6-4daf-9dd1-b139a2b3b166" enabled="false" order="475">
 		<condition field="destination_number" expression="^(?:(?:park\+\*?)|(?:\*))(59[0-9][0-9])$">
 			<action application="answer"/>
-			<action application="valet_park" data="park@${domain_name} $1"/>
+			<action application="valet_park" data="5900@${domain_name} $1"/>
 		</condition>
 	</extension>
 </context>


### PR DESCRIPTION
# Context
There were a couple of features of valet_park that were not exposed before by the default FusionPBX dialplan. This adds support for those features.

# Overview
- If the Referred-By header is set call the normal `auto in` code. If it isn't set that means someone called it directly, call `auto out` and attempt to pop the calls in the lot in FIFO order.
- This also changes the parking lot name from `park` to `5900` this allows phones to monitor `park+5900` to get the status of the whole parking lot. Before you would have to monitor `park+park` to get this functionality.
  - https://freeswitch.org/confluence/display/FREESWITCH/mod_valet_parking#mod_valet_parking-UsingPresence