### PR TITLE
Prevent Users without permission from clobbering ring_group_caller_id

### DIFF
--- a/app/ring_groups/ring_group_edit.php
+++ b/app/ring_groups/ring_group_edit.php
@@ -324,8 +324,12 @@
 			$array['ring_groups'][0]["ring_group_greeting"] = $ring_group_greeting;
 			$array['ring_groups'][0]["ring_group_strategy"] = $ring_group_strategy;
 			$array["ring_groups"][0]["ring_group_call_timeout"] = $ring_group_call_timeout;
-			$array["ring_groups"][0]["ring_group_caller_id_name"] = $ring_group_caller_id_name;
-			$array["ring_groups"][0]["ring_group_caller_id_number"] = $ring_group_caller_id_number;
+			if (permission_exists('ring_group_caller_id_name')) {
+				$array["ring_groups"][0]["ring_group_caller_id_name"] = $ring_group_caller_id_name;
+			}
+			if (permission_exists('ring_group_caller_id_number')) {
+				$array["ring_groups"][0]["ring_group_caller_id_number"] = $ring_group_caller_id_number;
+			}
 			if (permission_exists('ring_group_cid_name_prefix')) {
 				$array["ring_groups"][0]["ring_group_cid_name_prefix"] = $ring_group_cid_name_prefix;
 			}


### PR DESCRIPTION
Bring the ring_group_caller_id_name and number fields and permissions in line with the prefix permissions so that users without permission don't overwrite those fields by hitting save.