### PR TITLE
Order by start_epoch to Speed Up Query Execution

### DIFF
--- a/app/xml_cdr/xml_cdr_inc.php
+++ b/app/xml_cdr/xml_cdr_inc.php
@@ -187,7 +187,7 @@
 	}
 
 //create the sql query to get the xml cdr records
-	if (strlen($order_by) == 0) { $order_by  = "start_stamp"; }
+	if (strlen($order_by) == 0) { $order_by  = "start_epoch"; }
 	if (strlen($order) == 0) { $order  = "desc"; }
 
 //set a default number of rows to show


### PR DESCRIPTION
In some cases, this seems to speed up xml_cdr loading times by ~10x.

It appears one big cause of this is the final ORDER_BY statements are very slow in PostgreSQL for timestamp fields. Ordering by start_epoch field improves query execution time in a dramatic way and should result in the same ordering.