### PR TITLE
Fix accountcode not getting set on loopback

### DIFF
--- a/app/scripts/resources/scripts/app/xml_handler/resources/scripts/directory/directory.lua
+++ b/app/scripts/resources/scripts/app/xml_handler/resources/scripts/directory/directory.lua
@@ -644,7 +644,7 @@
 							end
 							table.insert(xml, [[								<variable name="record_stereo" value="true"/>]]);
 							table.insert(xml, [[								<variable name="transfer_fallback_extension" value="operator"/>]]);
-							table.insert(xml, [[								<variable name="export_vars" value="domain_name"/>]]);
+							table.insert(xml, [[								<variable name="export_vars" value="domain_name,accountcode"/>]]);
 							table.insert(xml, [[							</variables>]]);
 							table.insert(xml, [[						</user>]]);
 							table.insert(xml, [[					</users>]]);


### PR DESCRIPTION
if an extension calls a local extension or a ring group that goes out to an external destination accountcode won't get set because of loopback being used. Fixed by exporting accountcode 