### PR TITLE
Add Support for Validated Emergency Destinations/Caller ID

### DIFF
--- a/app/destinations/app_config.php
+++ b/app/destinations/app_config.php
@@ -123,6 +123,9 @@
 		$apps[$x]['permissions'][$y]['name'] = "destination_fax";
 		$apps[$x]['permissions'][$y]['groups'][] = "superadmin";
 		$y++;
+		$apps[$x]['permissions'][$y]['name'] = "destination_emergency";
+		$apps[$x]['permissions'][$y]['groups'][] = "superadmin";
+		$y++;
 		$apps[$x]['permissions'][$y]['name'] = "destination_destinations";
 		$apps[$x]['permissions'][$y]['groups'][] = "superadmin";
 		$apps[$x]['permissions'][$y]['groups'][] = "admin";
@@ -286,6 +289,10 @@
 		$apps[$x]['db'][$y]['fields'][$z]['name'] = "destination_type_fax";
 		$apps[$x]['db'][$y]['fields'][$z]['type'] = "numeric";
 		$apps[$x]['db'][$y]['fields'][$z]['description']['en-us'] = "Number is used for fax calls.";
+		$z++;
+		$apps[$x]['db'][$y]['fields'][$z]['name'] = "destination_type_emergency";
+		$apps[$x]['db'][$y]['fields'][$z]['type'] = "numeric";
+		$apps[$x]['db'][$y]['fields'][$z]['description']['en-us'] = "Number is used to place emergency calls.";
 		$z++;
 		$apps[$x]['db'][$y]['fields'][$z]['name'] = "destination_type_text";
 		$apps[$x]['db'][$y]['fields'][$z]['type'] = "numeric";

--- a/app/destinations/app_languages.php
+++ b/app/destinations/app_languages.php
@@ -883,6 +883,27 @@ $text['label-text']['ru-ru'] = "Текст";
 $text['label-text']['sv-se'] = "Text";
 $text['label-text']['uk-ua'] = "Текст";
 
+$text['label-emergency']['en-us'] = "Emergency";
+$text['label-emergency']['en-gb'] = "Emergency";
+$text['label-emergency']['ar-eg'] = "";
+$text['label-emergency']['de-at'] = "Anruferkennung"; //copied from de-de
+$text['label-emergency']['de-ch'] = "Anruferkennung";
+$text['label-emergency']['de-de'] = "Notruf Anruferkennung";
+$text['label-emergency']['es-cl'] = "Emergencia";
+$text['label-emergency']['es-mx'] = "Emergencia"; //copied from es-cl
+$text['label-emergency']['fr-ca'] = "Urgence"; //copied from fr-fr
+$text['label-emergency']['fr-fr'] = "Urgence";
+$text['label-emergency']['he-il'] = "";
+$text['label-emergency']['it-it'] = "Emergenze";
+$text['label-emergency']['nl-nl'] = "Noodnummer";
+$text['label-emergency']['pl-pl'] = "Prezentacja nazwy dzwoniącego (emergency)";
+$text['label-emergency']['pt-br'] = "Emergência";
+$text['label-emergency']['pt-pt'] = "Emergência";
+$text['label-emergency']['ro-ro'] = "";
+$text['label-emergency']['ru-ru'] = "Идентификатор (Caller ID) имени экстренного вызова";
+$text['label-emergency']['sv-se'] = "Nöd Namnpresentation";
+$text['label-emergency']['uk-ua'] = "";
+
 $text['header-destinations']['en-us'] = "Destinations";
 $text['header-destinations']['en-gb'] = "Destinations";
 $text['header-destinations']['ar-eg'] = "جهات الأتصال";

--- a/app/destinations/destination_edit.php
+++ b/app/destinations/destination_edit.php
@@ -107,6 +107,7 @@
 			$destination_type_voice = $_POST["destination_type_voice"];
 			$destination_type_fax = $_POST["destination_type_fax"];
 			$destination_type_text = $_POST["destination_type_text"];
+			$destination_type_emergency = $_POST["destination_type_emergency"];
 			$destination_carrier = trim($_POST["destination_carrier"]);
 
 		//get the destination app and data
@@ -671,6 +672,9 @@
 					$array['destinations'][0]["destination_type_voice"] = $destination_type_voice ? 1 : null;
 					$array['destinations'][0]["destination_type_fax"] = $destination_type_fax ? 1 : null;
 					$array['destinations'][0]["destination_type_text"] = $destination_type_text ? 1 : null;
+					if (permission_exists('destination_emergency')){
+						$array['destinations'][0]["destination_type_emergency"] = $destination_type_emergency ? 1 : null;
+					}
 					if ($destination->valid($destination_app.':'.$destination_data)) {
 						$array['destinations'][0]["destination_app"] = $destination_app;
 						$array['destinations'][0]["destination_data"] = $destination_data;
@@ -786,6 +790,7 @@
 				$destination_type_voice = $row["destination_type_voice"];
 				$destination_type_fax = $row["destination_type_fax"];
 				$destination_type_text = $row["destination_type_text"];
+				$destination_type_emergency = $row["destination_type_emergency"];
 				$destination_context = $row["destination_context"];
 				$destination_app = $row["destination_app"];
 				$destination_data = $row["destination_data"];
@@ -1233,6 +1238,9 @@
 	echo "	<label><input type='checkbox' name='destination_type_voice' id='destination_type_voice' value='1' ".($destination_type_voice ? "checked='checked'" : null)."> ".$text['label-voice']."</label>&nbsp;\n";
 	echo "	<label><input type='checkbox' name='destination_type_fax' id='destination_type_fax' value='1' ".($destination_type_fax ? "checked='checked'" : null)."> ".$text['label-fax']."</label>&nbsp;\n";
 	echo "	<label><input type='checkbox' name='destination_type_text' id='destination_type_text' value='1' ".($destination_type_text ? "checked='checked'" : null)."> ".$text['label-text']."</label>\n";
+	if (permission_exists('destination_emergency')){
+		echo "	<label><input type='checkbox' name='destination_type_emergency' id='destination_type_emergency' value='1' ".($destination_type_emergency ? "checked='checked'" : null)."> ".$text['label-emergency']."</label>\n";
+	}
 	echo "<br />\n";
 	echo $text['description-usage']."\n";
 	echo "</td>\n";

--- a/app/extensions/app_config.php
+++ b/app/extensions/app_config.php
@@ -169,6 +169,8 @@
 		$apps[$x]['permissions'][$y]['name'] = "emergency_caller_id_number";
 		$apps[$x]['permissions'][$y]['groups'][] = "superadmin";
 		$y++;
+		$apps[$x]['permissions'][$y]['name'] = "emergency_caller_id_select";
+		$y++;
 		$apps[$x]['permissions'][$y]['name'] = "extension_user_record";
 		$apps[$x]['permissions'][$y]['groups'][] = "superadmin";
 		$y++;

--- a/app/extensions/extension_edit.php
+++ b/app/extensions/extension_edit.php
@@ -800,6 +800,19 @@
 	$destinations = $database->select($sql, $parameters, 'all');
 	unset($sql, $parameters);
 
+//get the emergency destinations
+	if (permission_exists('emergency_caller_id_select')) {
+		$sql = "select * from v_destinations ";
+		$sql .= "where domain_uuid = :domain_uuid ";
+		$sql .= "and destination_type = 'inbound' ";
+		$sql .= "and destination_type_emergency = 1 ";
+		$sql .= "order by destination_number asc ";
+		$parameters['domain_uuid'] = $domain_uuid;
+		$database = new database;
+		$emergency_destinations = $database->select($sql, $parameters, 'all');
+		unset($sql, $parameters);
+	}
+
 //change toll allow delimiter
 	$toll_allow = str_replace(':',',', $toll_allow);
 
@@ -1298,7 +1311,31 @@
 		echo "    ".$text['label-emergency_caller_id_name']."\n";
 		echo "</td>\n";
 		echo "<td class='vtable' align='left'>\n";
-		if (permission_exists('outbound_caller_id_select')) {
+		if (permission_exists('emergency_caller_id_select')) {
+			if (count($emergency_destinations) > 0) {
+				echo "	<select name='emergency_caller_id_name' id='emergency_caller_id_name' class='formfld'>\n";
+				echo "		<option value=''></option>\n";
+				foreach ($emergency_destinations as &$row) {
+					$tmp = $row["destination_caller_id_name"];
+					if(strlen($tmp) == 0){
+						$tmp = $row["destination_description"];
+					}
+					if(strlen($tmp) > 0){
+						if ($emergency_caller_id_name == $tmp) {
+							echo "		<option value='".escape($tmp)."' selected='selected'>".escape($tmp)."</option>\n";
+						}
+						else {
+							echo "		<option value='".escape($tmp)."'>".escape($tmp)."</option>\n";
+						}
+					}
+				}
+				echo "	</select>\n";
+			}
+			else {
+				echo "	<input type=\"button\" class=\"btn\" name=\"\" alt=\"".$text['button-add']."\" onclick=\"window.location='".PROJECT_PATH."/app/destinations/destinations.php'\" value='".$text['button-add']."'>\n";
+			}
+		}
+		elseif (permission_exists('outbound_caller_id_select')) {
 			if (count($destinations) > 0) {
 				echo "	<select name='emergency_caller_id_name' id='emergency_caller_id_name' class='formfld'>\n";
 				echo "		<option value=''></option>\n";
@@ -1342,14 +1379,38 @@
 		echo "    ".$text['label-emergency_caller_id_number']."\n";
 		echo "</td>\n";
 		echo "<td class='vtable' align='left'>\n";
-		if (permission_exists('outbound_caller_id_select')) {
+		if (permission_exists('emergency_caller_id_select')) {
+			if (count($emergency_destinations) > 0) {
+				echo "	<select name='emergency_caller_id_number' id='emergency_caller_id_number' class='formfld'>\n";
+				//echo "	<option value=''></option>\n"; Don't allow no selection when validating emergency numbers this way
+				foreach ($emergency_destinations as &$row) {
+					$tmp = $row["destination_caller_id_number"];
+					if(strlen($tmp) == 0){
+						$tmp = $row["destination_number"];
+					}
+					if(strlen($tmp) > 0){
+						if ($emergency_caller_id_number == $tmp) {
+							echo "		<option value='".escape($tmp)."' selected='selected'>".escape($tmp)."</option>\n";
+						}
+						else {
+							echo "		<option value='".escape($tmp)."'>".escape($tmp)."</option>\n";
+						}
+					}
+				}
+				echo "		</select>\n";
+			}
+			else {
+				echo "	<input type=\"button\" class=\"btn\" name=\"\" alt=\"".$text['button-add']."\" onclick=\"window.location='".PROJECT_PATH."/app/destinations/destinations.php'\" value='".$text['button-add']."'>\n";
+			}
+		}
+		elseif (permission_exists('outbound_caller_id_select')) {
 			if (count($destinations) > 0) {
 				echo "	<select name='emergency_caller_id_number' id='emergency_caller_id_number' class='formfld'>\n";
 				echo "	<option value=''></option>\n";
 				foreach ($destinations as &$row) {
 					$tmp = $row["destination_caller_id_number"];
 					if(strlen($tmp) == 0){
-						$tmp = $row["destination_description"];
+						$tmp = $row["destination_number"];
 					}
 					if(strlen($tmp) > 0){
 						if ($emergency_caller_id_number == $tmp) {
@@ -1370,7 +1431,10 @@
 			echo "    <input class='formfld' type='text' name='emergency_caller_id_number' maxlength='255' min='0' step='1' value=\"".escape($emergency_caller_id_number)."\">\n";
 		}
 		echo "<br />\n";
-		if (permission_exists('outbound_caller_id_select') && count($destinations) > 0) {
+		if (permission_exists('emergency_caller_id_select') && count($emergency_destinations) > 0){
+			echo $text['description-emergency_caller_id_number-select']."\n";
+		}
+		elseif (permission_exists('outbound_caller_id_select') && count($destinations) > 0) {
 			echo $text['description-emergency_caller_id_number-select']."\n";
 		}
 		else {


### PR DESCRIPTION
### Schema Update
`v_destinations` has a new numeric column `destination_type_emergency` to be filled when a DID is validated to be used as a caller ID for emergency/E911 calls.

### New Permission:
`destination_emergency` defaults to superadmin only
- adds a checkbox to the "Destinations" page that allows admins to mark a DID for use for emergency calls. Typically, when they have validated/configured the E911 emergency services with the carrier they will select this box.

`emergency_caller_id_select` no default
- changes the "Emergency Caller ID Number" and "Emergency Caller Name" to dropdown selectors, similar to the `outbound_caller_id_select` permission
- Different from the outbound select, it uses the `destination_type_emergency` selection from the Destinations to limit the options to only DIDs that the admin has validated are configured for emergency calling.

### To-Do
This does not protect the POST from containing an invalid emergency number, just limits the UI elements. It appears that this is also true of `outbound_caller_id_select` in any case. Both situations should probably be resolved at some point as they constitute a (minor) security issue.


### Bug Fixed
There was a bug where if you had `outbound_caller_id_select`, the Emergency Caller ID Number field would check for the Destination's `destination_caller_id_number` field, and then fall back to `destination_description` field, when it should have fallen back to `destination_number`. This likely wasn't noticed because it was likely that most people who used the `outbound_caller_id_select` permission also had `emergency_caller_id_number` permission disabled. It is fixed with this PR though.