### PR TITLE
[4.4] Gives priority to key authentication

### DIFF
--- a/resources/check_auth.php
+++ b/resources/check_auth.php
@@ -65,12 +65,12 @@
 
 		//validate the username and password
 			$auth = new authentication;
-			if (isset($_REQUEST["username"]) && isset($_REQUEST["password"])) {
-				$auth->username = $_REQUEST["username"];
-				$auth->password = $_REQUEST["password"];
-			}
 			if (isset($_REQUEST["key"])) {
 				$auth->key = $_REQUEST["key"];
+			}
+			elseif (isset($_REQUEST["username"]) && isset($_REQUEST["password"])) {
+				$auth->username = $_REQUEST["username"];
+				$auth->password = $_REQUEST["password"];
 			}
 			$auth->debug = false;
 			$result = $auth->validate();


### PR DESCRIPTION
the current logic when authenticates verifies username variable. If that happens, it ignores the key variable (regardless if it is present). When this happens, authentication forcibly goes on user-password variables.
This could bring issues when the username and password variables are not used for authentication but editing/creating some elements. Since they are a very common name (more than one form uses in as an input field that is not authentication).

This patch gives priority to the key authentication if the key variable is present.