### PR TITLE
[4.4] Filter wrong CIDR

### DIFF
--- a/app/extensions/extension_edit.php
+++ b/app/extensions/extension_edit.php
@@ -131,6 +131,24 @@
 			if (!is_numeric($voicemail_id)) {
 				$voicemail_id = NULL;
 			}
+		
+			$cidrs = preg_split("/[\s,]+/", $cidr);
+			$ips = array();
+			foreach ($cidrs as $ipaddr){
+                                $cx = strpos($ipaddr, '/');
+                                if ($cx){
+                                        $subnet = (int)(substr($ipaddr, $cx+1));
+                                        $ipaddr = substr($ipaddr, 0, $cx);
+                                }
+                                else{
+                                        $subnet = 32;
+                                }
+
+                                if(($addr = inet_pton($ipaddr)) !== false){
+                                        $ips[] = $ipaddr.'/'.$subnet;
+                                }
+                        }
+                        $cidr = implode(',',$ips);
 	}
 
 //delete the user from the v_extension_users


### PR DESCRIPTION
FreeSWITCH could be broken if you input a wrong CIDR value in the extension settings. This patch filters out any wrong CIDR notation. If you input 300.5.599.99,1.1.1.1/32,alb.sfie, the invalid parts will be filter out and only 1.1.1.1/32 will be saved.