### PR TITLE
[4.5] Adds a new default setting type: unescapedtext

### DIFF
--- a/resources/footer.php
+++ b/resources/footer.php
@@ -120,6 +120,9 @@
 								if (isset($setting['text']) && $setting['text'] != '') {
 									$settings['theme'][$subcategory] = str_replace('&lowbar;','_',escape($setting['text']));
 								}
+								if (isset($setting['unescapedtext']) && $setting['unescapedtext'] != '') {
+									$settings['theme'][$subcategory] = str_replace('&lowbar;','_',($setting['unescapedtext']));
+								}
 								else if (isset($setting['numeric']) && is_numeric($setting['numeric'])) {
 									$settings['theme'][$subcategory] = $setting['numeric'];
 								}


### PR DESCRIPTION
So this is very handy when branding. Since in 4.5 the escape() function escapes any possible tag when branding you can not put a link to your website. For example, in the footer. Otherwise it will show HTML code instead of a link, tho.