### PR TITLE
[4.5] Fix the favicon and custom_css

### DIFF
--- a/resources/footer.php
+++ b/resources/footer.php
@@ -108,7 +108,7 @@
 										is_array($tmp_path) && @sizeof($tmp_path) != 0 &&
 										(
 											($tmp_url['scheme'] != '' && $tmp_url['scheme'].'://'.$tmp_url['host'].$tmp_url['path'] == $tmp_path['dirname'].'/'.$tmp_path['filename'].'.'.$tmp_path['extension']) //is url
-											|| $tmp_url['path'] == $tmp_path['dirname'].'/'.$tmp_path['filename'].'.'.$tmp_path['extension'] //is path
+											|| $tmp_url['path'] == ($tmp_path['dirname']=='/'?'':$tmp_path['dirname']).'/'.$tmp_path['filename'].'.'.$tmp_path['extension'] //is path
 										)) {
 										$settings['theme'][$subcategory] = $setting['text'];
 									}


### PR DESCRIPTION
If you put a default setting for favicon with a value of /file.ext  the current condition will fail as it concatenates a double //
This patch fixes it