### PR TITLE
Fix changing user status via the operator panel

### DIFF
--- a/app/basic_operator_panel/index.php
+++ b/app/basic_operator_panel/index.php
@@ -64,7 +64,12 @@
 			}
 
 		//update the status
-			if (permission_exists("user_account_setting_edit")) {
+			if (permission_exists("user_setting_edit")) {
+				//add the user_edit permission
+				$p = new permissions;
+				$p->add("user_edit", "temp");
+
+				//update the database user_status
 				$array['users'][0]['user_uuid'] = $_SESSION['user']['user_uuid'];
 				$array['users'][0]['domain_uuid'] = $_SESSION['user']['domain_uuid'];
 				$array['users'][0]['user_status'] = $user_status;
@@ -72,6 +77,10 @@
 				$database->app_name = 'operator_panel';
 				$database->app_uuid = 'dd3d173a-5d51-4231-ab22-b18c5b712bb2';
 				$database->save($array);
+
+				//remove the temporary permission
+				$p->delete("user_edit", "temp");
+
 				unset($array);
 			}
 

--- a/app/basic_operator_panel/resources/content.php
+++ b/app/basic_operator_panel/resources/content.php
@@ -82,7 +82,7 @@ echo "			<b>".$text['title-operator_panel']."</b>";
 echo "		</td>";
 echo "		<td valign='top' align='center' nowrap>";
 
-if (sizeof($_SESSION['user']['extensions']) > 0) {
+if (permission_exists("user_setting_edit") && sizeof($_SESSION['user']['extensions']) > 0) {
 	$status_options[1]['status'] = "Available";
 	$status_options[1]['label'] = $text['label-status_available'];
 	$status_options[1]['style'] = "op_btn_status_available";


### PR DESCRIPTION
# Context
Changing user status via the operator panel was broken due to an invalid permission and database update.

# Overview
- Switch from checking `user_account_setting_edit` to `user_setting_edit` as the permission
- Change the database update to how it's updated in [/app/calls/resources/classes/do_not_disturb.php#L51]( https://github.com/fusionpbx/fusionpbx/blob/master/app/calls/resources/classes/do_not_disturb.php#L51)
- Add a `user_setting_edit` permissions check in content.php to only show the buttons if there is permission to change the status.

# Outstanding Existing Issues
- Setting DND via the operator panel does not trigger the DND feature key sync found in the calls application.