### PR TITLE
[4.5] Let non admin users to list their own extensions only

### DIFF
--- a/app/extensions/app_config.php
+++ b/app/extensions/app_config.php
@@ -108,6 +108,10 @@
 		$apps[$x]['permissions'][$y]['name'] = "extension_domain";
 		$apps[$x]['permissions'][$y]['groups'][] = "superadmin";
 		$y++;
+		$apps[$x]['permissions'][$y]['name'] = "extension_domain_view";
+		$apps[$x]['permissions'][$y]['groups'][] = "superadmin";
+		$apps[$x]['permissions'][$y]['groups'][] = "admin";
+		$y++;
 		$apps[$x]['permissions'][$y]['name'] = "extension_enabled";
 		$apps[$x]['permissions'][$y]['groups'][] = "superadmin";
 		$apps[$x]['permissions'][$y]['groups'][] = "admin";

--- a/app/extensions/extensions.php
+++ b/app/extensions/extensions.php
@@ -82,7 +82,14 @@
 //get total extension count for domain
 if (is_numeric($_SESSION['limit']['extensions']['numeric'])) {
 	$sql = "select count(*) from v_extensions ";
+	if (!permission_exists('extension_domain_view')) {
+		$sql .= ' inner join v_extension_users using(extension_uuid) ';
+	}
 	$sql .= "where domain_uuid = :domain_uuid ";
+	if (!permission_exists('extension_domain_view')) {
+		$sql .= " and user_uuid = :user_uuid "; 
+		$parameters['user_uuid'] = $_SESSION['user_uuid'];
+	}
 	$parameters['domain_uuid'] = $_SESSION['domain_uuid'];
 	$database = new database;
 	$total_extensions = $database->select($sql, $parameters, 'column');


### PR DESCRIPTION
So far, at this point, only admin/superadmins members were able to list extensions.

This patch allows the listing of its own extensions only. extension ownership is given by linking the user when editing a given extension.

This will allow normal users to do basic self-management tasks such as password change (with a little of group config work)