### PR TITLE
Calls application feature class refactor and cleanup

### DIFF
--- a/app/calls/calls.php
+++ b/app/calls/calls.php
@@ -52,27 +52,39 @@
 
 //process the http post data by action
 	if ($action != '' && is_array($extensions) && @sizeof($extensions) != 0) {
+		//validate the token
+		$token = new token;
+		if (!$token->validate($_SERVER['PHP_SELF'])) {
+			message::add($text['message-invalid_token'],'negative');
+			header('Location: calls.php');
+			exit;
+		}
 		switch ($action) {
 			case 'toggle_call_forward':
 				if (permission_exists('call_forward')) {
 					$obj = new call_forward;
 					$obj->toggle($extensions);
+					//set message
+					message::add($text['message-toggle']);
 				}
 				break;
 			case 'toggle_follow_me':
 				if (permission_exists('follow_me')) {
 					$obj = new follow_me;
 					$obj->toggle($extensions);
+					//set message
+					message::add($text['message-toggle']);
 				}
 				break;
 			case 'toggle_do_not_disturb':
 				if (permission_exists('do_not_disturb')) {
 					$obj = new do_not_disturb;
 					$obj->toggle($extensions);
+					//set message
+					message::add($text['message-toggle']);
 				}
 				break;
 		}
-
 		header('Location: calls.php'.($search != '' ? '?search='.urlencode($search) : null));
 		exit;
 	}
@@ -288,8 +300,7 @@
 			echo "<tr class='list-row' href='".$list_row_url."'>\n";
 			if (!$is_included && $extensions) {
 				echo "	<td class='checkbox'>\n";
-				echo "		<input type='checkbox' name='extensions[$x][checked]' id='checkbox_".$x."' value='true' onclick=\"if (!this.checked) { document.getElementById('checkbox_all').checked = false; }\">\n";
-				echo "		<input type='hidden' name='extensions[$x][uuid]' value='".escape($row['extension_uuid'])."' />\n";
+				echo "		<input type='checkbox' name='extensions[]' id='checkbox_{$x}' value='".escape($row['extension_uuid'])."' onclick=\"if (!this.checked) { document.getElementById('checkbox_all').checked = false; }\">\n";
 				echo "	</td>\n";
 
 				if ($_GET['show'] == "all" && permission_exists('call_forward_all')) {

--- a/app/calls/resources/classes/call_forward.php
+++ b/app/calls/resources/classes/call_forward.php
@@ -71,7 +71,7 @@ include "root.php";
 		 * @param ?bool $new_state The new state or null to toggle
 		 */
 		private function set(array $uuids, ?bool $new_state) {
-			$extensions = $this->getExistingState($uuids);
+			$extensions = $this->get_existing_state($uuids);
 
 			// Set the DND state
 			$updates = array();

--- a/app/calls/resources/classes/call_forward.php
+++ b/app/calls/resources/classes/call_forward.php
@@ -57,13 +57,13 @@ include "root.php";
 		} //function
 
 		protected function update(array $extension) : array {
-			$extension = parent::update($extension);
 			//disable other features
 			if ($extension['forward_all_enabled'] == feature_base::enabled) {
 				$extension['do_not_disturb'] = feature_base::disabled; //false
 				$extension['follow_me_enabled'] = feature_base::disabled; //false
 			}
-			return $extension;
+			// Important to have the parent update last. Otherwise the above information will not be sent for feature key syncing.
+			return parent::update($extension);
 		}
 
 		/**

--- a/app/calls/resources/classes/call_forward.php
+++ b/app/calls/resources/classes/call_forward.php
@@ -24,259 +24,75 @@
 	Mark J Crane <markjcrane@fusionpbx.com>
 	Luis Daniel Lucio Quiroz <dlucio@okay.com.mx>
 	Errol Samuels <voiptology@gmail.com>
-
+	Andrew Querol <andrew@querol.me>
 */
 include "root.php";
 
 //define the call_forward class
-	class call_forward {
+	class call_forward extends feature_base {
+		public function disable(array $uuids) {
+			if (!permission_exists('call_forward')) {
+				return;
+			}
+			$this->set($uuids, false);
+		}
 
-		public $debug;
-		public $domain_uuid;
-		public $domain_name;
-		public $extension_uuid;
-		private $extension;
-		private $number_alias;
-		public $forward_all_destination;
-		public $forward_all_enabled;
-		private $dial_string;
-		private $toll_allow;
-		public $accountcode;
-		public $outbound_caller_id_name;
-		public $outbound_caller_id_number;
-
-		public function set() {
-			//determine whether to update the dial string
-				$sql = "select * from v_extensions ";
-				$sql .= "where domain_uuid = :domain_uuid ";
-				$sql .= "and extension_uuid = :extension_uuid ";
-				$parameters['domain_uuid'] = $this->domain_uuid;
-				$parameters['extension_uuid'] = $this->extension_uuid;
-				$database = new database;
-				$row = $database->select($sql, $parameters, 'row');
-				if (is_array($row) && @sizeof($row) != 0) {
-					$this->extension = $row["extension"];
-					$this->number_alias = $row["number_alias"];
-					$this->accountcode = $row["accountcode"];
-					$this->toll_allow = $row["toll_allow"];
-					$this->outbound_caller_id_name = $row["outbound_caller_id_name"];
-					$this->outbound_caller_id_number = $row["outbound_caller_id_number"];
-				}
-				unset($sql, $parameters, $row);
-
-			//build extension update array
-				$array['extensions'][0]['extension_uuid'] = $this->extension_uuid;
-				$array['extensions'][0]['forward_all_destination'] = strlen($this->forward_all_destination) != 0 ? $this->forward_all_destination : null;
-				if (strlen($this->forward_all_destination) == 0 || $this->forward_all_enabled == "false") {
-					$array['extensions'][0]['dial_string'] = null;
-					$array['extensions'][0]['forward_all_enabled'] = 'false';
-				}
-				else {
-					$array['extensions'][0]['dial_string'] = $this->dial_string;
-					$array['extensions'][0]['forward_all_enabled'] = 'true';
-				}
-
-			//grant temporary permissions
-				$p = new permissions;
-				$p->add('extension_add', 'temp');
-
-			//execute update
-				$database = new database;
-				$database->app_name = 'calls';
-				$database->app_uuid = '19806921-e8ed-dcff-b325-dd3e5da4959d';
-				$database->save($array);
-				unset($array);
-
-			//revoke temporary permissions
-				$p->delete('extension_add', 'temp');
-
-			//delete extension from the cache
-				$cache = new cache;
-				$cache->delete("directory:".$this->extension."@".$this->domain_name);
-				if(strlen($this->number_alias) > 0){
-					$cache->delete("directory:".$this->number_alias."@".$this->domain_name);
-				}
-
+		public function enable(array $uuids) {
+			if (!permission_exists('call_forward')) {
+				return;
+			}
+			$this->set($uuids, true);
 		}
 
 		/**
-		 * declare private variables
-		 */
-		private $app_name;
-		private $app_uuid;
-		private $permission;
-		private $list_page;
-		private $table;
-		private $uuid_prefix;
-		private $toggle_field;
-		private $toggle_values;
-
-		/**
 		 * toggle records
+		 * @param array $uuids The uuids to toggle
 		 */
-		public function toggle($records) {
-
-			//assign private variables
-				$this->app_name = 'calls';
-				$this->app_uuid = '19806921-e8ed-dcff-b325-dd3e5da4959d';
-				$this->permission = 'call_forward';
-				$this->list_page = 'calls.php';
-				$this->table = 'extensions';
-				$this->uuid_prefix = 'extension_';
-				$this->toggle_field = 'forward_all_enabled';
-				$this->toggle_values = ['true','false'];
-
-			if (permission_exists($this->permission)) {
-
-				//add multi-lingual support
-					$language = new text;
-					$text = $language->get();
-
-				//validate the token
-					$token = new token;
-					if (!$token->validate($_SERVER['PHP_SELF'])) {
-						message::add($text['message-invalid_token'],'negative');
-						header('Location: '.$this->list_page);
-						exit;
-					}
-
-				//toggle the checked records
-					if (is_array($records) && @sizeof($records) != 0) {
-
-						//get current toggle state
-							foreach($records as $x => $record) {
-								if ($record['checked'] == 'true' && is_uuid($record['uuid'])) {
-									$uuids[] = "'".$record['uuid']."'";
-								}
-							}
-							if (is_array($uuids) && @sizeof($uuids) != 0) {
-								$sql = "select ".$this->uuid_prefix."uuid as uuid, extension, number_alias, ";
-								$sql .= "call_timeout, do_not_disturb, ";
-								$sql .= "forward_all_enabled, forward_all_destination, ";
-								$sql .= "forward_busy_enabled, forward_busy_destination, ";
-								$sql .= "forward_no_answer_enabled, forward_no_answer_destination, ";
-								$sql .= $this->toggle_field." as toggle, follow_me_uuid ";
-								$sql .= "from v_".$this->table." ";
-								$sql .= "where (domain_uuid = :domain_uuid or domain_uuid is null) ";
-								$sql .= "and ".$this->uuid_prefix."uuid in (".implode(', ', $uuids).") ";
-								$parameters['domain_uuid'] = $_SESSION['domain_uuid'];
-								$database = new database;
-								$rows = $database->select($sql, $parameters, 'all');
-								if (is_array($rows) && @sizeof($rows) != 0) {
-									foreach ($rows as $row) {
-										$extensions[$row['uuid']]['extension'] = $row['extension'];
-										$extensions[$row['uuid']]['number_alias'] = $row['number_alias'];
-										$extensions[$row['uuid']]['call_timeout'] = $row['call_timeout'];
-										$extensions[$row['uuid']]['do_not_disturb'] = $row['do_not_disturb'];
-										$extensions[$row['uuid']]['forward_all_enabled'] = $row['forward_all_enabled'];
-										$extensions[$row['uuid']]['forward_all_destination'] = $row['forward_all_destination'];
-										$extensions[$row['uuid']]['forward_busy_enabled'] = $row['forward_busy_enabled'];
-										$extensions[$row['uuid']]['forward_busy_destination'] = $row['forward_busy_destination'];
-										$extensions[$row['uuid']]['forward_no_answer_enabled'] = $row['forward_no_answer_enabled'];
-										$extensions[$row['uuid']]['forward_no_answer_destination'] = $row['forward_no_answer_destination'];
-										$extensions[$row['uuid']]['state'] = $row['toggle'];
-										$extensions[$row['uuid']]['follow_me_uuid'] = $row['follow_me_uuid'];
-									}
-								}
-								unset($sql, $parameters, $rows, $row);
-							}
-
-						//build update array
-							$x = 0;
-							foreach ($extensions as $uuid => $extension) {
-
-								//check destination
-									$destination_exists = $extension['forward_all_destination'] != '' ? true : false;
-
-								//determine new state
-									$new_state = $extension['state'] == $this->toggle_values[1] && $destination_exists ? $this->toggle_values[0] : $this->toggle_values[1];
-
-								//toggle feature
-									if ($new_state != $extension['state']) {
-										$array[$this->table][$x][$this->uuid_prefix.'uuid'] = $uuid;
-										$array[$this->table][$x][$this->toggle_field] = $new_state;
-									}
-
-								//disable other features
-									if ($new_state == $this->toggle_values[0]) { //true
-										$array[$this->table][$x]['do_not_disturb'] = $this->toggle_values[1]; //false
-										$array[$this->table][$x]['follow_me_enabled'] = $this->toggle_values[1]; //false
-										if (is_uuid($extension['follow_me_uuid'])) {
-											$array['follow_me'][$x]['follow_me_uuid'] = $extension['follow_me_uuid'];
-											$array['follow_me'][$x]['follow_me_enabled'] = $this->toggle_values[1]; //false
-										}
-									}
-
-								//increment counter
-									$x++;
-
-							}
-
-						//save the changes
-							if (is_array($array) && @sizeof($array) != 0) {
-
-								//grant temporary permissions
-									$p = new permissions;
-									$p->add('extension_edit', 'temp');
-
-								//save the array
-									$database = new database;
-									$database->app_name = $this->app_name;
-									$database->app_uuid = $this->app_uuid;
-									$database->save($array);
-									unset($array);
-
-								//revoke temporary permissions
-									$p->delete('extension_edit', 'temp');
-
-								//send feature event notify to the phone
-									if ($_SESSION['device']['feature_sync']['boolean'] == "true") {
-										foreach ($extensions as $uuid => $extension) {
-											$feature_event_notify = new feature_event_notify;
-											$feature_event_notify->domain_name = $_SESSION['domain_name'];
-											$feature_event_notify->extension = $extension['extension'];
-											$feature_event_notify->do_not_disturb = $extension['do_not_disturb'];
-											$feature_event_notify->ring_count = ceil($extension['call_timeout'] / 6);
-											$feature_event_notify->forward_all_enabled = $extension['forward_all_enabled'];
-											$feature_event_notify->forward_busy_enabled = $extension['forward_busy_enabled'];
-											$feature_event_notify->forward_no_answer_enabled = $extension['forward_no_answer_enabled'];
-											//workarounds: send 0 as freeswitch doesn't send NOTIFY when destination values are nil
-											$feature_event_notify->forward_all_destination = $extension['forward_all_destination'] != '' ? $extension['forward_all_destination'] : '0';
-											$feature_event_notify->forward_busy_destination = $extension['forward_busy_destination'] != '' ? $extension['forward_busy_destination'] : '0';
-											$feature_event_notify->forward_no_answer_destination = $extension['forward_no_answer_destination'] != '' ? $extension['forward_no_answer_destination'] : '0';
-											$feature_event_notify->send_notify();
-											unset($feature_event_notify);
-										}
-									}
-
-								//synchronize configuration
-									if (is_readable($_SESSION['switch']['extensions']['dir'])) {
-										require_once "app/extensions/resources/classes/extension.php";
-										$ext = new extension;
-										$ext->xml();
-										unset($ext);
-									}
-
-								//clear the cache
-									$cache = new cache;
-									foreach ($extensions as $uuid => $extension) {
-										$cache->delete("directory:".$extension['extension']."@".$_SESSION['domain_name']);
-										if ($extension['number_alias'] != '') {
-											$cache->delete("directory:".$extension['number_alias']."@".$_SESSION['domain_name']);
-										}
-									}
-
-								//set message
-									message::add($text['message-toggle']);
-
-							}
-							unset($records, $extensions, $extension);
-					}
-
+		public function toggle(array $uuids) {
+			if (!permission_exists('call_forward')) {
+				return;
 			}
 
+			$this->set($uuids, null);
 		} //function
 
+		protected function update(array $extension) : array {
+			$extension = parent::update($extension);
+			//disable other features
+			if ($extension['forward_all_enabled'] == feature_base::enabled) {
+				$extension['do_not_disturb'] = feature_base::disabled; //false
+				$extension['follow_me_enabled'] = feature_base::disabled; //false
+			}
+			return $extension;
+		}
+
+		/**
+		 * @param array $uuids The extension UUIDs to perform this operation on
+		 * @param ?bool $new_state The new state or null to toggle
+		 */
+		private function set(array $uuids, ?bool $new_state) {
+			$extensions = $this->getExistingState($uuids);
+
+			// Set the DND state
+			$updates = array();
+			foreach ($extensions as $uuid => $extension) {
+				// Create a copy of $new_state since we do not want to clobber it when toggling.
+				$updated_state = $new_state;
+				if (is_null($new_state)) {
+					$updated_state = $extension['forward_all_enabled'] != feature_base::enabled;
+				}
+				$destination_exists = $extension['forward_all_destination'] != '';
+
+				// Update the extension array with the new DND state
+				$extension['forward_all_enabled'] = $updated_state && $destination_exists ? feature_base::enabled : feature_base::disabled;
+
+				// Build the update array and perform any per-extension updates
+				$updates['extensions'][] = $this->update($extension);
+			}
+			$this->save($updates);
+
+			unset($records, $extensions, $extension, $updates);
+		}
 	}// class
 
 ?>

--- a/app/calls/resources/classes/do_not_disturb.php
+++ b/app/calls/resources/classes/do_not_disturb.php
@@ -70,7 +70,7 @@ include "root.php";
 		 * @param ?bool $new_state The new state or null to toggle
 		 */
 		private function set(array $uuids, ?bool $new_state) {
-			$extensions = $this->getExistingState($uuids);
+			$extensions = $this->get_existing_state($uuids);
 
 			// Set the DND state
 			$updates = array();

--- a/app/calls/resources/classes/do_not_disturb.php
+++ b/app/calls/resources/classes/do_not_disturb.php
@@ -56,13 +56,13 @@ include "root.php";
 		} //function
 
 		protected function update(array $extension) : array {
-			$extension = parent::update($extension);
 			//disable other features
 			if ($extension['do_not_disturb'] == feature_base::enabled) {
 				$extension['forward_all_enabled'] = feature_base::disabled; //false
 				$extension['follow_me_enabled'] = feature_base::disabled; //false
 			}
-			return $extension;
+			// Important to have the parent update last. Otherwise the above information will not be sent for feature key syncing.
+			return parent::update($extension);
 		}
 
 		/**

--- a/app/calls/resources/classes/do_not_disturb.php
+++ b/app/calls/resources/classes/do_not_disturb.php
@@ -22,277 +22,74 @@
 
 	Contributor(s):
 	Mark J Crane <markjcrane@fusionpbx.com>
+	Andrew Querol <andrew@querol.me>
 */
 include "root.php";
 
 //define the dnd class
-	class do_not_disturb {
-		public $debug;
-		public $domain_uuid;
-		public $domain_name;
-		public $extension_uuid;
-		public $extension;
-		public $enabled;
-		private $dial_string;
+	class do_not_disturb extends feature_base {
 
-		//update the user_status
-		public function user_status() {
-			//update the status
-				if ($this->enabled == "true") {
-					//update the call center status
-						$user_status = "Logged Out";
-						$fp = event_socket_create($_SESSION['event_socket_ip_address'], $_SESSION['event_socket_port'], $_SESSION['event_socket_password']);
-						if ($fp) {
-							$switch_cmd .= "callcenter_config agent set status ".$_SESSION['username']."@".$this->domain_name." '".$user_status."'";
-							$switch_result = event_socket_request($fp, 'api '.$switch_cmd);
-						}
-
-					//update the database user_status
-						$user_status = "Do Not Disturb";
-						$sql  = "update v_users set ";
-						$sql .= "user_status = :user_status ";
-						$sql .= "where domain_uuid = :domain_uuid ";
-						$sql .= "and username = :username ";
-						$parameters['user_status'] = "Do Not Disturb";
-						$parameters['domain_uuid'] = $this->domain_uuid;
-						$parameters['username'] = $_SESSION['username'];
-						$database = new database;
-						$database->execute($sql);
-				}
+		public function disable(array $uuids) {
+			if (!permission_exists('do_not_disturb')) {
+				return;
+			}
+			$this->set($uuids, false);
 		}
 
-		public function set() {
-			//determine whether to update the dial string
-				$sql = "select extension_uuid, extension, number_alias ";
-				$sql .= "from v_extensions ";
-				$sql .= "where domain_uuid = :domain_uuid ";
-				if (is_uuid($this->extension_uuid)) {
-					$sql .= "and extension_uuid = :extension_uuid ";
-					$parameters['extension_uuid'] = $this->extension_uuid;
-				}
-				else {
-					$sql .= "and extension = :extension ";
-					$parameters['extension'] = $this->extension;
-				}
-				$parameters['domain_uuid'] = $this->domain_uuid;
-				$database = new database;
-				$row = $database->select($sql, $parameters, 'row');
-				if (is_array($row) && @sizeof($row) != 0) {
-					if (is_uuid($this->extension_uuid)) {
-						$this->extension_uuid = $row["extension_uuid"];
-					}
-					if (strlen($this->extension) == 0) {
-						if (strlen($row["number_alias"]) == 0) {
-							$this->extension = $row["extension"];
-						}
-						else {
-							$this->extension = $row["number_alias"];
-						}
-					}
-				}
-				unset($sql, $parameters, $row);
-
-			//set the dial string
-				$this->dial_string = $this->enabled == "true" ? "error/user_busy" : '';
-
-			//build extension update array
-				$array['extensions'][0]['extension_uuid'] = $this->extension_uuid;
-				$array['extensions'][0]['dial_string'] = $this->dial_string;
-				$array['extensions'][0]['do_not_disturb'] = $this->enabled;
-
-			//grant temporary permissions
-				$p = new permissions;
-				$p->add('extension_edit', 'temp');
-
-			//execute update
-				$database = new database;
-				$database->app_name = 'calls';
-				$database->app_uuid = '19806921-e8ed-dcff-b325-dd3e5da4959d';
-				$database->save($array);
-				unset($array);
-
-			//revoke temporary permissions
-				$p->delete('extension_edit', 'temp');
-
-			//delete extension from the cache
-				$cache = new cache;
-				$cache->delete("directory:".$this->extension."@".$this->domain_name);
-				if(strlen($this->number_alias) > 0){
-					$cache->delete("directory:".$this->number_alias."@".$this->domain_name);
-				}
-
-		} //function
-
-		/**
-		 * declare private variables
-		 */
-		private $app_name;
-		private $app_uuid;
-		private $permission;
-		private $list_page;
-		private $table;
-		private $uuid_prefix;
-		private $toggle_field;
-		private $toggle_values;
+		public function enable(array $uuids) {
+			if (!permission_exists('do_not_disturb')) {
+				return;
+			}
+			$this->set($uuids, true);
+		}
 
 		/**
 		 * toggle records
+		 * @param array $uuids The uuids to toggle
 		 */
-		public function toggle($records) {
-
-			//assign private variables
-				$this->app_name = 'calls';
-				$this->app_uuid = '19806921-e8ed-dcff-b325-dd3e5da4959d';
-				$this->permission = 'do_not_disturb';
-				$this->list_page = 'calls.php';
-				$this->table = 'extensions';
-				$this->uuid_prefix = 'extension_';
-				$this->toggle_field = 'do_not_disturb';
-				$this->toggle_values = ['true','false'];
-
-			if (permission_exists($this->permission)) {
-
-				//add multi-lingual support
-					$language = new text;
-					$text = $language->get();
-
-				//validate the token
-					$token = new token;
-					if (!$token->validate($_SERVER['PHP_SELF'])) {
-						message::add($text['message-invalid_token'],'negative');
-						header('Location: '.$this->list_page);
-						exit;
-					}
-
-				//toggle the checked records
-					if (is_array($records) && @sizeof($records) != 0) {
-
-						//get current toggle state
-							foreach($records as $x => $record) {
-								if ($record['checked'] == 'true' && is_uuid($record['uuid'])) {
-									$uuids[] = "'".$record['uuid']."'";
-								}
-							}
-							if (is_array($uuids) && @sizeof($uuids) != 0) {
-								$sql = "select ".$this->uuid_prefix."uuid as uuid, extension, number_alias, ";
-								$sql .= "call_timeout, do_not_disturb, ";
-								$sql .= "forward_all_enabled, forward_all_destination, ";
-								$sql .= "forward_busy_enabled, forward_busy_destination, ";
-								$sql .= "forward_no_answer_enabled, forward_no_answer_destination, ";
-								$sql .= $this->toggle_field." as toggle, follow_me_uuid ";
-								$sql .= "from v_".$this->table." ";
-								$sql .= "where (domain_uuid = :domain_uuid or domain_uuid is null) ";
-								$sql .= "and ".$this->uuid_prefix."uuid in (".implode(', ', $uuids).") ";
-								$parameters['domain_uuid'] = $_SESSION['domain_uuid'];
-								$database = new database;
-								$rows = $database->select($sql, $parameters, 'all');
-								if (is_array($rows) && @sizeof($rows) != 0) {
-									foreach ($rows as $row) {
-										$extensions[$row['uuid']]['extension'] = $row['extension'];
-										$extensions[$row['uuid']]['number_alias'] = $row['number_alias'];
-										$extensions[$row['uuid']]['call_timeout'] = $row['call_timeout'];
-										$extensions[$row['uuid']]['do_not_disturb'] = $row['do_not_disturb'];
-										$extensions[$row['uuid']]['forward_all_enabled'] = $row['forward_all_enabled'];
-										$extensions[$row['uuid']]['forward_all_destination'] = $row['forward_all_destination'];
-										$extensions[$row['uuid']]['forward_busy_enabled'] = $row['forward_busy_enabled'];
-										$extensions[$row['uuid']]['forward_busy_destination'] = $row['forward_busy_destination'];
-										$extensions[$row['uuid']]['forward_no_answer_enabled'] = $row['forward_no_answer_enabled'];
-										$extensions[$row['uuid']]['forward_no_answer_destination'] = $row['forward_no_answer_destination'];
-										$extensions[$row['uuid']]['state'] = $row['toggle'];
-										$extensions[$row['uuid']]['follow_me_uuid'] = $row['follow_me_uuid'];
-									}
-								}
-								unset($sql, $parameters, $rows, $row);
-							}
-
-						//build update array
-							$x = 0;
-							foreach ($extensions as $uuid => $extension) {
-
-								//toggle feature
-									$array[$this->table][$x][$this->uuid_prefix.'uuid'] = $uuid;
-									$array[$this->table][$x][$this->toggle_field] = $extension['state'] == $this->toggle_values[0] ? $this->toggle_values[1] : $this->toggle_values[0];
-
-								//disable other features
-									if ($array[$this->table][$x][$this->toggle_field] == $this->toggle_values[0]) { //true
-										$array[$this->table][$x]['forward_all_enabled'] = $this->toggle_values[1]; //false
-										$array[$this->table][$x]['follow_me_enabled'] = $this->toggle_values[1]; //false
-										if (is_uuid($extension['follow_me_uuid'])) {
-											$array['follow_me'][$x]['follow_me_uuid'] = $extension['follow_me_uuid'];
-											$array['follow_me'][$x]['follow_me_enabled'] = $this->toggle_values[1]; //false
-										}
-									}
-
-								//increment counter
-									$x++;
-
-							}
-
-						//save the changes
-							if (is_array($array) && @sizeof($array) != 0) {
-
-								//grant temporary permissions
-									$p = new permissions;
-									$p->add('extension_edit', 'temp');
-
-								//save the array
-									$database = new database;
-									$database->app_name = $this->app_name;
-									$database->app_uuid = $this->app_uuid;
-									$database->save($array);
-									unset($array);
-
-								//revoke temporary permissions
-									$p->delete('extension_edit', 'temp');
-
-								//send feature event notify to the phone
-									if ($_SESSION['device']['feature_sync']['boolean'] == "true") {
-										foreach ($extensions as $uuid => $extension) {
-											$feature_event_notify = new feature_event_notify;
-											$feature_event_notify->domain_name = $_SESSION['domain_name'];
-											$feature_event_notify->extension = $extension['extension'];
-											$feature_event_notify->do_not_disturb = $extension['do_not_disturb'];
-											$feature_event_notify->ring_count = ceil($extension['call_timeout'] / 6);
-											$feature_event_notify->forward_all_enabled = $extension['forward_all_enabled'];
-											$feature_event_notify->forward_busy_enabled = $extension['forward_busy_enabled'];
-											$feature_event_notify->forward_no_answer_enabled = $extension['forward_no_answer_enabled'];
-											//workarounds: send 0 as freeswitch doesn't send NOTIFY when destination values are nil
-											$feature_event_notify->forward_all_destination = $extension['forward_all_destination'] != '' ? $extension['forward_all_destination'] : '0';
-											$feature_event_notify->forward_busy_destination = $extension['forward_busy_destination'] != '' ? $extension['forward_busy_destination'] : '0';
-											$feature_event_notify->forward_no_answer_destination = $extension['forward_no_answer_destination'] != '' ? $extension['forward_no_answer_destination'] : '0';
-											$feature_event_notify->send_notify();
-											unset($feature_event_notify);
-										}
-									}
-
-								//synchronize configuration
-									if (is_readable($_SESSION['switch']['extensions']['dir'])) {
-										require_once "app/extensions/resources/classes/extension.php";
-										$ext = new extension;
-										$ext->xml();
-										unset($ext);
-									}
-
-								//clear the cache
-									$cache = new cache;
-									foreach ($extensions as $uuid => $extension) {
-										$cache->delete("directory:".$extension['extension']."@".$_SESSION['domain_name']);
-										if ($extension['number_alias'] != '') {
-											$cache->delete("directory:".$extension['number_alias']."@".$_SESSION['domain_name']);
-										}
-									}
-
-								//set message
-									message::add($text['message-toggle']);
-
-							}
-							unset($records, $extensions, $extension);
-					}
-
+		public function toggle(array $uuids) {
+			if (!permission_exists('do_not_disturb')) {
+				return;
 			}
 
+			$this->set($uuids, null);
 		} //function
 
+		protected function update(array $extension) : array {
+			$extension = parent::update($extension);
+			//disable other features
+			if ($extension['do_not_disturb'] == feature_base::enabled) {
+				$extension['forward_all_enabled'] = feature_base::disabled; //false
+				$extension['follow_me_enabled'] = feature_base::disabled; //false
+			}
+			return $extension;
+		}
+
+		/**
+		 * @param array $uuids The extension UUIDs to perform this operation on
+		 * @param ?bool $new_state The new state or null to toggle
+		 */
+		private function set(array $uuids, ?bool $new_state) {
+			$extensions = $this->getExistingState($uuids);
+
+			// Set the DND state
+			$updates = array();
+			foreach ($extensions as $uuid => $extension) {
+				// Create a copy of $new_state since we do not want to clobber it when toggling.
+				$updated_state = $new_state;
+				if (is_null($new_state)) {
+					$updated_state = $extension['do_not_disturb'] != feature_base::enabled;
+				}
+				// Update the extension array with the new DND state
+				$extension['do_not_disturb'] = $updated_state ? feature_base::enabled : feature_base::disabled;
+
+				// Build the update array and perform any per-extension updates
+				$updates['extensions'][] = $this->update($extension);
+			}
+			$this->save($updates);
+
+			unset($records, $extensions, $extension, $updates);
+		}
 	} //class
 
 ?>

--- a/app/calls/resources/classes/feature_base.php
+++ b/app/calls/resources/classes/feature_base.php
@@ -1,4 +1,29 @@
 <?php
+/*
+	FusionPBX
+	Version: MPL 1.1
+
+	The contents of this file are subject to the Mozilla Public License Version
+	1.1 (the "License"); you may not use this file except in compliance with
+	the License. You may obtain a copy of the License at
+	http://www.mozilla.org/MPL/
+
+	Software distributed under the License is distributed on an "AS IS" basis,
+	WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License
+	for the specific language governing rights and limitations under the
+	License.
+
+	The Original Code is FusionPBX
+
+	The Initial Developer of the Original Code is
+	Mark J Crane <markjcrane@fusionpbx.com>
+	Copyright (C) 2010 - 2016
+	All Rights Reserved.
+
+	Contributor(s):
+	Mark J Crane <markjcrane@fusionpbx.com>
+	Andrew Querol <andrew@querol.me>
+*/
 
 abstract class feature_base {
 	private const app_name = 'calls';

--- a/app/calls/resources/classes/feature_base.php
+++ b/app/calls/resources/classes/feature_base.php
@@ -1,0 +1,93 @@
+<?php
+
+abstract class feature_base {
+	private const app_name = 'calls';
+	private const app_uuid = '19806921-e8ed-dcff-b325-dd3e5da4959d';
+	protected const enabled  = 'true';
+	protected const disabled = 'false';
+
+	protected $cache;
+
+	public function __construct() {
+		$this->cache = new cache;
+	}
+
+	protected function getExistingState(array $uuids) : array {
+		if (is_array($uuids) && @sizeof($uuids) != 0) {
+			$sql  = "select extension_uuid, extension, number_alias, call_timeout, ";
+			$sql .= "do_not_disturb, forward_all_enabled, forward_all_destination, ";
+			$sql .= "forward_busy_enabled, forward_busy_destination, forward_no_answer_enabled, ";
+			$sql .= "forward_no_answer_destination, follow_me_enabled, follow_me_uuid ";
+			$sql .= "from v_extensions ";
+			$sql .= "where (domain_uuid = :domain_uuid or domain_uuid is null) ";
+			$sql .= "and extension_uuid in ('".implode('\', \'', $uuids)."') ";
+			$parameters['domain_uuid'] = $_SESSION['domain_uuid'];
+			$database = new database;
+			$rows = $database->select($sql, $parameters);
+			if (is_array($rows) && @sizeof($rows) != 0) {
+				return $rows;
+			}
+			unset($sql, $parameters, $rows, $row);
+		}
+		return array();
+	}
+
+	/**
+	 * @param array $extension The updated extension information
+	 * @return array The input extension is returned with possibly modified data
+	 */
+	protected function update(array $extension) : array {
+		// Feature key sync if enabled
+		if ($_SESSION['device']['feature_sync']['boolean'] == "true") {
+			$feature_event_notify = new feature_event_notify;
+			$feature_event_notify->domain_name = $_SESSION['domain_name'];
+			$feature_event_notify->extension = $extension['extension'];
+			$feature_event_notify->do_not_disturb = $extension['do_not_disturb'];
+			$feature_event_notify->ring_count = ceil($extension['call_timeout'] / 6);
+			$feature_event_notify->forward_all_enabled = $extension['forward_all_enabled'];
+			$feature_event_notify->forward_busy_enabled = $extension['forward_busy_enabled'];
+			$feature_event_notify->forward_no_answer_enabled = $extension['forward_no_answer_enabled'];
+			//workarounds: send 0 as freeswitch doesn't send NOTIFY when destination values are nil
+			$feature_event_notify->forward_all_destination = $extension['forward_all_destination'] != '' ? $extension['forward_all_destination'] : '0';
+			$feature_event_notify->forward_busy_destination = $extension['forward_busy_destination'] != '' ? $extension['forward_busy_destination'] : '0';
+			$feature_event_notify->forward_no_answer_destination = $extension['forward_no_answer_destination'] != '' ? $extension['forward_no_answer_destination'] : '0';
+			$feature_event_notify->send_notify();
+			unset($feature_event_notify);
+		}
+
+		// Clear the cache
+		$this->cache->delete("directory:{$extension['extension']}@{$_SESSION['domain_name']}");
+		if ($extension['number_alias'] != '') {
+			$this->cache->delete("directory:{$extension['number_alias']}@{$_SESSION['domain_name']}");
+		}
+
+		return $extension;
+	}
+
+	protected function save(array $updates) {
+		//save the changes
+		if (@sizeof($updates) > 0) {
+			//grant temporary permissions
+			$p = new permissions;
+			$p->add('extension_edit', 'temp');
+
+			//save the array
+			$database = new database;
+			$database->app_name = feature_base::app_name;
+			$database->app_uuid = feature_base::app_uuid;
+			$database->save($updates);
+			unset($updates);
+
+			//revoke temporary permissions
+			$p->delete('extension_edit', 'temp');
+		}
+
+		//synchronize configuration
+		if (is_readable($_SESSION['switch']['extensions']['dir'])) {
+			require_once "app/extensions/resources/classes/extension.php";
+			$ext = new extension;
+			$ext->xml();
+			unset($ext);
+		}
+	}
+}

--- a/app/calls/resources/classes/feature_base.php
+++ b/app/calls/resources/classes/feature_base.php
@@ -12,7 +12,7 @@ abstract class feature_base {
 		$this->cache = new cache;
 	}
 
-	protected function getExistingState(array $uuids) : array {
+	protected function get_existing_state(array $uuids) : array {
 		if (is_array($uuids) && @sizeof($uuids) != 0) {
 			$sql  = "select extension_uuid, extension, number_alias, call_timeout, ";
 			$sql .= "do_not_disturb, forward_all_enabled, forward_all_destination, ";

--- a/app/calls/resources/classes/follow_me.php
+++ b/app/calls/resources/classes/follow_me.php
@@ -26,435 +26,87 @@
 	Salvatore Caruso <salvatore.caruso@nems.it>
 	Riccardo Granchi <riccardo.granchi@nems.it>
 	Errol Samuels <voiptology@gmail.com>
+	Andrew Querol <andrew@querol.me>
 */
 include "root.php";
 
 //define the follow me class
-	class follow_me {
-		public $domain_uuid;
-		private $domain_name;
-		public $db_type;
-		public $follow_me_uuid;
-		public $cid_name_prefix;
-		public $cid_number_prefix;
-		public $accountcode;
-		public $follow_me_enabled;
-		public $follow_me_ignore_busy;
-		public $outbound_caller_id_name;
-		public $outbound_caller_id_number;
-		private $extension;
-		private $number_alias;
-		private $toll_allow;
-
-		public $destination_data_1;
-		public $destination_type_1;
-		public $destination_delay_1;
-		public $destination_prompt_1;
-		public $destination_timeout_1;
-
-		public $destination_data_2;
-		public $destination_type_2;
-		public $destination_delay_2;
-		public $destination_prompt_2;
-		public $destination_timeout_2;
-
-		public $destination_data_3;
-		public $destination_type_3;
-		public $destination_delay_3;
-		public $destination_prompt_3;
-		public $destination_timeout_3;
-
-		public $destination_data_4;
-		public $destination_type_4;
-		public $destination_delay_4;
-		public $destination_prompt_4;
-		public $destination_timeout_4;
-
-		public $destination_data_5;
-		public $destination_type_5;
-		public $destination_delay_5;
-		public $destination_prompt_5;
-		public $destination_timeout_5;
-
-		public $destination_timeout = 0;
-		public $destination_order = 1;
-
-		public function add() {
-
-			//build follow me insert array
-				$array['follow_me'][0]['follow_me_uuid'] = $this->follow_me_uuid;
-				$array['follow_me'][0]['domain_uuid'] = $this->domain_uuid;
-				$array['follow_me'][0]['cid_name_prefix'] = $this->cid_name_prefix;
-				if (strlen($this->cid_number_prefix) > 0) {
-					$array['follow_me'][0]['cid_number_prefix'] = $this->cid_number_prefix;
-				}
-
-				$array['follow_me'][0]['follow_me_enabled'] = $this->follow_me_enabled;
-				$array['follow_me'][0]['follow_me_ignore_busy'] = $this->follow_me_ignore_busy;
-			//grant temporary permissions
-				$p = new permissions;
-				$p->add('follow_me_add', 'temp');
-			//execute insert
-				$database = new database;
-				$database->app_name = 'calls';
-				$database->app_uuid = '19806921-e8ed-dcff-b325-dd3e5da4959d';
-				$database->save($array);
-				unset($array);
-			//revoke temporary permissions
-				$p->delete('follow_me_add', 'temp');
-
-				$this->follow_me_destinations();
-
+	class follow_me extends feature_base {
+		public function disable(array $uuids) {
+			if (!permission_exists('follow_me')) {
+				return;
+			}
+			$this->set($uuids, false);
 		}
 
-		public function update() {
-
-			//build follow me update array
-				$array['follow_me'][0]['follow_me_uuid'] = $this->follow_me_uuid;
-				$array['follow_me'][0]['cid_name_prefix'] = $this->cid_name_prefix;
-				$array['follow_me'][0]['cid_number_prefix'] = $this->cid_number_prefix;
-				$array['follow_me'][0]['follow_me_enabled'] = $this->follow_me_enabled;
-				$array['follow_me'][0]['follow_me_ignore_busy'] = $this->follow_me_ignore_busy;
-			//grant temporary permissions
-				$p = new permissions;
-				$p->add('follow_me_add', 'temp');
-			//execute update
-				$database = new database;
-				$database->app_name = 'calls';
-				$database->app_uuid = '19806921-e8ed-dcff-b325-dd3e5da4959d';
-				$database->save($array);
-				unset($array);
-			//revoke temporary permissions
-				$p->delete('follow_me_add', 'temp');
-
-				$this->follow_me_destinations();
-
+		public function enable(array $uuids) {
+			if (!permission_exists('follow_me')) {
+				return;
+			}
+			$this->set($uuids, true);
 		}
-
-		public function follow_me_destinations() {
-
-			//delete related follow me destinations
-				$array['follow_me_destinations'][0]['follow_me_uuid'] = $this->follow_me_uuid;
-				//grant temporary permissions
-					$p = new permissions;
-					$p->add('follow_me_destination_delete', 'temp');
-				//execute delete
-					$database = new database;
-					$database->app_name = 'calls';
-					$database->app_uuid = '19806921-e8ed-dcff-b325-dd3e5da4959d';
-					$database->delete($array);
-					unset($array);
-				//revoke temporary permissions
-					$p->delete('follow_me_destination_delete', 'temp');
-
-			//build follow me destinations insert array
-				$x = 0;
-				if (strlen($this->destination_data_1) > 0) {
-					$array['follow_me_destinations'][$x]['follow_me_destination_uuid'] = uuid();
-					$array['follow_me_destinations'][$x]['domain_uuid'] = $this->domain_uuid;
-					$array['follow_me_destinations'][$x]['follow_me_uuid'] = $this->follow_me_uuid;
-					$array['follow_me_destinations'][$x]['follow_me_destination'] = $this->destination_data_1;
-					$array['follow_me_destinations'][$x]['follow_me_timeout'] = $this->destination_timeout_1;
-					$array['follow_me_destinations'][$x]['follow_me_delay'] = $this->destination_delay_1;
-					$array['follow_me_destinations'][$x]['follow_me_prompt'] = $this->destination_prompt_1;
-					$array['follow_me_destinations'][$x]['follow_me_order'] = '1';
-					$this->destination_order++;
-					$x++;
-				}
-				if (strlen($this->destination_data_2) > 0) {
-					$array['follow_me_destinations'][$x]['follow_me_destination_uuid'] = uuid();
-					$array['follow_me_destinations'][$x]['domain_uuid'] = $this->domain_uuid;
-					$array['follow_me_destinations'][$x]['follow_me_uuid'] = $this->follow_me_uuid;
-					$array['follow_me_destinations'][$x]['follow_me_destination'] = $this->destination_data_2;
-					$array['follow_me_destinations'][$x]['follow_me_timeout'] = $this->destination_timeout_2;
-					$array['follow_me_destinations'][$x]['follow_me_delay'] = $this->destination_delay_2;
-					$array['follow_me_destinations'][$x]['follow_me_prompt'] = $this->destination_prompt_2;
-					$array['follow_me_destinations'][$x]['follow_me_order'] = '2';
-					$this->destination_order++;
-					$x++;
-				}
-				if (strlen($this->destination_data_3) > 0) {
-					$array['follow_me_destinations'][$x]['follow_me_destination_uuid'] = uuid();
-					$array['follow_me_destinations'][$x]['domain_uuid'] = $this->domain_uuid;
-					$array['follow_me_destinations'][$x]['follow_me_uuid'] = $this->follow_me_uuid;
-					$array['follow_me_destinations'][$x]['follow_me_destination'] = $this->destination_data_3;
-					$array['follow_me_destinations'][$x]['follow_me_timeout'] = $this->destination_timeout_3;
-					$array['follow_me_destinations'][$x]['follow_me_delay'] = $this->destination_delay_3;
-					$array['follow_me_destinations'][$x]['follow_me_prompt'] = $this->destination_prompt_3;
-					$array['follow_me_destinations'][$x]['follow_me_order'] = '3';
-					$this->destination_order++;
-					$x++;
-				}
-				if (strlen($this->destination_data_4) > 0) {
-					$array['follow_me_destinations'][$x]['follow_me_destination_uuid'] = uuid();
-					$array['follow_me_destinations'][$x]['domain_uuid'] = $this->domain_uuid;
-					$array['follow_me_destinations'][$x]['follow_me_uuid'] = $this->follow_me_uuid;
-					$array['follow_me_destinations'][$x]['follow_me_destination'] = $this->destination_data_4;
-					$array['follow_me_destinations'][$x]['follow_me_timeout'] = $this->destination_timeout_4;
-					$array['follow_me_destinations'][$x]['follow_me_delay'] = $this->destination_delay_4;
-					$array['follow_me_destinations'][$x]['follow_me_prompt'] = $this->destination_prompt_4;
-					$array['follow_me_destinations'][$x]['follow_me_order'] = '4';
-					$this->destination_order++;
-					$x++;
-				}
-				if (strlen($this->destination_data_5) > 0) {
-					$array['follow_me_destinations'][$x]['follow_me_destination_uuid'] = uuid();
-					$array['follow_me_destinations'][$x]['domain_uuid'] = $this->domain_uuid;
-					$array['follow_me_destinations'][$x]['follow_me_uuid'] = $this->follow_me_uuid;
-					$array['follow_me_destinations'][$x]['follow_me_destination'] = $this->destination_data_5;
-					$array['follow_me_destinations'][$x]['follow_me_timeout'] = $this->destination_timeout_5;
-					$array['follow_me_destinations'][$x]['follow_me_delay'] = $this->destination_delay_5;
-					$array['follow_me_destinations'][$x]['follow_me_prompt'] = $this->destination_prompt_5;
-					$array['follow_me_destinations'][$x]['follow_me_order'] = '5';
-					$this->destination_order++;
-					$x++;
-				}
-				if (is_array($array) && @sizeof($array) != 0) {
-					//grant temporary permissions
-						$p = new permissions;
-						$p->add('follow_me_destination_add', 'temp');
-					//execute insert
-						$database = new database;
-						$database->app_name = 'calls';
-						$database->app_uuid = '19806921-e8ed-dcff-b325-dd3e5da4959d';
-						$database->save($array);
-						unset($array);
-					//revoke temporary permissions
-						$p->delete('follow_me_destination_add', 'temp');
-				}
-		}
-
-		public function set() {
-
-			//get the extension_uuid
-				$parameters['follow_me_uuid'] = $this->follow_me_uuid;
-				$sql = "select extension_uuid from v_extensions ";
-				$sql .= "where follow_me_uuid = :follow_me_uuid ";
-				$database = new database;
-				$result = $database->select($sql, $parameters);
-				$extension_uuid = $result[0]['extension_uuid'];
-
-			//grant temporary permissions
-				$p = new permissions;
-				$p->add("follow_me_edit", 'temp');
-				$p->add("extension_edit", 'temp');
-
-			//add follow me to the array
-				$array['follow_me'][0]["follow_me_uuid"] = $this->follow_me_uuid;
-				$array['follow_me'][0]["domain_uuid"] = $this->domain_uuid;
-				$array['follow_me'][0]["dial_string"] = '';
-
-			//add extensions to the array
-				$array['extensions'][0]["extension_uuid"] = $extension_uuid;
-				$array['extensions'][0]["dial_domain"] = $this->domain_name;
-				$array['extensions'][0]["dial_string"] = '';
-				$array['extensions'][0]["follow_me_destinations"] = '';
-				$array['extensions'][0]["follow_me_enabled"] = $this->follow_me_enabled;
-
-			//save the destination
-				$database = new database;
-				$database->app_name = 'follow_me';
-				$database->app_uuid = '19806921-e8ed-dcff-b325-dd3e5da4959d';
-				$database->save($array);
-
-			//remove the temporary permission
-				$p->delete("follow_me_edit", 'temp');
-				$p->delete("extension_edit", 'temp');
-
-		} //function
-
-
-		/**
-		 * declare private variables
-		 */
-		private $app_name;
-		private $app_uuid;
-		private $permission;
-		private $list_page;
-		private $table;
-		private $uuid_prefix;
-		private $toggle_field;
-		private $toggle_values;
 
 		/**
 		 * toggle records
+		 * @param array $uuids The uuids to toggle
 		 */
-		public function toggle($records) {
-
-			//assign private variables
-				$this->app_name = 'calls';
-				$this->app_uuid = '19806921-e8ed-dcff-b325-dd3e5da4959d';
-				$this->permission = 'follow_me';
-				$this->list_page = 'calls.php';
-				$this->table = 'extensions';
-				$this->uuid_prefix = 'extension_';
-				$this->toggle_field = 'follow_me_enabled';
-				$this->toggle_values = ['true','false'];
-
-			if (permission_exists($this->permission)) {
-
-				//add multi-lingual support
-					$language = new text;
-					$text = $language->get();
-
-				//validate the token
-					$token = new token;
-					if (!$token->validate($_SERVER['PHP_SELF'])) {
-						message::add($text['message-invalid_token'],'negative');
-						header('Location: '.$this->list_page);
-						exit;
-					}
-
-				//toggle the checked records
-					if (is_array($records) && @sizeof($records) != 0) {
-
-						//get current toggle state
-							foreach($records as $x => $record) {
-								if ($record['checked'] == 'true' && is_uuid($record['uuid'])) {
-									$uuids[] = "'".$record['uuid']."'";
-								}
-							}
-							if (is_array($uuids) && @sizeof($uuids) != 0) {
-								$sql = "select ".$this->uuid_prefix."uuid as uuid, extension, number_alias, ";
-								$sql .= "call_timeout, do_not_disturb, ";
-								$sql .= "forward_all_enabled, forward_all_destination, ";
-								$sql .= "forward_busy_enabled, forward_busy_destination, ";
-								$sql .= "forward_no_answer_enabled, forward_no_answer_destination, ";
-								$sql .= $this->toggle_field." as toggle, follow_me_uuid ";
-								$sql .= "from v_".$this->table." ";
-								$sql .= "where (domain_uuid = :domain_uuid or domain_uuid is null) ";
-								$sql .= "and ".$this->uuid_prefix."uuid in (".implode(', ', $uuids).") ";
-								$parameters['domain_uuid'] = $_SESSION['domain_uuid'];
-								$database = new database;
-								$rows = $database->select($sql, $parameters, 'all');
-								if (is_array($rows) && @sizeof($rows) != 0) {
-									foreach ($rows as $row) {
-										$extensions[$row['uuid']]['extension'] = $row['extension'];
-										$extensions[$row['uuid']]['number_alias'] = $row['number_alias'];
-										$extensions[$row['uuid']]['call_timeout'] = $row['call_timeout'];
-										$extensions[$row['uuid']]['do_not_disturb'] = $row['do_not_disturb'];
-										$extensions[$row['uuid']]['forward_all_enabled'] = $row['forward_all_enabled'];
-										$extensions[$row['uuid']]['forward_all_destination'] = $row['forward_all_destination'];
-										$extensions[$row['uuid']]['forward_busy_enabled'] = $row['forward_busy_enabled'];
-										$extensions[$row['uuid']]['forward_busy_destination'] = $row['forward_busy_destination'];
-										$extensions[$row['uuid']]['forward_no_answer_enabled'] = $row['forward_no_answer_enabled'];
-										$extensions[$row['uuid']]['forward_no_answer_destination'] = $row['forward_no_answer_destination'];
-										$extensions[$row['uuid']]['state'] = $row['toggle'];
-										$extensions[$row['uuid']]['follow_me_uuid'] = $row['follow_me_uuid'];
-									}
-								}
-								unset($sql, $parameters, $rows, $row);
-							}
-
-						//build update array
-							$x = 0;
-							foreach ($extensions as $uuid => $extension) {
-
-								//count destinations
-									$destinations_exist = false;
-									if (
-										$extension['state']	== $this->toggle_values[1] //false becoming true
-										&& is_uuid($extension['follow_me_uuid'])
-										) {
-										$sql .= "select count(*) from v_follow_me_destinations where follow_me_uuid = :follow_me_uuid";
-										$parameters['follow_me_uuid'] = $extension['follow_me_uuid'];
-										$database = new database;
-										$num_rows = $database->select($sql, $parameters, 'column');
-										$destinations_exist = $num_rows ? true : false;
-										unset($sql, $parameters, $num_rows);
-									}
-
-								//determine new state
-									$new_state = $extension['state'] == $this->toggle_values[1] && $destinations_exist ? $this->toggle_values[0] : $this->toggle_values[1];
-
-								//toggle feature
-									if ($new_state != $extension['state']) {
-										$array[$this->table][$x][$this->uuid_prefix.'uuid'] = $uuid;
-										$array[$this->table][$x][$this->toggle_field] = $new_state;
-										if (is_uuid($extension['follow_me_uuid'])) {
-											$array['follow_me'][$x]['follow_me_uuid'] = $extension['follow_me_uuid'];
-											$array['follow_me'][$x]['follow_me_enabled'] = $new_state;
-										}
-									}
-
-								//disable other features
-									if ($new_state == $this->toggle_values[0]) { //true
-										$array[$this->table][$x]['forward_all_enabled'] = $this->toggle_values[1]; //false
-										$array[$this->table][$x]['do_not_disturb'] = $this->toggle_values[1]; //false
-									}
-
-								//increment counter
-									$x++;
-
-							}
-
-						//save the changes
-							if (is_array($array) && @sizeof($array) != 0) {
-
-								//grant temporary permissions
-									$p = new permissions;
-									$p->add('extension_edit', 'temp');
-									$p->add('follow_me_edit', 'temp');
-
-								//save the array
-									$database = new database;
-									$database->app_name = $this->app_name;
-									$database->app_uuid = $this->app_uuid;
-									$database->save($array);
-									unset($array);
-
-								//revoke temporary permissions
-									$p->delete('extension_edit', 'temp');
-									$p->delete('follow_me_edit', 'temp');
-
-								//send feature event notify to the phone
-									if ($_SESSION['device']['feature_sync']['boolean'] == "true") {
-										foreach ($extensions as $uuid => $extension) {
-											$feature_event_notify = new feature_event_notify;
-											$feature_event_notify->domain_name = $_SESSION['domain_name'];
-											$feature_event_notify->extension = $extension['extension'];
-											$feature_event_notify->do_not_disturb = $extension['do_not_disturb'];
-											$feature_event_notify->ring_count = ceil($extension['call_timeout'] / 6);
-											$feature_event_notify->forward_all_enabled = $extension['forward_all_enabled'];
-											$feature_event_notify->forward_busy_enabled = $extension['forward_busy_enabled'];
-											$feature_event_notify->forward_no_answer_enabled = $extension['forward_no_answer_enabled'];
-											//workarounds: send 0 as freeswitch doesn't send NOTIFY when destination values are nil
-											$feature_event_notify->forward_all_destination = $extension['forward_all_destination'] != '' ? $extension['forward_all_destination'] : '0';
-											$feature_event_notify->forward_busy_destination = $extension['forward_busy_destination'] != '' ? $extension['forward_busy_destination'] : '0';
-											$feature_event_notify->forward_no_answer_destination = $extension['forward_no_answer_destination'] != '' ? $extension['forward_no_answer_destination'] : '0';
-											$feature_event_notify->send_notify();
-											unset($feature_event_notify);
-										}
-									}
-
-								//synchronize configuration
-									if (is_readable($_SESSION['switch']['extensions']['dir'])) {
-										require_once "app/extensions/resources/classes/extension.php";
-										$ext = new extension;
-										$ext->xml();
-										unset($ext);
-									}
-
-								//clear the cache
-									$cache = new cache;
-									foreach ($extensions as $uuid => $extension) {
-										$cache->delete("directory:".$extension['extension']."@".$_SESSION['domain_name']);
-										if ($extension['number_alias'] != '') {
-											$cache->delete("directory:".$extension['number_alias']."@".$_SESSION['domain_name']);
-										}
-									}
-
-								//set message
-									message::add($text['message-toggle']);
-
-							}
-							unset($records, $extensions, $extension);
-					}
-
+		public function toggle(array $uuids) {
+			if (!permission_exists('follow_me')) {
+				return;
 			}
 
+			$this->set($uuids, null);
 		} //function
 
+		protected function update(array $extension) : array {
+			$extension = parent::update($extension);
+			//disable other features
+			if ($extension['follow_me_enabled'] == feature_base::enabled) {
+				$extension['do_not_disturb'] = feature_base::disabled; //false
+				$extension['forward_all_enabled'] = feature_base::disabled; //false
+			}
+			return $extension;
+		}
+
+		/**
+		 * @param array $uuids The extension UUIDs to perform this operation on
+		 * @param ?bool $new_state The new state or null to toggle
+		 */
+		private function set(array $uuids, ?bool $new_state) {
+			$extensions = $this->getExistingState($uuids);
+
+			// Set the DND state
+			$updates = array();
+			foreach ($extensions as $uuid => $extension) {
+				// Create a copy of $new_state since we do not want to clobber it when toggling.
+				$updated_state = $new_state;
+				if (is_null($new_state)) {
+					$updated_state = $extension['follow_me_enabled'] != feature_base::enabled;
+				}
+				$destination_exists = false;
+				if ($updated_state && is_uuid($extension['follow_me_uuid'])) {
+					$destination_exists = $this->get_follow_me_count($extension['follow_me_uuid']) > 0;
+				}
+
+				// Update the extension array with the new DND state
+				$extension['follow_me_enabled'] = $updated_state && $destination_exists ? feature_base::enabled : feature_base::disabled;
+
+				// Build the update array and perform any per-extension updates
+				$updates['extensions'][] = $this->update($extension);
+			}
+			$this->save($updates);
+
+			unset($records, $extensions, $extension, $updates);
+		}
+
+		private function get_follow_me_count(string $follow_me_uuid) : int {
+			$sql = "select count(*) from v_follow_me_destinations where follow_me_uuid = :follow_me_uuid";
+			$parameters['follow_me_uuid'] = $follow_me_uuid;
+			$database = new database;
+			$num_rows = $database->select($sql, $parameters, 'column');
+			unset($sql, $parameters);
+			return $num_rows;
+		}
 	} //class
 
 ?>

--- a/app/calls/resources/classes/follow_me.php
+++ b/app/calls/resources/classes/follow_me.php
@@ -73,7 +73,7 @@ include "root.php";
 		 * @param ?bool $new_state The new state or null to toggle
 		 */
 		private function set(array $uuids, ?bool $new_state) {
-			$extensions = $this->getExistingState($uuids);
+			$extensions = $this->get_existing_state($uuids);
 
 			// Set the DND state
 			$updates = array();

--- a/app/calls/resources/classes/follow_me.php
+++ b/app/calls/resources/classes/follow_me.php
@@ -59,13 +59,13 @@ include "root.php";
 		} //function
 
 		protected function update(array $extension) : array {
-			$extension = parent::update($extension);
 			//disable other features
 			if ($extension['follow_me_enabled'] == feature_base::enabled) {
 				$extension['do_not_disturb'] = feature_base::disabled; //false
 				$extension['forward_all_enabled'] = feature_base::disabled; //false
 			}
-			return $extension;
+			// Important to have the parent update last. Otherwise the above information will not be sent for feature key syncing.
+			return parent::update($extension);
 		}
 
 		/**


### PR DESCRIPTION
# Context
This MR contains all of the base changes needed to allow other applications to modify extension features without having to duplicate code. This was started to allow the operator panel to use feature key syncing without having to duplicate code into the operator panel application.

The operator panel change to use this new code is in a seperate MR #5698 

# Overview
- Remove all unused functions and variables from the classes. These functions were only referenced from commented out code in the calls application.
- Move token validation to calls.php to allow the function classes to be used outside of calls.php
- Move the toggle message to calls.php for the same reason
- Pull all common code into an abstract base PHP class to allow it to be shared among all of the feature classes.
  - `get_existing_state` Gets the existing extension feature state needed for all of the classes
  - `update` Does the per extension updates needed when things change
    - Currently only clearing the cache and sending feature key sync messages
  - `save` Saves the changes and regenerates the XML if needed
- Modify do_not_disturb, call_forward, and follow_me classes to extend feature_base and clean up their logic using the new abstracted functions 