### PR TITLE
Do not clobber caller ID names if no number is set

### DIFF
--- a/app/dialplans/resources/switch/conf/dialplan/080_default_caller_id.xml
+++ b/app/dialplans/resources/switch/conf/dialplan/080_default_caller_id.xml
@@ -1,11 +1,15 @@
 <context name="{v_context}">
 	<extension name="default_caller_id" number="" continue="true" app_uuid="9660e536-976d-47cb-872e-85957c51bd3d" order="80">
-		<condition field="${emergency_caller_id_number}" expression="^$" break="never">
+		<condition field="${emergency_caller_id_name}" expression="^$" break="never">
 			<action application="set" data="emergency_caller_id_name=${default_emergency_caller_id_name}" inline="true"/>
+		</condition>
+		<condition field="${emergency_caller_id_number}" expression="^$" break="never">
 			<action application="set" data="emergency_caller_id_number=${default_emergency_caller_id_number}" inline="true"/>
 		</condition>
-		<condition field="${outbound_caller_id_number}" expression="^$" break="never">
+		<condition field="${outbound_caller_id_name}" expression="^$" break="never">
 			<action application="set" data="outbound_caller_id_name=${default_outbound_caller_id_name}" inline="true"/>
+		</condition>
+		<condition field="${outbound_caller_id_number}" expression="^$" break="never">
 			<action application="set" data="outbound_caller_id_number=${default_outbound_caller_id_number}" inline="true"/>
 		</condition>
 	</extension>


### PR DESCRIPTION
# Context
By default custom caller ID names will get clobbered by this diaplan if no number is set. This is potentially problematic if you just want a custom caller ID name set for multiple extensions using the default caller ID number.

# Overview
- Split up the two groups in this dialplan to check the name values and it they are empty set them with the defaults.