### PR TITLE
CDR add permision to hide call center agent legs

### DIFF
--- a/app/xml_cdr/app_config.php
+++ b/app/xml_cdr/app_config.php
@@ -197,6 +197,9 @@
 		$apps[$x]['permissions'][$y]['name'] = "xml_cdr_lose_race";
 		$apps[$x]['permissions'][$y]['groups'][] = "superadmin";
 		$y++;
+		$apps[$x]['permissions'][$y]['name'] = "xml_cdr_cc_agent_side";
+		$apps[$x]['permissions'][$y]['groups'][] = "superadmin";
+		$y++;
 		$apps[$x]['permissions'][$y]['name'] = "xml_cdr_archive";
 		//$apps[$x]['permissions'][$y]['groups'][] = "superadmin";
 		$y++;

--- a/app/xml_cdr/xml_cdr.php
+++ b/app/xml_cdr/xml_cdr.php
@@ -820,10 +820,14 @@
 
 					$content .= "</tr>\n";
 
-				//show the leg b only to those with the permission
 					if (!permission_exists('xml_cdr_lose_race') && $row['hangup_cause'] == 'LOSE_RACE') {
 						$content = '';
 					}
+				//show agent originated legs only to those with the permission
+					if (!permission_exists('xml_cdr_cc_agent_side') && $row['cc_side'] == "agent") {
+						$content = '';
+					}
+				//show the leg b only to those with the permission
 					if ($row['leg'] == 'a') {
 						echo $content;
 					}

--- a/app/xml_cdr/xml_cdr_inc.php
+++ b/app/xml_cdr/xml_cdr_inc.php
@@ -242,6 +242,7 @@
 	$sql .= "c.source_number, \n";
 	$sql .= "c.destination_number, \n";
 	$sql .= "c.leg, \n";
+	$sql .= "c.cc_side, \n";
 	//$sql .= "(c.xml is not null or c.json is not null) as raw_data_exists, \n";
 	//$sql .= "c.json, \n";
 	if (is_array($_SESSION['cdr']['field'])) {


### PR DESCRIPTION
Freeswitch originates calls to call center agents in its own thread causing

* Every time the call center originates a call to an agent it will a save cdr record for that agent's leg
* If an agent didn't answer and it rings again to him after  wrapup time it will save another record in the cdr
* A call center queue with 10 agents that rang 4 times to all agents (in the case of ring-all strategy) will save 41 records

Added a permission `xml_cdr_cc_agent_leg` that will filter out the agent leg of the calls thus keeping a clean readable CDR