### PR TITLE
Remove footer from call center dashboard widget.

### DIFF
--- a/app/call_centers/call_center_agent_dashboard.php
+++ b/app/call_centers/call_center_agent_dashboard.php
@@ -212,7 +212,4 @@
 	echo "<input type='hidden' name='".$token['name']."' value='".$token['hash']."'>\n";
 	echo "</form>\n";
 
-//include footer
-	require_once "resources/footer.php";
-
 ?>


### PR DESCRIPTION
# Context
The footer was displaying inside the main content div causing the bottom of the page to look weird since the footer isn't in the same place as other pages.

# Overview
- Remove the footer call in the call_center_agent_dashboard.php file.
  - As far as I can tell this should never be needed in this file since the footer is added in the user_dashboard.php file.