### PR TITLE
Allow dragging the whole extension box instead of just the portrait.

### DIFF
--- a/app/basic_operator_panel/resources/content.php
+++ b/app/basic_operator_panel/resources/content.php
@@ -354,13 +354,11 @@ if (is_array($activity)) foreach ($activity as $extension => $ext) {
 			$status_hover = $text['label-status_logged_out_or_unknown'];
 		}
 
-	$block .= "<div id='".escape($extension)."' class='".$style."' ".(($_GET['vd_ext_from'] == $extension || $_GET['vd_ext_to'] == $extension) ? "style='border-style: dotted;'" : null)." ".(($ext_state != 'active' && $ext_state != 'ringing') ? "ondrop='drop(event, this.id);' ondragover='allowDrop(event, this.id);' ondragleave='discardDrop(event, this.id);'" : null).">"; // DRAG TO
+	$block  = "<div id='".escape($call_identifier)."' class='".$style."' ".(($_GET['vd_ext_from'] == $extension || $_GET['vd_ext_to'] == $extension) ? "style='border-style: dotted;'" : null)." ".(($ext_state != 'active' && $ext_state != 'ringing') ? "ondrop='drop(event, escape($extension));' ondragover='allowDrop(event, escape($extension));' ondragleave='discardDrop(event, escape($extension));'" : null).($draggable? "draggable='true' style='cursor: move;' ondragstart=\"drag(event, escape($extension));\"" : "onfocus='this.blur();' draggable='false' style='cursor: not-allowed;'").">"; // DRAG TO
 	$block .= "<table class='".$style."'>";
 	$block .= "	<tr>";
 	$block .= "		<td class='op_ext_icon'>";
-	$block .= "			<span name='".escape($extension)."'>"; // DRAG FROM
-	$block .= 				"<img id='".escape($call_identifier)."' class='op_ext_icon' src='resources/images/status_".$status_icon.".png' title='".$status_hover."' ".(($draggable) ? "draggable='true' ondragstart=\"drag(event, this.parentNode.getAttribute('name'));\" onclick=\"virtual_drag('".escape($call_identifier)."', '".escape($extension)."');\"" : "onfocus='this.blur();' draggable='false' style='cursor: not-allowed;'").">";
-	$block .= 			"</span>";
+	$block .= 			"<img class='op_ext_icon' src='resources/images/status_".$status_icon.".png' title='".$status_hover."' draggable='false' ".(($draggable) ? "onclick=\"virtual_drag('".escape($call_identifier)."', '".escape($extension)."');\"" : "style='cursor: not-allowed;'").">";
 	$block .= "		</td>";
 	$block .= "		<td class='op_ext_info ".$style."'>";
 	if ($dir_icon != '') {

--- a/themes/default/css.php
+++ b/themes/default/css.php
@@ -2021,7 +2021,7 @@ header('Expires: '.gmdate('D, d M Y H:i:s',time()+3600).' GMT');
 		}
 
 	img.op_ext_icon {
-		cursor: move;
+		cursor: pointer;
 		width: 39px;
 		height: 42px;
 		border: none;


### PR DESCRIPTION
# Context
Some of our users were getting confused when attempting to use the drag and drop calling functionality since the whole box wasn't draggable. It's a bit more intuitive to have the whole box draggable and easier to explain. It also gives more context on which extension your dragging from over the old style.

# Overview
- Add all of the draggable elements to the main div for the box.
  - The ID changed to the call identifier that used to be part of the image
  - The second parameter to the ondrop event was set directly to the escaped extension instead of the ID that is now the call ID.
  - The same was done to ondragleave, ondragover, and ondragstart.
- Removed the now unused span container for the portrait
- Set the portrait to not be draggable, this makes the main div start dragging if the user starts dragging when over the portrait
- The portrait still controls the virtual drag and I changed the cursor to a pointer to match that it's a button now versus the main dragging element.