### PR TITLE
Group extensions by call_group when viewing all groups in Operator Panel

### DIFF
--- a/app/basic_operator_panel/app_config.php
+++ b/app/basic_operator_panel/app_config.php
@@ -67,5 +67,13 @@
 		$apps[$x]['default_settings'][$y]['default_setting_enabled'] = "true";
 		$apps[$x]['default_settings'][$y]['default_setting_description'] = "Set the refresh rate in seconds (<=120) or milliseconds (>=500).";
 		$y++;
+		$apps[$x]['default_settings'][$y]['default_setting_uuid'] = "0c273cad-1ee4-48d9-9336-08bc8260579a";
+		$apps[$x]['default_settings'][$y]['default_setting_category'] = "operator_panel";
+		$apps[$x]['default_settings'][$y]['default_setting_subcategory'] = "group_extensions";
+		$apps[$x]['default_settings'][$y]['default_setting_name'] = "boolean";
+		$apps[$x]['default_settings'][$y]['default_setting_value'] = "true";
+		$apps[$x]['default_settings'][$y]['default_setting_enabled'] = "true";
+		$apps[$x]['default_settings'][$y]['default_setting_description'] = "Set if extensions are grouped by call_group when viewing all extensions.";
+		$y++;
 
 ?>

--- a/app/basic_operator_panel/resources/content.php
+++ b/app/basic_operator_panel/resources/content.php
@@ -168,6 +168,11 @@ echo "	</tr>";
 echo "</table>";
 echo "<br>";
 
+// Define the arrays to ensure no errors are omitted below with the sizeof operators
+$user_extensions = array();
+$grouped_extensions = array();
+$other_extensions = array();
+
 if (is_array($activity)) foreach ($activity as $extension => $ext) {
 	unset($block);
 
@@ -453,42 +458,49 @@ if (is_array($activity)) foreach ($activity as $extension => $ext) {
 
 	if (in_array($extension, $_SESSION['user']['extensions'])) {
 		$user_extensions[] = $block;
-	}
-	else {
+	} elseif (!empty($ext['call_group'])) {
+		$grouped_extensions[$ext['call_group']][] = $block;
+	} else {
 		$other_extensions[] = $block;
 	}
 }
 
-
-if (is_array($user_extensions) && @sizeof($user_extensions) > 0) {
+if (sizeof($user_extensions) > 0) {
 	echo "<table width='100%'><tr><td>";
 	if (is_array($user_extensions)) foreach ($user_extensions as $ext_block) {
 		echo $ext_block;
 	}
-	echo "</td></tr></table>";
+	echo "</td></tr></table><br>";
 }
 
-if ($_REQUEST['group'] != '') {
-	if (is_array($user_extensions) && @sizeof($user_extensions) > 0) { echo "<br>"; }
-	echo "<strong style='color: black;'>".ucwords(escape($_REQUEST['group']))."</strong>";
-	echo "<br><br>";
-}
-else if (is_array($user_extensions) && @sizeof($user_extensions) > 0) {
-	echo "<br>";
-	echo "<strong style='color: black;'>".$text['label-other_extensions']."</strong>";
-	echo "<br><br>";
+if (sizeof($grouped_extensions) > 0) {
+	// Ensure alphabetical order
+	ksort($grouped_extensions);
+	foreach ($grouped_extensions as $group => $extensions) {
+		echo "<strong style='color: black;'>".ucwords(escape($group))."</strong>";
+		echo "<br><br>";
+		echo "<table width='100%'><tr><td>";
+		foreach ($extensions as $ext_block) {
+			echo $ext_block;
+		}
+		echo "</td></tr></table><br>";
+	}
 }
 
 if (sizeof($other_extensions) > 0) {
+	echo "<strong style='color: black;'>".$text['label-other_extensions']."</strong>";
+	echo "<br><br>";
 	echo "<table width='100%'><tr><td>";
-	if (is_array($other_extensions)) foreach ($other_extensions as $ext_block) {
+	foreach ($other_extensions as $ext_block) {
 		echo $ext_block;
 	}
 	echo "</td></tr></table>";
 }
-else {
+
+if (sizeof($other_extensions) + sizeof($grouped_extensions) < 1) {
 	echo $text['label-no_extensions_found'];
 }
+
 echo "<br><br>";
 
 /*

--- a/app/basic_operator_panel/resources/content.php
+++ b/app/basic_operator_panel/resources/content.php
@@ -458,7 +458,7 @@ if (is_array($activity)) foreach ($activity as $extension => $ext) {
 
 	if (in_array($extension, $_SESSION['user']['extensions'])) {
 		$user_extensions[] = $block;
-	} elseif (!empty($ext['call_group'])) {
+	} elseif (!empty($ext['call_group']) && filter_var($_SESSION['operator_panel']['group_extensions']['boolean'], FILTER_VALIDATE_BOOLEAN)) {
 		$grouped_extensions[$ext['call_group']][] = $block;
 	} else {
 		$other_extensions[] = $block;


### PR DESCRIPTION
# Context
A quality of life improvement that allows extensions to be grouped by their group in the "ALL" view of the operator panel.

# Overview
- Initialized the extension arrays at the beginning to eliminate the need for some is_array checks and prevent errors on size checks.
- If an extension has a call_group and the setting to show them as groups is enabled add them to the new $grouped_extensions array with the call group as the key and an array of extensions as the value.
- Add a new block to iterate over all $grouped_extensions and print out the group name and all of the extension blocks.
- Change the no extensions found check to take into account the new grouped extensions map.
- Add a setting to allow disabling this behavior if other users prefer the extensions to always be grouped up together in the all view.