### PR TITLE
Bug Fix: No beep when bypassing the greeting

### DIFF
--- a/app/scripts/resources/scripts/app/voicemail/resources/functions/record_message.lua
+++ b/app/scripts/resources/scripts/app/voicemail/resources/functions/record_message.lua
@@ -520,6 +520,7 @@
 
 		--play the beep
 			dtmf_digits = '';
+			session:execute("playback","silence_stream://200");
 			session:streamFile("tone_stream://L=1;%(1000, 0, 640)");
 
 		--start epoch


### PR DESCRIPTION
We found that callers were not hearing the tone_stream if they pressed "#" to bypass the voicemail greeting. Inserting a very brief silence_stream seems to fix the issue.