### PR TITLE
Fix timeout action issue

### DIFF
--- a/app/call_centers/call_center_queue_edit.php
+++ b/app/call_centers/call_center_queue_edit.php
@@ -744,7 +744,7 @@
 	echo "    ".$text['label-timeout_action']."\n";
 	echo "</td>\n";
 	echo "<td class='vtable' align='left'>\n";
-	echo $destination->select('dialplan', 'queue_timeout_action', escape($queue_timeout_action));
+	echo $destination->select('dialplan', 'queue_timeout_action', $queue_timeout_action);
 	echo "<br />\n";
 	echo $text['description-timeout_action']."\n";
 	echo "</td>\n";


### PR DESCRIPTION
When saving timeout destination more than once in original code additional HTML entities (&amp;colon&) would be added to the timeout destination which would break the timeout. This change is in line with the updated in the 4.5 code base.