### PR TITLE
Add nway conference network URI to Yealink Templates

### DIFF
--- a/resources/templates/provision/yealink/cp860/{$mac}.cfg
+++ b/resources/templates/provision/yealink/cp860/{$mac}.cfg
@@ -381,10 +381,10 @@ account.1.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.1.conf_type =
+account.1.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.1.conf_uri =
+account.1.conf_uri = {if $nway_conference == true}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
 
 #######################################################################################
 ##                            cid_source                                             ##
@@ -852,10 +852,10 @@ account.2.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.2.conf_type =
+account.2.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.2.conf_uri =
+account.2.conf_uri = {if $nway_conference == true}nway{$account.2.user_id}@{$account.2.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -1367,10 +1367,10 @@ account.3.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.3.conf_type =
+account.3.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.3.conf_uri =
+account.3.conf_uri = {if $nway_conference == true}nway{$account.3.user_id}@{$account.3.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -1867,10 +1867,10 @@ account.4.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.4.conf_type =
+account.4.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.4.conf_uri =
+account.4.conf_uri = {if $nway_conference == true}nway{$account.4.user_id}@{$account.4.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -2364,10 +2364,10 @@ account.5.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.5.conf_type =
+account.5.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.5.conf_uri =
+account.5.conf_uri = {if $nway_conference == true}nway{$account.5.user_id}@{$account.5.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -2860,10 +2860,10 @@ account.6.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.6.conf_type =
+account.6.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.6.conf_uri =
+account.6.conf_uri = {if $nway_conference == true}nway{$account.6.user_id}@{$account.6.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##

--- a/resources/templates/provision/yealink/cp920/{$mac}.cfg
+++ b/resources/templates/provision/yealink/cp920/{$mac}.cfg
@@ -382,10 +382,10 @@ account.1.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.1.conf_type =
+account.1.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.1.conf_uri =
+account.1.conf_uri = {if $nway_conference == true}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
 
 #######################################################################################
 ##                            cid_source                                             ##
@@ -853,10 +853,10 @@ account.2.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.2.conf_type =
+account.2.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.2.conf_uri =
+account.2.conf_uri = {if $nway_conference == true}nway{$account.2.user_id}@{$account.2.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -1368,10 +1368,10 @@ account.3.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.3.conf_type =
+account.3.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.3.conf_uri =
+account.3.conf_uri = {if $nway_conference == true}nway{$account.3.user_id}@{$account.3.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -1868,10 +1868,10 @@ account.4.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.4.conf_type =
+account.4.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.4.conf_uri =
+account.4.conf_uri = {if $nway_conference == true}nway{$account.4.user_id}@{$account.4.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -2365,10 +2365,10 @@ account.5.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.5.conf_type =
+account.5.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.5.conf_uri =
+account.5.conf_uri = {if $nway_conference == true}nway{$account.5.user_id}@{$account.5.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -2861,10 +2861,10 @@ account.6.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.6.conf_type =
+account.6.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.6.conf_uri =
+account.6.conf_uri = {if $nway_conference == true}nway{$account.6.user_id}@{$account.6.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##

--- a/resources/templates/provision/yealink/cp960/{$mac}.cfg
+++ b/resources/templates/provision/yealink/cp960/{$mac}.cfg
@@ -382,10 +382,10 @@ account.1.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.1.conf_type =
+account.1.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.1.conf_uri =
+account.1.conf_uri = {if $nway_conference == true}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
 
 #######################################################################################
 ##                            cid_source                                             ##
@@ -853,10 +853,10 @@ account.2.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.2.conf_type =
+account.2.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.2.conf_uri =
+account.2.conf_uri = {if $nway_conference == true}nway{$account.2.user_id}@{$account.2.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -1368,10 +1368,10 @@ account.3.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.3.conf_type =
+account.3.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.3.conf_uri =
+account.3.conf_uri = {if $nway_conference == true}nway{$account.3.user_id}@{$account.3.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -1867,10 +1867,10 @@ account.4.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.4.conf_type =
+account.4.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.4.conf_uri =
+account.4.conf_uri = {if $nway_conference == true}nway{$account.4.user_id}@{$account.4.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -2364,10 +2364,10 @@ account.5.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.5.conf_type =
+account.5.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.5.conf_uri =
+account.5.conf_uri = {if $nway_conference == true}nway{$account.5.user_id}@{$account.5.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -2860,10 +2860,10 @@ account.6.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.6.conf_type =
+account.6.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.6.conf_uri =
+account.6.conf_uri = {if $nway_conference == true}nway{$account.6.user_id}@{$account.6.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##

--- a/resources/templates/provision/yealink/t19p/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t19p/{$mac}.cfg
@@ -186,10 +186,10 @@ account.1.register_line =
 account.1.reg_fail_retry_interval =
 
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.1.conf_type =
+account.1.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.1.conf_uri =
+account.1.conf_uri = {if $nway_conference == true}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
 
 #Configure the BLF list URI (a SIP URI, or use part of the SIP URI). For example, "2300_blflist@domain.com" or "2300_blflist".
 account.1.blf.blf_list_uri =
@@ -539,10 +539,10 @@ account.2.register_line =
 account.2.reg_fail_retry_interval =
 
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.2.conf_type =
+account.2.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.2.conf_uri =
+account.2.conf_uri = {if $nway_conference == true}nway{$account.2.user_id}@{$account.2.server_address}{/if}
 
 #Configure the BLF list URI (a SIP URI, or use part of the SIP URI). For example, "2300_blflist@domain.com" or "2300_blflist".
 account.2.blf.blf_list_uri =
@@ -864,10 +864,10 @@ account.3.register_line =
 account.3.reg_fail_retry_interval =
 
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.3.conf_type =
+account.3.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.3.conf_uri =
+account.3.conf_uri = {if $nway_conference == true}nway{$account.3.user_id}@{$account.3.server_address}{/if}
 
 #Configure the BLF list URI (a SIP URI, or use part of the SIP URI). For example, "2300_blflist@domain.com" or "2300_blflist".
 account.3.blf.blf_list_uri =
@@ -1190,10 +1190,10 @@ account.4.register_line =
 account.4.reg_fail_retry_interval =
 
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.4.conf_type =
+account.4.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.4.conf_uri =
+account.4.conf_uri = {if $nway_conference == true}nway{$account.4.user_id}@{$account.4.server_address}{/if}
 
 #Configure the BLF list URI (a SIP URI, or use part of the SIP URI). For example, "2300_blflist@domain.com" or "2300_blflist".
 account.4.blf.blf_list_uri =
@@ -1516,10 +1516,10 @@ account.5.register_line =
 account.5.reg_fail_retry_interval =
 
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.5.conf_type =
+account.5.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.5.conf_uri =
+account.5.conf_uri = {if $nway_conference == true}nway{$account.5.user_id}@{$account.5.server_address}{/if}
 
 #Configure the BLF list URI (a SIP URI, or use part of the SIP URI). For example, "2300_blflist@domain.com" or "2300_blflist".
 account.5.blf.blf_list_uri =
@@ -1839,10 +1839,10 @@ account.6.register_line =
 account.6.reg_fail_retry_interval =
 
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.6.conf_type =
+account.6.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.6.conf_uri =
+account.6.conf_uri = {if $nway_conference == true}nway{$account.6.user_id}@{$account.6.server_address}{/if}
 
 #Configure the BLF list URI (a SIP URI, or use part of the SIP URI). For example, "2300_blflist@domain.com" or "2300_blflist".
 account.6.blf.blf_list_uri =

--- a/resources/templates/provision/yealink/t20p/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t20p/{$mac}.cfg
@@ -186,10 +186,10 @@ account.1.register_line =
 account.1.reg_fail_retry_interval =
 
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.1.conf_type =
+account.1.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.1.conf_uri =
+account.1.conf_uri = {if $nway_conference == true}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
 
 #Configure the BLF list URI (a SIP URI, or use part of the SIP URI). For example, "2300_blflist@domain.com" or "2300_blflist".
 account.1.blf.blf_list_uri =
@@ -541,10 +541,10 @@ account.2.register_line =
 account.2.reg_fail_retry_interval =
 
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.2.conf_type =
+account.2.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.2.conf_uri =
+account.2.conf_uri = {if $nway_conference == true}nway{$account.2.user_id}@{$account.2.server_address}{/if}
 
 #Configure the BLF list URI (a SIP URI, or use part of the SIP URI). For example, "2300_blflist@domain.com" or "2300_blflist".
 account.2.blf.blf_list_uri =
@@ -866,10 +866,10 @@ account.3.register_line =
 account.3.reg_fail_retry_interval =
 
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.3.conf_type =
+account.3.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.3.conf_uri =
+account.3.conf_uri = {if $nway_conference == true}nway{$account.3.user_id}@{$account.3.server_address}{/if}
 
 #Configure the BLF list URI (a SIP URI, or use part of the SIP URI). For example, "2300_blflist@domain.com" or "2300_blflist".
 account.3.blf.blf_list_uri =
@@ -1191,10 +1191,10 @@ account.4.register_line =
 account.4.reg_fail_retry_interval =
 
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.4.conf_type =
+account.4.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.4.conf_uri =
+account.4.conf_uri = {if $nway_conference == true}nway{$account.4.user_id}@{$account.4.server_address}{/if}
 
 #Configure the BLF list URI (a SIP URI, or use part of the SIP URI). For example, "2300_blflist@domain.com" or "2300_blflist".
 account.4.blf.blf_list_uri =
@@ -1517,10 +1517,10 @@ account.5.register_line =
 account.5.reg_fail_retry_interval =
 
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.5.conf_type =
+account.5.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.5.conf_uri =
+account.5.conf_uri = {if $nway_conference == true}nway{$account.5.user_id}@{$account.5.server_address}{/if}
 
 #Configure the BLF list URI (a SIP URI, or use part of the SIP URI). For example, "2300_blflist@domain.com" or "2300_blflist".
 account.5.blf.blf_list_uri =
@@ -1840,10 +1840,10 @@ account.6.register_line =
 account.6.reg_fail_retry_interval =
 
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.6.conf_type =
+account.6.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.6.conf_uri =
+account.6.conf_uri = {if $nway_conference == true}nway{$account.6.user_id}@{$account.6.server_address}{/if}
 
 #Configure the BLF list URI (a SIP URI, or use part of the SIP URI). For example, "2300_blflist@domain.com" or "2300_blflist".
 account.6.blf.blf_list_uri =

--- a/resources/templates/provision/yealink/t21p/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t21p/{$mac}.cfg
@@ -382,10 +382,10 @@ account.1.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.1.conf_type =
+account.1.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.1.conf_uri =
+account.1.conf_uri = {if $nway_conference == true}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
 
 #######################################################################################
 ##                            cid_source                                             ##
@@ -851,10 +851,10 @@ account.2.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.2.conf_type =
+account.2.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.2.conf_uri =
+account.2.conf_uri = {if $nway_conference == true}nway{$account.2.user_id}@{$account.2.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -1364,10 +1364,10 @@ account.3.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.3.conf_type =
+account.3.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.3.conf_uri =
+account.3.conf_uri = {if $nway_conference == true}nway{$account.3.user_id}@{$account.3.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -1860,10 +1860,10 @@ account.4.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.4.conf_type =
+account.4.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.4.conf_uri =
+account.4.conf_uri = {if $nway_conference == true}nway{$account.4.user_id}@{$account.4.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -2356,10 +2356,10 @@ account.5.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.5.conf_type =
+account.5.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.5.conf_uri =
+account.5.conf_uri = {if $nway_conference == true}nway{$account.5.user_id}@{$account.5.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -2851,10 +2851,10 @@ account.6.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.6.conf_type =
+account.6.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.6.conf_uri =
+account.6.conf_uri = {if $nway_conference == true}nway{$account.6.user_id}@{$account.6.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##

--- a/resources/templates/provision/yealink/t22p/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t22p/{$mac}.cfg
@@ -186,10 +186,10 @@ account.1.register_line =
 account.1.reg_fail_retry_interval =
 
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.1.conf_type =
+account.1.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.1.conf_uri =
+account.1.conf_uri = {if $nway_conference == true}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
 
 #Configure the BLF list URI (a SIP URI, or use part of the SIP URI). For example, "2300_blflist@domain.com" or "2300_blflist".
 account.1.blf.blf_list_uri =
@@ -539,10 +539,10 @@ account.2.register_line =
 account.2.reg_fail_retry_interval =
 
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.2.conf_type =
+account.2.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.2.conf_uri =
+account.2.conf_uri = {if $nway_conference == true}nway{$account.2.user_id}@{$account.2.server_address}{/if}
 
 #Configure the BLF list URI (a SIP URI, or use part of the SIP URI). For example, "2300_blflist@domain.com" or "2300_blflist".
 account.2.blf.blf_list_uri =
@@ -864,10 +864,10 @@ account.3.register_line =
 account.3.reg_fail_retry_interval =
 
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.3.conf_type =
+account.3.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.3.conf_uri =
+account.3.conf_uri = {if $nway_conference == true}nway{$account.3.user_id}@{$account.3.server_address}{/if}
 
 #Configure the BLF list URI (a SIP URI, or use part of the SIP URI). For example, "2300_blflist@domain.com" or "2300_blflist".
 account.3.blf.blf_list_uri =
@@ -1190,10 +1190,10 @@ account.4.register_line =
 account.4.reg_fail_retry_interval =
 
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.4.conf_type =
+account.4.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.4.conf_uri =
+account.4.conf_uri = {if $nway_conference == true}nway{$account.4.user_id}@{$account.4.server_address}{/if}
 
 #Configure the BLF list URI (a SIP URI, or use part of the SIP URI). For example, "2300_blflist@domain.com" or "2300_blflist".
 account.4.blf.blf_list_uri =
@@ -1516,10 +1516,10 @@ account.5.register_line =
 account.5.reg_fail_retry_interval =
 
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.5.conf_type =
+account.5.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.5.conf_uri =
+account.5.conf_uri = {if $nway_conference == true}nway{$account.5.user_id}@{$account.5.server_address}{/if}
 
 #Configure the BLF list URI (a SIP URI, or use part of the SIP URI). For example, "2300_blflist@domain.com" or "2300_blflist".
 account.5.blf.blf_list_uri =
@@ -1839,10 +1839,10 @@ account.6.register_line =
 account.6.reg_fail_retry_interval =
 
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.6.conf_type =
+account.6.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.6.conf_uri =
+account.6.conf_uri = {if $nway_conference == true}nway{$account.6.user_id}@{$account.6.server_address}{/if}
 
 #Configure the BLF list URI (a SIP URI, or use part of the SIP URI). For example, "2300_blflist@domain.com" or "2300_blflist".
 account.6.blf.blf_list_uri =

--- a/resources/templates/provision/yealink/t23g/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t23g/{$mac}.cfg
@@ -395,10 +395,10 @@ account.1.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.1.conf_type =
+account.1.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.1.conf_uri =
+account.1.conf_uri = {if $nway_conference == true}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
 
 #######################################################################################
 ##                            cid_source                                             ##
@@ -867,10 +867,10 @@ account.2.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.2.conf_type =
+account.2.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.2.conf_uri =
+account.2.conf_uri = {if $nway_conference == true}nway{$account.2.user_id}@{$account.2.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -1353,10 +1353,10 @@ account.3.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.3.conf_type =
+account.3.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.3.conf_uri =
+account.3.conf_uri = {if $nway_conference == true}nway{$account.3.user_id}@{$account.3.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -1829,10 +1829,10 @@ account.4.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.4.conf_type =
+account.4.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.4.conf_uri =
+account.4.conf_uri = {if $nway_conference == true}nway{$account.4.user_id}@{$account.4.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -2305,10 +2305,10 @@ account.5.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.5.conf_type =
+account.5.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.5.conf_uri =
+account.5.conf_uri = {if $nway_conference == true}nway{$account.5.user_id}@{$account.5.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -2780,10 +2780,10 @@ account.6.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.6.conf_type =
+account.6.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.6.conf_uri =
+account.6.conf_uri = {if $nway_conference == true}nway{$account.6.user_id}@{$account.6.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##

--- a/resources/templates/provision/yealink/t23p/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t23p/{$mac}.cfg
@@ -381,10 +381,10 @@ account.1.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.1.conf_type =
+account.1.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.1.conf_uri =
+account.1.conf_uri = {if $nway_conference == true}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
 
 #######################################################################################
 ##                            cid_source                                             ##
@@ -853,10 +853,10 @@ account.2.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.2.conf_type =
+account.2.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.2.conf_uri =
+account.2.conf_uri = {if $nway_conference == true}nway{$account.2.user_id}@{$account.2.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -1339,10 +1339,10 @@ account.3.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.3.conf_type =
+account.3.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.3.conf_uri =
+account.3.conf_uri = {if $nway_conference == true}nway{$account.3.user_id}@{$account.3.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -1815,10 +1815,10 @@ account.4.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.4.conf_type =
+account.4.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.4.conf_uri =
+account.4.conf_uri = {if $nway_conference == true}nway{$account.4.user_id}@{$account.4.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -2291,10 +2291,10 @@ account.5.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.5.conf_type =
+account.5.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.5.conf_uri =
+account.5.conf_uri = {if $nway_conference == true}nway{$account.5.user_id}@{$account.5.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -2766,10 +2766,10 @@ account.6.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.6.conf_type =
+account.6.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.6.conf_uri =
+account.6.conf_uri = {if $nway_conference == true}nway{$account.6.user_id}@{$account.6.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##

--- a/resources/templates/provision/yealink/t26p/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t26p/{$mac}.cfg
@@ -186,10 +186,10 @@ account.1.register_line =
 account.1.reg_fail_retry_interval =
 
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.1.conf_type =
+account.1.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.1.conf_uri =
+account.1.conf_uri = {if $nway_conference == true}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
 
 #Configure the BLF list URI (a SIP URI, or use part of the SIP URI). For example, "2300_blflist@domain.com" or "2300_blflist".
 account.1.blf.blf_list_uri =
@@ -539,10 +539,10 @@ account.2.register_line =
 account.2.reg_fail_retry_interval =
 
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.2.conf_type =
+account.2.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.2.conf_uri =
+account.2.conf_uri = {if $nway_conference == true}nway{$account.2.user_id}@{$account.2.server_address}{/if}
 
 #Configure the BLF list URI (a SIP URI, or use part of the SIP URI). For example, "2300_blflist@domain.com" or "2300_blflist".
 account.2.blf.blf_list_uri =
@@ -865,10 +865,10 @@ account.3.register_line =
 account.3.reg_fail_retry_interval =
 
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.3.conf_type =
+account.3.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.3.conf_uri =
+account.3.conf_uri = {if $nway_conference == true}nway{$account.3.user_id}@{$account.3.server_address}{/if}
 
 #Configure the BLF list URI (a SIP URI, or use part of the SIP URI). For example, "2300_blflist@domain.com" or "2300_blflist".
 account.3.blf.blf_list_uri =
@@ -1190,10 +1190,10 @@ account.4.register_line =
 account.4.reg_fail_retry_interval =
 
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.4.conf_type =
+account.4.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.4.conf_uri =
+account.4.conf_uri = {if $nway_conference == true}nway{$account.4.user_id}@{$account.4.server_address}{/if}
 
 #Configure the BLF list URI (a SIP URI, or use part of the SIP URI). For example, "2300_blflist@domain.com" or "2300_blflist".
 account.4.blf.blf_list_uri =
@@ -1516,10 +1516,10 @@ account.5.register_line =
 account.5.reg_fail_retry_interval =
 
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.5.conf_type =
+account.5.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.5.conf_uri =
+account.5.conf_uri = {if $nway_conference == true}nway{$account.5.user_id}@{$account.5.server_address}{/if}
 
 #Configure the BLF list URI (a SIP URI, or use part of the SIP URI). For example, "2300_blflist@domain.com" or "2300_blflist".
 account.5.blf.blf_list_uri =
@@ -1839,10 +1839,10 @@ account.6.register_line =
 account.6.reg_fail_retry_interval =
 
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.6.conf_type =
+account.6.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.6.conf_uri =
+account.6.conf_uri = {if $nway_conference == true}nway{$account.6.user_id}@{$account.6.server_address}{/if}
 
 #Configure the BLF list URI (a SIP URI, or use part of the SIP URI). For example, "2300_blflist@domain.com" or "2300_blflist".
 account.6.blf.blf_list_uri =

--- a/resources/templates/provision/yealink/t27g/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t27g/{$mac}.cfg
@@ -395,10 +395,10 @@ account.1.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.1.conf_type =
+account.1.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.1.conf_uri =
+account.1.conf_uri = {if $nway_conference == true}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
 
 #######################################################################################
 ##                            cid_source                                             ##
@@ -866,10 +866,10 @@ account.2.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.2.conf_type =
+account.2.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.2.conf_uri =
+account.2.conf_uri = {if $nway_conference == true}nway{$account.2.user_id}@{$account.2.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -1351,10 +1351,10 @@ account.3.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.3.conf_type =
+account.3.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.3.conf_uri =
+account.3.conf_uri = {if $nway_conference == true}nway{$account.3.user_id}@{$account.3.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -1826,10 +1826,10 @@ account.4.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.4.conf_type =
+account.4.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.4.conf_uri =
+account.4.conf_uri = {if $nway_conference == true}nway{$account.4.user_id}@{$account.4.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -2301,10 +2301,10 @@ account.5.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.5.conf_type =
+account.5.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.5.conf_uri =
+account.5.conf_uri = {if $nway_conference == true}nway{$account.5.user_id}@{$account.5.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -2775,10 +2775,10 @@ account.6.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.6.conf_type =
+account.6.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.6.conf_uri =
+account.6.conf_uri = {if $nway_conference == true}nway{$account.6.user_id}@{$account.6.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##

--- a/resources/templates/provision/yealink/t27p/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t27p/{$mac}.cfg
@@ -395,10 +395,10 @@ account.1.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.1.conf_type =
+account.1.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.1.conf_uri =
+account.1.conf_uri = {if $nway_conference == true}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
 
 #######################################################################################
 ##                            cid_source                                             ##
@@ -866,10 +866,10 @@ account.2.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.2.conf_type =
+account.2.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.2.conf_uri =
+account.2.conf_uri = {if $nway_conference == true}nway{$account.2.user_id}@{$account.2.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -1351,10 +1351,10 @@ account.3.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.3.conf_type =
+account.3.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.3.conf_uri =
+account.3.conf_uri = {if $nway_conference == true}nway{$account.3.user_id}@{$account.3.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -1826,10 +1826,10 @@ account.4.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.4.conf_type =
+account.4.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.4.conf_uri =
+account.4.conf_uri = {if $nway_conference == true}nway{$account.4.user_id}@{$account.4.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -2301,10 +2301,10 @@ account.5.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.5.conf_type =
+account.5.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.5.conf_uri =
+account.5.conf_uri = {if $nway_conference == true}nway{$account.5.user_id}@{$account.5.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -2775,10 +2775,10 @@ account.6.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.6.conf_type =
+account.6.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.6.conf_uri =
+account.6.conf_uri = {if $nway_conference == true}nway{$account.6.user_id}@{$account.6.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##

--- a/resources/templates/provision/yealink/t28p/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t28p/{$mac}.cfg
@@ -186,10 +186,10 @@ account.1.register_line =
 account.1.reg_fail_retry_interval =
 
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.1.conf_type =
+account.1.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.1.conf_uri =
+account.1.conf_uri = {if $nway_conference == true}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
 
 #Configure the BLF list URI (a SIP URI, or use part of the SIP URI). For example, "2300_blflist@domain.com" or "2300_blflist".
 account.1.blf.blf_list_uri =
@@ -539,10 +539,10 @@ account.2.register_line =
 account.2.reg_fail_retry_interval =
 
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.2.conf_type =
+account.2.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.2.conf_uri =
+account.2.conf_uri = {if $nway_conference == true}nway{$account.2.user_id}@{$account.2.server_address}{/if}
 
 #Configure the BLF list URI (a SIP URI, or use part of the SIP URI). For example, "2300_blflist@domain.com" or "2300_blflist".
 account.2.blf.blf_list_uri =
@@ -865,10 +865,10 @@ account.3.register_line =
 account.3.reg_fail_retry_interval =
 
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.3.conf_type =
+account.3.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.3.conf_uri =
+account.3.conf_uri = {if $nway_conference == true}nway{$account.3.user_id}@{$account.3.server_address}{/if}
 
 #Configure the BLF list URI (a SIP URI, or use part of the SIP URI). For example, "2300_blflist@domain.com" or "2300_blflist".
 account.3.blf.blf_list_uri =
@@ -1190,10 +1190,10 @@ account.4.register_line =
 account.4.reg_fail_retry_interval =
 
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.4.conf_type =
+account.4.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.4.conf_uri =
+account.4.conf_uri = {if $nway_conference == true}nway{$account.4.user_id}@{$account.4.server_address}{/if}
 
 #Configure the BLF list URI (a SIP URI, or use part of the SIP URI). For example, "2300_blflist@domain.com" or "2300_blflist".
 account.4.blf.blf_list_uri =
@@ -1516,10 +1516,10 @@ account.5.register_line =
 account.5.reg_fail_retry_interval =
 
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.5.conf_type =
+account.5.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.5.conf_uri =
+account.5.conf_uri = {if $nway_conference == true}nway{$account.5.user_id}@{$account.5.server_address}{/if}
 
 #Configure the BLF list URI (a SIP URI, or use part of the SIP URI). For example, "2300_blflist@domain.com" or "2300_blflist".
 account.5.blf.blf_list_uri =
@@ -1839,10 +1839,10 @@ account.6.register_line =
 account.6.reg_fail_retry_interval =
 
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.6.conf_type =
+account.6.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.6.conf_uri =
+account.6.conf_uri = {if $nway_conference == true}nway{$account.6.user_id}@{$account.6.server_address}{/if}
 
 #Configure the BLF list URI (a SIP URI, or use part of the SIP URI). For example, "2300_blflist@domain.com" or "2300_blflist".
 account.6.blf.blf_list_uri =

--- a/resources/templates/provision/yealink/t29g/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t29g/{$mac}.cfg
@@ -395,10 +395,10 @@ account.1.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.1.conf_type =
+account.1.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.1.conf_uri =
+account.1.conf_uri = {if $nway_conference == true}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
 
 #######################################################################################
 ##                            cid_source                                             ##
@@ -867,10 +867,10 @@ account.2.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.2.conf_type =
+account.2.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.2.conf_uri =
+account.2.conf_uri = {if $nway_conference == true}nway{$account.2.user_id}@{$account.2.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -1353,10 +1353,10 @@ account.3.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.3.conf_type =
+account.3.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.3.conf_uri =
+account.3.conf_uri = {if $nway_conference == true}nway{$account.3.user_id}@{$account.3.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -1829,10 +1829,10 @@ account.4.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.4.conf_type =
+account.4.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.4.conf_uri =
+account.4.conf_uri = {if $nway_conference == true}nway{$account.4.user_id}@{$account.4.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -2305,10 +2305,10 @@ account.5.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.5.conf_type =
+account.5.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.5.conf_uri =
+account.5.conf_uri = {if $nway_conference == true}nway{$account.5.user_id}@{$account.5.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -2780,10 +2780,10 @@ account.6.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.6.conf_type =
+account.6.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.6.conf_uri =
+account.6.conf_uri = {if $nway_conference == true}nway{$account.6.user_id}@{$account.6.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##

--- a/resources/templates/provision/yealink/t2x/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t2x/{$mac}.cfg
@@ -342,10 +342,10 @@ account.{$row.line_number}.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type 0-Local (default), 2-Network Conference
-account.{$row.line_number}.conf_type =
+account.{$row.line_number}.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.{$row.line_number}.conf_uri =
+account.{$row.line_number}.conf_uri = {if $nway_conference == true}nway{$account.{$row.line_number}.user_id}@{$account.{$row.line_number}.server_address}{/if}
 
 #######################################################################################
 ##                            cid_source                                             ##

--- a/resources/templates/provision/yealink/t31g/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t31g/{$mac}.cfg
@@ -177,10 +177,10 @@ account.1.register_line =
 account.1.reg_fail_retry_interval =
 
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.1.conf_type =
+account.1.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.1.conf_uri =
+account.1.conf_uri = {if $nway_conference == true}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
 
 #Configure the BLF list URI (a SIP URI, or use part of the SIP URI). For example, "2300_blflist@domain.com" or "2300_blflist".
 account.1.blf.blf_list_uri =
@@ -522,10 +522,10 @@ account.2.register_line =
 account.2.reg_fail_retry_interval =
 
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.2.conf_type =
+account.2.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.2.conf_uri =
+account.2.conf_uri = {if $nway_conference == true}nway{$account.2.user_id}@{$account.2.server_address}{/if}
 
 #Configure the BLF list URI (a SIP URI, or use part of the SIP URI). For example, "2300_blflist@domain.com" or "2300_blflist".
 account.2.blf.blf_list_uri =
@@ -839,10 +839,10 @@ account.3.register_line =
 account.3.reg_fail_retry_interval =
 
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.3.conf_type =
+account.3.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.3.conf_uri =
+account.3.conf_uri = {if $nway_conference == true}nway{$account.3.user_id}@{$account.3.server_address}{/if}
 
 #Configure the BLF list URI (a SIP URI, or use part of the SIP URI). For example, "2300_blflist@domain.com" or "2300_blflist".
 account.3.blf.blf_list_uri =
@@ -1156,10 +1156,10 @@ account.4.register_line =
 account.4.reg_fail_retry_interval =
 
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.4.conf_type =
+account.4.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.4.conf_uri =
+account.4.conf_uri = {if $nway_conference == true}nway{$account.4.user_id}@{$account.4.server_address}{/if}
 
 #Configure the BLF list URI (a SIP URI, or use part of the SIP URI). For example, "2300_blflist@domain.com" or "2300_blflist".
 account.4.blf.blf_list_uri =
@@ -1474,10 +1474,10 @@ account.5.register_line =
 account.5.reg_fail_retry_interval =
 
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.5.conf_type =
+account.5.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.5.conf_uri =
+account.5.conf_uri = {if $nway_conference == true}nway{$account.5.user_id}@{$account.5.server_address}{/if}
 
 #Configure the BLF list URI (a SIP URI, or use part of the SIP URI). For example, "2300_blflist@domain.com" or "2300_blflist".
 account.5.blf.blf_list_uri =
@@ -1789,10 +1789,10 @@ account.6.register_line =
 account.6.reg_fail_retry_interval =
 
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.6.conf_type =
+account.6.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.6.conf_uri =
+account.6.conf_uri = {if $nway_conference == true}nway{$account.6.user_id}@{$account.6.server_address}{/if}
 
 #Configure the BLF list URI (a SIP URI, or use part of the SIP URI). For example, "2300_blflist@domain.com" or "2300_blflist".
 account.6.blf.blf_list_uri =

--- a/resources/templates/provision/yealink/t32g/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t32g/{$mac}.cfg
@@ -177,10 +177,10 @@ account.1.register_line =
 account.1.reg_fail_retry_interval =
 
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.1.conf_type =
+account.1.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.1.conf_uri =
+account.1.conf_uri = {if $nway_conference == true}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
 
 #Configure the BLF list URI (a SIP URI, or use part of the SIP URI). For example, "2300_blflist@domain.com" or "2300_blflist".
 account.1.blf.blf_list_uri =
@@ -522,10 +522,10 @@ account.2.register_line =
 account.2.reg_fail_retry_interval =
 
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.2.conf_type =
+account.2.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.2.conf_uri =
+account.2.conf_uri = {if $nway_conference == true}nway{$account.2.user_id}@{$account.2.server_address}{/if}
 
 #Configure the BLF list URI (a SIP URI, or use part of the SIP URI). For example, "2300_blflist@domain.com" or "2300_blflist".
 account.2.blf.blf_list_uri =
@@ -839,10 +839,10 @@ account.3.register_line =
 account.3.reg_fail_retry_interval =
 
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.3.conf_type =
+account.3.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.3.conf_uri =
+account.3.conf_uri = {if $nway_conference == true}nway{$account.3.user_id}@{$account.3.server_address}{/if}
 
 #Configure the BLF list URI (a SIP URI, or use part of the SIP URI). For example, "2300_blflist@domain.com" or "2300_blflist".
 account.3.blf.blf_list_uri =
@@ -1156,10 +1156,10 @@ account.4.register_line =
 account.4.reg_fail_retry_interval =
 
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.4.conf_type =
+account.4.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.4.conf_uri =
+account.4.conf_uri = {if $nway_conference == true}nway{$account.4.user_id}@{$account.4.server_address}{/if}
 
 #Configure the BLF list URI (a SIP URI, or use part of the SIP URI). For example, "2300_blflist@domain.com" or "2300_blflist".
 account.4.blf.blf_list_uri =
@@ -1474,10 +1474,10 @@ account.5.register_line =
 account.5.reg_fail_retry_interval =
 
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.5.conf_type =
+account.5.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.5.conf_uri =
+account.5.conf_uri = {if $nway_conference == true}nway{$account.5.user_id}@{$account.5.server_address}{/if}
 
 #Configure the BLF list URI (a SIP URI, or use part of the SIP URI). For example, "2300_blflist@domain.com" or "2300_blflist".
 account.5.blf.blf_list_uri =
@@ -1789,10 +1789,10 @@ account.6.register_line =
 account.6.reg_fail_retry_interval =
 
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.6.conf_type =
+account.6.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.6.conf_uri =
+account.6.conf_uri = {if $nway_conference == true}nway{$account.6.user_id}@{$account.6.server_address}{/if}
 
 #Configure the BLF list URI (a SIP URI, or use part of the SIP URI). For example, "2300_blflist@domain.com" or "2300_blflist".
 account.6.blf.blf_list_uri =

--- a/resources/templates/provision/yealink/t33g/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t33g/{$mac}.cfg
@@ -210,7 +210,7 @@ account.1.session_timer.refresher=
 account.1.session_timer.expires=
 account.1.session_timer.enable= {$yealink_session_timer}
 
-account.1.conf_type=
+account.1.conf_type = {if $nway_conference == true}2{/if}
 account.1.sip_server_type=
 
 ##V83 Add
@@ -516,7 +516,7 @@ account.1.call_recording.enable=
 #######################################################################################
 ##                                Network Conference                                  ##
 #######################################################################################
-account.1.conf_uri=
+account.1.conf_uri = {if $nway_conference == true}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
 
 
 #######################################################################################
@@ -781,7 +781,7 @@ account.2.session_timer.refresher=
 account.2.session_timer.expires=
 account.2.session_timer.enable= {$yealink_session_timer}
 
-account.2.conf_type=
+account.2.conf_type = {if $nway_conference == true}2{/if}
 account.2.sip_server_type=
 
 ##V83 Add
@@ -1084,7 +1084,7 @@ account.2.call_recording.enable=
 #######################################################################################
 ##                                Network Conference                                  ##
 #######################################################################################
-account.2.conf_uri=
+account.2.conf_uri = {if $nway_conference == true}nway{$account.2.user_id}@{$account.2.server_address}{/if}
 
 
 #######################################################################################
@@ -1349,7 +1349,7 @@ account.3.session_timer.refresher=
 account.3.session_timer.expires=
 account.3.session_timer.enable= {$yealink_session_timer}
 
-account.3.conf_type=
+account.3.conf_type = {if $nway_conference == true}2{/if}
 account.3.sip_server_type=
 
 ##V83 Add
@@ -1652,7 +1652,7 @@ account.3.call_recording.enable=
 #######################################################################################
 ##                                Network Conference                                  ##
 #######################################################################################
-account.3.conf_uri=
+account.3.conf_uri = {if $nway_conference == true}nway{$account.3.user_id}@{$account.3.server_address}{/if}
 
 
 #######################################################################################
@@ -1917,7 +1917,7 @@ account.4.session_timer.refresher=
 account.4.session_timer.expires=
 account.4.session_timer.enable= {$yealink_session_timer}
 
-account.4.conf_type=
+account.4.conf_type = {if $nway_conference == true}2{/if} 
 account.4.sip_server_type=
 
 ##V83 Add
@@ -2220,7 +2220,7 @@ account.4.call_recording.enable=
 #######################################################################################
 ##                                Network Conference                                  ##
 #######################################################################################
-account.4.conf_uri=
+account.4.conf_uri = {if $nway_conference == true}nway{$account.4.user_id}@{$account.4.server_address}{/if}
 
 
 #######################################################################################

--- a/resources/templates/provision/yealink/t38g/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t38g/{$mac}.cfg
@@ -177,10 +177,10 @@ account.1.register_line =
 account.1.reg_fail_retry_interval =
 
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.1.conf_type =
+account.1.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.1.conf_uri =
+account.1.conf_uri = {if $nway_conference == true}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
 
 #Configure the BLF list URI (a SIP URI, or use part of the SIP URI). For example, "2300_blflist@domain.com" or "2300_blflist".
 account.1.blf.blf_list_uri =
@@ -522,10 +522,10 @@ account.2.register_line =
 account.2.reg_fail_retry_interval =
 
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.2.conf_type =
+account.2.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.2.conf_uri =
+account.2.conf_uri = {if $nway_conference == true}nway{$account.2.user_id}@{$account.2.server_address}{/if}
 
 #Configure the BLF list URI (a SIP URI, or use part of the SIP URI). For example, "2300_blflist@domain.com" or "2300_blflist".
 account.2.blf.blf_list_uri =
@@ -839,10 +839,10 @@ account.3.register_line =
 account.3.reg_fail_retry_interval =
 
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.3.conf_type =
+account.3.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.3.conf_uri =
+account.3.conf_uri = {if $nway_conference == true}nway{$account.3.user_id}@{$account.3.server_address}{/if}
 
 #Configure the BLF list URI (a SIP URI, or use part of the SIP URI). For example, "2300_blflist@domain.com" or "2300_blflist".
 account.3.blf.blf_list_uri =
@@ -1156,10 +1156,10 @@ account.4.register_line =
 account.4.reg_fail_retry_interval =
 
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.4.conf_type =
+account.4.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.4.conf_uri =
+account.4.conf_uri = {if $nway_conference == true}nway{$account.4.user_id}@{$account.4.server_address}{/if}
 
 #Configure the BLF list URI (a SIP URI, or use part of the SIP URI). For example, "2300_blflist@domain.com" or "2300_blflist".
 account.4.blf.blf_list_uri =
@@ -1474,10 +1474,10 @@ account.5.register_line =
 account.5.reg_fail_retry_interval =
 
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.5.conf_type =
+account.5.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.5.conf_uri =
+account.5.conf_uri = {if $nway_conference == true}nway{$account.5.user_id}@{$account.5.server_address}{/if}
 
 #Configure the BLF list URI (a SIP URI, or use part of the SIP URI). For example, "2300_blflist@domain.com" or "2300_blflist".
 account.5.blf.blf_list_uri =
@@ -1789,10 +1789,10 @@ account.6.register_line =
 account.6.reg_fail_retry_interval =
 
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.6.conf_type =
+account.6.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.6.conf_uri =
+account.6.conf_uri = {if $nway_conference == true}nway{$account.6.user_id}@{$account.6.server_address}{/if}
 
 #Configure the BLF list URI (a SIP URI, or use part of the SIP URI). For example, "2300_blflist@domain.com" or "2300_blflist".
 account.6.blf.blf_list_uri =

--- a/resources/templates/provision/yealink/t40g/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t40g/{$mac}.cfg
@@ -395,10 +395,10 @@ account.1.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.1.conf_type =
+account.1.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.1.conf_uri =
+account.1.conf_uri = {if $nway_conference == true}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
 
 #######################################################################################
 ##                            cid_source                                             ##
@@ -867,10 +867,10 @@ account.2.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.2.conf_type =
+account.2.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.2.conf_uri =
+account.2.conf_uri = {if $nway_conference == true}nway{$account.2.user_id}@{$account.2.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -1383,10 +1383,10 @@ account.3.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.3.conf_type =
+account.3.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.3.conf_uri =
+account.3.conf_uri = {if $nway_conference == true}nway{$account.3.user_id}@{$account.3.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -1882,10 +1882,10 @@ account.4.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.4.conf_type =
+account.4.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.4.conf_uri =
+account.4.conf_uri = {if $nway_conference == true}nway{$account.4.user_id}@{$account.4.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -2381,10 +2381,10 @@ account.5.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.5.conf_type =
+account.5.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.5.conf_uri =
+account.5.conf_uri = {if $nway_conference == true}nway{$account.5.user_id}@{$account.5.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -2879,10 +2879,10 @@ account.6.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.6.conf_type =
+account.6.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.6.conf_uri =
+account.6.conf_uri = {if $nway_conference == true}nway{$account.6.user_id}@{$account.6.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##

--- a/resources/templates/provision/yealink/t40p/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t40p/{$mac}.cfg
@@ -382,10 +382,10 @@ account.1.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.1.conf_type =
+account.1.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.1.conf_uri =
+account.1.conf_uri = {if $nway_conference == true}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
 
 #######################################################################################
 ##                            cid_source                                             ##
@@ -851,10 +851,10 @@ account.2.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.2.conf_type =
+account.2.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.2.conf_uri =
+account.2.conf_uri = {if $nway_conference == true}nway{$account.2.user_id}@{$account.2.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -1364,10 +1364,10 @@ account.3.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.3.conf_type =
+account.3.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.3.conf_uri =
+account.3.conf_uri = {if $nway_conference == true}nway{$account.3.user_id}@{$account.3.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -1860,10 +1860,10 @@ account.4.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.4.conf_type =
+account.4.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.4.conf_uri =
+account.4.conf_uri = {if $nway_conference == true}nway{$account.4.user_id}@{$account.4.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -2356,10 +2356,10 @@ account.5.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.5.conf_type =
+account.5.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.5.conf_uri =
+account.5.conf_uri = {if $nway_conference == true}nway{$account.5.user_id}@{$account.5.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -2851,10 +2851,10 @@ account.6.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.6.conf_type =
+account.6.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.6.conf_uri =
+account.6.conf_uri = {if $nway_conference == true}nway{$account.6.user_id}@{$account.6.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##

--- a/resources/templates/provision/yealink/t41p/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t41p/{$mac}.cfg
@@ -381,10 +381,10 @@ account.1.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.1.conf_type =
+account.1.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.1.conf_uri =
+account.1.conf_uri = {if $nway_conference == true}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
 
 #######################################################################################
 ##                            cid_source                                             ##
@@ -850,10 +850,10 @@ account.2.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.2.conf_type =
+account.2.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.2.conf_uri =
+account.2.conf_uri = {if $nway_conference == true}nway{$account.2.user_id}@{$account.2.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -1363,10 +1363,10 @@ account.3.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.3.conf_type =
+account.3.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.3.conf_uri =
+account.3.conf_uri = {if $nway_conference == true}nway{$account.3.user_id}@{$account.3.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -1859,10 +1859,10 @@ account.4.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.4.conf_type =
+account.4.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.4.conf_uri =
+account.4.conf_uri = {if $nway_conference == true}nway{$account.4.user_id}@{$account.4.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -2355,10 +2355,10 @@ account.5.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.5.conf_type =
+account.5.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.5.conf_uri =
+account.5.conf_uri = {if $nway_conference == true}nway{$account.5.user_id}@{$account.5.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -2850,10 +2850,10 @@ account.6.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.6.conf_type =
+account.6.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.6.conf_uri =
+account.6.conf_uri = {if $nway_conference == true}nway{$account.6.user_id}@{$account.6.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##

--- a/resources/templates/provision/yealink/t41s/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t41s/{$mac}.cfg
@@ -394,10 +394,10 @@ account.1.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.1.conf_type =
+account.1.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.1.conf_uri =
+account.1.conf_uri = {if $nway_conference == true}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
 
 #######################################################################################
 ##                            cid_source                                             ##
@@ -870,10 +870,10 @@ account.2.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.2.conf_type =
+account.2.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.2.conf_uri =
+account.2.conf_uri = {if $nway_conference == true}nway{$account.2.user_id}@{$account.2.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -1357,10 +1357,10 @@ account.3.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.3.conf_type =
+account.3.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.3.conf_uri =
+account.3.conf_uri = {if $nway_conference == true}nway{$account.3.user_id}@{$account.3.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -1829,10 +1829,10 @@ account.4.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.4.conf_type =
+account.4.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.4.conf_uri =
+account.4.conf_uri = {if $nway_conference == true}nway{$account.4.user_id}@{$account.4.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -2301,10 +2301,10 @@ account.5.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.5.conf_type =
+account.5.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.5.conf_uri =
+account.5.conf_uri = {if $nway_conference == true}nway{$account.5.user_id}@{$account.5.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -2772,10 +2772,10 @@ account.6.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.6.conf_type =
+account.6.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.6.conf_uri =
+account.6.conf_uri = {if $nway_conference == true}nway{$account.6.user_id}@{$account.6.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##

--- a/resources/templates/provision/yealink/t42g/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t42g/{$mac}.cfg
@@ -395,10 +395,10 @@ account.1.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.1.conf_type =
+account.1.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.1.conf_uri =
+account.1.conf_uri = {if $nway_conference == true}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
 
 #######################################################################################
 ##                            cid_source                                             ##
@@ -867,10 +867,10 @@ account.2.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.2.conf_type =
+account.2.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.2.conf_uri =
+account.2.conf_uri = {if $nway_conference == true}nway{$account.2.user_id}@{$account.2.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -1353,10 +1353,10 @@ account.3.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.3.conf_type =
+account.3.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.3.conf_uri =
+account.3.conf_uri = {if $nway_conference == true}nway{$account.3.user_id}@{$account.3.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -1829,10 +1829,10 @@ account.4.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.4.conf_type =
+account.4.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.4.conf_uri =
+account.4.conf_uri = {if $nway_conference == true}nway{$account.4.user_id}@{$account.4.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -2305,10 +2305,10 @@ account.5.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.5.conf_type =
+account.5.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.5.conf_uri =
+account.5.conf_uri = {if $nway_conference == true}nway{$account.5.user_id}@{$account.5.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -2780,10 +2780,10 @@ account.6.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.6.conf_type =
+account.6.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.6.conf_uri =
+account.6.conf_uri = {if $nway_conference == true}nway{$account.6.user_id}@{$account.6.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##

--- a/resources/templates/provision/yealink/t42s/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t42s/{$mac}.cfg
@@ -394,10 +394,10 @@ account.1.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.1.conf_type =
+account.1.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.1.conf_uri =
+account.1.conf_uri = {if $nway_conference == true}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
 
 #######################################################################################
 ##                            cid_source                                             ##
@@ -870,10 +870,10 @@ account.2.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.2.conf_type =
+account.2.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.2.conf_uri =
+account.2.conf_uri = {if $nway_conference == true}nway{$account.2.user_id}@{$account.2.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -1358,10 +1358,10 @@ account.3.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.3.conf_type =
+account.3.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.3.conf_uri =
+account.3.conf_uri = {if $nway_conference == true}nway{$account.3.user_id}@{$account.3.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -1829,10 +1829,10 @@ account.4.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.4.conf_type =
+account.4.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.4.conf_uri =
+account.4.conf_uri = {if $nway_conference == true}nway{$account.4.user_id}@{$account.4.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -2300,10 +2300,10 @@ account.5.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.5.conf_type =
+account.5.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.5.conf_uri =
+account.5.conf_uri = {if $nway_conference == true}nway{$account.5.user_id}@{$account.5.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -2770,10 +2770,10 @@ account.6.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.6.conf_type =
+account.6.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.6.conf_uri =
+account.6.conf_uri = {if $nway_conference == true}nway{$account.6.user_id}@{$account.6.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##

--- a/resources/templates/provision/yealink/t43u/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t43u/{$mac}.cfg
@@ -206,7 +206,7 @@ account.1.session_timer.refresher=
 account.1.session_timer.expires=
 account.1.session_timer.enable= {$yealink_session_timer}
 
-account.1.conf_type=
+account.1.conf_type = {if $nway_conference == true}2{/if}
 account.1.sip_server_type=
 
 ##V83 Add
@@ -509,7 +509,7 @@ account.1.call_recording.enable=
 #######################################################################################
 ##                                Network Conference                                  ##
 #######################################################################################
-account.1.conf_uri=
+account.1.conf_uri = {if $nway_conference == true}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
 
 
 #######################################################################################
@@ -774,7 +774,7 @@ account.2.session_timer.refresher=
 account.2.session_timer.expires=
 account.2.session_timer.enable= {$yealink_session_timer}
 
-account.2.conf_type=
+account.2.conf_type = {if $nway_conference == true}2{/if}
 account.2.sip_server_type=
 
 ##V83 Add
@@ -1077,7 +1077,7 @@ account.2.call_recording.enable=
 #######################################################################################
 ##                                Network Conference                                  ##
 #######################################################################################
-account.2.conf_uri=
+account.2.conf_uri = {if $nway_conference == true}nway{$account.2.user_id}@{$account.2.server_address}{/if}
 
 
 #######################################################################################
@@ -1342,7 +1342,7 @@ account.3.session_timer.refresher=
 account.3.session_timer.expires=
 account.3.session_timer.enable= {$yealink_session_timer}
 
-account.3.conf_type=
+account.3.conf_type = {if $nway_conference == true}2{/if}
 account.3.sip_server_type=
 
 ##V83 Add
@@ -1645,7 +1645,7 @@ account.3.call_recording.enable=
 #######################################################################################
 ##                                Network Conference                                  ##
 #######################################################################################
-account.3.conf_uri=
+account.3.conf_uri = {if $nway_conference == true}nway{$account.3.user_id}@{$account.3.server_address}{/if}
 
 
 #######################################################################################
@@ -1910,7 +1910,7 @@ account.4.session_timer.refresher=
 account.4.session_timer.expires=
 account.4.session_timer.enable= {$yealink_session_timer}
 
-account.4.conf_type=
+account.4.conf_type = {if $nway_conference == true}2{/if} 
 account.4.sip_server_type=
 
 ##V83 Add
@@ -2213,7 +2213,7 @@ account.4.call_recording.enable=
 #######################################################################################
 ##                                Network Conference                                  ##
 #######################################################################################
-account.4.conf_uri=
+account.4.conf_uri = {if $nway_conference == true}nway{$account.4.user_id}@{$account.4.server_address}{/if}
 
 
 #######################################################################################
@@ -2478,7 +2478,7 @@ account.5.session_timer.refresher=
 account.5.session_timer.expires=
 account.5.session_timer.enable= {$yealink_session_timer}
 
-account.5.conf_type=
+account.5.conf_type = {if $nway_conference == true}2{/if}
 account.5.sip_server_type=
 
 ##V83 Add
@@ -2781,7 +2781,7 @@ account.5.call_recording.enable=
 #######################################################################################
 ##                                Network Conference                                  ##
 #######################################################################################
-account.5.conf_uri=
+account.5.conf_uri = {if $nway_conference == true}nway{$account.5.user_id}@{$account.5.server_address}{/if}
 
 
 #######################################################################################
@@ -3046,7 +3046,7 @@ account.6.session_timer.refresher=
 account.6.session_timer.expires=
 account.6.session_timer.enable= {$yealink_session_timer}
 
-account.6.conf_type=
+account.6.conf_type = {if $nway_conference == true}2{/if}
 account.6.sip_server_type=
 
 ##V83 Add
@@ -3349,7 +3349,7 @@ account.6.call_recording.enable=
 #######################################################################################
 ##                                Network Conference                                  ##
 #######################################################################################
-account.6.conf_uri=
+account.6.conf_uri = {if $nway_conference == true}nway{$account.6.user_id}@{$account.6.server_address}{/if}
 
 
 #######################################################################################

--- a/resources/templates/provision/yealink/t46g/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t46g/{$mac}.cfg
@@ -395,10 +395,11 @@ account.1.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.1.conf_type =
+
+account.1.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.1.conf_uri =
+account.1.conf_uri = {if $nway_conference == true}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
 
 #######################################################################################
 ##                            cid_source                                             ##
@@ -867,10 +868,10 @@ account.2.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.2.conf_type =
+account.2.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.2.conf_uri =
+account.2.conf_uri = {if $nway_conference == true}nway{$account.2.user_id}@{$account.2.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -1353,10 +1354,10 @@ account.3.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.3.conf_type =
+account.3.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.3.conf_uri =
+account.3.conf_uri = {if $nway_conference == true}nway{$account.3.user_id}@{$account.3.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -1829,10 +1830,10 @@ account.4.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.4.conf_type =
+account.4.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.4.conf_uri =
+account.4.conf_uri = {if $nway_conference == true}nway{$account.4.user_id}@{$account.4.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -2305,10 +2306,10 @@ account.5.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.5.conf_type =
+account.5.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.5.conf_uri =
+account.5.conf_uri = {if $nway_conference == true}nway{$account.5.user_id}@{$account.5.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -2780,10 +2781,10 @@ account.6.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.6.conf_type =
+account.6.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.6.conf_uri =
+account.6.conf_uri = {if $nway_conference == true}nway{$account.6.user_id}@{$account.6.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##

--- a/resources/templates/provision/yealink/t46s/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t46s/{$mac}.cfg
@@ -394,10 +394,10 @@ account.1.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.1.conf_type =
+account.1.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.1.conf_uri =
+account.1.conf_uri = {if $nway_conference == true}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
 
 #######################################################################################
 ##                            cid_source                                             ##
@@ -870,10 +870,10 @@ account.2.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.2.conf_type =
+account.2.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.2.conf_uri =
+account.2.conf_uri = {if $nway_conference == true}nway{$account.2.user_id}@{$account.2.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -1361,10 +1361,10 @@ account.3.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.3.conf_type =
+account.3.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.3.conf_uri =
+account.3.conf_uri = {if $nway_conference == true}nway{$account.3.user_id}@{$account.3.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -1837,10 +1837,10 @@ account.4.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.4.conf_type =
+account.4.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.4.conf_uri =
+account.4.conf_uri = {if $nway_conference == true}nway{$account.4.user_id}@{$account.4.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -2313,10 +2313,10 @@ account.5.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.5.conf_type =
+account.5.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.5.conf_uri =
+account.5.conf_uri = {if $nway_conference == true}nway{$account.5.user_id}@{$account.5.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -2788,10 +2788,10 @@ account.6.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.6.conf_type =
+account.6.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.6.conf_uri =
+account.6.conf_uri = {if $nway_conference == true}nway{$account.6.user_id}@{$account.6.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##

--- a/resources/templates/provision/yealink/t46u/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t46u/{$mac}.cfg
@@ -206,7 +206,7 @@ account.1.session_timer.refresher=
 account.1.session_timer.expires=
 account.1.session_timer.enable= {$yealink_session_timer}
 
-account.1.conf_type=
+account.1.conf_type = {if $nway_conference == true}2{/if}
 account.1.sip_server_type=
 
 ##V83 Add
@@ -509,7 +509,7 @@ account.1.call_recording.enable=
 #######################################################################################
 ##                                Network Conference                                  ##
 #######################################################################################
-account.1.conf_uri=
+account.1.conf_uri = {if $nway_conference == true}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
 
 
 #######################################################################################
@@ -769,7 +769,7 @@ account.2.session_timer.refresher=
 account.2.session_timer.expires=
 account.2.session_timer.enable= {$yealink_session_timer}
 
-account.2.conf_type=
+account.2.conf_type = {if $nway_conference == true}2{/if}
 account.2.sip_server_type=
 
 ##V83 Add
@@ -1072,7 +1072,7 @@ account.2.call_recording.enable=
 #######################################################################################
 ##                                Network Conference                                  ##
 #######################################################################################
-account.2.conf_uri=
+account.2.conf_uri = {if $nway_conference == true}nway{$account.2.user_id}@{$account.2.server_address}{/if}
 
 
 #######################################################################################
@@ -1332,7 +1332,7 @@ account.3.session_timer.refresher=
 account.3.session_timer.expires=
 account.3.session_timer.enable= {$yealink_session_timer}
 
-account.3.conf_type=
+account.3.conf_type = {if $nway_conference == true}2{/if}
 account.3.sip_server_type=
 
 ##V83 Add
@@ -1635,7 +1635,7 @@ account.3.call_recording.enable=
 #######################################################################################
 ##                                Network Conference                                  ##
 #######################################################################################
-account.3.conf_uri=
+account.3.conf_uri = {if $nway_conference == true}nway{$account.3.user_id}@{$account.3.server_address}{/if}
 
 
 #######################################################################################
@@ -1895,7 +1895,7 @@ account.4.session_timer.refresher=
 account.4.session_timer.expires=
 account.4.session_timer.enable= {$yealink_session_timer}
 
-account.4.conf_type=
+account.4.conf_type = {if $nway_conference == true}2{/if} 
 account.4.sip_server_type=
 
 ##V83 Add
@@ -2198,7 +2198,7 @@ account.4.call_recording.enable=
 #######################################################################################
 ##                                Network Conference                                  ##
 #######################################################################################
-account.4.conf_uri=
+account.4.conf_uri = {if $nway_conference == true}nway{$account.4.user_id}@{$account.4.server_address}{/if}
 
 
 #######################################################################################
@@ -2458,7 +2458,7 @@ account.5.session_timer.refresher=
 account.5.session_timer.expires=
 account.5.session_timer.enable= {$yealink_session_timer}
 
-account.5.conf_type=
+account.5.conf_type = {if $nway_conference == true}2{/if}
 account.5.sip_server_type=
 
 ##V83 Add
@@ -2761,7 +2761,7 @@ account.5.call_recording.enable=
 #######################################################################################
 ##                                Network Conference                                  ##
 #######################################################################################
-account.5.conf_uri=
+account.5.conf_uri = {if $nway_conference == true}nway{$account.5.user_id}@{$account.5.server_address}{/if}
 
 
 #######################################################################################
@@ -3021,7 +3021,7 @@ account.6.session_timer.refresher=
 account.6.session_timer.expires=
 account.6.session_timer.enable= {$yealink_session_timer}
 
-account.6.conf_type=
+account.6.conf_type = {if $nway_conference == true}2{/if}
 account.6.sip_server_type=
 
 ##V83 Add
@@ -3324,7 +3324,7 @@ account.6.call_recording.enable=
 #######################################################################################
 ##                                Network Conference                                  ##
 #######################################################################################
-account.6.conf_uri=
+account.6.conf_uri = {if $nway_conference == true}nway{$account.6.user_id}@{$account.6.server_address}{/if}
 
 
 #######################################################################################

--- a/resources/templates/provision/yealink/t48g/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t48g/{$mac}.cfg
@@ -395,10 +395,10 @@ account.1.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.1.conf_type =
+account.1.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.1.conf_uri =
+account.1.conf_uri = {if $nway_conference == true}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
 
 #######################################################################################
 ##                            cid_source                                             ##
@@ -867,10 +867,10 @@ account.2.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.2.conf_type =
+account.2.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.2.conf_uri =
+account.2.conf_uri = {if $nway_conference == true}nway{$account.2.user_id}@{$account.2.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -1353,10 +1353,10 @@ account.3.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.3.conf_type =
+account.3.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.3.conf_uri =
+account.3.conf_uri = {if $nway_conference == true}nway{$account.3.user_id}@{$account.3.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -1829,10 +1829,10 @@ account.4.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.4.conf_type =
+account.4.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.4.conf_uri =
+account.4.conf_uri = {if $nway_conference == true}nway{$account.4.user_id}@{$account.4.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -2305,10 +2305,10 @@ account.5.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.5.conf_type =
+account.5.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.5.conf_uri =
+account.5.conf_uri = {if $nway_conference == true}nway{$account.5.user_id}@{$account.5.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -2780,10 +2780,10 @@ account.6.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.6.conf_type =
+account.6.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.6.conf_uri =
+account.6.conf_uri = {if $nway_conference == true}nway{$account.6.user_id}@{$account.6.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##

--- a/resources/templates/provision/yealink/t48s/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t48s/{$mac}.cfg
@@ -394,10 +394,10 @@ account.1.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.1.conf_type =
+account.1.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.1.conf_uri =
+account.1.conf_uri = {if $nway_conference == true}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
 
 #######################################################################################
 ##                            cid_source                                             ##
@@ -870,10 +870,10 @@ account.2.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.2.conf_type =
+account.2.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.2.conf_uri =
+account.2.conf_uri = {if $nway_conference == true}nway{$account.2.user_id}@{$account.2.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -1357,10 +1357,10 @@ account.3.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.3.conf_type =
+account.3.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.3.conf_uri =
+account.3.conf_uri = {if $nway_conference == true}nway{$account.3.user_id}@{$account.3.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -1829,10 +1829,10 @@ account.4.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.4.conf_type =
+account.4.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.4.conf_uri =
+account.4.conf_uri = {if $nway_conference == true}nway{$account.4.user_id}@{$account.4.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -2301,10 +2301,10 @@ account.5.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.5.conf_type =
+account.5.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.5.conf_uri =
+account.5.conf_uri = {if $nway_conference == true}nway{$account.5.user_id}@{$account.5.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -2772,10 +2772,10 @@ account.6.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.6.conf_type =
+account.6.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.6.conf_uri =
+account.6.conf_uri = {if $nway_conference == true}nway{$account.6.user_id}@{$account.6.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##

--- a/resources/templates/provision/yealink/t49g/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t49g/{$mac}.cfg
@@ -395,10 +395,10 @@ account.1.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.1.conf_type =
+account.1.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.1.conf_uri =
+account.1.conf_uri = {if $nway_conference == true}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
 
 #######################################################################################
 ##                            cid_source                                             ##
@@ -867,10 +867,10 @@ account.2.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.2.conf_type =
+account.2.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.2.conf_uri =
+account.2.conf_uri = {if $nway_conference == true}nway{$account.2.user_id}@{$account.2.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -1392,10 +1392,10 @@ account.3.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.3.conf_type =
+account.3.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.3.conf_uri =
+account.3.conf_uri = {if $nway_conference == true}nway{$account.3.user_id}@{$account.3.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -1891,10 +1891,10 @@ account.4.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.4.conf_type =
+account.4.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.4.conf_uri =
+account.4.conf_uri = {if $nway_conference == true}nway{$account.4.user_id}@{$account.4.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -2390,10 +2390,10 @@ account.5.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.5.conf_type =
+account.5.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.5.conf_uri =
+account.5.conf_uri = {if $nway_conference == true}nway{$account.5.user_id}@{$account.5.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -2888,10 +2888,10 @@ account.6.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.6.conf_type =
+account.6.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.6.conf_uri =
+account.6.conf_uri = {if $nway_conference == true}nway{$account.6.user_id}@{$account.6.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##

--- a/resources/templates/provision/yealink/t4x/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t4x/{$mac}.cfg
@@ -347,10 +347,10 @@ account.{$row.line_number}.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type 0-Local (default), 2-Network Conference
-account.{$row.line_number}.conf_type =
+account.{$row.line_number}.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.{$row.line_number}.conf_uri =
+account.{$row.line_number}.conf_uri = {if $nway_conference == true}nway{$account.{$row.line_number}.user_id}@{$account.{$row.line_number}.server_address}{/if}
 
 #######################################################################################
 ##                            cid_source                                             ##

--- a/resources/templates/provision/yealink/t52s/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t52s/{$mac}.cfg
@@ -361,7 +361,7 @@ account.1.session_timer.refresher=
 account.1.session_timer.expires=
 account.1.session_timer.enable= {$yealink_session_timer}
 
-account.1.conf_type=
+account.1.conf_type = {if $nway_conference == true}2{/if}
 account.1.sip_server_type=
 
 account.2.nat.udp_update_enable= 3
@@ -387,7 +387,8 @@ account.2.session_timer.refresher=
 account.2.session_timer.expires=
 account.2.session_timer.enable= {$yealink_session_timer}
 
-account.2.conf_type=
+account.2.conf_type = {if $nway_conference == true}2{/if}
+account.2.conf_uri = {if $nway_conference == true}nway{$account.2.user_id}@{$account.2.server_address}{/if}
 account.2.sip_server_type=
 
 
@@ -668,7 +669,7 @@ account.1.refresh_remote_id.enable =
 #######################################################################################
 ##                                Network Conferene                                  ##       
 #######################################################################################
-account.1.conf_uri=
+account.1.conf_uri = {if $nway_conference == true}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
 
 
 #######################################################################################

--- a/resources/templates/provision/yealink/t53/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t53/{$mac}.cfg
@@ -205,7 +205,7 @@ account.1.session_timer.refresher=
 account.1.session_timer.expires=
 account.1.session_timer.enable= {$yealink_session_timer}
 
-account.1.conf_type=
+account.1.conf_type = {if $nway_conference == true}2{/if}
 account.1.sip_server_type=
 
 ##V83 Add
@@ -499,7 +499,7 @@ account.1.call_recording.enable=
 #######################################################################################
 ##                                Network Conferene                                  ##       
 #######################################################################################
-account.1.conf_uri=
+account.1.conf_uri = {if $nway_conference == true}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
 
 
 #######################################################################################
@@ -744,7 +744,7 @@ account.2.session_timer.refresher=
 account.2.session_timer.expires=
 account.2.session_timer.enable= {$yealink_session_timer}
 
-account.2.conf_type=
+account.2.conf_type = {if $nway_conference == true}2{/if}
 account.2.sip_server_type=
 
 ##V83 Add
@@ -1038,7 +1038,7 @@ account.2.call_recording.enable=
 #######################################################################################
 ##                                Network Conferene                                  ##       
 #######################################################################################
-account.2.conf_uri=
+account.2.conf_uri = {if $nway_conference == true}nway{$account.2.user_id}@{$account.2.server_address}{/if}
 
 
 #######################################################################################
@@ -1271,7 +1271,7 @@ account.3.session_timer.refresher=
 account.3.session_timer.expires=
 account.3.session_timer.enable= {$yealink_session_timer}
 
-account.3.conf_type=
+account.3.conf_type = {if $nway_conference == true}2{/if}
 account.3.sip_server_type=
 
 ##V83 Add
@@ -1565,7 +1565,7 @@ account.3.call_recording.enable=
 #######################################################################################
 ##                                Network Conferene                                  ##       
 #######################################################################################
-account.3.conf_uri=
+account.3.conf_uri = {if $nway_conference == true}nway{$account.3.user_id}@{$account.3.server_address}{/if}
 
 
 #######################################################################################
@@ -1798,7 +1798,7 @@ account.4.session_timer.refresher=
 account.4.session_timer.expires=
 account.4.session_timer.enable= {$yealink_session_timer}
 
-account.4.conf_type=
+account.4.conf_type = {if $nway_conference == true}2{/if} 
 account.4.sip_server_type=
 
 ##V83 Add
@@ -2092,7 +2092,7 @@ account.4.call_recording.enable=
 #######################################################################################
 ##                                Network Conferene                                  ##       
 #######################################################################################
-account.4.conf_uri=
+account.4.conf_uri = {if $nway_conference == true}nway{$account.4.user_id}@{$account.4.server_address}{/if}
 
 
 #######################################################################################
@@ -2324,7 +2324,7 @@ account.5.session_timer.refresher=
 account.5.session_timer.expires=
 account.5.session_timer.enable= {$yealink_session_timer}
 
-account.5.conf_type=
+account.5.conf_type = {if $nway_conference == true}2{/if}
 account.5.sip_server_type=
 
 ##V83 Add
@@ -2618,7 +2618,7 @@ account.5.call_recording.enable=
 #######################################################################################
 ##                                Network Conferene                                  ##       
 #######################################################################################
-account.5.conf_uri=
+account.5.conf_uri = {if $nway_conference == true}nway{$account.5.user_id}@{$account.5.server_address}{/if}
 
 
 #######################################################################################
@@ -2864,7 +2864,7 @@ account.6.session_timer.refresher=
 account.6.session_timer.expires=
 account.6.session_timer.enable= {$yealink_session_timer}
 
-account.6.conf_type=
+account.6.conf_type = {if $nway_conference == true}2{/if}
 account.6.sip_server_type=
 
 ##V83 Add
@@ -3158,7 +3158,7 @@ account.6.call_recording.enable=
 #######################################################################################
 ##                                Network Conferene                                  ##       
 #######################################################################################
-account.6.conf_uri=
+account.6.conf_uri = {if $nway_conference == true}nway{$account.6.user_id}@{$account.6.server_address}{/if}
 
 
 #######################################################################################

--- a/resources/templates/provision/yealink/t53w/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t53w/{$mac}.cfg
@@ -206,7 +206,7 @@ account.1.session_timer.refresher=
 account.1.session_timer.expires=
 account.1.session_timer.enable= {$yealink_session_timer}
 
-account.1.conf_type=
+account.1.conf_type = {if $nway_conference == true}2{/if}
 account.1.sip_server_type=
 
 ##V83 Add
@@ -500,7 +500,7 @@ account.1.call_recording.enable=
 #######################################################################################
 ##                                Network Conferene                                  ##       
 #######################################################################################
-account.1.conf_uri=
+account.1.conf_uri = {if $nway_conference == true}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
 
 
 #######################################################################################
@@ -746,7 +746,7 @@ account.2.session_timer.refresher=
 account.2.session_timer.expires=
 account.2.session_timer.enable= {$yealink_session_timer}
 
-account.2.conf_type=
+account.2.conf_type = {if $nway_conference == true}2{/if}
 account.2.sip_server_type=
 
 ##V83 Add
@@ -1040,7 +1040,7 @@ account.2.call_recording.enable=
 #######################################################################################
 ##                                Network Conferene                                  ##       
 #######################################################################################
-account.2.conf_uri=
+account.2.conf_uri = {if $nway_conference == true}nway{$account.2.user_id}@{$account.2.server_address}{/if}
 
 
 #######################################################################################
@@ -1274,7 +1274,7 @@ account.3.session_timer.refresher=
 account.3.session_timer.expires=
 account.3.session_timer.enable= {$yealink_session_timer}
 
-account.3.conf_type=
+account.3.conf_type = {if $nway_conference == true}2{/if}
 account.3.sip_server_type=
 
 ##V83 Add
@@ -1568,7 +1568,7 @@ account.3.call_recording.enable=
 #######################################################################################
 ##                                Network Conferene                                  ##       
 #######################################################################################
-account.3.conf_uri=
+account.3.conf_uri = {if $nway_conference == true}nway{$account.3.user_id}@{$account.3.server_address}{/if}
 
 
 #######################################################################################
@@ -1802,7 +1802,7 @@ account.4.session_timer.refresher=
 account.4.session_timer.expires=
 account.4.session_timer.enable= {$yealink_session_timer}
 
-account.4.conf_type=
+account.4.conf_type = {if $nway_conference == true}2{/if} 
 account.4.sip_server_type=
 
 ##V83 Add
@@ -2096,7 +2096,7 @@ account.4.call_recording.enable=
 #######################################################################################
 ##                                Network Conferene                                  ##       
 #######################################################################################
-account.4.conf_uri=
+account.4.conf_uri = {if $nway_conference == true}nway{$account.4.user_id}@{$account.4.server_address}{/if}
 
 
 #######################################################################################
@@ -2329,7 +2329,7 @@ account.5.session_timer.refresher=
 account.5.session_timer.expires=
 account.5.session_timer.enable= {$yealink_session_timer}
 
-account.5.conf_type=
+account.5.conf_type = {if $nway_conference == true}2{/if}
 account.5.sip_server_type=
 
 ##V83 Add
@@ -2623,7 +2623,7 @@ account.5.call_recording.enable=
 #######################################################################################
 ##                                Network Conferene                                  ##       
 #######################################################################################
-account.5.conf_uri=
+account.5.conf_uri = {if $nway_conference == true}nway{$account.5.user_id}@{$account.5.server_address}{/if}
 
 
 #######################################################################################
@@ -2870,7 +2870,7 @@ account.6.session_timer.refresher=
 account.6.session_timer.expires=
 account.6.session_timer.enable= {$yealink_session_timer}
 
-account.6.conf_type=
+account.6.conf_type = {if $nway_conference == true}2{/if}
 account.6.sip_server_type=
 
 ##V83 Add
@@ -3164,7 +3164,7 @@ account.6.call_recording.enable=
 #######################################################################################
 ##                                Network Conferene                                  ##       
 #######################################################################################
-account.6.conf_uri=
+account.6.conf_uri = {if $nway_conference == true}nway{$account.6.user_id}@{$account.6.server_address}{/if}
 
 
 #######################################################################################

--- a/resources/templates/provision/yealink/t54s/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t54s/{$mac}.cfg
@@ -362,7 +362,7 @@ account.1.session_timer.refresher=
 account.1.session_timer.expires=
 account.1.session_timer.enable= {$yealink_session_timer}
 
-account.1.conf_type=
+account.1.conf_type = {if $nway_conference == true}2{/if}
 account.1.sip_server_type=
 
 account.2.nat.udp_update_enable= 3
@@ -388,7 +388,8 @@ account.2.session_timer.refresher=
 account.2.session_timer.expires=
 account.2.session_timer.enable= {$yealink_session_timer}
 
-account.2.conf_type=
+account.2.conf_type = {if $nway_conference == true}2{/if}
+account.2.conf_uri = {if $nway_conference == true}nway{$account.2.user_id}@{$account.2.server_address}{/if}
 account.2.sip_server_type=
 
 
@@ -669,7 +670,7 @@ account.1.refresh_remote_id.enable =
 #######################################################################################
 ##                                Network Conferene                                  ##       
 #######################################################################################
-account.1.conf_uri=
+account.1.conf_uri = {if $nway_conference == true}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
 
 
 #######################################################################################

--- a/resources/templates/provision/yealink/t54w/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t54w/{$mac}.cfg
@@ -206,7 +206,7 @@ account.1.session_timer.refresher=
 account.1.session_timer.expires=
 account.1.session_timer.enable= {$yealink_session_timer}
 
-account.1.conf_type=
+account.1.conf_type = {if $nway_conference == true}2{/if}
 account.1.sip_server_type=
 
 ##V83 Add
@@ -500,7 +500,7 @@ account.1.call_recording.enable=
 #######################################################################################
 ##                                Network Conferene                                  ##       
 #######################################################################################
-account.1.conf_uri=
+account.1.conf_uri = {if $nway_conference == true}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
 
 
 #######################################################################################
@@ -746,7 +746,7 @@ account.2.session_timer.refresher=
 account.2.session_timer.expires=
 account.2.session_timer.enable= {$yealink_session_timer}
 
-account.2.conf_type=
+account.2.conf_type = {if $nway_conference == true}2{/if}
 account.2.sip_server_type=
 
 ##V83 Add
@@ -1040,7 +1040,7 @@ account.2.call_recording.enable=
 #######################################################################################
 ##                                Network Conferene                                  ##       
 #######################################################################################
-account.2.conf_uri=
+account.2.conf_uri = {if $nway_conference == true}nway{$account.2.user_id}@{$account.2.server_address}{/if}
 
 
 #######################################################################################
@@ -1274,7 +1274,7 @@ account.3.session_timer.refresher=
 account.3.session_timer.expires=
 account.3.session_timer.enable= {$yealink_session_timer}
 
-account.3.conf_type=
+account.3.conf_type = {if $nway_conference == true}2{/if}
 account.3.sip_server_type=
 
 ##V83 Add
@@ -1568,7 +1568,7 @@ account.3.call_recording.enable=
 #######################################################################################
 ##                                Network Conferene                                  ##       
 #######################################################################################
-account.3.conf_uri=
+account.3.conf_uri = {if $nway_conference == true}nway{$account.3.user_id}@{$account.3.server_address}{/if}
 
 
 #######################################################################################
@@ -1802,7 +1802,7 @@ account.4.session_timer.refresher=
 account.4.session_timer.expires=
 account.4.session_timer.enable= {$yealink_session_timer}
 
-account.4.conf_type=
+account.4.conf_type = {if $nway_conference == true}2{/if} 
 account.4.sip_server_type=
 
 ##V83 Add
@@ -2096,7 +2096,7 @@ account.4.call_recording.enable=
 #######################################################################################
 ##                                Network Conferene                                  ##       
 #######################################################################################
-account.4.conf_uri=
+account.4.conf_uri = {if $nway_conference == true}nway{$account.4.user_id}@{$account.4.server_address}{/if}
 
 
 #######################################################################################
@@ -2329,7 +2329,7 @@ account.5.session_timer.refresher=
 account.5.session_timer.expires=
 account.5.session_timer.enable= {$yealink_session_timer}
 
-account.5.conf_type=
+account.5.conf_type = {if $nway_conference == true}2{/if}
 account.5.sip_server_type=
 
 ##V83 Add
@@ -2623,7 +2623,7 @@ account.5.call_recording.enable=
 #######################################################################################
 ##                                Network Conferene                                  ##       
 #######################################################################################
-account.5.conf_uri=
+account.5.conf_uri = {if $nway_conference == true}nway{$account.5.user_id}@{$account.5.server_address}{/if}
 
 
 #######################################################################################
@@ -2870,7 +2870,7 @@ account.6.session_timer.refresher=
 account.6.session_timer.expires=
 account.6.session_timer.enable= {$yealink_session_timer}
 
-account.6.conf_type=
+account.6.conf_type = {if $nway_conference == true}2{/if}
 account.6.sip_server_type=
 
 ##V83 Add
@@ -3164,7 +3164,7 @@ account.6.call_recording.enable=
 #######################################################################################
 ##                                Network Conferene                                  ##       
 #######################################################################################
-account.6.conf_uri=
+account.6.conf_uri = {if $nway_conference == true}nway{$account.6.user_id}@{$account.6.server_address}{/if}
 
 
 #######################################################################################

--- a/resources/templates/provision/yealink/t56a/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t56a/{$mac}.cfg
@@ -369,11 +369,11 @@ account.1.picture_info_enable =
 #######################################################################################
 ##It configures the conference type for account X.0-Local Conference,2-Network Conference.
 ##The default value is 0.
-account.1.conf_type = 
+account.1.conf_type = {if $nway_conference == true}2{/if} 
 
 ##It configures the network conference URI for account X.
 ##The default value is blank.
-account.1.conf_uri = 
+account.1.conf_uri = {if $nway_conference == true}nway{$account.1.auth_id}@{$account.1.server_address}{/if} 
 
 
 #######################################################################################
@@ -833,10 +833,10 @@ account.2.picture_info_enable =
 #######################################################################################
 ##It configures the conference type for account X.0-Local Conference,2-Network Conference.
 ##The default value is 0.
-account.2.conf_type = 
+account.2.conf_type = {if $nway_conference == true}2{/if} 
 ##It configures the network conference URI for account X.
 ##The default value is blank.
-account.2.conf_uri = 
+account.2.conf_uri = {if $nway_conference == true}nway{$account.2.user_id}@{$account.2.server_address}{/if} 
 
 
 #######################################################################################
@@ -1296,10 +1296,10 @@ account.3.picture_info_enable =
 #######################################################################################
 ##It configures the conference type for account X.0-Local Conference,2-Network Conference.
 ##The default value is 0.
-account.3.conf_type = 
+account.3.conf_type = {if $nway_conference == true}2{/if} 
 ##It configures the network conference URI for account X.
 ##The default value is blank.
-account.3.conf_uri = 
+account.3.conf_uri = {if $nway_conference == true}nway{$account.3.user_id}@{$account.3.server_address}{/if} 
 
 
 #######################################################################################
@@ -1762,11 +1762,11 @@ account.4.picture_info_enable =
 #######################################################################################
 ##It configures the conference type for account X.0-Local Conference,2-Network Conference.
 ##The default value is 0.
-account.4.conf_type = 
+account.4.conf_type = {if $nway_conference == true}2{/if} 
 
 ##It configures the network conference URI for account X.
 ##The default value is blank.
-account.4.conf_uri = 
+account.4.conf_uri = {if $nway_conference == true}nway{$account.4.user_id}@{$account.4.server_address}{/if} 
 
 
 #######################################################################################
@@ -2230,11 +2230,11 @@ account.5.picture_info_enable =
 #######################################################################################
 ##It configures the conference type for account X.0-Local Conference,2-Network Conference.
 ##The default value is 0.
-account.5.conf_type = 
+account.5.conf_type = {if $nway_conference == true}2{/if} 
 
 ##It configures the network conference URI for account X.
 ##The default value is blank.
-account.5.conf_uri =
+account.5.conf_uri = {if $nway_conference == true}nway{$account.5.user_id}@{$account.5.server_address}{/if}
 
 
 #######################################################################################
@@ -2701,10 +2701,10 @@ account.6.picture_info_enable =
 #######################################################################################
 ##It configures the conference type for account X.0-Local Conference,2-Network Conference.
 ##The default value is 0.
-account.6.conf_type = 
+account.6.conf_type = {if $nway_conference == true}2{/if} 
 ##It configures the network conference URI for account X.
 ##The default value is blank.
-account.6.conf_uri = 
+account.6.conf_uri = {if $nway_conference == true}nway{$account.6.user_id}@{$account.6.server_address}{/if} 
 
 
 #######################################################################################

--- a/resources/templates/provision/yealink/t57w/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t57w/{$mac}.cfg
@@ -206,7 +206,7 @@ account.1.session_timer.refresher=
 account.1.session_timer.expires=
 account.1.session_timer.enable= {$yealink_session_timer}
 
-account.1.conf_type=
+account.1.conf_type = {if $nway_conference == true}2{/if}
 account.1.sip_server_type=
 
 ##V83 Add
@@ -500,7 +500,7 @@ account.1.call_recording.enable=
 #######################################################################################
 ##                                Network Conferene                                  ##       
 #######################################################################################
-account.1.conf_uri=
+account.1.conf_uri = {if $nway_conference == true}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
 
 
 #######################################################################################
@@ -745,7 +745,7 @@ account.2.session_timer.refresher=
 account.2.session_timer.expires=
 account.2.session_timer.enable= {$yealink_session_timer}
 
-account.2.conf_type=
+account.2.conf_type = {if $nway_conference == true}2{/if}
 account.2.sip_server_type=
 
 ##V83 Add
@@ -1039,7 +1039,7 @@ account.2.call_recording.enable=
 #######################################################################################
 ##                                Network Conferene                                  ##       
 #######################################################################################
-account.2.conf_uri=
+account.2.conf_uri = {if $nway_conference == true}nway{$account.2.user_id}@{$account.2.server_address}{/if}
 
 
 #######################################################################################
@@ -1272,7 +1272,7 @@ account.3.session_timer.refresher=
 account.3.session_timer.expires=
 account.3.session_timer.enable= {$yealink_session_timer}
 
-account.3.conf_type=
+account.3.conf_type = {if $nway_conference == true}2{/if}
 account.3.sip_server_type=
 
 ##V83 Add
@@ -1566,7 +1566,7 @@ account.3.call_recording.enable=
 #######################################################################################
 ##                                Network Conferene                                  ##       
 #######################################################################################
-account.3.conf_uri=
+account.3.conf_uri = {if $nway_conference == true}nway{$account.3.user_id}@{$account.3.server_address}{/if}
 
 
 #######################################################################################
@@ -1799,7 +1799,7 @@ account.4.session_timer.refresher=
 account.4.session_timer.expires=
 account.4.session_timer.enable= {$yealink_session_timer}
 
-account.4.conf_type=
+account.4.conf_type = {if $nway_conference == true}2{/if} 
 account.4.sip_server_type=
 
 ##V83 Add
@@ -2093,7 +2093,7 @@ account.4.call_recording.enable=
 #######################################################################################
 ##                                Network Conferene                                  ##       
 #######################################################################################
-account.4.conf_uri=
+account.4.conf_uri = {if $nway_conference == true}nway{$account.4.user_id}@{$account.4.server_address}{/if}
 
 
 #######################################################################################
@@ -2325,7 +2325,7 @@ account.5.session_timer.refresher=
 account.5.session_timer.expires=
 account.5.session_timer.enable= {$yealink_session_timer}
 
-account.5.conf_type=
+account.5.conf_type = {if $nway_conference == true}2{/if}
 account.5.sip_server_type=
 
 ##V83 Add
@@ -2619,7 +2619,7 @@ account.5.call_recording.enable=
 #######################################################################################
 ##                                Network Conferene                                  ##       
 #######################################################################################
-account.5.conf_uri=
+account.5.conf_uri = {if $nway_conference == true}nway{$account.5.user_id}@{$account.5.server_address}{/if}
 
 
 #######################################################################################
@@ -2865,7 +2865,7 @@ account.6.session_timer.refresher=
 account.6.session_timer.expires=
 account.6.session_timer.enable= {$yealink_session_timer}
 
-account.6.conf_type=
+account.6.conf_type = {if $nway_conference == true}2{/if}
 account.6.sip_server_type=
 
 ##V83 Add
@@ -3159,7 +3159,7 @@ account.6.call_recording.enable=
 #######################################################################################
 ##                                Network Conferene                                  ##       
 #######################################################################################
-account.6.conf_uri=
+account.6.conf_uri = {if $nway_conference == true}nway{$account.6.user_id}@{$account.6.server_address}{/if}
 
 
 #######################################################################################

--- a/resources/templates/provision/yealink/t58a/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t58a/{$mac}.cfg
@@ -369,11 +369,11 @@ account.1.picture_info_enable =
 #######################################################################################
 ##It configures the conference type for account X.0-Local Conference,2-Network Conference.
 ##The default value is 0.
-account.1.conf_type = 
+account.1.conf_type = {if $nway_conference == true}2{/if} 
 
 ##It configures the network conference URI for account X.
 ##The default value is blank.
-account.1.conf_uri = 
+account.1.conf_uri = {if $nway_conference == true}nway{$account.1.auth_id}@{$account.1.server_address}{/if} 
 
 
 #######################################################################################
@@ -833,10 +833,10 @@ account.2.picture_info_enable =
 #######################################################################################
 ##It configures the conference type for account X.0-Local Conference,2-Network Conference.
 ##The default value is 0.
-account.2.conf_type = 
+account.2.conf_type = {if $nway_conference == true}2{/if} 
 ##It configures the network conference URI for account X.
 ##The default value is blank.
-account.2.conf_uri = 
+account.2.conf_uri = {if $nway_conference == true}nway{$account.2.user_id}@{$account.2.server_address}{/if} 
 
 
 #######################################################################################
@@ -1296,10 +1296,10 @@ account.3.picture_info_enable =
 #######################################################################################
 ##It configures the conference type for account X.0-Local Conference,2-Network Conference.
 ##The default value is 0.
-account.3.conf_type = 
+account.3.conf_type = {if $nway_conference == true}2{/if} 
 ##It configures the network conference URI for account X.
 ##The default value is blank.
-account.3.conf_uri = 
+account.3.conf_uri = {if $nway_conference == true}nway{$account.3.user_id}@{$account.3.server_address}{/if} 
 
 
 #######################################################################################
@@ -1762,11 +1762,11 @@ account.4.picture_info_enable =
 #######################################################################################
 ##It configures the conference type for account X.0-Local Conference,2-Network Conference.
 ##The default value is 0.
-account.4.conf_type = 
+account.4.conf_type = {if $nway_conference == true}2{/if} 
 
 ##It configures the network conference URI for account X.
 ##The default value is blank.
-account.4.conf_uri = 
+account.4.conf_uri = {if $nway_conference == true}nway{$account.4.user_id}@{$account.4.server_address}{/if} 
 
 
 #######################################################################################
@@ -2230,11 +2230,11 @@ account.5.picture_info_enable =
 #######################################################################################
 ##It configures the conference type for account X.0-Local Conference,2-Network Conference.
 ##The default value is 0.
-account.5.conf_type = 
+account.5.conf_type = {if $nway_conference == true}2{/if} 
 
 ##It configures the network conference URI for account X.
 ##The default value is blank.
-account.5.conf_uri =
+account.5.conf_uri = {if $nway_conference == true}nway{$account.5.user_id}@{$account.5.server_address}{/if}
 
 
 #######################################################################################
@@ -2701,10 +2701,10 @@ account.6.picture_info_enable =
 #######################################################################################
 ##It configures the conference type for account X.0-Local Conference,2-Network Conference.
 ##The default value is 0.
-account.6.conf_type = 
+account.6.conf_type = {if $nway_conference == true}2{/if} 
 ##It configures the network conference URI for account X.
 ##The default value is blank.
-account.6.conf_uri = 
+account.6.conf_uri = {if $nway_conference == true}nway{$account.6.user_id}@{$account.6.server_address}{/if} 
 
 
 #######################################################################################

--- a/resources/templates/provision/yealink/t58v/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t58v/{$mac}.cfg
@@ -369,11 +369,11 @@ account.1.picture_info_enable =
 #######################################################################################
 ##It configures the conference type for account X.0-Local Conference,2-Network Conference.
 ##The default value is 0.
-account.1.conf_type = 
+account.1.conf_type = {if $nway_conference == true}2{/if} 
 
 ##It configures the network conference URI for account X.
 ##The default value is blank.
-account.1.conf_uri = 
+account.1.conf_uri = {if $nway_conference == true}nway{$account.1.auth_id}@{$account.1.server_address}{/if} 
 
 
 #######################################################################################
@@ -833,10 +833,10 @@ account.2.picture_info_enable =
 #######################################################################################
 ##It configures the conference type for account X.0-Local Conference,2-Network Conference.
 ##The default value is 0.
-account.2.conf_type = 
+account.2.conf_type = {if $nway_conference == true}2{/if} 
 ##It configures the network conference URI for account X.
 ##The default value is blank.
-account.2.conf_uri = 
+account.2.conf_uri = {if $nway_conference == true}nway{$account.2.user_id}@{$account.2.server_address}{/if} 
 
 
 #######################################################################################
@@ -1296,10 +1296,10 @@ account.3.picture_info_enable =
 #######################################################################################
 ##It configures the conference type for account X.0-Local Conference,2-Network Conference.
 ##The default value is 0.
-account.3.conf_type = 
+account.3.conf_type = {if $nway_conference == true}2{/if} 
 ##It configures the network conference URI for account X.
 ##The default value is blank.
-account.3.conf_uri = 
+account.3.conf_uri = {if $nway_conference == true}nway{$account.3.user_id}@{$account.3.server_address}{/if} 
 
 
 #######################################################################################
@@ -1762,11 +1762,11 @@ account.4.picture_info_enable =
 #######################################################################################
 ##It configures the conference type for account X.0-Local Conference,2-Network Conference.
 ##The default value is 0.
-account.4.conf_type = 
+account.4.conf_type = {if $nway_conference == true}2{/if} 
 
 ##It configures the network conference URI for account X.
 ##The default value is blank.
-account.4.conf_uri = 
+account.4.conf_uri = {if $nway_conference == true}nway{$account.4.user_id}@{$account.4.server_address}{/if} 
 
 
 #######################################################################################
@@ -2230,11 +2230,11 @@ account.5.picture_info_enable =
 #######################################################################################
 ##It configures the conference type for account X.0-Local Conference,2-Network Conference.
 ##The default value is 0.
-account.5.conf_type = 
+account.5.conf_type = {if $nway_conference == true}2{/if} 
 
 ##It configures the network conference URI for account X.
 ##The default value is blank.
-account.5.conf_uri =
+account.5.conf_uri = {if $nway_conference == true}nway{$account.5.user_id}@{$account.5.server_address}{/if}
 
 
 #######################################################################################
@@ -2701,10 +2701,10 @@ account.6.picture_info_enable =
 #######################################################################################
 ##It configures the conference type for account X.0-Local Conference,2-Network Conference.
 ##The default value is 0.
-account.6.conf_type = 
+account.6.conf_type = {if $nway_conference == true}2{/if} 
 ##It configures the network conference URI for account X.
 ##The default value is blank.
-account.6.conf_uri = 
+account.6.conf_uri = {if $nway_conference == true}nway{$account.6.user_id}@{$account.6.server_address}{/if} 
 
 
 #######################################################################################

--- a/resources/templates/provision/yealink/t5x/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t5x/{$mac}.cfg
@@ -325,10 +325,10 @@ account.{$row.line_number}.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type 0-Local (default), 2-Network Conference
-account.{$row.line_number}.conf_type =
+account.{$row.line_number}.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.{$row.line_number}.conf_uri =
+account.{$row.line_number}.conf_uri = {if $nway_conference == true}nway{$account.{$row.line_number}.user_id}@{$account.{$row.line_number}.server_address}{/if}
 
 #######################################################################################
 ##                            cid_source                                             ##

--- a/resources/templates/provision/yealink/vp530/{$mac}.cfg
+++ b/resources/templates/provision/yealink/vp530/{$mac}.cfg
@@ -376,10 +376,10 @@ account.1.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.1.conf_type =
+account.1.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.1.conf_uri =
+account.1.conf_uri = {if $nway_conference == true}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
 
 #######################################################################################
 ##                            cid_source                                             ##
@@ -841,10 +841,10 @@ account.2.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.2.conf_type =
+account.2.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.2.conf_uri =
+account.2.conf_uri = {if $nway_conference == true}nway{$account.2.user_id}@{$account.2.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -1350,10 +1350,10 @@ account.3.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.3.conf_type =
+account.3.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.3.conf_uri =
+account.3.conf_uri = {if $nway_conference == true}nway{$account.3.user_id}@{$account.3.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -1842,10 +1842,10 @@ account.4.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.4.conf_type =
+account.4.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.4.conf_uri =
+account.4.conf_uri = {if $nway_conference == true}nway{$account.4.user_id}@{$account.4.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -2334,10 +2334,10 @@ account.5.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.5.conf_type =
+account.5.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.5.conf_uri =
+account.5.conf_uri = {if $nway_conference == true}nway{$account.5.user_id}@{$account.5.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -2825,10 +2825,10 @@ account.6.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.6.conf_type =
+account.6.conf_type = {if $nway_conference == true}2{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.6.conf_uri =
+account.6.conf_uri = {if $nway_conference == true}nway{$account.6.user_id}@{$account.6.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##


### PR DESCRIPTION
Support for the nway_conference variable and dialplan (disabled by default) baked into the templates.