### PR TITLE
ring group release database handle before bridge

### DIFF
--- a/app/scripts/resources/scripts/app/ring_groups/index.lua
+++ b/app/scripts/resources/scripts/app/ring_groups/index.lua
@@ -882,6 +882,9 @@
 				end
 			end
 
+		--release dbh before bridge
+				dbh:release();
+				
 		--session execute
 			if (session:ready()) then
 				--set the variables
@@ -1006,6 +1009,7 @@
 									session:execute(ring_group_timeout_app, ring_group_timeout_data);
 								end
 						else
+							dbh = Database.new('system');
 							local sql = "SELECT ring_group_timeout_app, ring_group_timeout_data FROM v_ring_groups ";
 							sql = sql .. "where ring_group_uuid = :ring_group_uuid";
 							local params = {ring_group_uuid = ring_group_uuid};


### PR DESCRIPTION
ring group kept an open database connection for the duration of the bridge 