### PR TITLE
Ring group fix missed call alert

### DIFF
--- a/app/scripts/resources/scripts/app/ring_groups/index.lua
+++ b/app/scripts/resources/scripts/app/ring_groups/index.lua
@@ -325,6 +325,7 @@
 					if (debug["sql"]) then
 						freeswitch.consoleLog("notice", "[voicemail] SQL: " .. sql .. "; params:" .. json.encode(params) .. "\n");
 					end
+					dbh = Database.new('system');
 					dbh:query(sql, params, function(row)
 						subject = row["template_subject"];
 						body = row["template_body"];


### PR DESCRIPTION
Got broken yesterday after https://github.com/fusionpbx/fusionpbx/commit/a39a65d21ef89abd679b0e83a9b87f2df6a4a68a commit for releasing db handle before the bridge