### PR TITLE
Dont overload DB with conditions

### DIFF
--- a/app/dialplans/resources/classes/dialplan.php
+++ b/app/dialplans/resources/classes/dialplan.php
@@ -634,7 +634,6 @@
 							}
 							if (is_uuid($this->uuid)) {
 								$sql .= "and p.dialplan_uuid = :dialplan_uuid \n";
-								$sql .= "and s.dialplan_uuid = :dialplan_uuid \n";
 								$parameters['dialplan_uuid'] = $this->uuid;
 							}
 							$sql .= "and (s.dialplan_detail_enabled = 'true' or s.dialplan_detail_enabled is null) \n";


### PR DESCRIPTION
You already have the condition " p.dialplan_uuid = s.dialplan_uuid"

therefore, asking for s.dialplan_uuid with the same constant value just makes the DB work more without benefit.