### PR TITLE
Fixed "Missed" link and exclude LOSE_RACE from CDR stats

### DIFF
--- a/app/xml_cdr/xml_cdr_statistics.php
+++ b/app/xml_cdr/xml_cdr_statistics.php
@@ -314,7 +314,7 @@
 		echo "	<td>".escape($row['volume'])."&nbsp;</td>\n";
 		echo "	<td>".(round(escape($row['minutes']),2))."&nbsp;</td>\n";
 		echo "	<td>".(round(escape($row['avg_min']),2))."&nbsp;/&nbsp;".(round(escape($row['cpm_ans']),2))."&nbsp;</td>\n";
-		echo "	<td class='center'><a href=\"xml_cdr.php?missed=true&direction=$direction&start_epoch=".escape($row['start_epoch'])."&stop_epoch=".escape($row['stop_epoch'])."\">".escape($row['missed'])."</a>&nbsp;</td>\n";
+		echo "	<td class='center'><a href=\"xml_cdr.php?call_result=missed&direction=$direction&start_epoch=".escape($row['start_epoch'])."&stop_epoch=".escape($row['stop_epoch'])."\">".escape($row['missed'])."</a>&nbsp;</td>\n";
 		echo "	<td>".(round(escape($row['asr']),2))."&nbsp;</td>\n";
 		echo "	<td>".(round(escape($row['aloc']),2))."&nbsp;</td>\n";
 		echo "</tr >\n";

--- a/app/xml_cdr/xml_cdr_statistics_inc.php
+++ b/app/xml_cdr/xml_cdr_statistics_inc.php
@@ -280,6 +280,10 @@
 		$sql_where_ands[] = "leg = :leg";
 		$parameters['leg'] = $leg;
 	}
+	//If you can't see lose_race, don't run stats on it
+	if (!permission_exists('xml_cdr_lose_race')) {
+		$sql_where_ands[] = "hangup_cause != 'LOSE_RACE'";
+	}
 
 	//if not admin or superadmin, only show own calls
 	if (!permission_exists('xml_cdr_domain')) {


### PR DESCRIPTION
Simple change to exclude lose_race and fix a URL change for the xml_cdr page.