### PR TITLE
Fix outbound and some duplicate cdr records being marked as missed

### DIFF
--- a/app/xml_cdr/resources/classes/xml_cdr.php
+++ b/app/xml_cdr/resources/classes/xml_cdr.php
@@ -316,7 +316,7 @@ if (!class_exists('xml_cdr')) {
 
 					//set missed calls
 						$missed_call = 'false';
-						if (strlen($xml->variables->answer_stamp) == 0) {
+						if ($xml->variables->call_direction != 'outbound' && strlen($xml->variables->answer_stamp) == 0) {
 							$missed_call = 'true';
 						}
 						if ($xml->variables->missed_call == 'true') {
@@ -340,6 +340,7 @@ if (!class_exists('xml_cdr')) {
 						//$this->array[$key]['digits_dialed'] = urldecode($xml->variables->digits_dialed);
 						$this->array[$key]['sip_hangup_disposition'] = urldecode($xml->variables->sip_hangup_disposition);
 						$this->array[$key]['pin_number'] = urldecode($xml->variables->pin_number);
+						$this->array[$key]['originating_leg_uuid'] = urldecode($xml->variables->originating_leg_uuid);
 
 					//time
 						$this->array[$key]['start_epoch'] = urldecode($xml->variables->start_epoch);

--- a/app/xml_cdr/resources/classes/xml_cdr.php
+++ b/app/xml_cdr/resources/classes/xml_cdr.php
@@ -340,7 +340,6 @@ if (!class_exists('xml_cdr')) {
 						//$this->array[$key]['digits_dialed'] = urldecode($xml->variables->digits_dialed);
 						$this->array[$key]['sip_hangup_disposition'] = urldecode($xml->variables->sip_hangup_disposition);
 						$this->array[$key]['pin_number'] = urldecode($xml->variables->pin_number);
-						$this->array[$key]['originating_leg_uuid'] = urldecode($xml->variables->originating_leg_uuid);
 
 					//time
 						$this->array[$key]['start_epoch'] = urldecode($xml->variables->start_epoch);

--- a/app/xml_cdr/resources/classes/xml_cdr.php
+++ b/app/xml_cdr/resources/classes/xml_cdr.php
@@ -316,7 +316,7 @@ if (!class_exists('xml_cdr')) {
 
 					//set missed calls
 						$missed_call = 'false';
-						if ($xml->variables->call_direction != 'outbound' && strlen($xml->variables->answer_stamp) == 0) {
+						if (strlen($xml->variables->originating_leg_uuid) == 0 && $xml->variables->call_direction != 'outbound' && strlen($xml->variables->answer_stamp) == 0) {
 							$missed_call = 'true';
 						}
 						if ($xml->variables->missed_call == 'true') {


### PR DESCRIPTION
Outbound calls that weren't answered were being marked with missed_call=true
This should filter them out so we can trust the missed_call column a little more in the database.

Also added the same "missed call" fix for calls that are using enterprise ring groups so that missed calls to an enterprise ring group aren't counted multiple times because all legs of an Enterprise Ring Group have an "originating_leg_uuid" variable that isn't present elsewhere.

If anyone knows how to run SQL queries on the xml_cdr json column, could you do some queries to find out if there are any other call types that include the "originating_leg_uuid" variable?

If you don't like this method, we could alternatively update the xml_cdr app code to make the various missed call search/filters/statistics to exclude the "outbound" and Enterprise ring group legs.

To retroactively fix the CDRs, I think that something like UPDATE v_xml_cdr SET missed_call = false WHERE direction = 'outbound' because I don't think any call with a direction of 'outbound' should count as missed. For the enterprise ring group legs, the retroactive fix would requiring querying the "json" column, which I know lots of people clear out in their maintenance scripts so isn't really possible for lots of people. I'm considering adding it to the v_xml_cdr table during import in the future.

Remaining CDR Anomalies:

- Follow Me: A single external follow me destination makes the CDR show up as and "outbound" call. There is no separate entry for the inbound call. If there is more than one follow me destination, even if all of the destinations are external, the CDR shows a single entry with the direction = inbound.