### PR TITLE
Fix device MAC address imports not normalizing.

### DIFF
--- a/app/devices/device_imports.php
+++ b/app/devices/device_imports.php
@@ -291,6 +291,12 @@
 										$result[$key] = preg_replace('{\D}', '', $result[$key]);
 									}
 
+									//normalize the MAC address
+									if ($field_name == "device_mac_address") {
+										$result[$key] = strtolower($result[$key]);
+										$result[$key] = preg_replace('#[^a-fA-F0-9./]#', '', $result[$key]);
+									}
+
 									//build the data array
 									if (strlen($table_name) > 0) {
 										if (strlen($parent) == 0) {


### PR DESCRIPTION
# Context
MAC addresses were not being normalized when importing CSV files. If it is not normalized you can get a not found error when provisioning since that is checking the database with a normalized MAC address

# Overview
- Use the same normalization done in device_edit.php in device_imports.php