### PR TITLE
Improved Missed Call accuracy, cdr statistics, and hide duplicated CDRs from Enterprise Ring Groups

### DIFF
--- a/app/scripts/resources/scripts/app/voicemail/resources/functions/record_message.lua
+++ b/app/scripts/resources/scripts/app/voicemail/resources/functions/record_message.lua
@@ -587,7 +587,7 @@
 
 		--if the recording is below the minimal length then re-record the message
 			if (message_length > 2) then
-				--continue
+				session:setVariable("voicemail_message_seconds", message_length);
 			else
 				if (session:ready()) then
 					--your recording is below the minimal acceptable length, please try again

--- a/app/xml_cdr/app_config.php
+++ b/app/xml_cdr/app_config.php
@@ -564,6 +564,12 @@
 		$apps[$x]['db'][$y]['fields'][$z]['type'] = "text";
 		$apps[$x]['db'][$y]['fields'][$z]['description']['en-us'] = "Save the last application data.";
 		$z++;
+		$apps[$x]['db'][$y]['fields'][$z]['name'] = "voicemail_message";
+		$apps[$x]['db'][$y]['fields'][$z]['type']['pgsql'] = "boolean";
+		$apps[$x]['db'][$y]['fields'][$z]['type']['sqlite'] = "text";
+		$apps[$x]['db'][$y]['fields'][$z]['type']['mysql'] = "text";
+		$apps[$x]['db'][$y]['fields'][$z]['description']['en-us'] = "";
+		$z++;
 		$apps[$x]['db'][$y]['fields'][$z]['name'] = "missed_call";
 		$apps[$x]['db'][$y]['fields'][$z]['type']['pgsql'] = "boolean";
 		$apps[$x]['db'][$y]['fields'][$z]['type']['sqlite'] = "text";

--- a/app/xml_cdr/app_config.php
+++ b/app/xml_cdr/app_config.php
@@ -197,6 +197,9 @@
 		$apps[$x]['permissions'][$y]['name'] = "xml_cdr_lose_race";
 		$apps[$x]['permissions'][$y]['groups'][] = "superadmin";
 		$y++;
+		$apps[$x]['permissions'][$y]['name'] = "xml_cdr_enterprise_leg";
+		$apps[$x]['permissions'][$y]['groups'][] = "superadmin";
+		$y++;
 		$apps[$x]['permissions'][$y]['name'] = "xml_cdr_cc_agent_leg";
 		$apps[$x]['permissions'][$y]['groups'][] = "superadmin";
 		$y++;
@@ -536,6 +539,12 @@
 		$apps[$x]['db'][$y]['fields'][$z]['type']['sqlite'] = "text";
 		$apps[$x]['db'][$y]['fields'][$z]['type']['mysql'] = "char(1)";
 		$apps[$x]['db'][$y]['fields'][$z]['description']['en-us'] = "The leg of the call a or b.";
+		$z++;
+		$apps[$x]['db'][$y]['fields'][$z]['name'] = "originating_leg_uuid";
+		$apps[$x]['db'][$y]['fields'][$z]['type']['pgsql'] = "uuid";
+		$apps[$x]['db'][$y]['fields'][$z]['type']['sqlite'] = "text";
+		$apps[$x]['db'][$y]['fields'][$z]['type']['mysql'] = "char(36)";
+		$apps[$x]['db'][$y]['fields'][$z]['description']['en-us'] = "Originating Leg UUID. Used to identify legs of an enterprise ring group - and exclude them ";
 		$z++;
 		$apps[$x]['db'][$y]['fields'][$z]['name'] = "pdd_ms";
 		$apps[$x]['db'][$y]['fields'][$z]['type']['pgsql'] = "numeric";

--- a/app/xml_cdr/resources/classes/xml_cdr.php
+++ b/app/xml_cdr/resources/classes/xml_cdr.php
@@ -317,7 +317,7 @@ if (!class_exists('xml_cdr')) {
 
 					//set missed calls
 						$missed_call = 'false';
-						if (strlen($xml->variables->originating_leg_uuid) == 0 && $xml->variables->call_direction != 'outbound' && strlen($xml->variables->answer_stamp) == 0) {
+						if ($xml->variables->cc_side != "agent" && strlen($xml->variables->originating_leg_uuid) == 0 && $xml->variables->call_direction != 'outbound' && strlen($xml->variables->answer_stamp) == 0) {
 							$missed_call = 'true';
 						}
 						if ($xml->variables->missed_call == 'true') {

--- a/app/xml_cdr/resources/classes/xml_cdr.php
+++ b/app/xml_cdr/resources/classes/xml_cdr.php
@@ -145,6 +145,7 @@ if (!class_exists('xml_cdr')) {
 			$this->fields[] = "record_path";
 			$this->fields[] = "record_name";
 			$this->fields[] = "leg";
+			$this->fields[] = "originating_leg_uuid";
 			$this->fields[] = "pdd_ms";
 			$this->fields[] = "rtp_audio_in_mos";
 			$this->fields[] = "last_app";
@@ -316,7 +317,7 @@ if (!class_exists('xml_cdr')) {
 
 					//set missed calls
 						$missed_call = 'false';
-						if (strlen($xml->variables->answer_stamp) == 0) {
+						if (strlen($xml->variables->originating_leg_uuid) == 0 && $xml->variables->call_direction != 'outbound' && strlen($xml->variables->answer_stamp) == 0) {
 							$missed_call = 'true';
 						}
 						if ($xml->variables->missed_call == 'true') {
@@ -404,6 +405,9 @@ if (!class_exists('xml_cdr')) {
 					//store the call leg
 						$this->array[$key]['leg'] = $leg;
 
+					//store the originating leg uuid
+						$this->array[$key]['originating_leg_uuid'] = urldecode($xml->variables->originating_leg_uuid);
+
 					//store post dial delay, in milliseconds
 						$this->array[$key]['pdd_ms'] = urldecode($xml->variables->progress_mediamsec) + urldecode($xml->variables->progressmsec);
 
@@ -430,7 +434,7 @@ if (!class_exists('xml_cdr')) {
 						if (strlen($domain_name) == 0) {
 							$presence_id = urldecode($xml->variables->presence_id);
 							if (strlen($presence_id) > 0) {
-								$presence_array = explode($presence_id);
+								$presence_array = explode($presence_id, '%40');
 								$domain_name = $presence_array[1];
 							}
 						}
@@ -1210,7 +1214,7 @@ if (!class_exists('xml_cdr')) {
 				// If the range starts with an '-' we start from the beginning
 				// If not, we forward the file pointer
 				// And make sure to get the end byte if spesified
-				if ($range0 == '-') {
+				if ($range == '-') {
 					// The n-number of the last bytes is requested
 					$c_start = $size - substr($range, 1);
 				}

--- a/app/xml_cdr/resources/classes/xml_cdr.php
+++ b/app/xml_cdr/resources/classes/xml_cdr.php
@@ -973,7 +973,10 @@ if (!class_exists('xml_cdr')) {
 				$sql .= "filter ( \n";
 				$sql .= " where c.extension_uuid = e.extension_uuid \n";
 				$sql .= " and missed_call = true \n";
-				if (!permission_exists('xml_cdr_lose_race')) {
+				if (!permission_exists('xml_cdr_enterprise_leg')) {
+					$sql .= " and originating_leg_uuid is null \n";
+				}
+				elseif (!permission_exists('xml_cdr_lose_race')) {
 					$sql .= " and hangup_cause <> 'LOSE_RACE' \n";
 				}
 				if ($this->include_internal) {
@@ -1029,7 +1032,10 @@ if (!class_exists('xml_cdr')) {
 				$sql .= "count(*) \n";
 				$sql .= "filter ( \n";
 				$sql .= " where c.extension_uuid = e.extension_uuid \n";
-				if (!permission_exists('xml_cdr_lose_race')) {
+				if (!permission_exists('xml_cdr_enterprise_leg')) {
+					$sql .= " and originating_leg_uuid is null \n";
+				}
+				elseif (!permission_exists('xml_cdr_lose_race')) {
 					$sql .= " and hangup_cause <> 'LOSE_RACE' \n";
 				}
 				if ($this->include_internal) {

--- a/app/xml_cdr/v_xml_cdr_import.php
+++ b/app/xml_cdr/v_xml_cdr_import.php
@@ -198,6 +198,14 @@
 			$database->fields['last_app'] = urldecode($xml->variables->last_app);
 			$database->fields['last_arg'] = urldecode($xml->variables->last_arg);
 
+		//voicemail message success
+			if ($xml->variables->voicemail_action == "save" && $xml->variables->voicemail_message_seconds > 0){
+				$database->fields['voicemail_message'] = "true";
+			}
+			elseif ($xml->variables->voicemail_action == "save") {
+				$database->fields['voicemail_message'] = "false";
+			}
+
 		//conference
 			$database->fields['conference_name'] = urldecode($xml->variables->conference_name);
 			$database->fields['conference_uuid'] = urldecode($xml->variables->conference_uuid);

--- a/app/xml_cdr/v_xml_cdr_import.php
+++ b/app/xml_cdr/v_xml_cdr_import.php
@@ -211,7 +211,7 @@
 
 		//set missed calls
 			$database->fields['missed_call'] = 'false';
-			if (strlen($xml->variables->originating_leg_uuid) == 0 && $xml->variables->call_direction != 'outbound' && strlen($xml->variables->answer_stamp) == 0) {
+			if ($xml->variables->cc_side != "agent" && strlen($xml->variables->originating_leg_uuid) == 0 && $xml->variables->call_direction != 'outbound' && strlen($xml->variables->answer_stamp) == 0) {
 				$database->fields['missed_call'] = 'true';
 			}
 			if ($xml->variables->missed_call == 'true') {

--- a/app/xml_cdr/v_xml_cdr_import.php
+++ b/app/xml_cdr/v_xml_cdr_import.php
@@ -265,6 +265,9 @@
 
 		//store the call leg
 			$database->fields['leg'] = $leg;
+		
+		//store the originating leg
+			$database->fields['originating_leg_uuid'] = urldecode($xml->variables->originating_leg_uuid);
 
 		//store post dial delay, in milliseconds
 			$database->fields['pdd_ms'] = urldecode($xml->variables->progress_mediamsec) + urldecode($xml->variables->progressmsec);
@@ -292,7 +295,7 @@
 			if (strlen($domain_name) == 0) {
 				$presence_id = urldecode($xml->variables->presence_id);
 				if (strlen($presence_id) > 0) {
-					$presence_array = explode($presence_id);
+					$presence_array = explode($presence_id, '%40');
 					$domain_name = $presence_array[1];
 				}
 			}

--- a/app/xml_cdr/v_xml_cdr_import.php
+++ b/app/xml_cdr/v_xml_cdr_import.php
@@ -211,7 +211,7 @@
 
 		//set missed calls
 			$database->fields['missed_call'] = 'false';
-			if (strlen($xml->variables->answer_stamp) == 0) {
+			if (strlen($xml->variables->originating_leg_uuid) == 0 && $xml->variables->call_direction != 'outbound' && strlen($xml->variables->answer_stamp) == 0) {
 				$database->fields['missed_call'] = 'true';
 			}
 			if ($xml->variables->missed_call == 'true') {
@@ -265,9 +265,6 @@
 
 		//store the call leg
 			$database->fields['leg'] = $leg;
-		
-		//store the originating leg
-			$database->fields['originating_leg_uuid'] = urldecode($xml->variables->originating_leg_uuid);
 
 		//store post dial delay, in milliseconds
 			$database->fields['pdd_ms'] = urldecode($xml->variables->progress_mediamsec) + urldecode($xml->variables->progressmsec);

--- a/app/xml_cdr/xml_cdr.php
+++ b/app/xml_cdr/xml_cdr.php
@@ -823,10 +823,6 @@
 					}
 
 					$content .= "</tr>\n";
-				//show agent originated legs only to those with the permission
-					if (!permission_exists('xml_cdr_cc_agent_leg') && $row['cc_side'] == "agent") {
-						$content = '';
-					}
 				//show the leg b only to those with the permission
 					if ($row['leg'] == 'a') {
 						echo $content;

--- a/app/xml_cdr/xml_cdr.php
+++ b/app/xml_cdr/xml_cdr.php
@@ -823,7 +823,10 @@
 					}
 
 					$content .= "</tr>\n";
-
+				//show agent originated legs only to those with the permission
+					if (!permission_exists('xml_cdr_cc_agent_leg') && $row['cc_side'] == "agent") {
+						$content = '';
+					}
 				//show the leg b only to those with the permission
 					if ($row['leg'] == 'a') {
 						echo $content;

--- a/app/xml_cdr/xml_cdr.php
+++ b/app/xml_cdr/xml_cdr.php
@@ -796,7 +796,7 @@
 					}
 				//tta (time to answer)
 					if (permission_exists('xml_cdr_tta')) {
-						$content .= "	<td class='middle right hide-md-dn'>".(($row['tta'] > 0) ? $row['tta']."s" : "&nbsp;")."</td>\n";
+						$content .= "	<td class='middle right hide-md-dn'>".(($row['tta'] >= 0) ? $row['tta']."s" : "&nbsp;")."</td>\n";
 					}
 				//duration
 					if (permission_exists('xml_cdr_duration')) {

--- a/app/xml_cdr/xml_cdr.php
+++ b/app/xml_cdr/xml_cdr.php
@@ -824,13 +824,6 @@
 
 					$content .= "</tr>\n";
 
-					if (!permission_exists('xml_cdr_lose_race') && $row['hangup_cause'] == 'LOSE_RACE') {
-						$content = '';
-					}
-				//show agent originated legs only to those with the permission
-					if (!permission_exists('xml_cdr_cc_agent_leg') && $row['cc_side'] == "agent") {
-						$content = '';
-					}
 				//show the leg b only to those with the permission
 					if ($row['leg'] == 'a') {
 						echo $content;

--- a/app/xml_cdr/xml_cdr_export.php
+++ b/app/xml_cdr/xml_cdr_export.php
@@ -192,7 +192,7 @@
 				$data_body[$p] .= '<td>'.format_phone($fields['destination_number']).'</td>';
 				$data_body[$p] .= '<td>'.$fields['start_stamp'].'</td>';
 				$total['tta'] += ($fields['tta'] > 0) ? $fields['tta'] : 0;
-				$data_body[$p] .= '<td align="right">'.(($fields['tta'] > 0) ? $fields['tta'].'s' : null).'</td>';
+				$data_body[$p] .= '<td align="right">'.(($fields['tta'] >= 0) ? $fields['tta'].'s' : null).'</td>';
 				$seconds = ($fields['hangup_cause'] == "ORIGINATOR_CANCEL") ? $fields['duration'] : round(($fields['billmsec'] / 1000), 0, PHP_ROUND_HALF_UP);
 				$total['duration'] += $seconds;
 				$data_body[$p] .= '<td align="right">'.gmdate("G:i:s", $seconds).'</td>';

--- a/app/xml_cdr/xml_cdr_inc.php
+++ b/app/xml_cdr/xml_cdr_inc.php
@@ -413,9 +413,12 @@
 		$sql .= "and billsec like :billsec ";
 		$parameters['billsec'] = '%'.$billsec.'%';
 	}
-	if (strlen($hangup_cause) > 0) {
+	if (strlen($hangup_cause) > 0 && $hangup_cause != 'LOSE_RACE') {
 		$sql .= "and hangup_cause like :hangup_cause ";
 		$parameters['hangup_cause'] = '%'.$hangup_cause.'%';
+	}
+	elseif (!permission_exists('xml_cdr_lose_race')) {
+		$sql .= "and hangup_cause != 'LOSE_RACE' ";
 	}
 	if (strlen($call_result) > 0) {
 		switch ($call_result) {
@@ -491,6 +494,10 @@
 		$sql .= "and leg = :leg ";
 		$parameters['leg'] = $leg;
 	}
+	//exclude enterprise ring group legs
+	if (!permission_exists('xml_cdr_enterprise_leg')) {
+		$sql .= "and originating_leg_uuid IS NULL ";
+	}
 	if (is_numeric($tta_min)) {
 		$sql .= "and (c.answer_epoch - c.start_epoch) >= :tta_min ";
 		$parameters['tta_min'] = $tta_min;
@@ -506,6 +513,10 @@
 		if ($recording == 'false') {
 			$sql .= "and (c.record_path is null or c.record_name is null) ";
 		}
+	}
+	//show agent originated legs only to those with the permission
+	if (!permission_exists('xml_cdr_cc_agent_leg')) {
+		$sql .= "and cc_side != 'agent' ";
 	}
 	//end where
 	if (strlen($order_by) > 0) {

--- a/app/xml_cdr/xml_cdr_inc.php
+++ b/app/xml_cdr/xml_cdr_inc.php
@@ -453,7 +453,8 @@
 						))";
 				}
 				break;
-			default: //failed
+			default: 
+			    $sql .= "and (answer_stamp is null and bridge_uuid is null and duration = 0) ";
 				//$sql .= "and (answer_stamp is null and bridge_uuid is null and billsec = 0 and sip_hangup_disposition = 'send_refuse') ";
 		}
 	}

--- a/app/xml_cdr/xml_cdr_inc.php
+++ b/app/xml_cdr/xml_cdr_inc.php
@@ -417,7 +417,7 @@
 		$sql .= "and hangup_cause like :hangup_cause ";
 		$parameters['hangup_cause'] = '%'.$hangup_cause.'%';
 	}
-	elseif (!permission_exists('xml_cdr_lose_race') && permission_exists('xml_cdr_enterprise_leg')) {
+	elseif (!permission_exists('xml_cdr_lose_race') && !permission_exists('xml_cdr_enterprise_leg')) {
 		$sql .= "and hangup_cause != 'LOSE_RACE' ";
 	}
 	//exclude enterprise ring group legs
@@ -437,10 +437,20 @@
 				break;
 			case 'cancelled':
 				if ($direction == 'inbound' || $direction == 'local' || $call_result == 'missed') {
-					$sql = "and (answer_stamp is null and bridge_uuid is null and sip_hangup_disposition <> 'send_refuse') ";
+					$sql .= "
+						and ((
+							answer_stamp is null 
+							and bridge_uuid is null 
+							and sip_hangup_disposition <> 'send_refuse'
+						)
+						or (
+							answer_stamp is not null 
+							and bridge_uuid is null 
+							and voicemail_message = false
+						))";
 				}
 				else if ($direction == 'outbound') {
-					$sql = "and (answer_stamp is null and bridge_uuid is not null) ";
+					$sql .= "and (answer_stamp is null and bridge_uuid is not null) ";
 				}
 				else {
 					$sql .= "
@@ -454,6 +464,12 @@
 							direction = 'outbound'
 							and answer_stamp is null
 							and bridge_uuid is not null
+						)
+						or (
+							(direction = 'inbound' or direction = 'local')
+							and answer_stamp is not null
+							and bridge_uuid is null
+							and voicemail_message = false
 						))";
 				}
 				break;

--- a/app/xml_cdr/xml_cdr_inc.php
+++ b/app/xml_cdr/xml_cdr_inc.php
@@ -413,7 +413,7 @@
 		$sql .= "and billsec like :billsec ";
 		$parameters['billsec'] = '%'.$billsec.'%';
 	}
-	if (strlen($hangup_cause) > 0 && $hangup_cause != 'LOSE_RACE') {
+	if (strlen($hangup_cause) > 0) {
 		$sql .= "and hangup_cause like :hangup_cause ";
 		$parameters['hangup_cause'] = '%'.$hangup_cause.'%';
 	}
@@ -514,10 +514,6 @@
 		if ($recording == 'false') {
 			$sql .= "and (c.record_path is null or c.record_name is null) ";
 		}
-	}
-	//show agent originated legs only to those with the permission
-	if (!permission_exists('xml_cdr_cc_agent_leg')) {
-		$sql .= "and cc_side != 'agent' ";
 	}
 	//end where
 	if (strlen($order_by) > 0) {

--- a/app/xml_cdr/xml_cdr_inc.php
+++ b/app/xml_cdr/xml_cdr_inc.php
@@ -515,6 +515,10 @@
 			$sql .= "and (c.record_path is null or c.record_name is null) ";
 		}
 	}
+	//show agent originated legs only to those with the permission
+	if (!permission_exists('xml_cdr_cc_agent_leg')) {
+		$sql .= "and (cc_side is null or cc_side != 'agent') ";
+	}
 	//end where
 	if (strlen($order_by) > 0) {
 		$sql .= order_by($order_by, $order);

--- a/app/xml_cdr/xml_cdr_inc.php
+++ b/app/xml_cdr/xml_cdr_inc.php
@@ -417,8 +417,12 @@
 		$sql .= "and hangup_cause like :hangup_cause ";
 		$parameters['hangup_cause'] = '%'.$hangup_cause.'%';
 	}
-	elseif (!permission_exists('xml_cdr_lose_race')) {
+	elseif (!permission_exists('xml_cdr_lose_race') && permission_exists('xml_cdr_enterprise_leg')) {
 		$sql .= "and hangup_cause != 'LOSE_RACE' ";
+	}
+	//exclude enterprise ring group legs
+	if (!permission_exists('xml_cdr_enterprise_leg')) {
+		$sql .= "and originating_leg_uuid IS NULL ";
 	}
 	if (strlen($call_result) > 0) {
 		switch ($call_result) {
@@ -494,10 +498,6 @@
 	if (strlen($leg) > 0) {
 		$sql .= "and leg = :leg ";
 		$parameters['leg'] = $leg;
-	}
-	//exclude enterprise ring group legs
-	if (!permission_exists('xml_cdr_enterprise_leg')) {
-		$sql .= "and originating_leg_uuid IS NULL ";
 	}
 	if (is_numeric($tta_min)) {
 		$sql .= "and (c.answer_epoch - c.start_epoch) >= :tta_min ";

--- a/app/xml_cdr/xml_cdr_statistics_inc.php
+++ b/app/xml_cdr/xml_cdr_statistics_inc.php
@@ -153,7 +153,7 @@
 		$parameters['domain_uuid'] = $_SESSION['domain_uuid'];
 	}
 	if ($missed == true) {
-		$sql_where_ands[] = "billsec = '0'";
+		$sql_where_ands[] = "missed_call = true ";
 	}
 	if (strlen($start_epoch) > 0 && strlen($stop_epoch) > 0) {
 		$sql_where_ands[] = "start_epoch between :start_epoch and :stop_epoch";
@@ -284,6 +284,11 @@
 	if (!permission_exists('xml_cdr_lose_race')) {
 		$sql_where_ands[] = "hangup_cause != 'LOSE_RACE'";
 	}
+	//Exclude enterprise ring group legs
+	if (!permission_exists('xml_cdr_enterprise_leg')) {
+		$sql_where_ands[] .= "originating_leg_uuid IS NULL";
+	}
+	
 
 	//if not admin or superadmin, only show own calls
 	if (!permission_exists('xml_cdr_domain')) {
@@ -349,7 +354,7 @@
 
 //get the call volume between a start end end time in seconds
 	function get_call_volume_between($start, $end, $where, $parameters) {
-		$sql = "select count(*) as count, sum(billsec) as seconds from v_xml_cdr ";
+		$sql = "select count(*) as count, sum(billsec) as seconds, sum(answer_stamp - start_stamp) as tta from v_xml_cdr ";
 		$sql .= $where." ";
 		$sql .= "start_epoch between :start and :end ";
 		$parameters['start'] = $start;
@@ -360,6 +365,7 @@
 			return array(
 				'volume' => $row['count'],
 				'seconds' => $row['seconds'],
+				'tta' => $row['tta'],
 			);
 		}
 		return false;
@@ -379,14 +385,13 @@
 		$stats[$i]['volume'] = $stat_range ? $stat_range['volume'] : 0;
 		$stats[$i]['seconds'] = $stat_range ? $stat_range['seconds'] : 0;
 		$stats[$i]['minutes'] = $stats[$i]['seconds'] / 60;
-		$stats[$i]['avg_sec'] = $stats[$i]['volume'] == 0 ? 0 : $stats[$i]['seconds'] / $stats[$i]['volume'];
 
 		if ($missed) {
 			//we select only missed calls at first place - no reasons to select it again
 			$stats[$i]['missed'] = $stats[$i]['volume'];
 		}
 		else {
-			$where = $sql_where."billsec = '0' and ";
+			$where = $sql_where."missed_call = true and ";
 			$stat_range = get_call_volume_between($stats[$i]['start_epoch'], $stats[$i]['stop_epoch'], $where, $parameters);
 			$stats[$i]['missed'] = $stat_range ? $stat_range['volume'] : 0;
 		}
@@ -402,6 +407,9 @@
 
 		//answer / seizure ratio
 		$stats[$i]['asr'] = $stats[$i]['volume'] == 0 ? 0 : ($success_volume / $stats[$i]['volume'] * 100);
+
+		//average time to answer
+		$stats[$i]['avg_tta'] = $stats[$i]['volume'] == 0 ? 0 : round($stat_range['tta'] / $success_volume);
 
 		//average length of call
 		$stats[$i]['aloc'] = $success_volume == 0 ? 0 : $stats[$i]['minutes'] / $success_volume;

--- a/app/xml_cdr/xml_cdr_statistics_inc.php
+++ b/app/xml_cdr/xml_cdr_statistics_inc.php
@@ -280,13 +280,13 @@
 		$sql_where_ands[] = "leg = :leg";
 		$parameters['leg'] = $leg;
 	}
-	//If you can't see lose_race, don't run stats on it
-	if (!permission_exists('xml_cdr_lose_race')) {
-		$sql_where_ands[] = "hangup_cause != 'LOSE_RACE'";
-	}
 	//Exclude enterprise ring group legs
 	if (!permission_exists('xml_cdr_enterprise_leg')) {
 		$sql_where_ands[] .= "originating_leg_uuid IS NULL";
+	}
+	//If you can't see lose_race, don't run stats on it
+	elseif (!permission_exists('xml_cdr_lose_race')) {
+		$sql_where_ands[] = "hangup_cause != 'LOSE_RACE'";
 	}
 	
 


### PR DESCRIPTION
Purpose
----------
I have been getting clients wanting statistics on their calls and useful reports, but when we try to explain and validate the results of the CDR page and the CDR statistics page, I always come up short because the stats are just not accurate and broken in many ways. This is round 1 of improving this accuracy, making it more useful, and filtering out the remaining "chaff" that has no use except to clutter our views in the CDR and throw off missed call and volume statistics. I dug around with using external reporting tools, but 90% of the work is already there in fusionpbx.

Changes
-----------
  - Improve CDR Import Logic so that missed_call column is more accurate to the "missed" status. It would previously mark unanswered outbound calls as "missed", but they can be be more accurately filtered for by selecting Call status "Cancelled" and direction "Outbound".
  - Don't mark the CDRs of the "legs" of an Enterprise Ring Group call as missed, only the originating_leg will be marked (one missed call per call) - We could also just "skip" importing these call legs. Simultaneous ring groups don't have these duplicated CDRs for every ringing phone and are fine without them. The "Skip" approach might make most of the rest of this work irrelevant. The only benefit of having them is really for diagnostics.
  - Create `originating_leg_uuid` column in v_xml_cdr and import it into the database during CDR imports so it is available for filtering Enterprise Ring Group calls out of CDRs and reports.
  - Create `voicemail_message` boolean column in v_xml_cdr and a voicemail_message_seconds channel variable in voicemail lua app. On CDR import, voicemail_message is set to true if voicemail answered but a message was left, and false if the caller hung up before leaving a message.
  - If Voicemail answers, but the caller hangs up without leaving a message that call shows up in the "Cancelled" filter
  - Move logic that hides the agent leg of CC calls, LOSE_RACE calls, and the Enterprise Leg  from xml_cdr.php into xml_cdr_inc.php in the SQL query WHERE clause so the CDR page looks more consistent. The logic is the same, but these calls are now excluded from the query result entirely instead of having to "skip" rendering them in the list on the xml_cdr.php page.
  - Improved CDR statistics page to use the missed_call variable instead of relying upon billsec and answer_stamp/answer_epoch. Added the same logic as the xml_cdr pages to the query so it excludes enterprise ring group call legs.
  - Fixed a display bug for TTA in xml_cdr.php
  - Reimplemented the "Failed" Call status so it actually works to search the database
  - Laid the query groundwork in xml_cdr_statistics to report on Average TTA (No UI changes yet to include that statistic)

Retroactive Change Applications
-----------------------------------
There are a few changes going back in time to bring everything in line with this better reporting accuracy:
  - If you want to populate the `originating_leg_uuid column` in `v_xml_cdr` for calls prior to this update, it will rely upon having the `json` column and not having deleted the data from it like I know some people do for space saving (including me).
  - If you don't have the json column,  you are mostly out of luck for hiding the duplicate legs of Enterprise ring group calls historically. It might be possible, but it isn't going to be easy.
  - On Newer Versions of postgres, this works (I tested it on 13):
```
UPDATE v_xml_cdr SET originating_leg_uuid = (json->'variables'->>'originating_leg_uuid')::uuid WHERE json->'variables'->>'originating_leg_uuid' IS NOT NULL;
```
  - For some reason on postgres 9.4, I had to UPDATE every single record because I couldn't get it to allow the json syntax properly after the WHERE. This is fine, it doesn't change the end result it just means it has to run the UPDATE on every record, which will take a while
```
UPDATE v_xml_cdr SET originating_leg_uuid = (json->'variables'->>'originating_leg_uuid')::uuid;
```  
- To remove the `missed_call = true` on all your previous originating_leg/lose_race calls after they have had their leg column imported. If you don't have the json column you just can't trust your missed_call statistics for a while.
```
UPDATE v_xml_cdr SET missed_call = false WHERE originating_leg_uuid IS NOT NULL;
```
  - To remove the `missed_call = true` on all your previous outbound records so that they don't show up when you filter on missed (outbound unanswered calls can be accurately listed with TTA max 0 and direction outbound)
```
UPDATE v_xml_cdr SET missed_call = false WHERE direction = 'outbound' AND missed_call = true;
```



Future Improvements
-----------------------
There is still some work to do to make everything accurate and more useful. I haven't touched the extension summary yet, but it should benefit from some of this work already. I am also going to make a few minor feature improvements to the cdr statistics page such as including the average TTA like in the PDF export.
  - Bug 1: I still know about in the call detail records is with Follow Me. If an extension has follow me enabled and only has a single external destination, the CDR shows up as "outbound" even if the original caller was an external caller dialing the DID. If you add multiple Follow Me destinations, the CDR shows up as inbound as expected, even if all destinations are external numbers.
  - Bug 2: Extension Summary counts calls directly to voicemail as "missed" for the caller on internal calls. If 425 dials *99426, the extension summary seems to count that as a "missed" call for 425.
  - Bug 3: Calls that were put on park and picked up display their caller ID name in the CDR list prefixed by PARK