### PR TITLE
Update messages.php

### DIFF
--- a/resources/classes/messages.php
+++ b/resources/classes/messages.php
@@ -46,7 +46,9 @@ if (!class_exists('messages')) {
 				foreach ($_SESSION['messages'] as $message_mood => $message) {
 					$message_text = str_replace(array("\r\n", "\n", "\r"),'\\n',addslashes(join('<br/>', $message['message'])));
 					$message_delay = array_sum($message['delay'])/count($message['delay']);
-					$html .= "${spacer}display_message('$message_text', '$message_mood', '$message_delay');\n";
+					if(!is_array($message['message'][0])) {
+						$html .= "${spacer}display_message('$message_text', '$message_mood', '$message_delay');\n";
+					}
 				}
 			}
 			if($clear_messages) {


### PR DESCRIPTION
Somehow an array is getting passed into the first element of $message['message'].  I didn't have time to fully debug why this is happening.  Considering 1) this was causing the following warning and in turn breaking the domain select functionality, and 2) the master branch doesn't include this file anymore, I'm hoping that is enough to include this patch.

Warning: strlen() expects parameter 1 to be string, array given in /var/www/fusionpbx/resources/classes/messages.php on line 32