### PR TITLE
Grandstream: Hide BLF Remote Status And More Distinctive Ring

### DIFF
--- a/app/grandstream/app_config.php
+++ b/app/grandstream/app_config.php
@@ -422,6 +422,14 @@
 		$apps[$x]['default_settings'][$y]['default_setting_enabled'] = "true";
 		$apps[$x]['default_settings'][$y]['default_setting_description'] = "BLF Call-pickup. 0 - Auto, 1 - Force BLF Call-pickup by prefix, 2 - Disabled. Default is 0";
 		$y++;
+		$apps[$x]['default_settings'][$y]['default_setting_uuid'] = "53a9f955-d199-44f5-a97d-eed636348da5";
+		$apps[$x]['default_settings'][$y]['default_setting_category'] = "provision";
+		$apps[$x]['default_settings'][$y]['default_setting_subcategory'] = "grandstream_blf_remote_status";
+		$apps[$x]['default_settings'][$y]['default_setting_name'] = "numeric";
+		$apps[$x]['default_settings'][$y]['default_setting_value'] = "0";
+		$apps[$x]['default_settings'][$y]['default_setting_enabled'] = "true";
+		$apps[$x]['default_settings'][$y]['default_setting_description'] = "Hide BLF Remote Status. Default 0 - Not hidden, 1 - Hidden";
+		$y++;
 		$apps[$x]['default_settings'][$y]['default_setting_uuid'] = "09ed1352-2594-4eb8-b3f8-93cdaabe6302";
 		$apps[$x]['default_settings'][$y]['default_setting_category'] = "provision";
 		$apps[$x]['default_settings'][$y]['default_setting_subcategory'] = "grandstream_active_backlight_timeout";

--- a/resources/templates/provision/grandstream/gac2500/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gac2500/{$mac}.xml
@@ -502,7 +502,7 @@
 
     <!-- # Matching Incoming Caller ID. Matching Rule 1 -->
     <!-- # String -->
-    <P1488></P1488>
+    <P1488>{$grandstream_distinctive_ringtone_name_1}</P1488>
 
     <!-- # Matching Rule 1 Distinctive Ringtone. See ring tone options and value in the Ring Tone Value Table below -->
     <!-- # String -->
@@ -510,7 +510,7 @@
 
     <!-- # Matching Incoming Caller ID. Matching Rule 2 -->
     <!-- # String -->
-    <P1490></P1490>
+    <P1490>{$grandstream_distinctive_ringtone_name_2}</P1490>
 
     <!-- # Matching Rule 2 Distinctive Ringtone. See ring tone options and value in the Ring Tone Value Table below -->
     <!-- # String -->
@@ -518,7 +518,7 @@
 
     <!-- # Matching Incoming Caller ID. Matching Rule 3 -->
     <!-- # String -->
-    <P1492></P1492>
+    <P1492>{$grandstream_distinctive_ringtone_name_3}</P1492>
 
     <!-- # Matching Rule 3 Distinctive Ringtone. See ring tone options and value in the Ring Tone Value Table below -->
     <!-- # String -->
@@ -1632,7 +1632,7 @@
 
     <!-- # Matching Incoming Caller ID. Matching Rule 1 -->
     <!-- # String -->
-    <P1500></P1500>
+    <P1500>{$grandstream_distinctive_ringtone_name_1}</P1500>
 
     <!-- # Account Ring Tone. See ring tone options and value in the Ring Tone value table below -->
     <P523>content://settings/system/ringtone</P523>

--- a/resources/templates/provision/grandstream/grp2612/{$mac}.xml
+++ b/resources/templates/provision/grandstream/grp2612/{$mac}.xml
@@ -795,7 +795,7 @@
     <!-- # -1 - No Ringtone, 0 - system ring tone, 1 - custom ring tone 1, 2 - custom ring tone 2, 3 - custom ring tone 3, 4 - silent, 5 - Default Ringtone. Default is 5. -->
     <!-- # Number: -1, 0, 1, 2, 3, 4, 5 -->
     <!-- # Mandatory -->
-    <P1489>5</P1489>
+    <P1489>{$grandstream_distinctive_ringtone_1}</P1489>
 
     <!-- # Matching Incoming Caller ID. Matching Rule 2 -->
     <!-- # String -->
@@ -805,87 +805,87 @@
     <!-- # -1 - No Ringtone, 0 - system ring tone, 1 - custom ring tone 1, 2 - custom ring tone 2, 3 - custom ring tone 3, 4 - silent, 5 - Default Ringtone. Default is 5. -->
     <!-- # Number: -1, 0, 1, 2, 3, 4, 5 -->
     <!-- # Mandatory -->
-    <P1491>2</P1491>
+    <P1491>{$grandstream_distinctive_ringtone_2}</P1491>
 
     <!-- # Matching Incoming Caller ID. Matching Rule 3 -->
     <!-- # String -->
-    <P1492>ring3</P1492>
+    <P1492>{$grandstream_distinctive_ringtone_name_3}</P1492>
 
     <!-- # Matching Rule 3 Distinctive Ringtone -->
     <!-- # -1 - No Ringtone, 0 - system ring tone, 1 - custom ring tone 1, 2 - custom ring tone 2, 3 - custom ring tone 3, 4 - silent, 5 - Default Ringtone. Default is 5. -->
     <!-- # Number: -1, 0, 1, 2, 3, 4, 5 -->
     <!-- # Mandatory -->
-    <P1493>3</P1493>
+    <P1493>{$grandstream_distinctive_ringtone_3}</P1493>
 
     <!-- # Matching Incoming Caller ID. Matching Rule 4 -->
     <!-- # String -->
-    <P6716></P6716>
+    <P6716>{$grandstream_distinctive_ringtone_name_4}</P6716>
 
     <!-- # Matching Rule 4 Distinctive Ringtone -->
     <!-- # -1 - No Ringtone, 0 - system ring tone, 1 - custom ring tone 1, 2 - custom ring tone 2, 3 - custom ring tone 3, 4 - silent, 5 - Default Ringtone. Default is 5. -->
     <!-- # Number: -1, 0, 1, 2, 3, 4, 5 -->
     <!-- # Mandatory -->
-    <P6717>5</P6717>
+    <P6717>{$grandstream_distinctive_ringtone_4}</P6717>
 
     <!-- # Matching Incoming Caller ID. Matching Rule 5 -->
     <!-- # String -->
-    <P6718></P6718>
+    <P6718>{$grandstream_distinctive_ringtone_name_5}</P6718>
 
     <!-- # Matching Rule 5 Distinctive Ringtone -->
     <!-- # -1 - No Ringtone, 0 - system ring tone, 1 - custom ring tone 1, 2 - custom ring tone 2, 3 - custom ring tone 3, 4 - silent, 5 - Default Ringtone. Default is 5. -->
     <!-- # Number: -1, 0, 1, 2, 3, 4, 5 -->
     <!-- # Mandatory -->
-    <P6719>5</P6719>
+    <P6719>{$grandstream_distinctive_ringtone_5}</P6719>
 
     <!-- # Matching Incoming Caller ID. Matching Rule 6 -->
     <!-- # String -->
-    <P6720></P6720>
+    <P6720>{$grandstream_distinctive_ringtone_name_6}</P6720>
 
     <!-- # Matching Rule 6 Distinctive Ringtone -->
     <!-- # -1 - No Ringtone, 0 - system ring tone, 1 - custom ring tone 1, 2 - custom ring tone 2, 3 - custom ring tone 3, 4 - silent, 5 - Default Ringtone. Default is 5. -->
     <!-- # Number: -1, 0, 1, 2, 3, 4, 5 -->
     <!-- # Mandatory -->
-    <P6721>5</P6721>
+    <P6721>{$grandstream_distinctive_ringtone_6}</P6721>
 
     <!-- # Matching Incoming Caller ID. Matching Rule 7 -->
     <!-- # String -->
-    <P26064></P26064>
+    <P26064>{$grandstream_distinctive_ringtone_name_7}</P26064>
 
     <!-- # Matching Rule 7 Distinctive Ringtone -->
     <!-- # -1 - No Ringtone, 0 - system ring tone, 1 - custom ring tone 1, 2 - custom ring tone 2, 3 - custom ring tone 3, 4 - silent, 5 - Default Ringtone. Default is 5. -->
     <!-- # Number: -1, 0, 1, 2, 3, 4, 5 -->
     <!-- # Mandatory -->
-    <P26065>5</P26065>
+    <P26065>{$grandstream_distinctive_ringtone_7}</P26065>
 
     <!-- # Matching Incoming Caller ID. Matching Rule 8 -->
     <!-- # String -->
-    <P26066></P26066>
+    <P26066>{$grandstream_distinctive_ringtone_name_8}</P26066>
 
     <!-- # Matching Rule 8 Distinctive Ringtone -->
     <!-- # -1 - No Ringtone, 0 - system ring tone, 1 - custom ring tone 1, 2 - custom ring tone 2, 3 - custom ring tone 3, 4 - silent, 5 - Default Ringtone. Default is 5. -->
     <!-- # Number: -1, 0, 1, 2, 3, 4, 5 -->
     <!-- # Mandatory -->
-    <P26067>5</P26067>
+    <P26067>{$grandstream_distinctive_ringtone_8}</P26067>
 
     <!-- # Matching Incoming Caller ID. Matching Rule 9 -->
     <!-- # String -->
-    <P26068></P26068>
+    <P26068>{$grandstream_distinctive_ringtone_name_9}</P26068>
 
     <!-- # Matching Rule 9 Distinctive Ringtone -->
     <!-- # -1 - No Ringtone, 0 - system ring tone, 1 - custom ring tone 1, 2 - custom ring tone 2, 3 - custom ring tone 3, 4 - silent, 5 - Default Ringtone. Default is 5. -->
     <!-- # Number: -1, 0, 1, 2, 3, 4, 5 -->
     <!-- # Mandatory -->
-    <P26069>5</P26069>
+    <P26069>{$grandstream_distinctive_ringtone_9}</P26069>
 
     <!-- # Matching Incoming Caller ID. Matching Rule 10 -->
     <!-- # String -->
-    <P26096></P26096>
+    <P26096>{$grandstream_distinctive_ringtone_name_10}</P26096>
 
     <!-- # Matching Rule 10 Distinctive Ringtone -->
     <!-- # -1 - No Ringtone, 0 - system ring tone, 1 - custom ring tone 1, 2 - custom ring tone 2, 3 - custom ring tone 3, 4 - silent, 5 - Default Ringtone. Default is 5. -->
     <!-- # Number: -1, 0, 1, 2, 3, 4, 5 -->
     <!-- # Mandatory -->
-    <P26097>5</P26097>
+    <P26097>{$grandstream_distinctive_ringtone_10}</P26097>
 
     <!-- # Ring Timeout (in seconds). Default is 60 -->
     <!-- # Number: 30 - 3600 -->
@@ -3654,7 +3654,7 @@
     <!-- # Hide BLF Remote Status. 0 - No, 1 - Yes. Default is 0 -->
     <!-- # Number: 0, 1 -->
     <!-- # Mandatory -->
-    <P8374>0</P8374>
+    <P8374>{$grandstream_blf_remote_status}</P8374>
 
     <!-- # Show SIP Error Response. 0 - No, 1 - Yes. Default is 1 -->
     <!-- # Number: 0, 1 -->

--- a/resources/templates/provision/grandstream/grp2612w/{$mac}.xml
+++ b/resources/templates/provision/grandstream/grp2612w/{$mac}.xml
@@ -795,7 +795,7 @@
     <!-- # -1 - No Ringtone, 0 - system ring tone, 1 - custom ring tone 1, 2 - custom ring tone 2, 3 - custom ring tone 3, 4 - silent, 5 - Default Ringtone. Default is 5. -->
     <!-- # Number: -1, 0, 1, 2, 3, 4, 5 -->
     <!-- # Mandatory -->
-    <P1489>5</P1489>
+    <P1489>{$grandstream_distinctive_ringtone_1}</P1489>
 
     <!-- # Matching Incoming Caller ID. Matching Rule 2 -->
     <!-- # String -->
@@ -805,87 +805,87 @@
     <!-- # -1 - No Ringtone, 0 - system ring tone, 1 - custom ring tone 1, 2 - custom ring tone 2, 3 - custom ring tone 3, 4 - silent, 5 - Default Ringtone. Default is 5. -->
     <!-- # Number: -1, 0, 1, 2, 3, 4, 5 -->
     <!-- # Mandatory -->
-    <P1491>2</P1491>
+    <P1491>{$grandstream_distinctive_ringtone_2}</P1491>
 
     <!-- # Matching Incoming Caller ID. Matching Rule 3 -->
     <!-- # String -->
-    <P1492>ring3</P1492>
+    <P1492>{$grandstream_distinctive_ringtone_name_3}</P1492>
 
     <!-- # Matching Rule 3 Distinctive Ringtone -->
     <!-- # -1 - No Ringtone, 0 - system ring tone, 1 - custom ring tone 1, 2 - custom ring tone 2, 3 - custom ring tone 3, 4 - silent, 5 - Default Ringtone. Default is 5. -->
     <!-- # Number: -1, 0, 1, 2, 3, 4, 5 -->
     <!-- # Mandatory -->
-    <P1493>3</P1493>
+    <P1493>{$grandstream_distinctive_ringtone_3}</P1493>
 
     <!-- # Matching Incoming Caller ID. Matching Rule 4 -->
     <!-- # String -->
-    <P6716></P6716>
+    <P6716>{$grandstream_distinctive_ringtone_name_4}</P6716>
 
     <!-- # Matching Rule 4 Distinctive Ringtone -->
     <!-- # -1 - No Ringtone, 0 - system ring tone, 1 - custom ring tone 1, 2 - custom ring tone 2, 3 - custom ring tone 3, 4 - silent, 5 - Default Ringtone. Default is 5. -->
     <!-- # Number: -1, 0, 1, 2, 3, 4, 5 -->
     <!-- # Mandatory -->
-    <P6717>5</P6717>
+    <P6717>{$grandstream_distinctive_ringtone_4}</P6717>
 
     <!-- # Matching Incoming Caller ID. Matching Rule 5 -->
     <!-- # String -->
-    <P6718></P6718>
+    <P6718>{$grandstream_distinctive_ringtone_name_5}</P6718>
 
     <!-- # Matching Rule 5 Distinctive Ringtone -->
     <!-- # -1 - No Ringtone, 0 - system ring tone, 1 - custom ring tone 1, 2 - custom ring tone 2, 3 - custom ring tone 3, 4 - silent, 5 - Default Ringtone. Default is 5. -->
     <!-- # Number: -1, 0, 1, 2, 3, 4, 5 -->
     <!-- # Mandatory -->
-    <P6719>5</P6719>
+    <P6719>{$grandstream_distinctive_ringtone_5}</P6719>
 
     <!-- # Matching Incoming Caller ID. Matching Rule 6 -->
     <!-- # String -->
-    <P6720></P6720>
+    <P6720>{$grandstream_distinctive_ringtone_name_6}</P6720>
 
     <!-- # Matching Rule 6 Distinctive Ringtone -->
     <!-- # -1 - No Ringtone, 0 - system ring tone, 1 - custom ring tone 1, 2 - custom ring tone 2, 3 - custom ring tone 3, 4 - silent, 5 - Default Ringtone. Default is 5. -->
     <!-- # Number: -1, 0, 1, 2, 3, 4, 5 -->
     <!-- # Mandatory -->
-    <P6721>5</P6721>
+    <P6721>{$grandstream_distinctive_ringtone_6}</P6721>
 
     <!-- # Matching Incoming Caller ID. Matching Rule 7 -->
     <!-- # String -->
-    <P26064></P26064>
+    <P26064>{$grandstream_distinctive_ringtone_name_7}</P26064>
 
     <!-- # Matching Rule 7 Distinctive Ringtone -->
     <!-- # -1 - No Ringtone, 0 - system ring tone, 1 - custom ring tone 1, 2 - custom ring tone 2, 3 - custom ring tone 3, 4 - silent, 5 - Default Ringtone. Default is 5. -->
     <!-- # Number: -1, 0, 1, 2, 3, 4, 5 -->
     <!-- # Mandatory -->
-    <P26065>5</P26065>
+    <P26065>{$grandstream_distinctive_ringtone_7}</P26065>
 
     <!-- # Matching Incoming Caller ID. Matching Rule 8 -->
     <!-- # String -->
-    <P26066></P26066>
+    <P26066>{$grandstream_distinctive_ringtone_name_8}</P26066>
 
     <!-- # Matching Rule 8 Distinctive Ringtone -->
     <!-- # -1 - No Ringtone, 0 - system ring tone, 1 - custom ring tone 1, 2 - custom ring tone 2, 3 - custom ring tone 3, 4 - silent, 5 - Default Ringtone. Default is 5. -->
     <!-- # Number: -1, 0, 1, 2, 3, 4, 5 -->
     <!-- # Mandatory -->
-    <P26067>5</P26067>
+    <P26067>{$grandstream_distinctive_ringtone_8}</P26067>
 
     <!-- # Matching Incoming Caller ID. Matching Rule 9 -->
     <!-- # String -->
-    <P26068></P26068>
+    <P26068>{$grandstream_distinctive_ringtone_name_9}</P26068>
 
     <!-- # Matching Rule 9 Distinctive Ringtone -->
     <!-- # -1 - No Ringtone, 0 - system ring tone, 1 - custom ring tone 1, 2 - custom ring tone 2, 3 - custom ring tone 3, 4 - silent, 5 - Default Ringtone. Default is 5. -->
     <!-- # Number: -1, 0, 1, 2, 3, 4, 5 -->
     <!-- # Mandatory -->
-    <P26069>5</P26069>
+    <P26069>{$grandstream_distinctive_ringtone_9}</P26069>
 
     <!-- # Matching Incoming Caller ID. Matching Rule 10 -->
     <!-- # String -->
-    <P26096></P26096>
+    <P26096>{$grandstream_distinctive_ringtone_name_10}</P26096>
 
     <!-- # Matching Rule 10 Distinctive Ringtone -->
     <!-- # -1 - No Ringtone, 0 - system ring tone, 1 - custom ring tone 1, 2 - custom ring tone 2, 3 - custom ring tone 3, 4 - silent, 5 - Default Ringtone. Default is 5. -->
     <!-- # Number: -1, 0, 1, 2, 3, 4, 5 -->
     <!-- # Mandatory -->
-    <P26097>5</P26097>
+    <P26097>{$grandstream_distinctive_ringtone_10}</P26097>
 
     <!-- # Ring Timeout (in seconds). Default is 60 -->
     <!-- # Number: 30 - 3600 -->
@@ -3749,7 +3749,7 @@
     <!-- # Hide BLF Remote Status. 0 - No, 1 - Yes. Default is 0 -->
     <!-- # Number: 0, 1 -->
     <!-- # Mandatory -->
-    <P8374>0</P8374>
+    <P8374>{$grandstream_blf_remote_status}</P8374>
 
     <!-- # Show SIP Error Response. 0 - No, 1 - Yes. Default is 1 -->
     <!-- # Number: 0, 1 -->

--- a/resources/templates/provision/grandstream/grp2613/{$mac}.xml
+++ b/resources/templates/provision/grandstream/grp2613/{$mac}.xml
@@ -795,7 +795,7 @@
     <!-- # -1 - No Ringtone, 0 - system ring tone, 1 - custom ring tone 1, 2 - custom ring tone 2, 3 - custom ring tone 3, 4 - silent, 5 - Default Ringtone. Default is 5. -->
     <!-- # Number: -1, 0, 1, 2, 3, 4, 5 -->
     <!-- # Mandatory -->
-    <P1489>5</P1489>
+    <P1489>{$grandstream_distinctive_ringtone_1}</P1489>
 
     <!-- # Matching Incoming Caller ID. Matching Rule 2 -->
     <!-- # String -->
@@ -805,87 +805,87 @@
     <!-- # -1 - No Ringtone, 0 - system ring tone, 1 - custom ring tone 1, 2 - custom ring tone 2, 3 - custom ring tone 3, 4 - silent, 5 - Default Ringtone. Default is 5. -->
     <!-- # Number: -1, 0, 1, 2, 3, 4, 5 -->
     <!-- # Mandatory -->
-    <P1491>2</P1491>
+    <P1491>{$grandstream_distinctive_ringtone_2}</P1491>
 
     <!-- # Matching Incoming Caller ID. Matching Rule 3 -->
     <!-- # String -->
-    <P1492>ring3</P1492>
+    <P1492>{$grandstream_distinctive_ringtone_name_3}</P1492>
 
     <!-- # Matching Rule 3 Distinctive Ringtone -->
     <!-- # -1 - No Ringtone, 0 - system ring tone, 1 - custom ring tone 1, 2 - custom ring tone 2, 3 - custom ring tone 3, 4 - silent, 5 - Default Ringtone. Default is 5. -->
     <!-- # Number: -1, 0, 1, 2, 3, 4, 5 -->
     <!-- # Mandatory -->
-    <P1493>3</P1493>
+    <P1493>{$grandstream_distinctive_ringtone_3}</P1493>
 
     <!-- # Matching Incoming Caller ID. Matching Rule 4 -->
     <!-- # String -->
-    <P6716></P6716>
+    <P6716>{$grandstream_distinctive_ringtone_name_4}</P6716>
 
     <!-- # Matching Rule 4 Distinctive Ringtone -->
     <!-- # -1 - No Ringtone, 0 - system ring tone, 1 - custom ring tone 1, 2 - custom ring tone 2, 3 - custom ring tone 3, 4 - silent, 5 - Default Ringtone. Default is 5. -->
     <!-- # Number: -1, 0, 1, 2, 3, 4, 5 -->
     <!-- # Mandatory -->
-    <P6717>5</P6717>
+    <P6717>{$grandstream_distinctive_ringtone_4}</P6717>
 
     <!-- # Matching Incoming Caller ID. Matching Rule 5 -->
     <!-- # String -->
-    <P6718></P6718>
+    <P6718>{$grandstream_distinctive_ringtone_name_5}</P6718>
 
     <!-- # Matching Rule 5 Distinctive Ringtone -->
     <!-- # -1 - No Ringtone, 0 - system ring tone, 1 - custom ring tone 1, 2 - custom ring tone 2, 3 - custom ring tone 3, 4 - silent, 5 - Default Ringtone. Default is 5. -->
     <!-- # Number: -1, 0, 1, 2, 3, 4, 5 -->
     <!-- # Mandatory -->
-    <P6719>5</P6719>
+    <P6719>{$grandstream_distinctive_ringtone_5}</P6719>
 
     <!-- # Matching Incoming Caller ID. Matching Rule 6 -->
     <!-- # String -->
-    <P6720></P6720>
+    <P6720>{$grandstream_distinctive_ringtone_name_6}</P6720>
 
     <!-- # Matching Rule 6 Distinctive Ringtone -->
     <!-- # -1 - No Ringtone, 0 - system ring tone, 1 - custom ring tone 1, 2 - custom ring tone 2, 3 - custom ring tone 3, 4 - silent, 5 - Default Ringtone. Default is 5. -->
     <!-- # Number: -1, 0, 1, 2, 3, 4, 5 -->
     <!-- # Mandatory -->
-    <P6721>5</P6721>
+    <P6721>{$grandstream_distinctive_ringtone_6}</P6721>
 
     <!-- # Matching Incoming Caller ID. Matching Rule 7 -->
     <!-- # String -->
-    <P26064></P26064>
+    <P26064>{$grandstream_distinctive_ringtone_name_7}</P26064>
 
     <!-- # Matching Rule 7 Distinctive Ringtone -->
     <!-- # -1 - No Ringtone, 0 - system ring tone, 1 - custom ring tone 1, 2 - custom ring tone 2, 3 - custom ring tone 3, 4 - silent, 5 - Default Ringtone. Default is 5. -->
     <!-- # Number: -1, 0, 1, 2, 3, 4, 5 -->
     <!-- # Mandatory -->
-    <P26065>5</P26065>
+    <P26065>{$grandstream_distinctive_ringtone_7}</P26065>
 
     <!-- # Matching Incoming Caller ID. Matching Rule 8 -->
     <!-- # String -->
-    <P26066></P26066>
+    <P26066>{$grandstream_distinctive_ringtone_name_8}</P26066>
 
     <!-- # Matching Rule 8 Distinctive Ringtone -->
     <!-- # -1 - No Ringtone, 0 - system ring tone, 1 - custom ring tone 1, 2 - custom ring tone 2, 3 - custom ring tone 3, 4 - silent, 5 - Default Ringtone. Default is 5. -->
     <!-- # Number: -1, 0, 1, 2, 3, 4, 5 -->
     <!-- # Mandatory -->
-    <P26067>5</P26067>
+    <P26067>{$grandstream_distinctive_ringtone_8}</P26067>
 
     <!-- # Matching Incoming Caller ID. Matching Rule 9 -->
     <!-- # String -->
-    <P26068></P26068>
+    <P26068>{$grandstream_distinctive_ringtone_name_9}</P26068>
 
     <!-- # Matching Rule 9 Distinctive Ringtone -->
     <!-- # -1 - No Ringtone, 0 - system ring tone, 1 - custom ring tone 1, 2 - custom ring tone 2, 3 - custom ring tone 3, 4 - silent, 5 - Default Ringtone. Default is 5. -->
     <!-- # Number: -1, 0, 1, 2, 3, 4, 5 -->
     <!-- # Mandatory -->
-    <P26069>5</P26069>
+    <P26069>{$grandstream_distinctive_ringtone_9}</P26069>
 
     <!-- # Matching Incoming Caller ID. Matching Rule 10 -->
     <!-- # String -->
-    <P26096></P26096>
+    <P26096>{$grandstream_distinctive_ringtone_name_10}</P26096>
 
     <!-- # Matching Rule 10 Distinctive Ringtone -->
     <!-- # -1 - No Ringtone, 0 - system ring tone, 1 - custom ring tone 1, 2 - custom ring tone 2, 3 - custom ring tone 3, 4 - silent, 5 - Default Ringtone. Default is 5. -->
     <!-- # Number: -1, 0, 1, 2, 3, 4, 5 -->
     <!-- # Mandatory -->
-    <P26097>5</P26097>
+    <P26097>{$grandstream_distinctive_ringtone_10}</P26097>
 
     <!-- # Ring Timeout (in seconds). Default is 60 -->
     <!-- # Number: 30 - 3600 -->
@@ -2615,7 +2615,7 @@
 
     <!-- # Matching Incoming Caller ID. Matching Rule 1 -->
     <!-- # String -->
-    <P1500></P1500>
+    <P1500>{$grandstream_distinctive_ringtone_name_1}</P1500>
 
     <!-- # Matching Rule 1 Distinctive Ringtone -->
     <!-- # -1 - No Ringtone, 0 - system ring tone, 1 - custom ring tone 1, 2 - custom ring tone 2, 3 - custom ring tone 3, 4 - silent, 5 - Default Ringtone. Default is 0. -->
@@ -4482,7 +4482,7 @@
     <!-- # Hide BLF Remote Status. 0 - No, 1 - Yes. Default is 0 -->
     <!-- # Number: 0, 1 -->
     <!-- # Mandatory -->
-    <P8374>0</P8374>
+    <P8374>{$grandstream_blf_remote_status}</P8374>
 
     <!-- # Show SIP Error Response. 0 - No, 1 - Yes. Default is 1 -->
     <!-- # Number: 0, 1 -->

--- a/resources/templates/provision/grandstream/grp2614/{$mac}.xml
+++ b/resources/templates/provision/grandstream/grp2614/{$mac}.xml
@@ -795,7 +795,7 @@
     <!-- # -1 - No Ringtone, 0 - system ring tone, 1 - custom ring tone 1, 2 - custom ring tone 2, 3 - custom ring tone 3, 4 - silent, 5 - Default Ringtone. Default is 5. -->
     <!-- # Number: -1, 0, 1, 2, 3, 4, 5 -->
     <!-- # Mandatory -->
-    <P1489>5</P1489>
+    <P1489>{$grandstream_distinctive_ringtone_1}</P1489>
 
     <!-- # Matching Incoming Caller ID. Matching Rule 2 -->
     <!-- # String -->
@@ -805,87 +805,87 @@
     <!-- # -1 - No Ringtone, 0 - system ring tone, 1 - custom ring tone 1, 2 - custom ring tone 2, 3 - custom ring tone 3, 4 - silent, 5 - Default Ringtone. Default is 5. -->
     <!-- # Number: -1, 0, 1, 2, 3, 4, 5 -->
     <!-- # Mandatory -->
-    <P1491>2</P1491>
+    <P1491>{$grandstream_distinctive_ringtone_2}</P1491>
 
     <!-- # Matching Incoming Caller ID. Matching Rule 3 -->
     <!-- # String -->
-    <P1492>ring3</P1492>
+    <P1492>{$grandstream_distinctive_ringtone_name_3}</P1492>
 
     <!-- # Matching Rule 3 Distinctive Ringtone -->
     <!-- # -1 - No Ringtone, 0 - system ring tone, 1 - custom ring tone 1, 2 - custom ring tone 2, 3 - custom ring tone 3, 4 - silent, 5 - Default Ringtone. Default is 5. -->
     <!-- # Number: -1, 0, 1, 2, 3, 4, 5 -->
     <!-- # Mandatory -->
-    <P1493>3</P1493>
+    <P1493>{$grandstream_distinctive_ringtone_3}</P1493>
 
     <!-- # Matching Incoming Caller ID. Matching Rule 4 -->
     <!-- # String -->
-    <P6716></P6716>
+    <P6716>{$grandstream_distinctive_ringtone_name_4}</P6716>
 
     <!-- # Matching Rule 4 Distinctive Ringtone -->
     <!-- # -1 - No Ringtone, 0 - system ring tone, 1 - custom ring tone 1, 2 - custom ring tone 2, 3 - custom ring tone 3, 4 - silent, 5 - Default Ringtone. Default is 5. -->
     <!-- # Number: -1, 0, 1, 2, 3, 4, 5 -->
     <!-- # Mandatory -->
-    <P6717>5</P6717>
+    <P6717>{$grandstream_distinctive_ringtone_4}</P6717>
 
     <!-- # Matching Incoming Caller ID. Matching Rule 5 -->
     <!-- # String -->
-    <P6718></P6718>
+    <P6718>{$grandstream_distinctive_ringtone_name_5}</P6718>
 
     <!-- # Matching Rule 5 Distinctive Ringtone -->
     <!-- # -1 - No Ringtone, 0 - system ring tone, 1 - custom ring tone 1, 2 - custom ring tone 2, 3 - custom ring tone 3, 4 - silent, 5 - Default Ringtone. Default is 5. -->
     <!-- # Number: -1, 0, 1, 2, 3, 4, 5 -->
     <!-- # Mandatory -->
-    <P6719>5</P6719>
+    <P6719>{$grandstream_distinctive_ringtone_5}</P6719>
 
     <!-- # Matching Incoming Caller ID. Matching Rule 6 -->
     <!-- # String -->
-    <P6720></P6720>
+    <P6720>{$grandstream_distinctive_ringtone_name_6}</P6720>
 
     <!-- # Matching Rule 6 Distinctive Ringtone -->
     <!-- # -1 - No Ringtone, 0 - system ring tone, 1 - custom ring tone 1, 2 - custom ring tone 2, 3 - custom ring tone 3, 4 - silent, 5 - Default Ringtone. Default is 5. -->
     <!-- # Number: -1, 0, 1, 2, 3, 4, 5 -->
     <!-- # Mandatory -->
-    <P6721>5</P6721>
+    <P6721>{$grandstream_distinctive_ringtone_6}</P6721>
 
     <!-- # Matching Incoming Caller ID. Matching Rule 7 -->
     <!-- # String -->
-    <P26064></P26064>
+    <P26064>{$grandstream_distinctive_ringtone_name_7}</P26064>
 
     <!-- # Matching Rule 7 Distinctive Ringtone -->
     <!-- # -1 - No Ringtone, 0 - system ring tone, 1 - custom ring tone 1, 2 - custom ring tone 2, 3 - custom ring tone 3, 4 - silent, 5 - Default Ringtone. Default is 5. -->
     <!-- # Number: -1, 0, 1, 2, 3, 4, 5 -->
     <!-- # Mandatory -->
-    <P26065>5</P26065>
+    <P26065>{$grandstream_distinctive_ringtone_7}</P26065>
 
     <!-- # Matching Incoming Caller ID. Matching Rule 8 -->
     <!-- # String -->
-    <P26066></P26066>
+    <P26066>{$grandstream_distinctive_ringtone_name_8}</P26066>
 
     <!-- # Matching Rule 8 Distinctive Ringtone -->
     <!-- # -1 - No Ringtone, 0 - system ring tone, 1 - custom ring tone 1, 2 - custom ring tone 2, 3 - custom ring tone 3, 4 - silent, 5 - Default Ringtone. Default is 5. -->
     <!-- # Number: -1, 0, 1, 2, 3, 4, 5 -->
     <!-- # Mandatory -->
-    <P26067>5</P26067>
+    <P26067>{$grandstream_distinctive_ringtone_8}</P26067>
 
     <!-- # Matching Incoming Caller ID. Matching Rule 9 -->
     <!-- # String -->
-    <P26068></P26068>
+    <P26068>{$grandstream_distinctive_ringtone_name_9}</P26068>
 
     <!-- # Matching Rule 9 Distinctive Ringtone -->
     <!-- # -1 - No Ringtone, 0 - system ring tone, 1 - custom ring tone 1, 2 - custom ring tone 2, 3 - custom ring tone 3, 4 - silent, 5 - Default Ringtone. Default is 5. -->
     <!-- # Number: -1, 0, 1, 2, 3, 4, 5 -->
     <!-- # Mandatory -->
-    <P26069>5</P26069>
+    <P26069>{$grandstream_distinctive_ringtone_9}</P26069>
 
     <!-- # Matching Incoming Caller ID. Matching Rule 10 -->
     <!-- # String -->
-    <P26096></P26096>
+    <P26096>{$grandstream_distinctive_ringtone_name_10}</P26096>
 
     <!-- # Matching Rule 10 Distinctive Ringtone -->
     <!-- # -1 - No Ringtone, 0 - system ring tone, 1 - custom ring tone 1, 2 - custom ring tone 2, 3 - custom ring tone 3, 4 - silent, 5 - Default Ringtone. Default is 5. -->
     <!-- # Number: -1, 0, 1, 2, 3, 4, 5 -->
     <!-- # Mandatory -->
-    <P26097>5</P26097>
+    <P26097>{$grandstream_distinctive_ringtone_10}</P26097>
 
     <!-- # Ring Timeout (in seconds). Default is 60 -->
     <!-- # Number: 30 - 3600 -->
@@ -2615,7 +2615,7 @@
 
     <!-- # Matching Incoming Caller ID. Matching Rule 1 -->
     <!-- # String -->
-    <P1500></P1500>
+    <P1500>{$grandstream_distinctive_ringtone_name_1}</P1500>
 
     <!-- # Matching Rule 1 Distinctive Ringtone -->
     <!-- # -1 - No Ringtone, 0 - system ring tone, 1 - custom ring tone 1, 2 - custom ring tone 2, 3 - custom ring tone 3, 4 - silent, 5 - Default Ringtone. Default is 0. -->
@@ -5745,7 +5745,7 @@
     <!-- # Hide BLF Remote Status. 0 - No, 1 - Yes. Default is 0 -->
     <!-- # Number: 0, 1 -->
     <!-- # Mandatory -->
-    <P8374>0</P8374>
+    <P8374>{$grandstream_blf_remote_status}</P8374>
 
     <!-- # Show SIP Error Response. 0 - No, 1 - Yes. Default is 1 -->
     <!-- # Number: 0, 1 -->

--- a/resources/templates/provision/grandstream/grp2615/{$mac}.xml
+++ b/resources/templates/provision/grandstream/grp2615/{$mac}.xml
@@ -795,7 +795,7 @@
     <!-- # -1 - No Ringtone, 0 - system ring tone, 1 - custom ring tone 1, 2 - custom ring tone 2, 3 - custom ring tone 3, 4 - silent, 5 - Default Ringtone. Default is 5. -->
     <!-- # Number: -1, 0, 1, 2, 3, 4, 5 -->
     <!-- # Mandatory -->
-    <P1489>5</P1489>
+    <P1489>{$grandstream_distinctive_ringtone_1}</P1489>
 
     <!-- # Matching Incoming Caller ID. Matching Rule 2 -->
     <!-- # String -->
@@ -805,87 +805,87 @@
     <!-- # -1 - No Ringtone, 0 - system ring tone, 1 - custom ring tone 1, 2 - custom ring tone 2, 3 - custom ring tone 3, 4 - silent, 5 - Default Ringtone. Default is 5. -->
     <!-- # Number: -1, 0, 1, 2, 3, 4, 5 -->
     <!-- # Mandatory -->
-    <P1491>2</P1491>
+    <P1491>{$grandstream_distinctive_ringtone_2}</P1491>
 
     <!-- # Matching Incoming Caller ID. Matching Rule 3 -->
     <!-- # String -->
-    <P1492>ring3</P1492>
+    <P1492>{$grandstream_distinctive_ringtone_name_3}</P1492>
 
     <!-- # Matching Rule 3 Distinctive Ringtone -->
     <!-- # -1 - No Ringtone, 0 - system ring tone, 1 - custom ring tone 1, 2 - custom ring tone 2, 3 - custom ring tone 3, 4 - silent, 5 - Default Ringtone. Default is 5. -->
     <!-- # Number: -1, 0, 1, 2, 3, 4, 5 -->
     <!-- # Mandatory -->
-    <P1493>3</P1493>
+    <P1493>{$grandstream_distinctive_ringtone_3}</P1493>
 
     <!-- # Matching Incoming Caller ID. Matching Rule 4 -->
     <!-- # String -->
-    <P6716></P6716>
+    <P6716>{$grandstream_distinctive_ringtone_name_4}</P6716>
 
     <!-- # Matching Rule 4 Distinctive Ringtone -->
     <!-- # -1 - No Ringtone, 0 - system ring tone, 1 - custom ring tone 1, 2 - custom ring tone 2, 3 - custom ring tone 3, 4 - silent, 5 - Default Ringtone. Default is 5. -->
     <!-- # Number: -1, 0, 1, 2, 3, 4, 5 -->
     <!-- # Mandatory -->
-    <P6717>5</P6717>
+    <P6717>{$grandstream_distinctive_ringtone_4}</P6717>
 
     <!-- # Matching Incoming Caller ID. Matching Rule 5 -->
     <!-- # String -->
-    <P6718></P6718>
+    <P6718>{$grandstream_distinctive_ringtone_name_5}</P6718>
 
     <!-- # Matching Rule 5 Distinctive Ringtone -->
     <!-- # -1 - No Ringtone, 0 - system ring tone, 1 - custom ring tone 1, 2 - custom ring tone 2, 3 - custom ring tone 3, 4 - silent, 5 - Default Ringtone. Default is 5. -->
     <!-- # Number: -1, 0, 1, 2, 3, 4, 5 -->
     <!-- # Mandatory -->
-    <P6719>5</P6719>
+    <P6719>{$grandstream_distinctive_ringtone_5}</P6719>
 
     <!-- # Matching Incoming Caller ID. Matching Rule 6 -->
     <!-- # String -->
-    <P6720></P6720>
+    <P6720>{$grandstream_distinctive_ringtone_name_6}</P6720>
 
     <!-- # Matching Rule 6 Distinctive Ringtone -->
     <!-- # -1 - No Ringtone, 0 - system ring tone, 1 - custom ring tone 1, 2 - custom ring tone 2, 3 - custom ring tone 3, 4 - silent, 5 - Default Ringtone. Default is 5. -->
     <!-- # Number: -1, 0, 1, 2, 3, 4, 5 -->
     <!-- # Mandatory -->
-    <P6721>5</P6721>
+    <P6721>{$grandstream_distinctive_ringtone_6}</P6721>
 
     <!-- # Matching Incoming Caller ID. Matching Rule 7 -->
     <!-- # String -->
-    <P26064></P26064>
+    <P26064>{$grandstream_distinctive_ringtone_name_7}</P26064>
 
     <!-- # Matching Rule 7 Distinctive Ringtone -->
     <!-- # -1 - No Ringtone, 0 - system ring tone, 1 - custom ring tone 1, 2 - custom ring tone 2, 3 - custom ring tone 3, 4 - silent, 5 - Default Ringtone. Default is 5. -->
     <!-- # Number: -1, 0, 1, 2, 3, 4, 5 -->
     <!-- # Mandatory -->
-    <P26065>5</P26065>
+    <P26065>{$grandstream_distinctive_ringtone_7}</P26065>
 
     <!-- # Matching Incoming Caller ID. Matching Rule 8 -->
     <!-- # String -->
-    <P26066></P26066>
+    <P26066>{$grandstream_distinctive_ringtone_name_8}</P26066>
 
     <!-- # Matching Rule 8 Distinctive Ringtone -->
     <!-- # -1 - No Ringtone, 0 - system ring tone, 1 - custom ring tone 1, 2 - custom ring tone 2, 3 - custom ring tone 3, 4 - silent, 5 - Default Ringtone. Default is 5. -->
     <!-- # Number: -1, 0, 1, 2, 3, 4, 5 -->
     <!-- # Mandatory -->
-    <P26067>5</P26067>
+    <P26067>{$grandstream_distinctive_ringtone_8}</P26067>
 
     <!-- # Matching Incoming Caller ID. Matching Rule 9 -->
     <!-- # String -->
-    <P26068></P26068>
+    <P26068>{$grandstream_distinctive_ringtone_name_9}</P26068>
 
     <!-- # Matching Rule 9 Distinctive Ringtone -->
     <!-- # -1 - No Ringtone, 0 - system ring tone, 1 - custom ring tone 1, 2 - custom ring tone 2, 3 - custom ring tone 3, 4 - silent, 5 - Default Ringtone. Default is 5. -->
     <!-- # Number: -1, 0, 1, 2, 3, 4, 5 -->
     <!-- # Mandatory -->
-    <P26069>5</P26069>
+    <P26069>{$grandstream_distinctive_ringtone_9}</P26069>
 
     <!-- # Matching Incoming Caller ID. Matching Rule 10 -->
     <!-- # String -->
-    <P26096></P26096>
+    <P26096>{$grandstream_distinctive_ringtone_name_10}</P26096>
 
     <!-- # Matching Rule 10 Distinctive Ringtone -->
     <!-- # -1 - No Ringtone, 0 - system ring tone, 1 - custom ring tone 1, 2 - custom ring tone 2, 3 - custom ring tone 3, 4 - silent, 5 - Default Ringtone. Default is 5. -->
     <!-- # Number: -1, 0, 1, 2, 3, 4, 5 -->
     <!-- # Mandatory -->
-    <P26097>5</P26097>
+    <P26097>{$grandstream_distinctive_ringtone_10}</P26097>
 
     <!-- # Ring Timeout (in seconds). Default is 60 -->
     <!-- # Number: 30 - 3600 -->
@@ -2615,7 +2615,7 @@
 
     <!-- # Matching Incoming Caller ID. Matching Rule 1 -->
     <!-- # String -->
-    <P1500></P1500>
+    <P1500>{$grandstream_distinctive_ringtone_name_1}</P1500>
 
     <!-- # Matching Rule 1 Distinctive Ringtone -->
     <!-- # -1 - No Ringtone, 0 - system ring tone, 1 - custom ring tone 1, 2 - custom ring tone 2, 3 - custom ring tone 3, 4 - silent, 5 - Default Ringtone. Default is 0. -->
@@ -6680,7 +6680,7 @@
     <!-- # Hide BLF Remote Status. 0 - No, 1 - Yes. Default is 0 -->
     <!-- # Number: 0, 1 -->
     <!-- # Mandatory -->
-    <P8374>0</P8374>
+    <P8374>{$grandstream_blf_remote_status}</P8374>
 
     <!-- # Show SIP Error Response. 0 - No, 1 - Yes. Default is 1 -->
     <!-- # Number: 0, 1 -->

--- a/resources/templates/provision/grandstream/grp2616/{$mac}.xml
+++ b/resources/templates/provision/grandstream/grp2616/{$mac}.xml
@@ -795,7 +795,7 @@
     <!-- # -1 - No Ringtone, 0 - system ring tone, 1 - custom ring tone 1, 2 - custom ring tone 2, 3 - custom ring tone 3, 4 - silent, 5 - Default Ringtone. Default is 5. -->
     <!-- # Number: -1, 0, 1, 2, 3, 4, 5 -->
     <!-- # Mandatory -->
-    <P1489>5</P1489>
+    <P1489>{$grandstream_distinctive_ringtone_1}</P1489>
 
     <!-- # Matching Incoming Caller ID. Matching Rule 2 -->
     <!-- # String -->
@@ -805,87 +805,87 @@
     <!-- # -1 - No Ringtone, 0 - system ring tone, 1 - custom ring tone 1, 2 - custom ring tone 2, 3 - custom ring tone 3, 4 - silent, 5 - Default Ringtone. Default is 5. -->
     <!-- # Number: -1, 0, 1, 2, 3, 4, 5 -->
     <!-- # Mandatory -->
-    <P1491>2</P1491>
+    <P1491>{$grandstream_distinctive_ringtone_2}</P1491>
 
     <!-- # Matching Incoming Caller ID. Matching Rule 3 -->
     <!-- # String -->
-    <P1492>ring3</P1492>
+    <P1492>{$grandstream_distinctive_ringtone_name_3}</P1492>
 
     <!-- # Matching Rule 3 Distinctive Ringtone -->
     <!-- # -1 - No Ringtone, 0 - system ring tone, 1 - custom ring tone 1, 2 - custom ring tone 2, 3 - custom ring tone 3, 4 - silent, 5 - Default Ringtone. Default is 5. -->
     <!-- # Number: -1, 0, 1, 2, 3, 4, 5 -->
     <!-- # Mandatory -->
-    <P1493>3</P1493>
+    <P1493>{$grandstream_distinctive_ringtone_3}</P1493>
 
     <!-- # Matching Incoming Caller ID. Matching Rule 4 -->
     <!-- # String -->
-    <P6716></P6716>
+    <P6716>{$grandstream_distinctive_ringtone_name_4}</P6716>
 
     <!-- # Matching Rule 4 Distinctive Ringtone -->
     <!-- # -1 - No Ringtone, 0 - system ring tone, 1 - custom ring tone 1, 2 - custom ring tone 2, 3 - custom ring tone 3, 4 - silent, 5 - Default Ringtone. Default is 5. -->
     <!-- # Number: -1, 0, 1, 2, 3, 4, 5 -->
     <!-- # Mandatory -->
-    <P6717>5</P6717>
+    <P6717>{$grandstream_distinctive_ringtone_4}</P6717>
 
     <!-- # Matching Incoming Caller ID. Matching Rule 5 -->
     <!-- # String -->
-    <P6718></P6718>
+    <P6718>{$grandstream_distinctive_ringtone_name_5}</P6718>
 
     <!-- # Matching Rule 5 Distinctive Ringtone -->
     <!-- # -1 - No Ringtone, 0 - system ring tone, 1 - custom ring tone 1, 2 - custom ring tone 2, 3 - custom ring tone 3, 4 - silent, 5 - Default Ringtone. Default is 5. -->
     <!-- # Number: -1, 0, 1, 2, 3, 4, 5 -->
     <!-- # Mandatory -->
-    <P6719>5</P6719>
+    <P6719>{$grandstream_distinctive_ringtone_5}</P6719>
 
     <!-- # Matching Incoming Caller ID. Matching Rule 6 -->
     <!-- # String -->
-    <P6720></P6720>
+    <P6720>{$grandstream_distinctive_ringtone_name_6}</P6720>
 
     <!-- # Matching Rule 6 Distinctive Ringtone -->
     <!-- # -1 - No Ringtone, 0 - system ring tone, 1 - custom ring tone 1, 2 - custom ring tone 2, 3 - custom ring tone 3, 4 - silent, 5 - Default Ringtone. Default is 5. -->
     <!-- # Number: -1, 0, 1, 2, 3, 4, 5 -->
     <!-- # Mandatory -->
-    <P6721>5</P6721>
+    <P6721>{$grandstream_distinctive_ringtone_6}</P6721>
 
     <!-- # Matching Incoming Caller ID. Matching Rule 7 -->
     <!-- # String -->
-    <P26064></P26064>
+    <P26064>{$grandstream_distinctive_ringtone_name_7}</P26064>
 
     <!-- # Matching Rule 7 Distinctive Ringtone -->
     <!-- # -1 - No Ringtone, 0 - system ring tone, 1 - custom ring tone 1, 2 - custom ring tone 2, 3 - custom ring tone 3, 4 - silent, 5 - Default Ringtone. Default is 5. -->
     <!-- # Number: -1, 0, 1, 2, 3, 4, 5 -->
     <!-- # Mandatory -->
-    <P26065>5</P26065>
+    <P26065>{$grandstream_distinctive_ringtone_7}</P26065>
 
     <!-- # Matching Incoming Caller ID. Matching Rule 8 -->
     <!-- # String -->
-    <P26066></P26066>
+    <P26066>{$grandstream_distinctive_ringtone_name_8}</P26066>
 
     <!-- # Matching Rule 8 Distinctive Ringtone -->
     <!-- # -1 - No Ringtone, 0 - system ring tone, 1 - custom ring tone 1, 2 - custom ring tone 2, 3 - custom ring tone 3, 4 - silent, 5 - Default Ringtone. Default is 5. -->
     <!-- # Number: -1, 0, 1, 2, 3, 4, 5 -->
     <!-- # Mandatory -->
-    <P26067>5</P26067>
+    <P26067>{$grandstream_distinctive_ringtone_8}</P26067>
 
     <!-- # Matching Incoming Caller ID. Matching Rule 9 -->
     <!-- # String -->
-    <P26068></P26068>
+    <P26068>{$grandstream_distinctive_ringtone_name_9}</P26068>
 
     <!-- # Matching Rule 9 Distinctive Ringtone -->
     <!-- # -1 - No Ringtone, 0 - system ring tone, 1 - custom ring tone 1, 2 - custom ring tone 2, 3 - custom ring tone 3, 4 - silent, 5 - Default Ringtone. Default is 5. -->
     <!-- # Number: -1, 0, 1, 2, 3, 4, 5 -->
     <!-- # Mandatory -->
-    <P26069>5</P26069>
+    <P26069>{$grandstream_distinctive_ringtone_9}</P26069>
 
     <!-- # Matching Incoming Caller ID. Matching Rule 10 -->
     <!-- # String -->
-    <P26096></P26096>
+    <P26096>{$grandstream_distinctive_ringtone_name_10}</P26096>
 
     <!-- # Matching Rule 10 Distinctive Ringtone -->
     <!-- # -1 - No Ringtone, 0 - system ring tone, 1 - custom ring tone 1, 2 - custom ring tone 2, 3 - custom ring tone 3, 4 - silent, 5 - Default Ringtone. Default is 5. -->
     <!-- # Number: -1, 0, 1, 2, 3, 4, 5 -->
     <!-- # Mandatory -->
-    <P26097>5</P26097>
+    <P26097>{$grandstream_distinctive_ringtone_10}</P26097>
 
     <!-- # Ring Timeout (in seconds). Default is 60 -->
     <!-- # Number: 30 - 3600 -->
@@ -2615,7 +2615,7 @@
 
     <!-- # Matching Incoming Caller ID. Matching Rule 1 -->
     <!-- # String -->
-    <P1500></P1500>
+    <P1500>{$grandstream_distinctive_ringtone_name_1}</P1500>
 
     <!-- # Matching Rule 1 Distinctive Ringtone -->
     <!-- # -1 - No Ringtone, 0 - system ring tone, 1 - custom ring tone 1, 2 - custom ring tone 2, 3 - custom ring tone 3, 4 - silent, 5 - Default Ringtone. Default is 0. -->
@@ -7644,7 +7644,7 @@
     <!-- # Hide BLF Remote Status. 0 - No, 1 - Yes. Default is 0 -->
     <!-- # Number: 0, 1 -->
     <!-- # Mandatory -->
-    <P8374>0</P8374>
+    <P8374>{$grandstream_blf_remote_status}</P8374>
 
     <!-- # Show SIP Error Response. 0 - No, 1 - Yes. Default is 1 -->
     <!-- # Number: 0, 1 -->

--- a/resources/templates/provision/grandstream/grp26xx/{$mac}.xml
+++ b/resources/templates/provision/grandstream/grp26xx/{$mac}.xml
@@ -802,7 +802,7 @@
     <!-- # 1 - No Ringtone, 0 - system ring tone, 1 - custom ring tone 1, 2 - custom ring tone 2, 3 - custom ring tone 3, 4 - silent, 5 - Default Ringtone. Default is 5. -->
     <!-- # Number: -1, 0, 1, 2, 3, 4, 5 -->
     <!-- # Mandatory -->
-    <P1489>5</P1489>
+    <P1489>{$grandstream_distinctive_ringtone_1}</P1489>
 
     <!-- # Matching Incoming Caller ID. Matching Rule 2 -->
     <!-- # String -->
@@ -812,87 +812,87 @@
     <!-- # -1 - No Ringtone, 0 - system ring tone, 1 - custom ring tone 1, 2 - custom ring tone 2, 3 - custom ring tone 3, 4 - silent, 5 - Default Ringtone. Default is 5. -->
     <!-- # Number: -1, 0, 1, 2, 3, 4, 5 -->
     <!-- # Mandatory -->
-    <P1491>2</P1491>
+    <P1491>{$grandstream_distinctive_ringtone_2}</P1491>
 
     <!-- # Matching Incoming Caller ID. Matching Rule 3 -->
     <!-- # String -->
-    <P1492>ring3</P1492>
+    <P1492>{$grandstream_distinctive_ringtone_name_3}</P1492>
 
     <!-- # Matching Rule 3 Distinctive Ringtone -->
     <!-- # -1 - No Ringtone, 0 - system ring tone, 1 - custom ring tone 1, 2 - custom ring tone 2, 3 - custom ring tone 3, 4 - silent, 5 - Default Ringtone. Default is 5. -->
     <!-- # Number: -1, 0, 1, 2, 3, 4, 5 -->
     <!-- # Mandatory -->
-    <P1493>3</P1493>
+    <P1493>{$grandstream_distinctive_ringtone_3}</P1493>
 
     <!-- # Matching Incoming Caller ID. Matching Rule 4 -->
     <!-- # String -->
-    <P6716></P6716>
+    <P6716>{$grandstream_distinctive_ringtone_name_4}</P6716>
 
     <!-- # Matching Rule 4 Distinctive Ringtone -->
     <!-- # 1 - No Ringtone, 0 - system ring tone, 1 - custom ring tone 1, 2 - custom ring tone 2, 3 - custom ring tone 3, 4 - silent, 5 - Default Ringtone. Default is 5. -->
     <!-- # Number: -1, 0, 1, 2, 3, 4, 5 -->
     <!-- # Mandatory -->
-    <P6717>5</P6717>
+    <P6717>{$grandstream_distinctive_ringtone_4}</P6717>
 
     <!-- # Matching Incoming Caller ID. Matching Rule 5 -->
     <!-- # String -->
-    <P6718></P6718>
+    <P6718>{$grandstream_distinctive_ringtone_name_5}</P6718>
 
     <!-- # Matching Rule 5 Distinctive Ringtone -->
     <!-- # 1 - No Ringtone, 0 - system ring tone, 1 - custom ring tone 1, 2 - custom ring tone 2, 3 - custom ring tone 3, 4 - silent, 5 - Default Ringtone. Default is 5. -->
     <!-- # Number: -1, 0, 1, 2, 3, 4, 5 -->
     <!-- # Mandatory -->
-    <P6719>5</P6719>
+    <P6719>{$grandstream_distinctive_ringtone_5}</P6719>
 
     <!-- # Matching Incoming Caller ID. Matching Rule 6 -->
     <!-- # String -->
-    <P6720></P6720>
+    <P6720>{$grandstream_distinctive_ringtone_name_6}</P6720>
 
     <!-- # Matching Rule 6 Distinctive Ringtone -->
     <!-- # 1 - No Ringtone, 0 - system ring tone, 1 - custom ring tone 1, 2 - custom ring tone 2, 3 - custom ring tone 3, 4 - silent, 5 - Default Ringtone. Default is 5. -->
     <!-- # Number: -1, 0, 1, 2, 3, 4, 5 -->
     <!-- # Mandatory -->
-    <P6721>5</P6721>
+    <P6721>{$grandstream_distinctive_ringtone_6}</P6721>
 
     <!-- # Matching Incoming Caller ID. Matching Rule 7 -->
     <!-- # String -->
-    <P26064></P26064>
+    <P26064>{$grandstream_distinctive_ringtone_name_7}</P26064>
 
     <!-- # Matching Rule 7 Distinctive Ringtone -->
     <!-- # 1 - No Ringtone, 0 - system ring tone, 1 - custom ring tone 1, 2 - custom ring tone 2, 3 - custom ring tone 3, 4 - silent, 5 - Default Ringtone. Default is 5. -->
     <!-- # Number: -1, 0, 1, 2, 3, 4, 5 -->
     <!-- # Mandatory -->
-    <P26065>5</P26065>
+    <P26065>{$grandstream_distinctive_ringtone_7}</P26065>
 
     <!-- # Matching Incoming Caller ID. Matching Rule 8 -->
     <!-- # String -->
-    <P26066></P26066>
+    <P26066>{$grandstream_distinctive_ringtone_name_8}</P26066>
 
     <!-- # Matching Rule 8 Distinctive Ringtone -->
     <!-- # 1 - No Ringtone, 0 - system ring tone, 1 - custom ring tone 1, 2 - custom ring tone 2, 3 - custom ring tone 3, 4 - silent, 5 - Default Ringtone. Default is 5. -->
     <!-- # Number: -1, 0, 1, 2, 3, 4, 5 -->
     <!-- # Mandatory -->
-    <P26067>5</P26067>
+    <P26067>{$grandstream_distinctive_ringtone_8}</P26067>
 
     <!-- # Matching Incoming Caller ID. Matching Rule 9 -->
     <!-- # String -->
-    <P26068></P26068>
+    <P26068>{$grandstream_distinctive_ringtone_name_9}</P26068>
 
     <!-- # Matching Rule 9 Distinctive Ringtone -->
     <!-- # 1 - No Ringtone, 0 - system ring tone, 1 - custom ring tone 1, 2 - custom ring tone 2, 3 - custom ring tone 3, 4 - silent, 5 - Default Ringtone. Default is 5. -->
     <!-- # Number: -1, 0, 1, 2, 3, 4, 5 -->
     <!-- # Mandatory -->
-    <P26069>5</P26069>
+    <P26069>{$grandstream_distinctive_ringtone_9}</P26069>
 
     <!-- # Matching Incoming Caller ID. Matching Rule 10 -->
     <!-- # String -->
-    <P26096></P26096>
+    <P26096>{$grandstream_distinctive_ringtone_name_10}</P26096>
 
     <!-- # Matching Rule 10 Distinctive Ringtone -->
     <!-- # 1 - No Ringtone, 0 - system ring tone, 1 - custom ring tone 1, 2 - custom ring tone 2, 3 - custom ring tone 3, 4 - silent, 5 - Default Ringtone. Default is 5. -->
     <!-- # Number: -1, 0, 1, 2, 3, 4, 5 -->
     <!-- # Mandatory -->
-    <P26097>5</P26097>
+    <P26097>{$grandstream_distinctive_ringtone_10}</P26097>
 
     <!-- # Ring Timeout (in seconds). Default is 60 -->
     <!-- # Number: 30 - 3600 -->
@@ -2733,7 +2733,7 @@
 
     <!-- # Matching Incoming Caller ID. Matching Rule 1 -->
     <!-- # String -->
-    <P1500></P1500>
+    <P1500>{$grandstream_distinctive_ringtone_name_1}</P1500>
 
     <!-- # Matching Rule 1 Distinctive Ringtone -->
     <!-- # -1 - No Ringtone, 0 - system ring tone, 1 - custom ring tone 1, 2 - custom ring tone 2, 3 - custom ring tone 3, 4 - silent, 5 - Default Ringtone. Default is 0. -->
@@ -6999,7 +6999,7 @@
     <!-- # Hide BLF Remote Status. 0 - No, 1 - Yes. Default is 0 -->
     <!-- # Number: 0, 1 -->
     <!-- # Mandatory -->
-    <P8374>0</P8374>
+    <P8374>{$grandstream_blf_remote_status}</P8374>
 
     <!-- # Show SIP Error Response. 0 - No, 1 - Yes. Default is 1 -->
     <!-- # Number: 0, 1 -->

--- a/resources/templates/provision/grandstream/gxp110x/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp110x/{$mac}.xml
@@ -609,33 +609,33 @@
 
 <!-- Matching Incoming Caller ID. Matching Rule 1 -->
 <!-- String -->
-<P1488></P1488>
+<P1488>{$grandstream_distinctive_ringtone_name_1}</P1488>
 
 <!-- Matching Rule 1 Distinctive Ringtone -->
 <!-- 0 - system ring tone, 1 - custom ring tone 1, 2 - custom ring tone 2, 3 - custom ring tone 3. Default is 0. -->
 <!-- Number: 0, 1, 2, 3 -->
 <!-- Mandatory -->
-<P1489>0</P1489>
+<P1489>{$grandstream_distinctive_ringtone_1}</P1489>
 
 <!-- Matching Incoming Caller ID. Matching Rule 2 -->
 <!-- String -->
-<P1490></P1490>
+<P1490>{$grandstream_distinctive_ringtone_name_2}</P1490>
 
 <!-- Matching Rule 2 Distinctive Ringtone -->
 <!-- 0 - system ring tone, 1 - custom ring tone 1, 2 - custom ring tone 2, 3 - custom ring tone 3. Default is 0 -->
 <!-- Number: 0, 1, 2, 3 -->
 <!-- Mandatory -->
-<P1491>0</P1491>
+<P1491>{$grandstream_distinctive_ringtone_2}</P1491>
 
 <!-- Matching Incoming Caller ID. Matching Rule 3 -->
 <!-- String -->
-<P1492></P1492>
+<P1492>{$grandstream_distinctive_ringtone_name_3}</P1492>
 
 <!-- Matching Rule 3 Distinctive Ringtone -->
 <!-- 0 - system ring tone, 1 - custom ring tone 1, 2 - custom ring tone 2, 3 - custom ring tone 3. Default is 0 -->
 <!-- Number: 0, 1, 2, 3 -->
 <!-- Mandatory -->
-<P1493>0</P1493>
+<P1493>{$grandstream_distinctive_ringtone_3}</P1493>
 
 <!-- Ring Timeout (in seconds). Default is 60 -->
 <!-- Number: 30 - 3600 -->

--- a/resources/templates/provision/grandstream/gxp116x/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp116x/{$mac}.xml
@@ -478,33 +478,33 @@
 
 <!--  Matching Incoming Caller ID. Matching Rule 1 -->
 <!--  String -->
-<P1488></P1488>
+<P1488>{$grandstream_distinctive_ringtone_name_1}</P1488>
 
 <!--  Matching Rule 1 Distinctive Ringtone -->
 <!--  0 - system ring tone, 1 - custom ring tone 1, 2 - custom ring tone 2, 3 - custom ring tone 3. Default is 0. -->
 <!--  Number: 0, 1, 2, 3 -->
 <!--  Mandatory -->
-<P1489>0</P1489>
+<P1489>{$grandstream_distinctive_ringtone_1}</P1489>
 
 <!--  Matching Incoming Caller ID. Matching Rule 2 -->
 <!--  String -->
-<P1490></P1490>
+<P1490>{$grandstream_distinctive_ringtone_name_2}</P1490>
 
 <!--  Matching Rule 2 Distinctive Ringtone -->
 <!--  0 - system ring tone, 1 - custom ring tone 1, 2 - custom ring tone 2, 3 - custom ring tone 3. Default is 0 -->
 <!--  Number: 0, 1, 2, 3 -->
 <!--  Mandatory -->
-<P1491>0</P1491>
+<P1491>{$grandstream_distinctive_ringtone_2}</P1491>
 
 <!--  Matching Incoming Caller ID. Matching Rule 3 -->
 <!--  String -->
-<P1492></P1492>
+<P1492>{$grandstream_distinctive_ringtone_name_3}</P1492>
 
 <!--  Matching Rule 3 Distinctive Ringtone -->
 <!--  0 - system ring tone, 1 - custom ring tone 1, 2 - custom ring tone 2, 3 - custom ring tone 3. Default is 0 -->
 <!--  Number: 0, 1, 2, 3 -->
 <!--  Mandatory -->
-<P1493>0</P1493>
+<P1493>{$grandstream_distinctive_ringtone_3}</P1493>
 
 <!--  Ring Timeout (in seconds). Default is 60 -->
 <!--  Number: 30 - 3600 -->

--- a/resources/templates/provision/grandstream/gxp140x/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp140x/{$mac}.xml
@@ -504,28 +504,28 @@
     <P104>0</P104>
     <!--  Matching Incoming Caller ID. Matching Rule 1 -->
     <!--  String -->
-    <P1488></P1488>
+    <P1488>{$grandstream_distinctive_ringtone_name_1}</P1488>
     <!--  Matching Rule 1 Distinctive Ringtone -->
     <!--  0 - system ring tone, 1 - custom ring tone 1, 2 - custom ring tone 2, 3 - custom ring tone 3. Default is 0. -->
     <!--  Number: 0, 1, 2, 3 -->
     <!--  Mandatory -->
-    <P1489>0</P1489>
+    <P1489>{$grandstream_distinctive_ringtone_1}</P1489>
     <!--  Matching Incoming Caller ID. Matching Rule 2 -->
     <!--  String -->
-    <P1490></P1490>
+    <P1490>{$grandstream_distinctive_ringtone_name_2}</P1490>
     <!--  Matching Rule 2 Distinctive Ringtone -->
     <!--  0 - system ring tone, 1 - custom ring tone 1, 2 - custom ring tone 2, 3 - custom ring tone 3. Default is 0 -->
     <!--  Number: 0, 1, 2, 3 -->
     <!--  Mandatory -->
-    <P1491>0</P1491>
+    <P1491>{$grandstream_distinctive_ringtone_2}</P1491>
     <!--  Matching Incoming Caller ID. Matching Rule 3 -->
     <!--  String -->
-    <P1492></P1492>
+    <P1492>{$grandstream_distinctive_ringtone_name_3}</P1492>
     <!--  Matching Rule 3 Distinctive Ringtone -->
     <!--  0 - system ring tone, 1 - custom ring tone 1, 2 - custom ring tone 2, 3 - custom ring tone 3. Default is 0 -->
     <!--  Number: 0, 1, 2, 3 -->
     <!--  Mandatory -->
-    <P1493>0</P1493>
+    <P1493>{$grandstream_distinctive_ringtone_3}</P1493>
     <!--  Ring Timeout (in seconds). Default is 60 -->
     <!--  Number: 30 - 3600 -->
     <!--  Mandatory -->

--- a/resources/templates/provision/grandstream/gxp140xbk/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp140xbk/{$mac}.xml
@@ -504,28 +504,28 @@
     <P104>0</P104>
     <!--  Matching Incoming Caller ID. Matching Rule 1 -->
     <!--  String -->
-    <P1488></P1488>
+    <P1488>{$grandstream_distinctive_ringtone_name_1}</P1488>
     <!--  Matching Rule 1 Distinctive Ringtone -->
     <!--  0 - system ring tone, 1 - custom ring tone 1, 2 - custom ring tone 2, 3 - custom ring tone 3. Default is 0. -->
     <!--  Number: 0, 1, 2, 3 -->
     <!--  Mandatory -->
-    <P1489>0</P1489>
+    <P1489>{$grandstream_distinctive_ringtone_1}</P1489>
     <!--  Matching Incoming Caller ID. Matching Rule 2 -->
     <!--  String -->
-    <P1490></P1490>
+    <P1490>{$grandstream_distinctive_ringtone_name_2}</P1490>
     <!--  Matching Rule 2 Distinctive Ringtone -->
     <!--  0 - system ring tone, 1 - custom ring tone 1, 2 - custom ring tone 2, 3 - custom ring tone 3. Default is 0 -->
     <!--  Number: 0, 1, 2, 3 -->
     <!--  Mandatory -->
-    <P1491>0</P1491>
+    <P1491>{$grandstream_distinctive_ringtone_2}</P1491>
     <!--  Matching Incoming Caller ID. Matching Rule 3 -->
     <!--  String -->
-    <P1492></P1492>
+    <P1492>{$grandstream_distinctive_ringtone_name_3}</P1492>
     <!--  Matching Rule 3 Distinctive Ringtone -->
     <!--  0 - system ring tone, 1 - custom ring tone 1, 2 - custom ring tone 2, 3 - custom ring tone 3. Default is 0 -->
     <!--  Number: 0, 1, 2, 3 -->
     <!--  Mandatory -->
-    <P1493>0</P1493>
+    <P1493>{$grandstream_distinctive_ringtone_3}</P1493>
     <!--  Ring Timeout (in seconds). Default is 60 -->
     <!--  Number: 30 - 3600 -->
     <!--  Mandatory -->

--- a/resources/templates/provision/grandstream/gxp1450/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp1450/{$mac}.xml
@@ -673,33 +673,33 @@
 
 <!-- Matching Incoming Caller ID. Matching Rule 1 -->
 <!-- String -->
-<P1488></P1488>
+<P1488>{$grandstream_distinctive_ringtone_name_1}</P1488>
 
 <!-- Matching Rule 1 Distinctive Ringtone -->
 <!-- 0 - system ring tone, 1 - custom ring tone 1, 2 - custom ring tone 2, 3 - custom ring tone 3. Default is 0. -->
 <!-- Number: 0, 1, 2, 3 -->
 <!-- Mandatory -->
-<P1489>0</P1489>
+<P1489>{$grandstream_distinctive_ringtone_1}</P1489>
 
 <!-- Matching Incoming Caller ID. Matching Rule 2 -->
 <!-- String -->
-<P1490></P1490>
+<P1490>{$grandstream_distinctive_ringtone_name_2}</P1490>
 
 <!-- Matching Rule 2 Distinctive Ringtone -->
 <!-- 0 - system ring tone, 1 - custom ring tone 1, 2 - custom ring tone 2, 3 - custom ring tone 3. Default is 0 -->
 <!-- Number: 0, 1, 2, 3 -->
 <!-- Mandatory -->
-<P1491>0</P1491>
+<P1491>{$grandstream_distinctive_ringtone_2}</P1491>
 
 <!-- Matching Incoming Caller ID. Matching Rule 3 -->
 <!-- String -->
-<P1492></P1492>
+<P1492>{$grandstream_distinctive_ringtone_name_3}</P1492>
 
 <!-- Matching Rule 3 Distinctive Ringtone -->
 <!-- 0 - system ring tone, 1 - custom ring tone 1, 2 - custom ring tone 2, 3 - custom ring tone 3. Default is 0 -->
 <!-- Number: 0, 1, 2, 3 -->
 <!-- Mandatory -->
-<P1493>0</P1493>
+<P1493>{$grandstream_distinctive_ringtone_3}</P1493>
 
 <!-- Ring Timeout (in seconds). Default is 60 -->
 <!-- Number: 30 - 3600 -->

--- a/resources/templates/provision/grandstream/gxp1450bk/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp1450bk/{$mac}.xml
@@ -482,33 +482,33 @@
 
 <!-- Matching Incoming Caller ID. Matching Rule 1 -->
 <!-- String -->
-<P1488></P1488>
+<P1488>{$grandstream_distinctive_ringtone_name_1}</P1488>
 
 <!-- Matching Rule 1 Distinctive Ringtone -->
 <!-- 0 - system ring tone, 1 - custom ring tone 1, 2 - custom ring tone 2, 3 - custom ring tone 3. Default is 0. -->
 <!-- Number: 0, 1, 2, 3 -->
 <!-- Mandatory -->
-<P1489>0</P1489>
+<P1489>{$grandstream_distinctive_ringtone_1}</P1489>
 
 <!-- Matching Incoming Caller ID. Matching Rule 2 -->
 <!-- String -->
-<P1490></P1490>
+<P1490>{$grandstream_distinctive_ringtone_name_2}</P1490>
 
 <!-- Matching Rule 2 Distinctive Ringtone -->
 <!-- 0 - system ring tone, 1 - custom ring tone 1, 2 - custom ring tone 2, 3 - custom ring tone 3. Default is 0 -->
 <!-- Number: 0, 1, 2, 3 -->
 <!-- Mandatory -->
-<P1491>0</P1491>
+<P1491>{$grandstream_distinctive_ringtone_2}</P1491>
 
 <!-- Matching Incoming Caller ID. Matching Rule 3 -->
 <!-- String -->
-<P1492></P1492>
+<P1492>{$grandstream_distinctive_ringtone_name_3}</P1492>
 
 <!-- Matching Rule 3 Distinctive Ringtone -->
 <!-- 0 - system ring tone, 1 - custom ring tone 1, 2 - custom ring tone 2, 3 - custom ring tone 3. Default is 0 -->
 <!-- Number: 0, 1, 2, 3 -->
 <!-- Mandatory -->
-<P1493>0</P1493>
+<P1493>{$grandstream_distinctive_ringtone_3}</P1493>
 
 <!-- Ring Timeout (in seconds). Default is 60 -->
 <!-- Number: 30 - 3600 -->

--- a/resources/templates/provision/grandstream/gxp16xx/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp16xx/{$mac}.xml
@@ -1686,7 +1686,7 @@
 <P523>0</P523>
 <!--  Matching Incoming Caller ID. Matching Rule 1 -->
 <!--  String -->
-<P1500></P1500>
+<P1500>{$grandstream_distinctive_ringtone_name_1}</P1500>
 <!--  Matching Rule 1 Distinctive Ringtone -->
 <!--  0 - system ring tone, 1 - custom ring tone 1, 2 - custom ring tone 2, 3 - custom ring tone 3. Default is 0. -->
 <!--  Number: 0, 1, 2, 3 -->

--- a/resources/templates/provision/grandstream/gxp17xx/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp17xx/{$mac}.xml
@@ -1361,33 +1361,33 @@
 
 <!-- # Matching Incoming Caller ID. Matching Rule 1 -->
 <!-- # String -->
-<P1488></P1488>
+<P1488>{$grandstream_distinctive_ringtone_name_1}</P1488>
 
 <!-- # Matching Rule 1 Distinctive Ringtone -->
 <!-- # 0 - system ring tone, 1 - custom ring tone 1, 2 - custom ring tone 2, 3 - custom ring tone 3. Default is 0. -->
 <!-- # Number: 0, 1, 2, 3 -->
 <!-- # Mandatory -->
-<P1489>0</P1489>
+<P1489>{$grandstream_distinctive_ringtone_1}</P1489>
 
 <!-- # Matching Incoming Caller ID. Matching Rule 2 -->
 <!-- # String -->
-<P1490></P1490>
+<P1490>{$grandstream_distinctive_ringtone_name_2}</P1490>
 
 <!-- # Matching Rule 2 Distinctive Ringtone -->
 <!-- # 0 - system ring tone, 1 - custom ring tone 1, 2 - custom ring tone 2, 3 - custom ring tone 3. Default is 0 -->
 <!-- # Number: 0, 1, 2, 3 -->
 <!-- # Mandatory -->
-<P1491>0</P1491>
+<P1491>{$grandstream_distinctive_ringtone_2}</P1491>
 
 <!-- # Matching Incoming Caller ID. Matching Rule 3 -->
 <!-- # String -->
-<P1492></P1492>
+<P1492>{$grandstream_distinctive_ringtone_name_3}</P1492>
 
 <!-- # Matching Rule 3 Distinctive Ringtone -->
 <!-- # 0 - system ring tone, 1 - custom ring tone 1, 2 - custom ring tone 2, 3 - custom ring tone 3. Default is 0 -->
 <!-- # Number: 0, 1, 2, 3 -->
 <!-- # Mandatory -->
-<P1493>0</P1493>
+<P1493>{$grandstream_distinctive_ringtone_3}</P1493>
 
 <!-- # Ring Timeout (in seconds). Default is 60 -->
 <!-- # Number: 30 - 3600 -->
@@ -2764,7 +2764,7 @@
 
 <!-- # Matching Incoming Caller ID. Matching Rule 1 -->
 <!-- # String -->
-<P1500></P1500>
+<P1500>{$grandstream_distinctive_ringtone_name_1}</P1500>
 
 <!-- # Matching Rule 1 Distinctive Ringtone -->
 <!-- # 0 - system ring tone, 1 - custom ring tone 1, 2 - custom ring tone 2, 3 - custom ring tone 3. Default is 0 -->

--- a/resources/templates/provision/grandstream/gxp2100/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp2100/{$mac}.xml
@@ -540,33 +540,33 @@
 
 <!--# Matching Incoming Caller ID. Matching Rule 1-->
 <!--# String-->
-    <P1488></P1488>
+    <P1488>{$grandstream_distinctive_ringtone_name_1}</P1488>
 
 <!--# Matching Rule 1 Distinctive Ringtone-->
 <!--# 0 - system ring tone, 1 - custom ring tone 1, 2 - custom ring tone 2, 3 - custom ring tone 3. Default is 0.-->
 <!--# Number: 0, 1, 2, 3-->
 <!--# Mandatory-->
-    <P1489>0</P1489>
+    <P1489>{$grandstream_distinctive_ringtone_1}</P1489>
 
 <!--# Matching Incoming Caller ID. Matching Rule 2-->
 <!--# String-->
-    <P1490></P1490>
+    <P1490>{$grandstream_distinctive_ringtone_name_2}</P1490>
 
 <!--# Matching Rule 2 Distinctive Ringtone-->
 <!--# 0 - system ring tone, 1 - custom ring tone 1, 2 - custom ring tone 2, 3 - custom ring tone 3. Default is 0-->
 <!--# Number: 0, 1, 2, 3-->
 <!--# Mandatory-->
-    <P1491>0</P1491>
+    <P1491>{$grandstream_distinctive_ringtone_2}</P1491>
 
 <!--# Matching Incoming Caller ID. Matching Rule 3-->
 <!--# String-->
-    <P1492></P1492>
+    <P1492>{$grandstream_distinctive_ringtone_name_3}</P1492>
 
 <!--# Matching Rule 3 Distinctive Ringtone-->
 <!--# 0 - system ring tone, 1 - custom ring tone 1, 2 - custom ring tone 2, 3 - custom ring tone 3. Default is 0-->
 <!--# Number: 0, 1, 2, 3-->
 <!--# Mandatory-->
-    <P1493>0</P1493>
+    <P1493>{$grandstream_distinctive_ringtone_3}</P1493>
 
 <!--# Ring Timeout (in seconds). Default is 60-->
 <!--# Number: 30 - 3600-->
@@ -1796,7 +1796,7 @@
 
 <!--# Matching Incoming Caller ID. Matching Rule 1-->
 <!--# String-->
-    <P1500></P1500>
+    <P1500>{$grandstream_distinctive_ringtone_name_1}</P1500>
 
 <!--# Matching Rule 1 Distinctive Ringtone-->
 <!--# 0 - system ring tone, 1 - custom ring tone 1, 2 - custom ring tone 2, 3 - custom ring tone 3. Default is 0-->

--- a/resources/templates/provision/grandstream/gxp2124/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp2124/{$mac}.xml
@@ -380,28 +380,28 @@
     <P104>0</P104>
     <!-- Matching Incoming Caller ID. Matching Rule 1-->
     <!-- String-->
-    <P1488></P1488>
+    <P1488>{$grandstream_distinctive_ringtone_name_1}</P1488>
     <!-- Matching Rule 1 Distinctive Ringtone-->
     <!-- 0 - system ring tone, 1 - custom ring tone 1, 2 - custom ring tone 2, 3 - custom ring tone 3. Default is 0.-->
     <!-- Number: 0, 1, 2, 3-->
     <!-- Mandatory -->
-    <P1489>0</P1489>
+    <P1489>{$grandstream_distinctive_ringtone_1}</P1489>
     <!-- Matching Incoming Caller ID. Matching Rule 2-->
     <!-- String-->
-    <P1490>0</P1490>
+    <P1490>{$grandstream_distinctive_ringtone_name_2}</P1490>
     <!-- Matching Rule 2 Distinctive Ringtone-->
     <!-- 0 - system ring tone, 1 - custom ring tone 1, 2 - custom ring tone 2, 3 - custom ring tone 3. Default is 0-->
     <!-- Number: 0, 1, 2, 3-->
     <!-- Mandatory-->
-    <P1491>0</P1491>
+    <P1491>{$grandstream_distinctive_ringtone_2}</P1491>
     <!-- Matching Incoming Caller ID. Matching Rule 3-->
     <!-- String-->
-    <P1492></P1492>
+    <P1492>{$grandstream_distinctive_ringtone_name_3}</P1492>
     <!-- Matching Rule 3 Distinctive Ringtone -->
     <!-- 0 - system ring tone, 1 - custom ring tone 1, 2 - custom ring tone 2, 3 - custom ring tone 3. Default is 0 -->
     <!-- Number: 0, 1, 2,3-->
     <!-- Mandatory -->
-    <P1493>0</P1493>
+    <P1493>{$grandstream_distinctive_ringtone_3}</P1493>
     <!-- Ring Timeout (in seconds). Default is 60 -->
     <!-- Number: 30 - 3600 -->
     <!-- Mandatory -->
@@ -1243,7 +1243,7 @@
     <P523>0</P523>
     <!-- Matching Incoming Caller ID. Matching Rule 1 -->
     <!-- String -->
-    <P1500></P1500>
+    <P1500>{$grandstream_distinctive_ringtone_name_1}</P1500>
     <!-- Matching Rule 1 Distinctive Ringtone -->
     <!-- 0 - system ring tone, 1 - custom ring tone 1, 2 - custom ring tone 2, 3 - custom ring tone 3. Default is 0 -->
     <!-- Number: 0, 1, 2, 3 -->

--- a/resources/templates/provision/grandstream/gxp2130/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp2130/{$mac}.xml
@@ -2615,7 +2615,7 @@
 
     <!-- # Matching Incoming Caller ID. Matching Rule 1 -->
     <!-- # String -->
-    <P1500>grandstream_distinctive_ringtone_name_1</P1500>
+    <P1500>{$grandstream_distinctive_ringtone_name_1}</P1500>
 
     <!-- # Matching Rule 1 Distinctive Ringtone -->
     <!-- # -1 - No Ringtone, 0 - system ring tone, 1 - custom ring tone 1, 2 - custom ring tone 2, 3 - custom ring tone 3, 4 - silent, 5 - Default Ringtone. Default is 0. -->
@@ -7607,7 +7607,7 @@
     <!-- # Hide BLF Remote Status. 0 - No, 1 - Yes. Default is 0 -->
     <!-- # Number: 0, 1 -->
     <!-- # Mandatory -->
-    <P8374>0</P8374>
+    <P8374>{$grandstream_blf_remote_status}</P8374>
 
     <!-- # Show SIP Error Response. 0 - No, 1 - Yes. Default is 1 -->
     <!-- # Number: 0, 1 -->

--- a/resources/templates/provision/grandstream/gxp2135/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp2135/{$mac}.xml
@@ -2615,7 +2615,7 @@
 
     <!-- # Matching Incoming Caller ID. Matching Rule 1 -->
     <!-- # String -->
-    <P1500>grandstream_distinctive_ringtone_name_1</P1500>
+    <P1500>{$grandstream_distinctive_ringtone_name_1}</P1500>
 
     <!-- # Matching Rule 1 Distinctive Ringtone -->
     <!-- # -1 - No Ringtone, 0 - system ring tone, 1 - custom ring tone 1, 2 - custom ring tone 2, 3 - custom ring tone 3, 4 - silent, 5 - Default Ringtone. Default is 0. -->
@@ -7599,7 +7599,7 @@
     <!-- # Hide BLF Remote Status. 0 - No, 1 - Yes. Default is 0 -->
     <!-- # Number: 0, 1 -->
     <!-- # Mandatory -->
-    <P8374>0</P8374>
+    <P8374>{$grandstream_blf_remote_status}</P8374>
 
     <!-- # Show SIP Error Response. 0 - No, 1 - Yes. Default is 1 -->
     <!-- # Number: 0, 1 -->

--- a/resources/templates/provision/grandstream/gxp2140/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp2140/{$mac}.xml
@@ -2615,7 +2615,7 @@
 
     <!-- # Matching Incoming Caller ID. Matching Rule 1 -->
     <!-- # String -->
-    <P1500>grandstream_distinctive_ringtone_name_1</P1500>
+    <P1500>{$grandstream_distinctive_ringtone_name_1}</P1500>
 
     <!-- # Matching Rule 1 Distinctive Ringtone -->
     <!-- # -1 - No Ringtone, 0 - system ring tone, 1 - custom ring tone 1, 2 - custom ring tone 2, 3 - custom ring tone 3, 4 - silent, 5 - Default Ringtone. Default is 0. -->
@@ -7599,7 +7599,7 @@
     <!-- # Hide BLF Remote Status. 0 - No, 1 - Yes. Default is 0 -->
     <!-- # Number: 0, 1 -->
     <!-- # Mandatory -->
-    <P8374>0</P8374>
+    <P8374>{$grandstream_blf_remote_status}</P8374>
 
     <!-- # Show SIP Error Response. 0 - No, 1 - Yes. Default is 1 -->
     <!-- # Number: 0, 1 -->

--- a/resources/templates/provision/grandstream/gxp2160/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp2160/{$mac}.xml
@@ -2615,7 +2615,7 @@
 
     <!-- # Matching Incoming Caller ID. Matching Rule 1 -->
     <!-- # String -->
-    <P1500>grandstream_distinctive_ringtone_name_1</P1500>
+    <P1500>{$grandstream_distinctive_ringtone_name_1}</P1500>
 
     <!-- # Matching Rule 1 Distinctive Ringtone -->
     <!-- # -1 - No Ringtone, 0 - system ring tone, 1 - custom ring tone 1, 2 - custom ring tone 2, 3 - custom ring tone 3, 4 - silent, 5 - Default Ringtone. Default is 0. -->
@@ -7611,7 +7611,7 @@
     <!-- # Hide BLF Remote Status. 0 - No, 1 - Yes. Default is 0 -->
     <!-- # Number: 0, 1 -->
     <!-- # Mandatory -->
-    <P8374>0</P8374>
+    <P8374>{$grandstream_blf_remote_status}</P8374>
 
     <!-- # Show SIP Error Response. 0 - No, 1 - Yes. Default is 1 -->
     <!-- # Number: 0, 1 -->

--- a/resources/templates/provision/grandstream/gxp2170/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp2170/{$mac}.xml
@@ -2615,7 +2615,7 @@
 
     <!-- # Matching Incoming Caller ID. Matching Rule 1 -->
     <!-- # String -->
-    <P1500>grandstream_distinctive_ringtone_name_1</P1500>
+    <P1500>{$grandstream_distinctive_ringtone_name_1}</P1500>
 
     <!-- # Matching Rule 1 Distinctive Ringtone -->
     <!-- # -1 - No Ringtone, 0 - system ring tone, 1 - custom ring tone 1, 2 - custom ring tone 2, 3 - custom ring tone 3, 4 - silent, 5 - Default Ringtone. Default is 0. -->
@@ -7599,7 +7599,7 @@
     <!-- # Hide BLF Remote Status. 0 - No, 1 - Yes. Default is 0 -->
     <!-- # Number: 0, 1 -->
     <!-- # Mandatory -->
-    <P8374>0</P8374>
+    <P8374>{$grandstream_blf_remote_status}</P8374>
 
     <!-- # Show SIP Error Response. 0 - No, 1 - Yes. Default is 1 -->
     <!-- # Number: 0, 1 -->

--- a/resources/templates/provision/grandstream/gxp21xx/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp21xx/{$mac}.xml
@@ -324,28 +324,28 @@
     <P104>0</P104>
     <!-- Matching Incoming Caller ID. Matching Rule 1 -->
     <!-- String -->
-    <P1488></P1488>
+    <P1488>{$grandstream_distinctive_ringtone_name_1}</P1488>
     <!-- Matching Rule 1 Distinctive Ringtone -->
     <!-- 0 - system ring tone, 1 - custom ring tone 1, 2 - custom ring tone 2, 3 - custom ring tone 3. Default is 0. -->
     <!-- Number: 0, 1, 2, 3 -->
     <!-- Mandatory -->
-    <P1489>0</P1489>
+    <P1489>{$grandstream_distinctive_ringtone_1}</P1489>
     <!-- Matching Incoming Caller ID. Matching Rule 2 -->
     <!-- String -->
-    <P1490></P1490>
+    <P1490>{$grandstream_distinctive_ringtone_name_2}</P1490>
     <!-- Matching Rule 2 Distinctive Ringtone -->
     <!-- 0 - system ring tone, 1 - custom ring tone 1, 2 - custom ring tone 2, 3 - custom ring tone 3. Default is 0 -->
     <!-- Number: 0, 1, 2, 3 -->
     <!-- Mandatory -->
-    <P1491>0</P1491>
+    <P1491>{$grandstream_distinctive_ringtone_2}</P1491>
     <!-- Matching Incoming Caller ID. Matching Rule 3 -->
     <!-- String -->
-    <P1492></P1492>
+    <P1492>{$grandstream_distinctive_ringtone_name_3}</P1492>
     <!-- Matching Rule 3 Distinctive Ringtone -->
     <!-- 0 - system ring tone, 1 - custom ring tone 1, 2 - custom ring tone 2, 3 - custom ring tone 3. Default is 0 -->
     <!-- Number: 0, 1, 2, 3 -->
     <!-- Mandatory -->
-    <P1493>0</P1493>
+    <P1493>{$grandstream_distinctive_ringtone_3}</P1493>
     <!-- Ring Timeout (in seconds). Default is 60 -->
     <!-- Number: 30 - 3600 -->
     <!-- Mandatory -->
@@ -1185,7 +1185,7 @@
     <P523>0</P523>
     <!-- Matching Incoming Caller ID. Matching Rule 1 -->
     <!-- String -->
-    <P1500></P1500>
+    <P1500>{$grandstream_distinctive_ringtone_name_1}</P1500>
     <!-- Matching Rule 1 Distinctive Ringtone -->
     <!-- 0 - system ring tone, 1 - custom ring tone 1, 2 - custom ring tone 2, 3 - custom ring tone 3. Default is 0 -->
     <!-- Number: 0, 1, 2, 3 -->

--- a/resources/templates/provision/grandstream/gxp21xxbk/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp21xxbk/{$mac}.xml
@@ -530,33 +530,33 @@
 <!-- Matching Incoming Caller ID. Matching Rule 1 -->
 <!-- String -->
 
-<P1488></P1488>
+<P1488>{$grandstream_distinctive_ringtone_name_1}</P1488>
 
 <!-- Matching Rule 1 Distinctive Ringtone -->
 <!-- 0 - system ring tone, 1 - custom ring tone 1, 2 - custom ring tone 2, 3 - custom ring tone 3. Default is 0. -->
 <!-- Number: 0, 1, 2, 3 -->
 <!-- Mandatory -->
-<P1489>0</P1489>
+<P1489>{$grandstream_distinctive_ringtone_1}</P1489>
 
 <!-- Matching Incoming Caller ID. Matching Rule 2 -->
 <!-- String -->
-<P1490></P1490>
+<P1490>{$grandstream_distinctive_ringtone_name_2}</P1490>
 
 <!-- Matching Rule 2 Distinctive Ringtone -->
 <!-- 0 - system ring tone, 1 - custom ring tone 1, 2 - custom ring tone 2, 3 - custom ring tone 3. Default is 0 -->
 <!-- Number: 0, 1, 2, 3 -->
 <!-- Mandatory -->
-<P1491>0</P1491>
+<P1491>{$grandstream_distinctive_ringtone_2}</P1491>
 
 <!-- Matching Incoming Caller ID. Matching Rule 3 -->
 <!-- String -->
-<P1492></P1492>
+<P1492>{$grandstream_distinctive_ringtone_name_3}</P1492>
 
 <!-- Matching Rule 3 Distinctive Ringtone -->
 <!-- 0 - system ring tone, 1 - custom ring tone 1, 2 - custom ring tone 2, 3 - custom ring tone 3. Default is 0 -->
 <!-- Number: 0, 1, 2, 3 -->
 <!-- Mandatory -->
-<P1493>0</P1493>
+<P1493>{$grandstream_distinctive_ringtone_3}</P1493>
 
 <!-- Ring Timeout (in seconds). Default is 60 -->
 <!-- Number: 30 - 3600 -->
@@ -1647,7 +1647,7 @@
 
 <!-- Matching Incoming Caller ID. Matching Rule 1 -->
 <!-- String -->
-<P1500></P1500>
+<P1500>{$grandstream_distinctive_ringtone_name_1}</P1500>
 
 <!-- Matching Rule 1 Distinctive Ringtone -->
 <!-- 0 - system ring tone, 1 - custom ring tone 1, 2 - custom ring tone 2, 3 - custom ring tone 3. Default is 0 -->

--- a/resources/templates/provision/grandstream/gxp2200/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp2200/{$mac}.xml
@@ -367,7 +367,7 @@
 
 <!-- Matching Incoming Caller ID. Matching Rule 1 -->
 <!-- String -->
-<P1488></P1488>
+<P1488>{$grandstream_distinctive_ringtone_name_1}</P1488>
 
 <!-- Matching Rule 1 Distinctive Ringtone. See ring tone options and value in the Ring Tone Value Table below -->
 <!-- String -->
@@ -375,7 +375,7 @@
 
 <!-- Matching Incoming Caller ID. Matching Rule 2 -->
 <!-- String -->
-<P1490></P1490>
+<P1490>{$grandstream_distinctive_ringtone_name_2}</P1490>
 
 <!-- Matching Rule 2 Distinctive Ringtone. See ring tone options and value in the Ring Tone Value Table below -->
 <!-- String -->
@@ -383,7 +383,7 @@
 
 <!-- Matching Incoming Caller ID. Matching Rule 3 -->
 <!-- String -->
-<P1492></P1492>
+<P1492>{$grandstream_distinctive_ringtone_name_3}</P1492>
 
 <!-- Matching Rule 3 Distinctive Ringtone. See ring tone options and value in the Ring Tone Value Table below -->
 <!-- String -->
@@ -1214,7 +1214,7 @@ VNumber: 0, 1, 2. -->
 
 <!-- Matching Incoming Caller ID. Matching Rule 1 -->
 <!-- String -->
-<P1500></P1500>
+<P1500>{$grandstream_distinctive_ringtone_name_1}</P1500>
 
 <!-- Matching Rule 1 Distinctive Ringtone. See ring tone options and value in the Ring Tone value table below -->
 <!-- String -->

--- a/resources/templates/provision/grandstream/gxp3240/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp3240/{$mac}.xml
@@ -578,7 +578,7 @@
 
 <!-- Matching Incoming Caller ID. Matching Rule 1 -->
 <!-- String -->
-<P1488></P1488>
+<P1488>{$grandstream_distinctive_ringtone_name_1}</P1488>
 
 <!-- Matching Rule 1 Distinctive Ringtone. See ring tone options and value in the Ring Tone Value Table below -->
 <!-- String -->
@@ -586,7 +586,7 @@
 
 <!-- Matching Incoming Caller ID. Matching Rule 2 -->
 <!-- String -->
-<P1490></P1490>
+<P1490>{$grandstream_distinctive_ringtone_name_2}</P1490>
 
 <!-- Matching Rule 2 Distinctive Ringtone. See ring tone options and value in the Ring Tone Value Table below -->
 <!-- String -->
@@ -594,7 +594,7 @@
 
 <!-- Matching Incoming Caller ID. Matching Rule 3 -->
 <!-- String -->
-<P1492></P1492>
+<P1492>{$grandstream_distinctive_ringtone_name_3}</P1492>
 
 <!-- Matching Rule 3 Distinctive Ringtone. See ring tone options and value in the Ring Tone Value Table below -->
 <!-- String -->
@@ -1425,7 +1425,7 @@ VNumber: 0, 1, 2. -->
 
 <!-- Matching Incoming Caller ID. Matching Rule 1 -->
 <!-- String -->
-<P1500></P1500>
+<P1500>{$grandstream_distinctive_ringtone_name_1}</P1500>
 
 <!-- Matching Rule 1 Distinctive Ringtone. See ring tone options and value in the Ring Tone value table below -->
 <!-- String -->

--- a/resources/templates/provision/grandstream/gxv3240/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxv3240/{$mac}.xml
@@ -1924,7 +1924,7 @@
 
 <!-- Matching Incoming Caller ID. Matching Rule 1 -->
 <!-- String -->
-<P1500></P1500>
+<P1500>{$grandstream_distinctive_ringtone_name_1}</P1500>
 
 <!-- Matching Rule 1 Distinctive Ringtone. See ring tone options and value in the Ring Tone value table below -->
 <!-- String -->

--- a/resources/templates/provision/grandstream/gxv3275/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxv3275/{$mac}.xml
@@ -583,7 +583,7 @@
 
 <!-- Matching Incoming Caller ID. Matching Rule 1 -->
 <!-- String -->
-<P1488></P1488>
+<P1488>{$grandstream_distinctive_ringtone_name_1}</P1488>
 
 <!-- Matching Rule 1 Distinctive Ringtone. See ring tone options and value in the Ring Tone Value Table below -->
 <!-- String -->
@@ -591,7 +591,7 @@
 
 <!-- Matching Incoming Caller ID. Matching Rule 2 -->
 <!-- String -->
-<P1490></P1490>
+<P1490>{$grandstream_distinctive_ringtone_name_2}</P1490>
 
 <!-- Matching Rule 2 Distinctive Ringtone. See ring tone options and value in the Ring Tone Value Table below -->
 <!-- String -->
@@ -599,7 +599,7 @@
 
 <!-- Matching Incoming Caller ID. Matching Rule 3 -->
 <!-- String -->
-<P1492></P1492>
+<P1492>{$grandstream_distinctive_ringtone_name_3}</P1492>
 
 <!-- Matching Rule 3 Distinctive Ringtone. See ring tone options and value in the Ring Tone Value Table below -->
 <!-- String -->
@@ -1430,7 +1430,7 @@ VNumber: 0, 1, 2. -->
 
 <!-- Matching Incoming Caller ID. Matching Rule 1 -->
 <!-- String -->
-<P1500></P1500>
+<P1500>{$grandstream_distinctive_ringtone_name_1}</P1500>
 
 <!-- Matching Rule 1 Distinctive Ringtone. See ring tone options and value in the Ring Tone value table below -->
 <!-- String -->

--- a/resources/templates/provision/grandstream/wp820/{$mac}.xml
+++ b/resources/templates/provision/grandstream/wp820/{$mac}.xml
@@ -556,19 +556,19 @@
 
 <!-- # Matching Incoming Caller ID. Matching Rule 1 -->
 <!-- # String -->
-<P1488></P1488>
+<P1488>{$grandstream_distinctive_ringtone_name_1}</P1488>
 
 <!-- # Matching Rule 1 Distinctive Ringtone (Cannot be provisioned by config template currently) -->
 
 <!-- # Matching Incoming Caller ID. Matching Rule 2 -->
 <!-- # String -->
-<P1490></P1490>
+<P1490>{$grandstream_distinctive_ringtone_name_2}</P1490>
 
 <!-- # Matching Rule 2 Distinctive Ringtone (Cannot be provisioned by config template currently) -->
 
 <!-- # Matching Incoming Caller ID. Matching Rule 3 -->
 <!-- # String -->
-<P1492></P1492>
+<P1492>{$grandstream_distinctive_ringtone_name_3}</P1492>
 
 <!-- # Matching Rule 3 Distinctive Ringtone (Cannot be provisioned by config template currently) -->
 
@@ -1185,7 +1185,7 @@
 
 <!-- # Match Incoming Caller ID. Matching Rule 1 -->
 <!-- # String -->
-<P1488></P1488>
+<P1488>{$grandstream_distinctive_ringtone_name_1}</P1488>
 
 <!-- # Matching Rule 1 Distinctive Ringtone -->
 <!-- # -1 - No Ringtone. Default is 0. -->
@@ -1195,23 +1195,23 @@
 
 <!-- # Matching Incoming Caller ID. Matching Rule 2 -->
 <!-- # String -->
-<P1490></P1490>
+<P1490>{$grandstream_distinctive_ringtone_name_2}</P1490>
 
 <!-- # Matching Rule 2 Distinctive Ringtone -->
 <!-- # -1 - No Rington Default is 0. -->
 <!-- # Number: -->
 <!-- # Mandatory -->
-<P1491>0</P1491>
+<P1491>{$grandstream_distinctive_ringtone_2}</P1491>
 
 <!-- # Matching Incoming Caller ID. Matching Rule 3 -->
 <!-- # String -->
-<P1492></P1492>
+<P1492>{$grandstream_distinctive_ringtone_name_3}</P1492>
 
 <!-- # Matching Rule 3 Distinctive Ringtone -->
 <!-- # -1 - No Ringtone Default is 0. -->
 <!-- # Number: -->
 <!-- # Mandatory -->
-<P1493>0</P1493>
+<P1493>{$grandstream_distinctive_ringtone_3}</P1493>
 
 <!-- ############################################################### -->
 <!-- # Account 2/Advanced Settings -->


### PR DESCRIPTION
Hide the other connected party on the BLF of supported phones. When not hidden a busy BLF will show the other connected party/sttaus of the call by flashing back and forth between the BLF label and the caller ID.
It also impacts the park buttons, but they typically only show the word "park" because of the character limitations.
Also did more effective find/replace for the distnctive ring variables with regex! (plus a typo was made in the previous version)