### PR TITLE
CDR - Don't Check Filesystem for Recording on Load

### DIFF
--- a/app/xml_cdr/xml_cdr.php
+++ b/app/xml_cdr/xml_cdr.php
@@ -762,7 +762,7 @@
 					}
 				//recording
 					if (permission_exists('xml_cdr_recording') && (permission_exists('xml_cdr_recording_play') || permission_exists('xml_cdr_recording_download'))) {
-						if ($record_path != '' && file_exists($record_path.'/'.$record_name)) {
+						if ($record_path != '') {
 							$content .= "	<td class='middle button center no-link no-wrap'>";
 							if (permission_exists('xml_cdr_recording_play')) {
 								$content .= 	"<audio id='recording_audio_".escape($row['xml_cdr_uuid'])."' style='display: none;' preload='none' ontimeupdate=\"update_progress('".escape($row['xml_cdr_uuid'])."')\" onended=\"recording_reset('".escape($row['xml_cdr_uuid'])."');\" src=\"download.php?id=".escape($row['xml_cdr_uuid'])."&t=record\" type='".escape($record_type)."'></audio>";


### PR DESCRIPTION
I have been debugging slow loading on our CDR pages for the last few days now.

One issue that we have encountered is that currently as the page loads, it checks the filesystem for each file one at a time. In our case, we move recordings to object storage after 1 week, so each time we check for a file it passes api calls which take over 1 second each to return a result. This causes this page to not load at all for us in many cases.

Regardless, this current method is unnecessarily I/O intensive and really page load is probably not the time to be checking for each file one by one.

So this PR is the simplest solution - remove the check entirely. I would contend that the administrator should remove the record_path from the database if the file was removed so this should be acceptable.

This solves this particular issue for us, but would need feedback from others if not checking for files makes sense.