### PR TITLE
Adding Call Center Base Score Time in Seconds

### DIFF
--- a/app/call_centers/app_config.php
+++ b/app/call_centers/app_config.php
@@ -337,7 +337,7 @@
 		$apps[$x]['db'][$y]['fields'][$z]['type'] = "text";
 		$apps[$x]['db'][$y]['fields'][$z]['description']['en-us'] = "";
 		$z++;
-		$apps[$x]['db'][$y]['fields'][$z]['name'] = "queue_time_base_score_seconds";
+		$apps[$x]['db'][$y]['fields'][$z]['name'] = "queue_time_base_score_sec";
 		$apps[$x]['db'][$y]['fields'][$z]['type'] = "numeric";
 		$apps[$x]['db'][$y]['fields'][$z]['description']['en-us'] = "Used to set the time base score of the Call Center to prioritize one call center over another.";
 		$z++;

--- a/app/call_centers/app_config.php
+++ b/app/call_centers/app_config.php
@@ -337,6 +337,10 @@
 		$apps[$x]['db'][$y]['fields'][$z]['type'] = "text";
 		$apps[$x]['db'][$y]['fields'][$z]['description']['en-us'] = "";
 		$z++;
+		$apps[$x]['db'][$y]['fields'][$z]['name'] = "queue_time_base_score_seconds";
+		$apps[$x]['db'][$y]['fields'][$z]['type'] = "numeric";
+		$apps[$x]['db'][$y]['fields'][$z]['description']['en-us'] = "Used to set the time base score of the Call Center to prioritize one call center over another.";
+		$z++;
 		$apps[$x]['db'][$y]['fields'][$z]['name'] = "queue_max_wait_time";
 		$apps[$x]['db'][$y]['fields'][$z]['type'] = "numeric";
 		$apps[$x]['db'][$y]['fields'][$z]['description']['en-us'] = "";

--- a/app/call_centers/app_languages.php
+++ b/app/call_centers/app_languages.php
@@ -925,6 +925,27 @@ $text['label-time_base_score']['ru-ru'] = "Оценка по времени";
 $text['label-time_base_score']['sv-se'] = "Tidsbaserat Resultat";
 $text['label-time_base_score']['uk-ua'] = "";
 
+$text['label-time_base_score_sec']['en-us'] = "Time Base Score - Seconds";
+$text['label-time_base_score_sec']['en-gb'] = "Time Base Score - Seconds";
+$text['label-time_base_score_sec']['ar-eg'] = "";
+$text['label-time_base_score_sec']['de-at'] = "Zeitgeber für Klassifikation- Seconden- Seconden"; //copied from de-de
+$text['label-time_base_score_sec']['de-ch'] = "Zeitgeber für Klassifikation- Seconden"; //copied from de-de
+$text['label-time_base_score_sec']['de-de'] = "Zeitgeber für Klassifikation- Seconden";
+$text['label-time_base_score_sec']['es-cl'] = "Puntuación basada en tiempo- Segundos";
+$text['label-time_base_score_sec']['es-mx'] = "Puntuación basada en tiempo- Segundos"; //copied from es-cl
+$text['label-time_base_score_sec']['fr-ca'] = "Score basé sur le temps- Seconds";
+$text['label-time_base_score_sec']['fr-fr'] = "Score Basé sur le temps- Seconds";
+$text['label-time_base_score_sec']['he-il'] = "";
+$text['label-time_base_score_sec']['it-it'] = "Punteggio su Base Tempo- Secondi";
+$text['label-time_base_score_sec']['nl-nl'] = "Tijd basis score";
+$text['label-time_base_score_sec']['pl-pl'] = "Wynik oparty na czasie- Sekundy";
+$text['label-time_base_score_sec']['pt-br'] = "Pontuação baseada no tempo- Segundos"; //copied from pt-pt
+$text['label-time_base_score_sec']['pt-pt'] = "Pontuação baseada no tempo- Segundos";
+$text['label-time_base_score_sec']['ro-ro'] = "";
+$text['label-time_base_score_sec']['ru-ru'] = "Оценка по времени- секунды";
+$text['label-time_base_score_sec']['sv-se'] = "Tidsbaserat Resultat- Sekunder";
+$text['label-time_base_score_sec']['uk-ua'] = "";
+
 $text['label-tiers']['en-us'] = "Tiers";
 $text['label-tiers']['en-gb'] = "Tiers";
 $text['label-tiers']['ar-eg'] = "";

--- a/app/call_centers/app_languages.php
+++ b/app/call_centers/app_languages.php
@@ -2059,6 +2059,28 @@ $text['description-time_base_score']['ru-ru'] = "Выберие оценку п�
 $text['description-time_base_score']['sv-se'] = "Ange tids-baserad poäng.";
 $text['description-time_base_score']['uk-ua'] = "";
 
+
+$text['description-time_base_score_sec']['en-us'] = "Set the time base score in seconds. Higher numbers mean higher priority over other call centers.";
+$text['description-time_base_score_sec']['en-gb'] = "Set the time base score in seconds. Higher numbers mean higher priority over other call centers.";
+$text['description-time_base_score_sec']['ar-eg'] = "";
+$text['description-time_base_score_sec']['de-at'] = "";
+$text['description-time_base_score_sec']['de-ch'] = "";
+$text['description-time_base_score_sec']['de-de'] = "";
+$text['description-time_base_score_sec']['es-cl'] = "";
+$text['description-time_base_score_sec']['es-mx'] = "";
+$text['description-time_base_score_sec']['fr-ca'] = "";
+$text['description-time_base_score_sec']['fr-fr'] = "";
+$text['description-time_base_score_sec']['he-il'] = "";
+$text['description-time_base_score_sec']['it-it'] = "";
+$text['description-time_base_score_sec']['nl-nl'] = "";
+$text['description-time_base_score_sec']['pl-pl'] = "";
+$text['description-time_base_score_sec']['pt-br'] = "";
+$text['description-time_base_score_sec']['pt-pt'] = "";
+$text['description-time_base_score_sec']['ro-ro'] = "";
+$text['description-time_base_score_sec']['ru-ru'] = "";
+$text['description-time_base_score_sec']['sv-se'] = "";
+$text['description-time_base_score_sec']['uk-ua'] = "";
+
 $text['description-tiers']['en-us'] = "Tiers assign agents to queues.";
 $text['description-tiers']['en-gb'] = "Tiers assign agents to queues.";
 $text['description-tiers']['ar-eg'] = "";

--- a/app/call_centers/call_center_queue_edit.php
+++ b/app/call_centers/call_center_queue_edit.php
@@ -86,6 +86,7 @@
 			$queue_moh_sound = $_POST["queue_moh_sound"];
 			$queue_record_template = $_POST["queue_record_template"];
 			$queue_time_base_score = $_POST["queue_time_base_score"];
+			$queue_time_base_score = $_POST["queue_time_base_score_sec"];
 			$queue_max_wait_time = $_POST["queue_max_wait_time"];
 			$queue_max_wait_time_with_no_agent = $_POST["queue_max_wait_time_with_no_agent"];
 			$queue_max_wait_time_with_no_agent_time_reached = $_POST["queue_max_wait_time_with_no_agent_time_reached"];
@@ -188,6 +189,7 @@
 			//if (strlen($queue_moh_sound) == 0) { $msg .= $text['message-required'].$text['label-music_on_hold']."<br>\n"; }
 			//if (strlen($queue_record_template) == 0) { $msg .= $text['message-required'].$text['label-record_template']."<br>\n"; }
 			//if (strlen($queue_time_base_score) == 0) { $msg .= $text['message-required'].$text['label-time_base_score']."<br>\n"; }
+			//if (strlen($queue_time_base_score_sec) == 0) { $msg .= $text['message-required'].$text['label-time_base_score_sec']."<br>\n"; }
 			//if (strlen($queue_max_wait_time) == 0) { $msg .= $text['message-required'].$text['label-max_wait_time']."<br>\n"; }
 			//if (strlen($queue_max_wait_time_with_no_agent) == 0) { $msg .= $text['message-required'].$text['label-max_wait_time_with_no_agent']."<br>\n"; }
 			//if (strlen($queue_max_wait_time_with_no_agent_time_reached) == 0) { $msg .= $text['message-required'].$text['label-max_wait_time_with_no_agent_time_reached']."<br>\n"; }
@@ -269,6 +271,7 @@
 			$array['call_center_queues'][0]['queue_moh_sound'] = $queue_moh_sound;
 			$array['call_center_queues'][0]['queue_record_template'] = $queue_record_template;
 			$array['call_center_queues'][0]['queue_time_base_score'] = $queue_time_base_score;
+			$array['call_center_queues'][0]['queue_time_base_score_sec'] = $queue_time_base_score_sec;
 			$array['call_center_queues'][0]['queue_max_wait_time'] = $queue_max_wait_time;
 			$array['call_center_queues'][0]['queue_max_wait_time_with_no_agent'] = $queue_max_wait_time_with_no_agent;
 			$array['call_center_queues'][0]['queue_max_wait_time_with_no_agent_time_reached'] = $queue_max_wait_time_with_no_agent_time_reached;
@@ -324,6 +327,7 @@
 			$dialplan_xml .= "	<condition field=\"destination_number\" expression=\"^".$queue_extension."$\">\n";
 			$dialplan_xml .= "		<action application=\"answer\" data=\"\"/>\n";
 			$dialplan_xml .= "		<action application=\"set\" data=\"hangup_after_bridge=true\"/>\n";
+			$dialplan_xml .= "		<action application=\"set\" data=\"cc_base_score=".$queue_default_time_base_score."\"/>\n";
 			if ($queue_greeting_path != '') {
 				$greeting_array = explode(':', $queue_greeting_path);
 				if (count($greeting_array) == 1) {
@@ -481,6 +485,7 @@
 				$queue_moh_sound = $row["queue_moh_sound"];
 				$queue_record_template = $row["queue_record_template"];
 				$queue_time_base_score = $row["queue_time_base_score"];
+				$queue_time_base_score_sec = $row["queue_time_base_score_sec"];
 				$queue_max_wait_time = $row["queue_max_wait_time"];
 				$queue_max_wait_time_with_no_agent = $row["queue_max_wait_time_with_no_agent"];
 				$queue_max_wait_time_with_no_agent_time_reached = $row["queue_max_wait_time_with_no_agent_time_reached"];
@@ -551,6 +556,7 @@
 	if (strlen($queue_strategy) == 0) { $queue_strategy = "longest-idle-agent"; }
 	if (strlen($queue_moh_sound) == 0) { $queue_moh_sound = "\$\${hold_music}"; }
 	if (strlen($queue_time_base_score) == 0) { $queue_time_base_score = "system"; }
+	if (strlen($queue_time_base_score) == 0) { $queue_time_base_score = ""; }
 	if (strlen($queue_max_wait_time) == 0) { $queue_max_wait_time = "0"; }
 	if (strlen($queue_max_wait_time_with_no_agent) == 0) { $queue_max_wait_time_with_no_agent = "90"; }
 	if (strlen($queue_max_wait_time_with_no_agent_time_reached) == 0) { $queue_max_wait_time_with_no_agent_time_reached = "30"; }
@@ -894,6 +900,17 @@
 	echo "	</select>\n";
 	echo "<br />\n";
 	echo $text['description-time_base_score']."\n";
+	echo "</td>\n";
+	echo "</tr>\n";
+
+	echo "<tr>\n";
+	echo "<td class='vncell' valign='top' align='left' nowrap>\n";
+	echo "	".$text['label-time_base_score_sec']."\n";
+	echo "</td>\n";
+	echo "<td class='vtable' align='left'>\n";
+	echo "  <input class='formfld' type='number' name='queue_time_base_score_sec' maxlength='255' min='0' step='1' value='".escape($queue_time_base_score_sec)."'>\n";
+	echo "<br />\n";
+	echo $text['description-time_base_score_sec']."\n";
 	echo "</td>\n";
 	echo "</tr>\n";
 

--- a/app/call_centers/call_center_queue_edit.php
+++ b/app/call_centers/call_center_queue_edit.php
@@ -327,7 +327,9 @@
 			$dialplan_xml .= "	<condition field=\"destination_number\" expression=\"^".$queue_extension."$\">\n";
 			$dialplan_xml .= "		<action application=\"answer\" data=\"\"/>\n";
 			$dialplan_xml .= "		<action application=\"set\" data=\"hangup_after_bridge=true\"/>\n";
-			$dialplan_xml .= "		<action application=\"set\" data=\"cc_base_score=".$queue_default_time_base_score."\"/>\n";
+			if ($queue_default_time_base_score != '') {
+				$dialplan_xml .= "		<action application=\"set\" data=\"cc_base_score=".$queue_default_time_base_score."\"/>\n";
+			}
 			if ($queue_greeting_path != '') {
 				$greeting_array = explode(':', $queue_greeting_path);
 				if (count($greeting_array) == 1) {

--- a/app/call_centers/call_center_queue_edit.php
+++ b/app/call_centers/call_center_queue_edit.php
@@ -327,8 +327,8 @@
 			$dialplan_xml .= "	<condition field=\"destination_number\" expression=\"^".$queue_extension."$\">\n";
 			$dialplan_xml .= "		<action application=\"answer\" data=\"\"/>\n";
 			$dialplan_xml .= "		<action application=\"set\" data=\"hangup_after_bridge=true\"/>\n";
-			if ($queue_default_time_base_score != '') {
-				$dialplan_xml .= "		<action application=\"set\" data=\"cc_base_score=".$queue_default_time_base_score."\"/>\n";
+			if ($queue_time_base_score_sec != '') {
+				$dialplan_xml .= "		<action application=\"set\" data=\"cc_base_score=".$queue_time_base_score_sec."\"/>\n";
 			}
 			if ($queue_greeting_path != '') {
 				$greeting_array = explode(':', $queue_greeting_path);

--- a/app/call_centers/call_center_queues.php
+++ b/app/call_centers/call_center_queues.php
@@ -185,6 +185,7 @@
 	//echo th_order_by('queue_moh_sound', $text['label-music_on_hold'], $order_by, $order);
 	//echo th_order_by('queue_record_template', $text['label-record_template'], $order_by, $order);
 	//echo th_order_by('queue_time_base_score', $text['label-time_base_score'], $order_by, $order);
+	//echo th_order_by('queue_time_base_score_sec', $text['label-time_base_score_sec'], $order_by, $order);
 	//echo th_order_by('queue_max_wait_time', $text['label-max_wait_time'], $order_by, $order);
 	//echo th_order_by('queue_max_wait_time_with_no_agent', $text['label-max_wait_time_with_no_agent'], $order_by, $order);
 	echo th_order_by('queue_tier_rules_apply', $text['label-tier_rules_apply'], $order_by, $order);
@@ -225,6 +226,7 @@
 			//echo "	<td>".escape($row[queue_moh_sound])."&nbsp;</td>\n";
 			//echo "	<td>".escape($row[queue_record_template])."&nbsp;</td>\n";
 			//echo "	<td>".escape($row[queue_time_base_score])."&nbsp;</td>\n";
+			//echo "	<td>".escape($row[queue_time_base_score_sec])."&nbsp;</td>\n";
 			//echo "	<td>".escape($row[queue_max_wait_time])."&nbsp;</td>\n";
 			//echo "	<td>".escape($row[queue_max_wait_time_with_no_agent])."&nbsp;</td>\n";
 			echo "	<td>".ucwords(escape($row['queue_tier_rules_apply']))."</td>\n";


### PR DESCRIPTION
This pull request is to add a field in Call Centers to manually specify the Time Score when entering the Call Center. I was requested by a customer that they wanted one Call Center to be prioritized over another.

I was able to do this by editing the XML in the dialplan however I did not like that solution since it would be hard to explain to all techs in our company.

Hopefully this pull request is ok with you guys. Let me know if you have any questions.