### PR TITLE
Do not load base64 data into phrase edit.

### DIFF
--- a/app/phrases/phrase_edit.php
+++ b/app/phrases/phrase_edit.php
@@ -296,8 +296,8 @@
 		unset($sql, $parameters);
 	}
 
-//get the recordings
-	$sql = "select * from v_recordings ";
+//get the recording names from the database. Do not select everything otherwise we can pull in large base64 data for no reason
+	$sql = "select recording_name, recording_filename from v_recordings ";
 	$sql .= "where domain_uuid = :domain_uuid ";
 	$sql .= "order by recording_name asc ";
 	$parameters['domain_uuid'] = $_SESSION['domain_uuid'];


### PR DESCRIPTION
# Context
Currently if you are using base64 database backed recordings when you edit a phrase all recording data will be pulled into memory. This will fix unnecessary memory usage/latency in this application when dealing with base64 recordings.

# Overview
- Only select recording_name and recording_filename from the database