### PR TITLE
Update switch_recordings.php to optimize base64 recordings

### DIFF
--- a/app/recordings/resources/classes/switch_recordings.php
+++ b/app/recordings/resources/classes/switch_recordings.php
@@ -76,7 +76,7 @@ if (!class_exists('switch_recordings')) {
 		 * list recordings
 		 */
 		public function list_recordings() {
-			$sql = "select recording_uuid, recording_filename, recording_base64 ";
+			$sql = "select recording_uuid, recording_filename ";
 			$sql .= "from v_recordings ";
 			$sql .= "where domain_uuid = :domain_uuid ";
 			$parameters['domain_uuid'] = $this->domain_uuid;


### PR DESCRIPTION
# Context
recording_base64 was pulled from the database and never used. Remove it to optimise base64 handling.

# Overview
- Remove `recording_base64` from the select statement