### PR TITLE
Do not load base64 data into MOH edit

### DIFF
--- a/app/music_on_hold/music_on_hold_edit.php
+++ b/app/music_on_hold/music_on_hold_edit.php
@@ -365,7 +365,7 @@
 		*/
 	//recordings
 		$tmp_selected = false;
-		$sql = "select * from v_recordings where domain_uuid = :domain_uuid ";
+		$sql = "select recording_name, recording_filename from v_recordings where domain_uuid = :domain_uuid ";
 		$parameters['domain_uuid'] = $domain_uuid;
 		$database = new database;
 		$recordings = $database->select($sql, $parameters, 'all');


### PR DESCRIPTION
# Context
Currently if you are using base64 database backed recordings when you edit MOH all recording data will be pulled into memory. This will fix unnecessary memory usage/latency in this application when dealing with base64 recordings.

# Overview
- Only select recording_name and recording_filename from the database