### PR TITLE
Update recording edit to not pull base64 data

### DIFF
--- a/app/recordings/recording_edit.php
+++ b/app/recordings/recording_edit.php
@@ -148,7 +148,7 @@ if (count($_POST) > 0 && strlen($_POST["persistformvar"]) == 0) {
 //pre-populate the form
 	if (count($_GET)>0 && $_POST["persistformvar"] != "true") {
 		$recording_uuid = $_GET["id"];
-		$sql = "select * from v_recordings ";
+		$sql = "select recording_name, recording_filename, recording_description from v_recordings ";
 		$sql .= "where domain_uuid = :domain_uuid ";
 		$sql .= "and recording_uuid = :recording_uuid ";
 		$parameters['domain_uuid'] = $domain_uuid;


### PR DESCRIPTION
# Context
This is less of an improvement than the other changes I proposed since it's only doing it for one file. But it still doesn't need to pull that recordings base64 data here if it has it.

# Overview
- Only select recording_name, recording_filename, recording_description as used by the code to prevent loading base64 data if present.