### PR TITLE
Small error in Fax Retry.lua

### DIFF
--- a/app/scripts/resources/scripts/app/fax/resources/scripts/queue/retry.lua
+++ b/app/scripts/resources/scripts/app/fax/resources/scripts/queue/retry.lua
@@ -223,8 +223,8 @@
 			fax_file                       = fax_file or dbh.NULL;
 			fax_ecm_used                   = fax_ecm_used or dbh.NULL;
 			fax_local_station_id           = fax_local_station_id or dbh.NULL;
-			fax_document_transferred_pages = fax_document_transferred_pages or "'0'";
-			fax_document_total_pages       = fax_document_total_pages or "'0'";
+			fax_document_transferred_pages = fax_document_transferred_pages or '0';
+			fax_document_total_pages       = fax_document_total_pages or '0';
 			fax_image_resolution           = fax_image_resolution or dbh.NULL;
 			fax_image_size                 = fax_image_size or dbh.NULL;
 			fax_bad_rows                   = fax_bad_rows or dbh.NULL;


### PR DESCRIPTION
Zero should not be wrapped in double quotes as it's causing an SQL error.

PGRES_FATAL_ERROR
2021-03-11 10:30:47.738673 [ERR] switch_pgsql.c:680 Error executing query:
ERROR:  invalid input syntax for type numeric: "'0'"
LINE 1: ...p/c8505148-1b02-4f6f-9157-b5cf64ebcc4d.tif','','','''0''',''...
                                                             ^