### PR TITLE
Update provision write() to match render()

### DIFF
--- a/app/provision/resources/classes/provision.php
+++ b/app/provision/resources/classes/provision.php
@@ -1200,11 +1200,12 @@ include "root.php";
 				$provision = array();
 				if (is_array($_SESSION['provision'])) {
 					foreach ($_SESSION['provision'] as $key => $val) {
-						if (strlen($val['var']) > 0) { $value = $val['var']; }
-						if (strlen($val['text']) > 0) { $value = $val['text']; }
-						if (strlen($val['boolean']) > 0) { $value = $val['boolean']; }
-						if (strlen($val['numeric']) > 0) { $value = $val['numeric']; }
-						if (strlen($value) > 0) { $provision[$key] = $value; }
+						if (isset($val['var'])) { $value = $val['var']; }
+						elseif (isset($val['text'])) { $value = $val['text']; }
+						elseif (isset($val['boolean'])) { $value = $val['boolean']; }
+						elseif (isset($val['numeric'])) { $value = $val['numeric']; }
+						elseif (is_array($val) && !is_uuid($val['uuid'])) { $value = $val; }
+						if (isset($value)) { $provision[$key] = $value; }
 						unset($value);
 					}
 				}


### PR DESCRIPTION
# Context
This will ensure that anyone using TFTP still can use array template variables. I am one of those unlucky ones that have to support a few devices that do not have HTTP provisioning.

# Overview
- Apply changes from 906b86d3dc4c00ad53e2b93a52f854ab5b5d9b46
- Apply changes from 0b91af9f424cae593625dd133ca61d1a77e72b02