### PR TITLE
Fix bulk device imports with TFTP path enabled

### DIFF
--- a/app/devices/device_imports.php
+++ b/app/devices/device_imports.php
@@ -357,6 +357,12 @@
 						$database->save($array);
 						//$message = $database->message;
 					}
+				
+					if (strlen($_SESSION['provision']['path']['text']) > 0) {
+						$prov = new provision;
+						$prov->domain_uuid = $domain_uuid;
+						$response = $prov->write();
+					}
 
 				//send the redirect header
 					header("Location: devices.php");


### PR DESCRIPTION
# Context
If you bulk imported devices and had the TFTP path set the configuration files would not be written out to the TFTP path. This MR fixes it to trigger write() in this condition just like `device_edit.php` and other files.

# Overview
- Trigger provision->write() if ['provision']['path']['text'] is set.