### PR TITLE
Fix follow_me_uuid error when enabling DND

### DIFF
--- a/app/scripts/resources/scripts/do_not_disturb.lua
+++ b/app/scripts/resources/scripts/do_not_disturb.lua
@@ -100,7 +100,7 @@
 		extension = row.extension;
 		number_alias = row.number_alias or '';
 		accountcode = row.accountcode;
-		follow_me_uuid = row.follow_me_uuid;
+		follow_me_uuid = row.follow_me_uuid or nil;
 		do_not_disturb = row.do_not_disturb;
 		forward_all_destination = row.forward_all_destination;
 		forward_all_enabled = row.forward_all_enabled;


### PR DESCRIPTION
The follow me update code in do_not_disturb.lua was being executed even when the follow me uuid didn't exist. Let me know if this is the wrong approach to fix this in lua, I'm not particularly well versed in this but this seemed to have fixed it in my testing.

I have some concerns about this section of code in general though, it seems that enabling server side DND will turn off follow me, but then turning off DND won't return follow me to its original state. Is this the intended behavior? and if so we might need to make a workaround.