### PR TITLE
Add "Settings" link to Domains list

### DIFF
--- a/core/domains/domains.php
+++ b/core/domains/domains.php
@@ -267,6 +267,10 @@
 			echo "	</td>\n";
 			echo "	<td class='no-link center'>\n";
 			echo "		<a href='".PROJECT_PATH."/core/domains/domains.php?domain_uuid=".escape($row['domain_uuid'])."&domain_change=true'>".$text['label-manage']."</a>";
+			if (permission_exists('domain_setting_view')) {
+				$list_setting_url = PROJECT_PATH."/core/domain_settings/domain_settings.php?id=".urlencode($row['domain_uuid']);
+				echo " | <a href='".$list_setting_url."'\">".$text['button-settings'];
+			}
 			echo "	</td>\n";
 			if (permission_exists('domain_edit')) {
 				echo "	<td class='no-link center'>\n";


### PR DESCRIPTION
Skip the step of clicking on the domain then clicking settings. I very rarely want to edit a domain's basic settings, 99% of the time I am wanting to either manage the domain or edit domain_settings.

![](https://i.imgur.com/iv3qDsQ.png)

There are a few other potential improvements to the "Settings" workflow that I'm tossing around:
- Rename "Default Settings" to "Domain Settings" and have it open the current domain's settings.
  - The settings that are "custom" per domain would be highlighted, possibly with a filter to show which ones have been edited.
  - A setting that is marked as "default" is still visible, but you can "Edit". The act of editing it will do the same as the current "copy" function, just in one transparent step. 
  - If a user has permissions, there will be a separate "Edit Global Default" edit button for that particular setting
  - Setting a setting to "Global Default" deletes the "Domain Setting" entry, and just reverts it back to displaying as "unmodified/default"
- "Array" settings type edit all values in a single pane of glass. Managing an array as individual entries is annoying.