### PR TITLE
Fix DND Feature Sync loop

### DIFF
--- a/app/scripts/resources/scripts/app/feature_event/resources/functions/feature_event_notify.lua
+++ b/app/scripts/resources/scripts/app/feature_event/resources/functions/feature_event_notify.lua
@@ -80,6 +80,8 @@ function feature_event_notify.dnd(user, host, sip_profile, do_not_disturb)
 		event:addHeader("Feature-Event", "DoNotDisturbEvent")
 		event:addHeader("doNotDisturbOn", do_not_disturb)
 		--freeswitch.consoleLog("notice","[events] " .. event:serialize("xml") .. "\n");
+		local socket = require 'socket'
+		socket.sleep(0.2)
 		event:fire()
 end
 
@@ -94,6 +96,8 @@ function feature_event_notify.forward_immediate(user, host, sip_profile, forward
 		event:addHeader("forward_immediate_enabled", forward_immediate_enabled)
 		event:addHeader("forward_immediate", forward_immediate_destination);
 		freeswitch.consoleLog("notice","[events] " .. event:serialize("xml") .. "\n");
+		local socket = require 'socket'
+		socket.sleep(0.2)
 		event:fire()
 end
 
@@ -107,6 +111,8 @@ function feature_event_notify.forward_busy(user, host, sip_profile, forward_busy
 		event:addHeader("Feature-Event", "ForwardingEvent")
 		event:addHeader("forward_busy", forward_busy_destination)
 		event:addHeader("forward_busy_enabled", forward_busy_enabled)
+		local socket = require 'socket'
+		socket.sleep(0.2)
 		event:fire()
 end
 
@@ -121,6 +127,8 @@ function feature_event_notify.forward_no_answer(user, host, sip_profile, forward
 		event:addHeader("forward_no_answer", forward_no_answer_destination)
 		event:addHeader("forward_no_answer_enabled", forward_no_answer_enabled)
 		event:addHeader("ringCount", ring_count)
+		local socket = require 'socket'
+		socket.sleep(0.2)
 		event:fire()
 end
 
@@ -142,6 +150,8 @@ function feature_event_notify.init(user, host, sip_profile, forward_immediate_en
 		event:addHeader("ringCount", ring_count)		
 		event:addHeader("Feature-Event", "DoNotDisturbEvent")
 		event:addHeader("doNotDisturbOn", do_not_disturb)
+		local socket = require 'socket'
+		socket.sleep(0.2)
 		event:fire()
 end
 


### PR DESCRIPTION
Add Delay to prevent infinite feature key Loops on some phones (Yealink....)

With some phones (easy to reproduce on Yealink) if a user toggles the DND too quickly it would create a loop where it kept turning DND off and on again repeatedly, often until you rebooted the phone. Even harder with multiple devices on the same extension.

This adds a short delay before firing the feature sync notification event and prevents the loop.