### PR TITLE
fix send_email function for multi-part addresses

### DIFF
--- a/app/email_logs/email_test.php
+++ b/app/email_logs/email_test.php
@@ -35,63 +35,58 @@
 	$text = $language->get();
 
 //send email
-	if (valid_email($_POST['to'])) {
 
-		//validate the token
-			$token = new token;
-			if (!$token->validate('/app/email_logs/email_logs.php')) {
-				//message::add($text['message-invalid_token'],'negative');
-				echo "<script>display_message('".$text['message-invalid_token']."', 'negative');</script>";
-				echo "<center>\n";
-				echo 	$text['message-invalid_token'];
-				echo "	<br><br>\n";
-				echo "	<input type='button' class='btn' style='margin-top: 15px;' value='".$text['button-close']."' onclick=\"$('#test_result_layer').fadeOut(200);\">\n";
-				echo "</center>\n";
-				exit;
+	//validate the token
+		$token = new token;
+		if (!$token->validate('/app/email_logs/email_logs.php')) {
+			//message::add($text['message-invalid_token'],'negative');
+			echo "<script>display_message('".$text['message-invalid_token']."', 'negative');</script>";
+			echo "<center>\n";
+			echo 	$text['message-invalid_token'];
+			echo "	<br><br>\n";
+			echo "	<input type='button' class='btn' style='margin-top: 15px;' value='".$text['button-close']."' onclick=\"$('#test_result_layer').fadeOut(200);\">\n";
+			echo "</center>\n";
+			exit;
+		}
+
+	$recipient = check_str($_POST['to']);
+
+	echo "<b>".$text['header-settings']."</b>\n";
+	echo "<br><br>\n";
+	ksort($_SESSION['email']);
+	foreach ($_SESSION['email'] as $name => $setting) {
+		foreach ($setting as $type => $value) {
+			if ($type == 'uuid') { $uuid = $value; continue; }
+			if ($name == 'smtp_password') { $value = '[REDACTED]'; }
+			if (permission_exists('default_setting_edit')) {
+				echo "<a href='../../core/default_settings/default_setting_edit.php?id=".$uuid."' target='_blank'>".$name.'</a>: '.$value."<br>\n";
 			}
-
-		$recipient = check_str($_POST['to']);
-
-		echo "<b>".$text['header-settings']."</b>\n";
-		echo "<br><br>\n";
-		ksort($_SESSION['email']);
-		foreach ($_SESSION['email'] as $name => $setting) {
-			foreach ($setting as $type => $value) {
-				if ($type == 'uuid') { $uuid = $value; continue; }
-				if ($name == 'smtp_password') { $value = '[REDACTED]'; }
-				if (permission_exists('default_setting_edit')) {
-					echo "<a href='../../core/default_settings/default_setting_edit.php?id=".$uuid."' target='_blank'>".$name.'</a>: '.$value."<br>\n";
-				}
-				else {
-					echo $name.': '.$value."<br>\n";
-				}
+			else {
+				echo $name.': '.$value."<br>\n";
 			}
 		}
-		echo "<br><br>\n";
-
-		echo "<b>".$text['header-connection']."</b>\n";
-		echo "<br><br>\n";
-
-		$eml_body = "<b>Test Message</b><br /><br />\n";
-		$eml_body .= "This message is a test of the SMTP settings configured within your PBX.<br />\n";
-		$eml_body .= "If you received this message, your current SMTP settings are valid.<br /><br />\n";
-
-		ob_start();
-		$sent = !send_email($recipient, 'Test Message', $eml_body, $eml_error, null, null, 3, 3) ? false : true;
-		$response = ob_get_clean();
-
-		echo $response;
-
-		echo "<br><br>\n";
-
-		echo "<b>".$text['header-result']."</b>\n";
-		echo "<br><br>\n";
-		echo $sent ? "Message Sent Successfully<br>Receipient: <a href='mailto:".$recipient."'>".$recipient."</a>" : "Message Failed...<br>".$eml_error;
-
 	}
-	else {
-		echo "Error: Invalid Recipient Address";
-	}
+	echo "<br><br>\n";
+
+	echo "<b>".$text['header-connection']."</b>\n";
+	echo "<br><br>\n";
+
+	$eml_body = "<b>Test Message</b><br /><br />\n";
+	$eml_body .= "This message is a test of the SMTP settings configured within your PBX.<br />\n";
+	$eml_body .= "If you received this message, your current SMTP settings are valid.<br /><br />\n";
+
+	ob_start();
+	$sent = !send_email($recipient, 'Test Message', $eml_body, $eml_error, null, null, 3, 3) ? false : true;
+	$response = ob_get_clean();
+
+	echo $response;
+
+	echo "<br><br>\n";
+
+	echo "<b>".$text['header-result']."</b>\n";
+	echo "<br><br>\n";
+	echo $sent ? "Message Sent Successfully<br>Receipient: <a href='mailto:".$recipient."'>".$recipient."</a>" : "Message Failed...<br>".$eml_error;
+
 
 	echo "<br>\n";
 	echo "<center>\n";

--- a/resources/functions.php
+++ b/resources/functions.php
@@ -1411,44 +1411,32 @@ function number_pad($number,$n) {
 
 			if (!is_array($eml_recipients)) { // must be a single or delimited recipient address(s)
 				$eml_recipients = str_replace(' ', '', $eml_recipients);
-				if (substr_count(',', $eml_recipients)) { $delim = ','; }
-				if (substr_count(';', $eml_recipients)) { $delim = ';'; }
-				if ($delim) { $eml_recipients = explode($delim, $eml_recipients); } // delimiter found, convert to array of addresses
+				$eml_recipients = str_replace(array(';',','), ' ', $eml_recipients);
+				$eml_recipients = explode(' ', $eml_recipients); // convert to array of addresses
 			}
-
-			if (is_array($eml_recipients)) { // check if multiple recipients
-				foreach ($eml_recipients as $eml_recipient) {
-					if (is_array($eml_recipient)) { // check if each recipient has multiple fields
-						if ($eml_recipient["address"] != '' && preg_match($regexp, $eml_recipient["address"]) == 1) { // check if valid address
-							switch ($eml_recipient["delivery"]) {
-								case "cc" :		$mail -> AddCC($eml_recipient["address"], ($eml_recipient["name"]) ? $eml_recipient["name"] : $eml_recipient["address"]);			break;
-								case "bcc" :	$mail -> AddBCC($eml_recipient["address"], ($eml_recipient["name"]) ? $eml_recipient["name"] : $eml_recipient["address"]);			break;
-								default :		$mail -> AddAddress($eml_recipient["address"], ($eml_recipient["name"]) ? $eml_recipient["name"] : $eml_recipient["address"]);
-							}
-							$address_found = true;
+			foreach ($eml_recipients as $eml_recipient) {
+				if (is_array($eml_recipient)) { // check if each recipient has multiple fields
+					if ($eml_recipient["address"] != '' && preg_match($regexp, $eml_recipient["address"]) == 1) { // check if valid address
+						switch ($eml_recipient["delivery"]) {
+							case "cc" :		$mail -> AddCC($eml_recipient["address"], ($eml_recipient["name"]) ? $eml_recipient["name"] : $eml_recipient["address"]);			break;
+							case "bcc" :	$mail -> AddBCC($eml_recipient["address"], ($eml_recipient["name"]) ? $eml_recipient["name"] : $eml_recipient["address"]);			break;
+							default :		$mail -> AddAddress($eml_recipient["address"], ($eml_recipient["name"]) ? $eml_recipient["name"] : $eml_recipient["address"]);
 						}
-					}
-					else if ($eml_recipient != '' && preg_match($regexp, $eml_recipient) == 1) { // check if recipient value is simply (only) an address
-						$mail -> AddAddress($eml_recipient);
 						$address_found = true;
 					}
 				}
-
-				if (!$address_found) {
-					$eml_error = "No valid e-mail address provided.";
-					return false;
-				}
-
-			}
-			else { // just a single e-mail address found, not an array of addresses
-				if ($eml_recipients != '' && preg_match($regexp, $eml_recipients) == 1) { // check if email syntax is valid
-					$mail -> AddAddress($eml_recipients);
-				}
-				else {
-					$eml_error = "No valid e-mail address provided.";
-					return false;
+				else if ($eml_recipient != '' && preg_match($regexp, $eml_recipient) == 1) { // check if recipient value is simply (only) an address
+					$mail -> AddAddress($eml_recipient);
+					$address_found = true;
 				}
 			}
+
+			if (!$address_found) {
+				$eml_error = "No valid e-mail address provided.";
+				return false;
+			}
+
+
 
 			if (is_array($eml_attachments) && sizeof($eml_attachments) > 0) {
 				foreach ($eml_attachments as $attachment) {


### PR DESCRIPTION
The send_email function wasn't successfully parsing ; or , separated email address lists. I simplified it's processing and fixed it.

While I was at it I removed the "valid email" check from email_test.php because that step is already being done in the send_email function that is called and it safely returns the appropriate error. I would have had to rewrite that function to handle the multiple email lists otherwise.


This edit looks much larger than it actually is because I adjusted indentation on blocks of code that were moved out of an if statement.