### PR TITLE
Template Alias Support

### DIFF
--- a/app/devices/device_edit.php
+++ b/app/devices/device_edit.php
@@ -826,7 +826,7 @@
 				$prov = new provision;
 				$prov->domain_uuid = $domain_uuid;
 				$template_dir = $prov->template_dir;
-				$files = glob($template_dir.'/'.$device_template.'/*');
+				$files = glob($prov->resolve_template($template_dir, $device_template).'/*');
 			//add file buttons and the file list
 				echo button::create(['type'=>'button','id'=>'button_files','label'=>$text['button-files'],'icon'=>$_SESSION['theme']['button_icon_download'],'onclick'=>'show_files()']);
 				echo 		"<select class='formfld' style='display: none; width: auto;' name='target_file' id='target_file' onchange='download(this.value)'>\n";


### PR DESCRIPTION
# Context
There are a bunch of templates that are copies and are exactly the same. This MR adds support for a `.alias` file that would allow templates to instead use the files of a different template. This can allow us to clean up some of the duplicated templates while retaining the user friendly naming and backwards compatibility.

# Overview
- Add a new resolve_template function to take care of the template path resolution in a single spot
- Modify render() to use resolve_template
- Modify write() to resolve template
- Add support in write() for custom domain_name template directories
- Modify device_edit.php to use the resolve_template function

# Example .alias file
Inside of cisco/7841/.alias:
```
cisco/79x1
```