### PR TITLE
Registrations list is empty

### DIFF
--- a/app/registrations/resources/classes/registrations.php
+++ b/app/registrations/resources/classes/registrations.php
@@ -88,7 +88,7 @@ if (!class_exists('registrations')) {
 						//get sofia status profile information including registrations
 							$cmd = "api sofia xmlstatus profile '".$field['sip_profile_name']."' reg";
 							$xml_response = trim(event_socket_request($fp, $cmd));
-							if (function_exists('iconv')) { $xml_response = iconv("utf-8", "utf-8//ignore", $xml_response); }
+							if (function_exists('iconv')) { $xml_response = iconv("utf-8", "utf-8//IGNORE", $xml_response); }
 							$xml_response = preg_replace('/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/u', '', $xml_response);
 							if ($xml_response == "Invalid Profile!") { $xml_response = "<error_msg>".$text['label-message']."</error_msg>"; }
 							$xml_response = str_replace("<profile-info>", "<profile_info>", $xml_response);


### PR DESCRIPTION
Registrations make exception on got illegal character from sip phones
In iconv("utf-8", "utf-8//ignore" is not working, only like this:
iconv("utf-8", "utf-8//IGNORE"
in
app/registrations/resources/classes/registrations.php

Correct ignore to IGNORE in iconv paramter.