### PR TITLE
Fix CLI editors with faulty syntax highlining.

### DIFF
--- a/app/dialplans/resources/classes/dialplan.php
+++ b/app/dialplans/resources/classes/dialplan.php
@@ -179,6 +179,7 @@
 
 				//get the array of xml files
 					$xml_list = glob($_SERVER["DOCUMENT_ROOT"] . PROJECT_PATH . "/*/*/resources/switch/conf/dialplan/*.xml");
+				/* **/
 
 				//build the dialplan xml array
 					/*


### PR DESCRIPTION
When editing in the CLI with any editor that does syntax highlight, the * breaks it. Adding on the following line /* **/ restores the right highlighting