### PR TITLE
T57W fix static dns

### DIFF
--- a/resources/templates/provision/yealink/t57w/y000000000097.cfg
+++ b/resources/templates/provision/yealink/t57w/y000000000097.cfg
@@ -60,6 +60,7 @@ static.network.ip_address_mode = {$yealink_ip_address_mode}
 static.network.span_to_pc_port =
 static.network.vlan.pc_port_mode =
 {if isset($dns_server_primary)}static.network.static_dns_enable = 1{else}static.network.static_dns_enable = 0{/if}
+
 static.network.pc_port.enable = 1
 static.network.primary_dns = {$dns_server_primary}
 static.network.secondary_dns = {$dns_server_secondary}


### PR DESCRIPTION
missing newline causes smarty to combine `static.network.static_dns_enable` with the next line and breaking it