### PR TITLE
Dialplan Fix for Feature Key Sync Race

### DIFF
--- a/app/dialplans/resources/switch/conf/dialplan/490_do-not-disturb.xml
+++ b/app/dialplans/resources/switch/conf/dialplan/490_do-not-disturb.xml
@@ -1,18 +1,22 @@
 <context name="{v_context}">
 	<extension name="do-not-disturb" number="*77,*78,*79" continue="false" app_uuid="df32d982-e39e-4ae5-a46d-aed1893873f2" enabled="true" order="490">
 		<condition field="destination_number" expression="^\*77$" break="on-true">
+			<action application="limit" data="hash dnd ${sip_from_uri} 1 !USER_BUSY"/>
 			<action application="set" data="enabled=toggle"/>
 			<action application="lua" data="do_not_disturb.lua"/>
 		</condition>
 		<condition field="destination_number" expression="^\*78$|\*363$" break="on-true">
+			<action application="limit" data="hash dnd ${sip_from_uri} 1 !USER_BUSY"/>
 			<action application="set" data="enabled=true"/>
 			<action application="lua" data="do_not_disturb.lua"/>
 		</condition>
 		<condition field="destination_number" expression="^\*79$" break="on-true">
+			<action application="limit" data="hash dnd ${sip_from_uri} 1 !USER_BUSY"/>
 			<action application="set" data="enabled=false"/>
 			<action application="lua" data="do_not_disturb.lua"/>
 		</condition>
 		<condition field="destination_number" expression="^dnd\+${caller_id_number}$" break="on-true">
+			<action application="limit" data="hash dnd ${sip_from_uri} 1 !USER_BUSY"/>
 			<action application="set" data="enabled=toggle"/>
 			<action application="lua" data="do_not_disturb.lua"/>
 		</condition>

--- a/app/scripts/resources/scripts/app/feature_event/resources/functions/feature_event_notify.lua
+++ b/app/scripts/resources/scripts/app/feature_event/resources/functions/feature_event_notify.lua
@@ -94,7 +94,6 @@ function feature_event_notify.dnd(user, host, sip_profiles, do_not_disturb)
 		event:addHeader("Feature-Event", "DoNotDisturbEvent")
 		event:addHeader("doNotDisturbOn", do_not_disturb)
 		--freeswitch.consoleLog("notice","[events] " .. event:serialize("xml") .. "\n");
-		freeswitch.msleep(200);
 		event:fire()
 	end
 end
@@ -111,7 +110,6 @@ function feature_event_notify.forward_immediate(user, host, sip_profiles, forwar
 		event:addHeader("forward_immediate_enabled", forward_immediate_enabled)
 		event:addHeader("forward_immediate", forward_immediate_destination);
 		freeswitch.consoleLog("notice","[events] " .. event:serialize("xml") .. "\n");
-		freeswitch.msleep(200);
 		event:fire()
 	end
 end
@@ -127,7 +125,6 @@ function feature_event_notify.forward_busy(user, host, sip_profiles, forward_bus
 		event:addHeader("Feature-Event", "ForwardingEvent")
 		event:addHeader("forward_busy", forward_busy_destination)
 		event:addHeader("forward_busy_enabled", forward_busy_enabled)
-		freeswitch.msleep(200);
 		event:fire()
 	end
 end
@@ -144,7 +141,6 @@ function feature_event_notify.forward_no_answer(user, host, sip_profiles, forwar
 		event:addHeader("forward_no_answer", forward_no_answer_destination)
 		event:addHeader("forward_no_answer_enabled", forward_no_answer_enabled)
 		event:addHeader("ringCount", ring_count)
-		freeswitch.msleep(200);
 		event:fire()
 	end
 end
@@ -168,7 +164,6 @@ function feature_event_notify.init(user, host, sip_profiles, forward_immediate_e
 		event:addHeader("ringCount", ring_count)		
 		event:addHeader("Feature-Event", "DoNotDisturbEvent")
 		event:addHeader("doNotDisturbOn", do_not_disturb)
-		freeswitch.msleep(200);
 		event:fire()
 	end
 end


### PR DESCRIPTION
This is a dialplan approach to fix the feature key sync loop/race with yealink phones. This approach may also need to be extended to the Call Forward dialplans. It limits the number of simultaneous calls for a particular user to change their DND/Forwarding status to a single call at a time and returns user busy. The yealink phones will re-try their background feature key sync phone call several times and the call is very short it doesn't introduce any risk of the phones being "out of sync" with the server's DND status.

I am also reverting the lua approach because it was not reliable and can still easily allow the loop to occur.