### PR TITLE
[4.5] AS support to the [cdr][field] default setting

### DIFF
--- a/app/xml_cdr/resources/classes/xml_cdr.php
+++ b/app/xml_cdr/resources/classes/xml_cdr.php
@@ -108,6 +108,7 @@ if (!class_exists('xml_cdr')) {
 		 * cdr fields in the database schema
 		 */
 		public function fields() {
+			$pattern = '/\s+as\s+/i';
 
 			$this->fields[] = "xml_cdr_uuid";
 			$this->fields[] = "domain_uuid";
@@ -176,9 +177,16 @@ if (!class_exists('xml_cdr')) {
 			$this->fields[] = "sip_hangup_disposition";
 			if (is_array($_SESSION['cdr']['field'])) {
 				foreach ($_SESSION['cdr']['field'] as $field) {
-					$this->fields[] = $field;
+					if (preg_match($pattern, $field)){
+						$field_pattern = preg_split ($pattern, $field);
+						$field = $field_pattern[0];
+					}
+					if (!in_array($field, $this->fields)){
+						$this->fields[] = $field;
+					}
 				}
 			}
+			$this->fields = array_unique($this->fields);
 		}
 
 		/**
@@ -453,15 +461,24 @@ if (!class_exists('xml_cdr')) {
 							foreach ($_SESSION['cdr']['field'] as $field) {
 								$fields = explode(",", $field);
 								$field_name = end($fields);
-								$this->fields[] = $field_name;
+								$pattern = '/\s+as\s+/i';
+								if (preg_match($pattern, $field_name)){
+									$field_pattern = preg_split ($pattern, $field_name);
+									$field_name = $field_pattern[0];
+								}
+								if (!in_array($field_name, $this->fields))
+									$this->fields[] = $field_name;
 								if (count($fields) == 1) {
-									$this->array[$key][$field_name] = urldecode($xml->variables->$fields[0]);
+									if (is_null($this->array[$key][$field_name]))
+										$this->array[$key][$field_name] = urldecode($xml->variables->$fields[0]);
 								}
 								if (count($fields) == 2) {
-									$this->array[$key][$field_name] = urldecode($xml->$fields[0]->$fields[1]);
+									if (is_null($this->array[$key][$field_name]))
+										$this->array[$key][$field_name] = urldecode($xml->$fields[0]->$fields[1]);
 								}
 								if (count($fields) == 3) {
-									$this->array[$key][$field_name] = urldecode($xml->$fields[0]->$fields[1]->$fields[2]);
+									if (is_null($this->array[$key][$field_name]))
+										$this->array[$key][$field_name] = urldecode($xml->$fields[0]->$fields[1]->$fields[2]);
 								}
 							}
 						}

--- a/app/xml_cdr/xml_cdr.php
+++ b/app/xml_cdr/xml_cdr.php
@@ -167,6 +167,11 @@
 		foreach ($_SESSION['cdr']['field'] as $field) {
 			$array = explode(",", $field);
 			$field_name = $array[count($array) - 1];
+			$pattern = '/\s+as\s+/i';
+			if (preg_match($pattern, $field_name)){
+				$field_pattern = preg_split ($pattern, $field_name);
+				$field_name = $field_pattern[1];
+			}
 			if (isset($_REQUEST[$field_name])) {
 				echo "	<input type='hidden' name='".escape($field_name)."' value='".escape($$field_name)."'>\n";
 			}
@@ -472,6 +477,11 @@
 					foreach ($_SESSION['cdr']['field'] as $field) {
 						$array = explode(",", $field);
 						$field_name = end($array);
+						$pattern = '/\s+as\s+/i';
+						if (preg_match($pattern, $field_name)){
+							$field_pattern = preg_split ($pattern, $field_name);
+							$field_name = $field_pattern[1];
+						}
 						$field_label = ucwords(str_replace("_", " ", $field_name));
 						$field_label = str_replace("Sip", "SIP", $field_label);
 						if ($field_name != "destination_number") {
@@ -564,6 +574,11 @@
 			foreach ($_SESSION['cdr']['field'] as $field) {
 				$array = explode(",", $field);
 				$field_name = end($array);
+				$pattern = '/\s+as\s+/i';
+				if (preg_match($pattern, $field_name)){
+					$field_pattern = preg_split ($pattern, $field_name);
+					$field_name = $field_pattern[1];
+				}
 				$field_label = ucwords(str_replace("_", " ", $field_name));
 				$field_label = str_replace("Sip", "SIP", $field_label);
 				if ($field_name != "destination_number") {

--- a/app/xml_cdr/xml_cdr_inc.php
+++ b/app/xml_cdr/xml_cdr_inc.php
@@ -83,6 +83,11 @@
 			foreach ($_SESSION['cdr']['field'] as $field) {
 				$array = explode(",", $field);
 				$field_name = end($array);
+				$pattern = '/\s+as\s+/i';
+				if (preg_match($pattern, $field_name)){
+					$field_pattern = preg_split ($pattern, $field_name);
+					$field_name = $field_pattern[1];
+				}
 				if (isset($_REQUEST[$field_name])) {
 					$$field_name = $_REQUEST[$field_name];
 				}
@@ -173,6 +178,11 @@
 	if (is_array($_SESSION['cdr']['field'])) {
 		foreach ($_SESSION['cdr']['field'] as $field) {
 			$array = explode(",", $field);
+			$pattern = '/\s+as\s+/i';
+			if (preg_match($pattern, $field_name)){
+				$field_pattern = preg_split ($pattern, $field_name);
+				$field_name = $field_pattern[0];
+			}
 			$field_name = end($array);
 			if (isset($$field_name)) {
 				$param .= "&".$field_name."=".urlencode($$field_name);


### PR DESCRIPTION
if you put a default setting like

_SESSION[cdr][field][array] = xml_cdr_uuid as CDR

it allows you to present a column with an alternative name. 

The best use case is letting users see their CALL UUID (when reporting a call) without letting them view the call detail. Very handy to do support.