### PR TITLE
MWI for Multi Registrations on Multi Profiles

### DIFF
--- a/app/scripts/resources/scripts/app/voicemail/resources/functions/mwi_notify.lua
+++ b/app/scripts/resources/scripts/app/voicemail/resources/functions/mwi_notify.lua
@@ -1,5 +1,5 @@
 
---define a function to send email
+--define a function to send mwi notify
 	function mwi_notify(account, new_messages, saved_messages)
 
 		--includes
@@ -8,26 +8,48 @@
 
 		--create the api object
 		api = freeswitch.API();
-		local sofia_contact = trim(api:executeString("sofia_contact */"..account));
-		array = explode("/", sofia_contact);
-		sip_profile = array[2];
 
-		--debug info
-		--freeswitch.consoleLog("NOTICE", "sofia_contact */"..account.."\n");
-		--freeswitch.consoleLog("NOTICE", "sip_profile="..sip_profile.."\n");
-		--freeswitch.consoleLog("NOTICE", "sofia_contact="..sofia_contact.."\n");
+		local sofia_contacts = trim(api:executeString("sofia_contact */"..account));
+		local sofia_contact_table = explode(",", sofia_contacts);
 
-		--set the variables
-		new_messages   = tonumber(new_messages)   or 0
-		saved_messages = tonumber(saved_messages) or 0
+		local sip_profile_table = {};
 
-		--set the event and send it
-		local event = freeswitch.Event("message_waiting")
-		event:addHeader("MWI-Messages-Waiting", (new_messages == 0) and "no" or "yes")
-		event:addHeader("MWI-Message-Account", "sip:" .. account)
-		event:addHeader("MWI-Voice-Message", string.format("%d/%d (0/0)", new_messages, saved_messages))
-		event:addHeader("sofia-profile", sip_profile)
-		return event:fire()
+		for key,value in pairs(sofia_contact_table) do
+			f = explode("/", value);
+			sip_profile = f[2];
+
+
+			--check to see if a notify has already been sent to this profile
+			new = "true";
+			for profile_index, profile_table_value in pairs(sip_profile_table) do
+				if profile_table_value == sip_profile then
+					new = "false";
+				end
+			end
+
+			if new == "true" then 
+				--debug info
+				--freeswitch.consoleLog("NOTICE", "sofia_contact */"..account.."\n");
+				--freeswitch.consoleLog("NOTICE", "sip_profile="..sip_profile.."\n");
+				--freeswitch.consoleLog("NOTICE", "sofia_contacts="..sofia_contacts.."\n");
+		
+				--set the variables
+				new_messages   = tonumber(new_messages)   or 0
+				saved_messages = tonumber(saved_messages) or 0
+		
+				--set the event and send it
+				local event = freeswitch.Event("message_waiting")
+				event:addHeader("MWI-Messages-Waiting", (new_messages == 0) and "no" or "yes")
+				event:addHeader("MWI-Message-Account", "sip:" .. account)
+				event:addHeader("MWI-Voice-Message", string.format("%d/%d (0/0)", new_messages, saved_messages))
+				event:addHeader("sofia-profile", sip_profile)
+				event:fire()
+				
+				table.insert(sip_profile_table,sip_profile);
+			end
+				
+		end
+		
 	end
 
 --return module value


### PR DESCRIPTION
Sometimes you can have multiple registrations for the same extension across multiple SIP profiles. This adds the functionality to fire an event for each unique SIP profile. I also added a check to see if we have already send an event for a profile since you don't want multiple events fired one SIP profile.