### PR TITLE
[callcenter] Add ability for callcenter presence

### DIFF
--- a/app/call_center_active/call_center_active_inc.php
+++ b/app/call_center_active/call_center_active_inc.php
@@ -116,7 +116,7 @@
 
 			//send the event socket command and get the response
 				//callcenter_config queue list tiers [queue_name] |
-				$switch_command = 'callcenter_config queue list tiers '.$queue_uuid;
+				$switch_command = 'callcenter_config queue list tiers '.$queue_uuid."@".$_SESSION["domain_name"];
 				$event_socket_str = trim(event_socket_request($fp, 'api '.$switch_command));
 				$result = str_to_named_array($event_socket_str, '|');
 
@@ -138,7 +138,7 @@
 
 			//send the event socket command and get the response
 				//callcenter_config queue list agents [queue_name] [status] |
-				$switch_command = 'callcenter_config queue list agents '.$queue_uuid;
+				$switch_command = 'callcenter_config queue list agents '.$queue_uuid."@".$_SESSION["domain_name"];
 				$event_socket_str = trim(event_socket_request($fp, 'api '.$switch_command));
 				$agent_result = str_to_named_array($event_socket_str, '|');
 
@@ -287,7 +287,7 @@
 			//send the event socket command and get the response
 				//callcenter_config queue list members [queue_name]
 				if (is_uuid($queue_uuid)) {
-					$switch_command = 'callcenter_config queue list members '.$queue_uuid;
+					$switch_command = 'callcenter_config queue list members '.$queue_uuid."@".$_SESSION["domain_name"];
 					$event_socket_str = trim(event_socket_request($fp, 'api '.$switch_command));
 					$result = str_to_named_array($event_socket_str, '|');
 					if (!is_array($result)) { unset($result); }

--- a/app/call_centers/call_center_queue_edit.php
+++ b/app/call_centers/call_center_queue_edit.php
@@ -142,7 +142,7 @@
 			if ($fp) {
 				//callcenter_config tier del [queue_name] [agent_name]
 				if (is_uuid($call_center_queue_uuid) && is_uuid($call_center_agent_uuid)) {
-					$cmd = "api callcenter_config tier del ".$call_center_queue_uuid." ".$call_center_agent_uuid;
+					$cmd = "api callcenter_config tier del ".$call_center_queue_uuid."@".$_SESSION['domain_name']." ".$call_center_agent_uuid;
 					$response = event_socket_request($fp, $cmd);
 				}
 			}
@@ -347,7 +347,7 @@
 			if (strlen($queue_cc_exit_keys) > 0) {
 				$dialplan_xml .= "		<action application=\"set\" data=\"cc_exit_keys=".$queue_cc_exit_keys."\"/>\n";
 			}
-			$dialplan_xml .= "		<action application=\"callcenter\" data=\"".$call_center_queue_uuid."\"/>\n";
+			$dialplan_xml .= "		<action application=\"callcenter\" data=\"".$call_center_queue_uuid."@".$_SESSION["domain_name"]."\"/>\n";
 			if ($destination->valid($queue_timeout_app.':'.$queue_timeout_data)) {
 				$dialplan_xml .= "		<action application=\"".$queue_timeout_app."\" data=\"".$queue_timeout_data."\"/>\n";
 			}
@@ -430,19 +430,19 @@
 						*/
 						//add the agent
 						if (is_uuid($call_center_queue_uuid) && is_uuid($call_center_agent_uuid) && is_numeric($tier_level) && is_numeric($tier_position)) {
-							$cmd = "api callcenter_config tier add ".$call_center_queue_uuid." ".$call_center_agent_uuid." ".$tier_level." ".$tier_position;
+							$cmd = "api callcenter_config tier add ".$call_center_queue_uuid."@".$_SESSION["domain_name"]." ".$call_center_agent_uuid." ".$tier_level." ".$tier_position;
 							$response = event_socket_request($fp, $cmd);
 						}
 						usleep(200);
 						//agent set level
 						if (is_uuid($call_center_queue_uuid) && is_uuid($call_center_agent_uuid) && is_numeric($tier_level)) {
-							$cmd = "api callcenter_config tier set level ".$call_center_queue_uuid." ".$call_center_agent_uuid." ".$tier_level;
+							$cmd = "api callcenter_config tier set level ".$call_center_queue_uuid."@".$_SESSION["domain_name"]." ".$call_center_agent_uuid." ".$tier_level;
 							$response = event_socket_request($fp, $cmd);
 						}
 						usleep(200);
 						//agent set position
 						if (is_uuid($call_center_queue_uuid) && is_uuid($call_center_agent_uuid) && is_numeric($tier_position)) {
-							$cmd = "api callcenter_config tier set position ".$call_center_queue_uuid." ".$call_center_agent_uuid." ".$tier_position;
+							$cmd = "api callcenter_config tier set position ".$call_center_queue_uuid."@".$_SESSION["domain_name"]." ".$tier_position;
 							$response = event_socket_request($fp, $cmd);
 						}
 						usleep(200);

--- a/app/call_centers/cmd.php
+++ b/app/call_centers/cmd.php
@@ -67,7 +67,7 @@
 	if ($fp) {
 		$response = event_socket_request($fp, 'api reloadxml');
 		if (isset($cmd) && isset($queue)) {
-			$response = event_socket_request($fp, 'api callcenter_config queue '.$cmd. ' '.$queue);
+			$response = event_socket_request($fp, 'api callcenter_config queue '.$cmd. ' '.$queue."@".$_SESSION["domain_name"]);
 		}
 		fclose($fp);
 	}

--- a/app/call_centers/resources/classes/call_center.php
+++ b/app/call_centers/resources/classes/call_center.php
@@ -352,7 +352,7 @@
 									//delete the queue in the switch
 										if ($fp) {
 											foreach ($uuids as $uuid) {
-												$cmd = "api callcenter_config queue unload ".$uuid;
+												$cmd = "api callcenter_config queue unload ".$uuid."@".$_SESSION["domin_name"];
 												$response = event_socket_request($fp, $cmd);
 											}
 										}

--- a/app/scripts/resources/scripts/app/xml_handler/resources/scripts/configuration/callcenter.conf.lua
+++ b/app/scripts/resources/scripts/app/xml_handler/resources/scripts/configuration/callcenter.conf.lua
@@ -101,7 +101,7 @@
 					queue_name = queue_name:gsub(" ", "-");
 
 				--start the xml
-					table.insert(xml, [[                            <queue name="]]..queue_uuid..[[" label="]]..queue_name..[[@]]..domain_name..[[">]]);
+					table.insert(xml, [[                            <queue name="]]..queue_uuid..[[@]]..domain_name..[[" label="]]..queue_name..[[@]]..domain_name..[[">]]);
 					table.insert(xml, [[                                    <param name="strategy" value="]]..queue_strategy..[["/>]]);
 				--set ringback
 					queue_ringback = format_ringback(queue_moh_sound);
@@ -272,7 +272,7 @@
 				--build the xml
 					table.insert(xml, [[                            <tier ]]);
 					table.insert(xml, [[                            	agent="]]..agent_uuid..[[" ]]);
-					table.insert(xml, [[                            	queue="]]..queue_uuid..[[" ]]);
+					table.insert(xml, [[                            	queue="]]..queue_uuid..[[@]]..domain_name..[[" ]]);
 					table.insert(xml, [[                            	domain_name="]]..domain_name..[[" ]]);
 					--table.insert(xml, [[                            	agent_name="]]..agent_name..[[" ]]);
 					--table.insert(xml, [[                            	queue_name="]]..queue_name..[[" ]]);

--- a/app/xml_cdr/resources/classes/xml_cdr.php
+++ b/app/xml_cdr/resources/classes/xml_cdr.php
@@ -372,7 +372,14 @@ if (!class_exists('xml_cdr')) {
 						$this->array[$key]['cc_side'] = urldecode($xml->variables->cc_side);
 						$this->array[$key]['cc_member_uuid'] = urldecode($xml->variables->cc_member_uuid);
 						$this->array[$key]['cc_queue_joined_epoch'] = urldecode($xml->variables->cc_queue_joined_epoch);
-						$this->array[$key]['cc_queue'] = urldecode($xml->variables->cc_queue);
+						//remove the @domain from the queue name
+						$cc_queue = urldecode($xml->variables->cc_queue);
+						if (strpos($cc_queue, "@")) {
+							$this->array[$key]['cc_queue'] = substr($cc_queue, 0, strpos($cc_queue, "@"));
+						}
+						else {
+							$this->array[$key]['cc_queue'] = $cc_queue;
+						}
 						$this->array[$key]['cc_member_session_uuid'] = urldecode($xml->variables->cc_member_session_uuid);
 						$this->array[$key]['cc_agent_uuid'] = urldecode($xml->variables->cc_agent_uuid);
 						$this->array[$key]['cc_agent'] = urldecode($xml->variables->cc_agent);


### PR DESCRIPTION
* Freeswitch requires callcenter to have queue_name@domain for presence to work. this commit adds queuename@domain to be used for callcenter
* you can get a queues presence by subscribing to callcenter+queue_name@domain