### PR TITLE
Update valet parking dialplan to allow it to work with the auto parking dialplan

### DIFF
--- a/app/dialplans/resources/switch/conf/dialplan/470_valet_park.xml
+++ b/app/dialplans/resources/switch/conf/dialplan/470_valet_park.xml
@@ -1,18 +1,17 @@
 <context name="{v_context}">
-	<extension name="valet_park" number="park+*5901-*5999" continue="false" app_uuid="3cc8363d-5ce3-48aa-8ac1-143cf297c4f7" enabled="true" order="470">
-		<condition field="destination_number" expression="^(park\+)?\*(59[0-9][0-9])$" break="never"/>
+	<extension name="valet_park" number="park+5901-5999" continue="false" app_uuid="3cc8363d-5ce3-48aa-8ac1-143cf297c4f7" enabled="true" order="470">
+		<condition field="destination_number" expression="^(?:(?:park\+\*?)|(?:\*))((?:590[1-9])|(?:59[1-9][0-9]))$" break="never"/>
 		<condition field="${sip_h_Referred-By}" expression="sip:(.*)@.*" break="never">
 			<action application="set" data="referred_by_user=$1" inline="true"/>
 		</condition>
-		<condition field="destination_number" expression="^(park\+)?\*(59[0-9][0-9])$" break="never">
+		<condition field="destination_number" expression="^(?:(?:park\+\*?)|(?:\*))((?:590[1-9])|(?:59[1-9][0-9]))$" break="never">
 			<action application="set" data="park_in_use=false" inline="true"/>
-			<action application="set" data="park_lot=$2" inline="true"/>
-			<action application="info" data=""/>
+			<action application="set" data="park_lot=$1" inline="true"/>
 		</condition>
-		<condition field="destination_number" expression="^(park\+)?\*(59[0-9][0-9])$"/>
+		<condition field="destination_number" expression="^(?:(?:park\+\*?)|(?:\*))((?:590[1-9])|(?:59[1-9][0-9]))$"/>
 		<condition field="${referred_by_user}" expression="^.+$" break="never">
-			<action application="set" data="valet_info_park=${valet_info park@${domain_name}}|\*${park_lot}" inline="true"/>
-			<action application="set" data="park_in_use=${regex ${valet_info park@${domain_name}}|\*${park_lot}}" inline="true"/>
+			<action application="set" data="valet_info_park=${valet_info 5900@${domain_name}}|${park_lot}" inline="true"/>
+			<action application="set" data="park_in_use=${regex ${valet_info 5900@${domain_name}}|${park_lot}}" inline="true"/>
 		</condition>
 		<condition field="${park_in_use}" expression="true" break="never">
 			<action application="transfer" data="${referred_by_user} XML ${context}"/>
@@ -21,7 +20,7 @@
 			<anti-action application="set" data="valet_hold_music=${hold_music}"/>
 			<anti-action application="set" data="valet_parking_orbit_exten=${referred_by_user}"/>
 			<anti-action application="answer" data=""/>
-			<anti-action application="valet_park" data="park@${domain_name} *${park_lot}"/>
+			<anti-action application="valet_park" data="5900@${domain_name} ${park_lot}"/>
 		</condition>
 	</extension>
 </context>

--- a/app/dialplans/resources/switch/conf/dialplan/470_valet_park_auto.xml
+++ b/app/dialplans/resources/switch/conf/dialplan/470_valet_park_auto.xml
@@ -1,5 +1,5 @@
 <context name="{v_context}">
-	<extension name="valet_park_auto" number="park+5900" continue="false" app_uuid="c192ee50-084d-40d8-8d9a-6959369382c8" enabled="false" order="470">
+	<extension name="valet_park_auto" number="park+5900" continue="false" app_uuid="c192ee50-084d-40d8-8d9a-6959369382c8" enabled="true" order="470">
 		<condition field="destination_number" expression="^(?:(?:park\+\*?)|(?:\*))(5900)$"/>
 		<condition field="${sip_h_Referred-By}" expression="sip:(.*)@.*" break="never">
 			<action application="valet_park" data="5900@${domain_name} auto in 5901 5999"/>

--- a/app/dialplans/resources/switch/conf/dialplan/475_valet_park_out.xml
+++ b/app/dialplans/resources/switch/conf/dialplan/475_valet_park_out.xml
@@ -1,8 +1,0 @@
-<context name="{v_context}">
-	<extension name="valet_park_out" number="park+5901-5999" continue="false" app_uuid="242130d4-61d6-4daf-9dd1-b139a2b3b166" enabled="false" order="475">
-		<condition field="destination_number" expression="^(?:(?:park\+\*?)|(?:\*))(59[0-9][0-9])$">
-			<action application="answer"/>
-			<action application="valet_park" data="5900@${domain_name} $1"/>
-		</condition>
-	</extension>
-</context>

--- a/app/scripts/resources/scripts/park_compatibility.lua
+++ b/app/scripts/resources/scripts/park_compatibility.lua
@@ -1,0 +1,28 @@
+if event:getHeader("proto") ~= "park" then
+    return
+end
+
+-- Get the domain name and parking lot if in the form of 59xx@domain_name
+-- park+ gets added on downstream in sofia_presence.c#L2026 if proto == park
+-- See https://github.com/signalwire/freeswitch/blob/master/src/mod/applications/mod_valet_parking/mod_valet_parking.c#L278
+-- https://github.com/signalwire/freeswitch/blob/master/src/mod/endpoints/mod_sofia/sofia_presence.c#L2026
+_, _, parking_lot, domain_name = string.find(event:getHeader("from"), "^(59%d%d)@(.+)$")
+if parking_lot == nil or domain_name == nil then
+    return
+end
+
+local newLot = "*" .. parking_lot
+local newFrom = newLot .. "@" .. domain_name
+
+freeswitch.consoleLog("NOTICE", "Forwarding " .. event:getHeader("from") .. " To " .. newFrom)
+
+-- Delete the headers before we replace them with new ones
+event:delHeader("from")
+event:delHeader("login")
+
+-- Set the new headers
+event:addHeader("from", newFrom)
+event:addHeader("login", newLot)
+
+-- Fire the event
+event:fire()

--- a/resources/templates/conf/autoload_configs/lua.conf.xml
+++ b/resources/templates/conf/autoload_configs/lua.conf.xml
@@ -58,5 +58,8 @@
 
     <!-- Subscribe to events -->
     <!--<hook event="PHONE_FEATURE_SUBSCRIBE" subclass="" script="app.lua feature_event"/>-->
+
+    <!-- FusionPBX: Valet Parking Backwards Compatibility, forwards park+59xx presence events to park+*59xx -->
+    <hook event="PRESENCE_IN" subclass="" script="park_compatibility.lua" />
   </settings>
 </configuration>


### PR DESCRIPTION
# Context
This is a continuation of the work reverted in #5611 and effectively reverts #5918

**This PR is still considered a draft and untested currently**

I plan on testing this out this week to ensure this kind of hook/forwarding works as I expect it to but I wanted to get it out there for comments and concerns with this kind of approach.

# Overview
* Parking lots are no longer directly prefixed with *. But for backwards compatibility can be called that way still.
* A lua event hook is added to forward `park+59xx` events to `park+*59xx` for BLFs still listening to that 
* Parking lot name changed from park to 5900 to match #5612 for whole lot BLF monitoring
  * https://freeswitch.org/confluence/display/FREESWITCH/mod_valet_parking#mod_valet_parking-UsingPresence
* Fix regex from matching 5900 to allow this dialplan to work with the valet_park_auto
* Enable valet_park_auto by default now that it can be safely and sanely used in combination with manual parking.
* Remove 475_valet_park_out.xml as it is not needed since the normal valet_park 470 order diaplan can now retrieve calls in the parking lots.