### PR TITLE
[voicemail] allow setting greeting_number_id to default

### DIFF
--- a/app/scripts/resources/scripts/app/voicemail/resources/functions/play_greeting.lua
+++ b/app/scripts/resources/scripts/app/voicemail/resources/functions/play_greeting.lua
@@ -45,7 +45,7 @@
 
 				--play the greeting
 					dtmf_digits = '';
-					if (string.len(greeting_id) > 0) then
+					if (string.len(greeting_id) > 0 and greeting_id ~= "default") then
 
 						--sleep
 							session:execute("playback","silence_stream://200");


### PR DESCRIPTION
This adds the ability to override any set greeting_id to use the default greeting 