### PR TITLE
GXP21XX Dual Registration Support

### DIFF
--- a/app/dialplans/resources/switch/conf/dialplan/470_valet_park.xml
+++ b/app/dialplans/resources/switch/conf/dialplan/470_valet_park.xml
@@ -16,7 +16,7 @@
 		</condition>
 		<condition field="${park_in_use}" expression="true" break="never">
 			<action application="transfer" data="${referred_by_user} XML ${context}"/>
-			<anti-action application="set" data="effective_caller_id_name=park#${caller_id_name}" inline="true"/>
+			<anti-action application="set" data="effective_caller_id_name=${cond ${regex ${direction} | inbound} == true ? 'park#${caller_id_name}' : 'park#${callee_id_name}'}" inline="true"/>
 			<anti-action application="set" data="valet_parking_timeout=180"/>
 			<anti-action application="set" data="valet_hold_music=${hold_music}"/>
 			<anti-action application="set" data="valet_parking_orbit_exten=${referred_by_user}"/>

--- a/app/extensions/extension_edit.php
+++ b/app/extensions/extension_edit.php
@@ -397,6 +397,11 @@
 									if (permission_exists('extension_accountcode')) {
 										$array["extensions"][$i]["accountcode"] = $accountcode;
 									}
+									else {
+										if ($action == "add") {
+											$array["extensions"][$i]["accountcode"] = get_accountcode();
+										}
+									}
 									if (permission_exists("effective_caller_id_name")) {
 										$array["extensions"][$i]["effective_caller_id_name"] = $effective_caller_id_name;
 									}
@@ -878,6 +883,7 @@
 //set the defaults
 	if (strlen($user_context) == 0) { $user_context = $_SESSION['domain_name']; }
 	if (strlen($max_registrations) == 0) { $max_registrations = $_SESSION['extension']['max_registrations']['numeric']; }
+	if (strlen($accountcode) == 0) { $accountcode = get_accountcode(); }
 	if (strlen($limit_max) == 0) { $limit_max = '5'; }
 	if (strlen($limit_destination) == 0) { $limit_destination = 'error/user_busy'; }
 	if (strlen($call_timeout) == 0) { $call_timeout = '30'; }

--- a/resources/functions.php
+++ b/resources/functions.php
@@ -2192,4 +2192,19 @@ function number_pad($number,$n) {
 	    }
 	}
 
+//get accountode
+	if (!function_exists('get_accountcode')) {
+		function get_accountcode() {
+			if (strlen($accountcode = $_SESSION['domain']['accountcode']['text']) > 0) {
+				if ($accountcode == "none") {
+					return;
+				}
+			}
+			else {
+				$accountcode = $_SESSION['domain_name'];
+			}
+			return $accountcode;
+		}
+	}
+
 ?>

--- a/resources/templates/provision/grandstream/gxp2130/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp2130/{$mac}.xml
@@ -4,7 +4,7 @@
 <mac>{$mac|replace:'-':''}</mac>
   <config version="1">
     <!-- ########################################################################################## -->
-    <!-- ## Configuration Template For GXP2130/2140/2160/2170/2135 Firmware Version 1.0.9.127    ## -->
+    <!-- ## Configuration Template For GXP2130/2140/2160/2170/2135 Firmware Version 1.0.10.35    ## -->
     <!-- ########################################################################################## -->
 
     <!-- #################################################################### -->
@@ -62,7 +62,11 @@
 
     <!-- # SIP User ID -->
     <!-- # String -->
+{if isset($account.1.server_address_secondary)}
+    <P35>{$account.1.user_id}@{$account.1.server_address}</P35>
+{else}
     <P35>{$account.1.user_id}</P35>
+{/if}
 
     <!-- # Authenticate ID -->
     <!-- # String -->

--- a/resources/templates/provision/grandstream/gxp2135/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp2135/{$mac}.xml
@@ -4,7 +4,7 @@
 <mac>{$mac|replace:'-':''}</mac>
   <config version="1">
     <!-- ########################################################################################## -->
-    <!-- ## Configuration Template For GXP2130/2140/2160/2170/2135 Firmware Version 1.0.9.127    ## -->
+    <!-- ## Configuration Template For GXP2130/2140/2160/2170/2135 Firmware Version 1.0.10.35    ## -->
     <!-- ########################################################################################## -->
 
     <!-- #################################################################### -->
@@ -62,7 +62,11 @@
 
     <!-- # SIP User ID -->
     <!-- # String -->
+{if isset($account.1.server_address_secondary)}
+    <P35>{$account.1.user_id}@{$account.1.server_address}</P35>
+{else}
     <P35>{$account.1.user_id}</P35>
+{/if}
 
     <!-- # Authenticate ID -->
     <!-- # String -->

--- a/resources/templates/provision/grandstream/gxp2140/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp2140/{$mac}.xml
@@ -4,7 +4,7 @@
 <mac>{$mac|replace:'-':''}</mac>
   <config version="1">
     <!-- ########################################################################################## -->
-    <!-- ## Configuration Template For GXP2130/2140/2160/2170/2135 Firmware Version 1.0.9.127    ## -->
+    <!-- ## Configuration Template For GXP2130/2140/2160/2170/2135 Firmware Version 1.0.10.35    ## -->
     <!-- ########################################################################################## -->
 
     <!-- #################################################################### -->
@@ -62,7 +62,11 @@
 
     <!-- # SIP User ID -->
     <!-- # String -->
+{if isset($account.1.server_address_secondary)}
+    <P35>{$account.1.user_id}@{$account.1.server_address}</P35>
+{else}
     <P35>{$account.1.user_id}</P35>
+{/if}
 
     <!-- # Authenticate ID -->
     <!-- # String -->

--- a/resources/templates/provision/grandstream/gxp2160/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp2160/{$mac}.xml
@@ -4,7 +4,7 @@
 <mac>{$mac|replace:'-':''}</mac>
   <config version="1">
     <!-- ########################################################################################## -->
-    <!-- ## Configuration Template For GXP2130/2140/2160/2170/2135 Firmware Version 1.0.9.127    ## -->
+    <!-- ## Configuration Template For GXP2130/2140/2160/2170/2135 Firmware Version 1.0.10.35    ## -->
     <!-- ########################################################################################## -->
 
     <!-- #################################################################### -->
@@ -62,7 +62,11 @@
 
     <!-- # SIP User ID -->
     <!-- # String -->
+{if isset($account.1.server_address_secondary)}
+    <P35>{$account.1.user_id}@{$account.1.server_address}</P35>
+{else}
     <P35>{$account.1.user_id}</P35>
+{/if}
 
     <!-- # Authenticate ID -->
     <!-- # String -->

--- a/resources/templates/provision/grandstream/gxp2170/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp2170/{$mac}.xml
@@ -4,7 +4,7 @@
 <mac>{$mac|replace:'-':''}</mac>
   <config version="1">
     <!-- ########################################################################################## -->
-    <!-- ## Configuration Template For GXP2130/2140/2160/2170/2135 Firmware Version 1.0.9.127    ## -->
+    <!-- ## Configuration Template For GXP2130/2140/2160/2170/2135 Firmware Version 1.0.10.35    ## -->
     <!-- ########################################################################################## -->
 
     <!-- #################################################################### -->
@@ -62,7 +62,11 @@
 
     <!-- # SIP User ID -->
     <!-- # String -->
+{if isset($account.1.server_address_secondary)}
+    <P35>{$account.1.user_id}@{$account.1.server_address}</P35>
+{else}
     <P35>{$account.1.user_id}</P35>
+{/if}
 
     <!-- # Authenticate ID -->
     <!-- # String -->


### PR DESCRIPTION
This is a new feature for grandstream, supporting dual simultaneous registrations. Only the very latest firmware 1.0.10.35 has it fully working, the last few versions had various partially working versions. This formats the username correctly when a secondary server is present.

There are more phone models that support this feature, but since it has been hit and miss on getting it going I am not going to enable it on those templates unless I have one of each to fully test because if the secondary server is added for a phone with an older firmware, the phone will not register to either server.