### PR TITLE
[voicemails] Option to have voicemail emailed upon request only

### DIFF
--- a/app/scripts/resources/scripts/app/voicemail/index.lua
+++ b/app/scripts/resources/scripts/app/voicemail/index.lua
@@ -626,7 +626,7 @@
 
 						--send the email with the voicemail recording attached
 							if (tonumber(message_length) > 2) then
-								send_email(voicemail_id_copy, voicemail_message_uuid);
+								send_email(voicemail_id_copy, voicemail_message_uuid, true);
 								if (voicemail_to_sms) then
 									send_sms(voicemail_id_copy, voicemail_message_uuid);
 								end

--- a/app/scripts/resources/scripts/app/voicemail/resources/functions/send_email.lua
+++ b/app/scripts/resources/scripts/app/voicemail/resources/functions/send_email.lua
@@ -29,7 +29,7 @@
 	local Settings = require "resources.functions.lazy_settings"
 
 --define a function to send email
-	function send_email(id, uuid)
+	function send_email(id, uuid, auto)
 		local db = dbh or Database.new('system')
 		local settings = Settings.new(db, domain_name, domain_uuid)
 		local transcribe_enabled = settings:get('voicemail', 'transcribe_enabled', 'boolean');
@@ -48,11 +48,16 @@
 				--voicemail_password = row["voicemail_password"];
 				--greeting_id = row["greeting_id"];
 				voicemail_mail_to = row["voicemail_mail_to"];
+				voicemail_auto_mail = row["voicemail_auto_mail"];
 				voicemail_transcription_enabled = row["voicemail_transcription_enabled"];
 				voicemail_file = row["voicemail_file"];
 				voicemail_local_after_email = row["voicemail_local_after_email"];
 				voicemail_description = row["voicemail_description"];
 			end);
+
+			if (voicemail_auto_mail == "false" and auto) then
+				return;
+			end
 
 		--set default values
 			if (voicemail_local_after_email == nil) then

--- a/app/voicemails/app_config.php
+++ b/app/voicemails/app_config.php
@@ -344,6 +344,10 @@
 		$apps[$x]['db'][$y]['fields'][$z]['search'] = 'true';
 		$apps[$x]['db'][$y]['fields'][$z]['description']['en-us'] = "Enter the email address to send voicemail to.";
 		$z++;
+		$apps[$x]['db'][$y]['fields'][$z]['name'] = "voicemail_auto_mail";
+		$apps[$x]['db'][$y]['fields'][$z]['type'] = "text";
+		$apps[$x]['db'][$y]['fields'][$z]['description']['en-us'] = "Choose whether to automatically send the vocemail to email.";
+		$z++;
 		$apps[$x]['db'][$y]['fields'][$z]['name'] = "voicemail_sms_to";
 		$apps[$x]['db'][$y]['fields'][$z]['type'] = "text";
 		$apps[$x]['db'][$y]['fields'][$z]['description']['en-us'] = "Enter the sms did to send voicemail to.";

--- a/app/voicemails/app_languages.php
+++ b/app/voicemails/app_languages.php
@@ -465,6 +465,27 @@ $text['label-voicemail_mail_to']['ru-ru'] = "Почта для";
 $text['label-voicemail_mail_to']['sv-se'] = "E-post Till";
 $text['label-voicemail_mail_to']['uk-ua'] = "Надсилати на";
 
+$text['label-voicemail_auto_mail']['en-us'] = "Auto send mail";
+$text['label-voicemail_auto_mail']['en-gb'] = "Auto send mail";
+$text['label-voicemail_auto_mail']['ar-eg'] = "";
+$text['label-voicemail_auto_mail']['de-at'] = "";
+$text['label-voicemail_auto_mail']['de-ch'] = "";
+$text['label-voicemail_auto_mail']['de-de'] = "";
+$text['label-voicemail_auto_mail']['es-cl'] = "";
+$text['label-voicemail_auto_mail']['es-mx'] = "";
+$text['label-voicemail_auto_mail']['fr-ca'] = "";
+$text['label-voicemail_auto_mail']['fr-fr'] = "";
+$text['label-voicemail_auto_mail']['he-il'] = "";
+$text['label-voicemail_auto_mail']['it-it'] = "";
+$text['label-voicemail_auto_mail']['nl-nl'] = "";
+$text['label-voicemail_auto_mail']['pl-pl'] = "";
+$text['label-voicemail_auto_mail']['pt-br'] = "";
+$text['label-voicemail_auto_mail']['pt-pt'] = "";
+$text['label-voicemail_auto_mail']['ro-ro'] = "";
+$text['label-voicemail_auto_mail']['ru-ru'] = "";
+$text['label-voicemail_auto_mail']['sv-se'] = "";
+$text['label-voicemail_auto_mail']['uk-ua'] = "";
+
 $text['label-voicemail_local_after_email']['en-us'] = "Keep Local";
 $text['label-voicemail_local_after_email']['en-gb'] = "Keep Local";
 $text['label-voicemail_local_after_email']['ar-eg'] = "";

--- a/app/voicemails/voicemail_edit.php
+++ b/app/voicemails/voicemail_edit.php
@@ -84,6 +84,7 @@
 			$voicemail_options = $_POST["voicemail_options"];
 			$voicemail_alternate_greet_id = $_POST["voicemail_alternate_greet_id"];
 			$voicemail_mail_to = $_POST["voicemail_mail_to"];
+			$voicemail_auto_mail = $_POST["voicemail_auto_mail"];
 			$voicemail_sms_to = $_POST["voicemail_sms_to"];
 			$voicemail_transcription_enabled = $_POST["voicemail_transcription_enabled"];
 			$voicemail_file = $_POST["voicemail_file"];
@@ -149,6 +150,7 @@
 					$array['voicemails'][0]['greeting_id'] = $greeting_id != '' ? $greeting_id : null;
 					$array['voicemails'][0]['voicemail_alternate_greet_id'] = $voicemail_alternate_greet_id != '' ? $voicemail_alternate_greet_id : null;
 					$array['voicemails'][0]['voicemail_mail_to'] = $voicemail_mail_to;
+					$array['voicemails'][0]['voicemail_auto_mail'] = $voicemail_auto_mail;
 					$array['voicemails'][0]['voicemail_sms_to'] = $voicemail_sms_to;
 					$array['voicemails'][0]['voicemail_transcription_enabled'] = $voicemail_transcription_enabled;
 					$array['voicemails'][0]['voicemail_tutorial'] = $voicemail_tutorial;
@@ -286,6 +288,7 @@
 			$greeting_id = $row["greeting_id"];
 			$voicemail_alternate_greet_id = $row["voicemail_alternate_greet_id"];
 			$voicemail_mail_to = $row["voicemail_mail_to"];
+			$voicemail_auto_mail = $row["voicemail_auto_mail"];
 			$voicemail_sms_to = $row["voicemail_sms_to"];
 			$voicemail_transcription_enabled = $row["voicemail_transcription_enabled"];
 			$voicemail_tutorial = $row["voicemail_tutorial"];
@@ -306,6 +309,7 @@
 
 //set defaults
 	if (strlen($voicemail_local_after_email) == 0) { $voicemail_local_after_email = "true"; }
+	if (strlen($voicemail_auto_mail) == 0) { $voicemail_auto_mail = "true"; }
 	if (strlen($voicemail_enabled) == 0) { $voicemail_enabled = "true"; }
 	if (strlen($voicemail_transcription_enabled) == 0) { $voicemail_transcription_enabled = $_SESSION['voicemail']['transcription_enabled_default']['boolean'] ?: "false"; }	
 	if (strlen($voicemail_tutorial) == 0) { $voicemail_tutorial = "false"; }
@@ -624,6 +628,20 @@
 	echo "	<input class='formfld' type='text' name='voicemail_mail_to' maxlength='255' value=\"".escape($voicemail_mail_to)."\">\n";
 	echo "<br />\n";
 	echo $text['description-voicemail_mail_to']."\n";
+	echo "</td>\n";
+	echo "</tr>\n";
+
+	echo "<tr>\n";
+	echo "<td class='vncell' valign='top' align='left' nowrap='nowrap'>\n";
+	echo "	".$text['label-voicemail_auto_mail']."\n";
+	echo "</td>\n";
+	echo "<td class='vtable' align='left'>\n";
+	echo "	<select class='formfld' name='voicemail_auto_mail' id='voicemail_auto_mail'>\n";
+	echo "    	<option value='true' ".(($voicemail_auto_mail == "true") ? "selected='selected'" : null).">".$text['label-true']."</option>\n";
+	echo "    	<option value='false' ".(($voicemail_auto_mail == "false") ? "selected='selected'" : null).">".$text['label-false']."</option>\n";
+	echo "	</select>\n";
+	echo "<br />\n";
+	echo $text['voicemail_auto_mail']."\n";
 	echo "</td>\n";
 	echo "</tr>\n";
 


### PR DESCRIPTION
Voicemail to email automatically sends an email if the `voicemail_mail_to` field has an email in it. There are some cases where people only want to get their voicemails emailed only when they request it from option 9 of the `listen_to_recording`

This commit adds an option to set voicemail_auto_mail to false and won't automatically get voicemails to email