### PR TITLE
Fix HT802 Line 2 not setting SRV DNS

### DIFF
--- a/resources/templates/provision/grandstream/ht802/{$mac}.xml
+++ b/resources/templates/provision/grandstream/ht802/{$mac}.xml
@@ -1509,7 +1509,11 @@
     <!-- # DNS Mode. 0 - A Record, 1 - SRV, 2 - NAPTR/SRV. -->
     <!-- # Number: 0, 1, 2 -->
     <!-- # Mandatory -->
+{if isset($grandstream_dns_mode)}
+    <P702>{$grandstream_dns_mode}</P702>
+{else}
     <P702>0</P702>
+{/if}
 
     <!-- # Tel URI. 0 - Disabled, 1 - User=Phone, 2 - Enabled -->
     <!-- # Number: 0, 1, 2 -->


### PR DESCRIPTION
DNS Type wasn't being applied to the second line.