### PR TITLE
Callcenter agent default status fix

### DIFF
--- a/app/call_centers/app_languages.php
+++ b/app/call_centers/app_languages.php
@@ -1114,6 +1114,27 @@ $text['label-strategy']['ru-ru'] = "Стратегия";
 $text['label-strategy']['sv-se'] = "Strategi";
 $text['label-strategy']['uk-ua'] = "";
 
+$text['label-default-status']['en-us'] = "Default Status";
+$text['label-default-status']['en-gb'] = "Default Status";
+$text['label-default-status']['ar-eg'] = "";
+$text['label-default-status']['de-at'] = "Standard Status"; //copied from de-de
+$text['label-default-status']['de-ch'] = "Standard Status"; //copied from de-de
+$text['label-default-status']['de-de'] = "Standard Status";
+$text['label-default-status']['es-cl'] = "Estado Predeterminado";
+$text['label-default-status']['es-mx'] = "Estado Predeterminado"; //copied from es-cl
+$text['label-default-status']['fr-ca'] = "État par défaut";
+$text['label-default-status']['fr-fr'] = "État par défaut";
+$text['label-default-status']['he-il'] = "";
+$text['label-default-status']['it-it'] = "Stato predefinito";
+$text['label-default-status']['nl-nl'] = "Standaard Status";
+$text['label-default-status']['pl-pl'] = "Domyślny Status";
+$text['label-default-status']['pt-br'] = "Estado Padrão"; //copied from pt-pt
+$text['label-default-status']['pt-pt'] = "Estado Padrão";
+$text['label-default-status']['ro-ro'] = "";
+$text['label-default-status']['ru-ru'] = "Статус по умолчанию";
+$text['label-default-status']['sv-se'] = "Standardstatus";
+$text['label-default-status']['uk-ua'] = "Статус за замовчуванням";
+
 $text['label-status']['en-us'] = "Status";
 $text['label-status']['en-gb'] = "Status";
 $text['label-status']['ar-eg'] = "";

--- a/app/call_centers/call_center_agent_edit.php
+++ b/app/call_centers/call_center_agent_edit.php
@@ -241,11 +241,11 @@
 					$response = event_socket_request($fp, $cmd);
 					usleep(200);
 				//agent set status, for newly created agents only
-                    if ($action == "add") {
-                        $cmd = "api callcenter_config agent set status ".$call_center_agent_uuid." '".$agent_status."'";
-                        $response = event_socket_request($fp, $cmd);
-                        usleep(200);
-                    }
+					if ($action == "add") {
+						$cmd = "api callcenter_config agent set status ".$call_center_agent_uuid." '".$agent_status."'";
+						$response = event_socket_request($fp, $cmd);
+						usleep(200);
+					}
 				//agent set reject_delay_time
 					$cmd = "api callcenter_config agent set reject_delay_time ".$call_center_agent_uuid." ".$agent_reject_delay_time;
 					$response = event_socket_request($fp, $cmd);

--- a/app/call_centers/call_center_agent_edit.php
+++ b/app/call_centers/call_center_agent_edit.php
@@ -240,10 +240,12 @@
 					$cmd = "api callcenter_config agent set contact ".$call_center_agent_uuid." ".$agent_contact;
 					$response = event_socket_request($fp, $cmd);
 					usleep(200);
-				//agent set status
-					$cmd = "api callcenter_config agent set status ".$call_center_agent_uuid." '".$agent_status."'";
-					$response = event_socket_request($fp, $cmd);
-					usleep(200);
+				//agent set status, for newly created agents only
+                    if ($action == "add") {
+                        $cmd = "api callcenter_config agent set status ".$call_center_agent_uuid." '".$agent_status."'";
+                        $response = event_socket_request($fp, $cmd);
+                        usleep(200);
+                    }
 				//agent set reject_delay_time
 					$cmd = "api callcenter_config agent set reject_delay_time ".$call_center_agent_uuid." ".$agent_reject_delay_time;
 					$response = event_socket_request($fp, $cmd);
@@ -446,7 +448,7 @@
 			echo "			<option value='".escape($field['user_uuid'])."' selected='selected'>".escape($field['username'])."</option>\n";
 		}
 		else {
-			echo "			<option value='".escape($field['user_uuid'])."' $selected>".escape($field['username'])."</option>\n";
+			echo "			<option value='".escape($field['user_uuid'])."'>".escape($field['username'])."</option>\n";
 		}
 	}
 	echo "			</select>";
@@ -492,7 +494,7 @@
 
 	echo "<tr>\n";
 	echo "<td class='vncell' valign='top' align='left' nowrap='nowrap'>\n";
-	echo "	".$text['label-status']."\n";
+	echo "	".$text['label-default-status']."\n";
 	echo "</td>\n";
 	echo "<td class='vtable' align='left'>\n";
 	echo "	<select class='formfld' name='agent_status'>\n";


### PR DESCRIPTION
Saving a call-center agent does not update their status (unless adding a new agent)
Renamed the call-center agent "Status" field to "Default Status"