### PR TITLE
Fix for ajax redirects when logged out

### DIFF
--- a/app/basic_operator_panel/index.php
+++ b/app/basic_operator_panel/index.php
@@ -244,11 +244,20 @@ unset($refresh_default);
 	}
 
 	loadXmlHttp.prototype.stateChanged=function () {
-	if (this.xmlHttp.readyState == 4 && (this.xmlHttp.status == 200 || !/^http/.test(window.location.href)))
-		//this.el.innerHTML = this.xmlHttp.responseText;
-		document.getElementById('ajax_reponse').innerHTML = this.xmlHttp.responseText;
-		if(document.getElementById('sort')){
-			 if(document.getElementById('sort').value != "") 
+		var url = new URL(this.xmlHttp.responseURL);
+		if (/login\.php$/.test(url.pathname)) {
+			// You are logged out. Stop refresh!
+			refresh_stop();
+			url.searchParams.set('path', '<?php echo $_SERVER['REQUEST_URI']; ?>');
+			window.location.href = url.href;
+			return;
+		}
+
+		if (this.xmlHttp.readyState == 4 && (this.xmlHttp.status == 200 || !/^http/.test(window.location.href)))
+			//this.el.innerHTML = this.xmlHttp.responseText;
+			document.getElementById('ajax_reponse').innerHTML = this.xmlHttp.responseText;
+		if (document.getElementById('sort')) {
+			if (document.getElementById('sort').value != "")
 				document.getElementById('sort1').value=document.getElementById('sort').value;
 		}
 	}

--- a/app/call_center_active/call_center_active.php
+++ b/app/call_center_active/call_center_active.php
@@ -85,9 +85,17 @@
 	}
 
 	loadXmlHttp.prototype.stateChanged=function () {
-	if (this.xmlHttp.readyState == 4 && (this.xmlHttp.status == 200 || !/^http/.test(window.location.href)))
-		//this.el.innerHTML = this.xmlHttp.responseText;
-		document.getElementById('ajax_response').innerHTML = this.xmlHttp.responseText;
+		var url = new URL(this.xmlHttp.responseURL);
+        if (/login\.php$/.test(url.pathname)) {
+			// You are logged out. Stop refresh!
+			url.searchParams.set('path', '<?php echo $_SERVER['REQUEST_URI']; ?>');
+			window.location.href = url.href;
+			return;
+		}
+
+		if (this.xmlHttp.readyState == 4 && (this.xmlHttp.status == 200 || !/^http/.test(window.location.href)))
+			//this.el.innerHTML = this.xmlHttp.responseText;
+			document.getElementById('ajax_response').innerHTML = this.xmlHttp.responseText;
 
 		//link table rows (except the last - the list_control_icons cell) on a table with a class of 'tr_hover', according to the href attribute of the <tr> tag
 			$('.tr_hover tr,.list tr').each(function(i,e) {

--- a/app/conferences_active/conference_interactive.php
+++ b/app/conferences_active/conference_interactive.php
@@ -84,9 +84,17 @@ function loadXmlHttp(url, id) {
 }
 
 loadXmlHttp.prototype.stateChanged=function () {
-if (this.xmlHttp.readyState == 4 && (this.xmlHttp.status == 200 || !/^http/.test(window.location.href)))
-	//this.el.innerHTML = this.xmlHttp.responseText;
-	document.getElementById('ajax_reponse').innerHTML = this.xmlHttp.responseText;
+	var url = new URL(this.xmlHttp.responseURL);
+	if (/login\.php$/.test(url.pathname)) {
+		// You are logged out. Stop refresh!
+		url.searchParams.set('path', '<?php echo $_SERVER['REQUEST_URI']; ?>');
+		window.location.href = url.href;
+		return;
+	}
+
+	if (this.xmlHttp.readyState == 4 && (this.xmlHttp.status == 200 || !/^http/.test(window.location.href)))
+		//this.el.innerHTML = this.xmlHttp.responseText;
+		document.getElementById('ajax_reponse').innerHTML = this.xmlHttp.responseText;
 
 	//link table rows (except the last - the list_control_icons cell) on a table with a class of 'tr_hover', according to the href attribute of the <tr> tag
 		$('.tr_hover tr,.list tr').each(function(i,e) {

--- a/app/conferences_active/conferences_active.php
+++ b/app/conferences_active/conferences_active.php
@@ -79,9 +79,17 @@ function loadXmlHttp(url, id) {
 }
 
 loadXmlHttp.prototype.stateChanged=function () {
-if (this.xmlHttp.readyState == 4 && (this.xmlHttp.status == 200 || !/^http/.test(window.location.href)))
-	//this.el.innerHTML = this.xmlHttp.responseText;
-	document.getElementById('ajax_response').innerHTML = this.xmlHttp.responseText;
+	var url = new URL(this.xmlHttp.responseURL);
+	if (/login\.php$/.test(url.pathname)) {
+		// You are logged out. Stop refresh!
+		url.searchParams.set('path', '<?php echo $_SERVER['REQUEST_URI']; ?>');
+		window.location.href = url.href;
+		return;
+	}
+
+	if (this.xmlHttp.readyState == 4 && (this.xmlHttp.status == 200 || !/^http/.test(window.location.href)))
+		//this.el.innerHTML = this.xmlHttp.responseText;
+		document.getElementById('ajax_response').innerHTML = this.xmlHttp.responseText;
 
 	//link table rows (except the last - the list_control_icons cell) on a table with a class of 'tr_hover', according to the href attribute of the <tr> tag
 		$('.tr_hover tr,.list tr').each(function(i,e) {

--- a/app/destinations/resources/classes/destinations.php
+++ b/app/destinations/resources/classes/destinations.php
@@ -440,6 +440,12 @@ if (!class_exists('destinations')) {
 						//alert(action);
 						var xhttp = new XMLHttpRequest();
 						xhttp.onreadystatechange = function() {
+							var url = new URL(this.xmlHttp.responseURL);
+							if (/login\.php$/.test(url.pathname)) {
+								// You are logged out. Not much we can de here.
+								return;
+							}
+
 							if (this.readyState == 4 && this.status == 200) {
 								document.getElementById(id).innerHTML = this.responseText;
 							}

--- a/app/fifo_list/fifo_interactive.php
+++ b/app/fifo_list/fifo_interactive.php
@@ -93,9 +93,17 @@ function loadXmlHttp(url, id) {
 }
 
 loadXmlHttp.prototype.stateChanged=function () {
-if (this.xmlHttp.readyState == 4 && (this.xmlHttp.status == 200 || !/^http/.test(window.location.href)))
-	//this.el.innerHTML = this.xmlHttp.responseText;
-	document.getElementById('ajax_reponse').innerHTML = this.xmlHttp.responseText;
+	var url = new URL(this.xmlHttp.responseURL);
+	if (/login\.php$/.test(url.pathname)) {
+		// You are logged out. Stop refresh!
+		url.searchParams.set('path', '<?php echo $_SERVER['REQUEST_URI']; ?>');
+		window.location.href = url.href;
+		return;
+	}
+
+	if (this.xmlHttp.readyState == 4 && (this.xmlHttp.status == 200 || !/^http/.test(window.location.href)))
+		//this.el.innerHTML = this.xmlHttp.responseText;
+		document.getElementById('ajax_reponse').innerHTML = this.xmlHttp.responseText;
 }
 
 var requestTime = function() {

--- a/app/fifo_list/fifo_list.php
+++ b/app/fifo_list/fifo_list.php
@@ -71,9 +71,17 @@ function loadXmlHttp(url, id) {
 }
 
 loadXmlHttp.prototype.stateChanged=function () {
-if (this.xmlHttp.readyState == 4 && (this.xmlHttp.status == 200 || !/^http/.test(window.location.href)))
-	//this.el.innerHTML = this.xmlHttp.responseText;
-	document.getElementById('ajax_reponse').innerHTML = this.xmlHttp.responseText;
+	var url = new URL(this.xmlHttp.responseURL);
+	if (/login\.php$/.test(url.pathname)) {
+		// You are logged out. Stop refresh!
+		url.searchParams.set('path', '<?php echo $_SERVER['REQUEST_URI']; ?>');
+		window.location.href = url.href;
+		return;
+	}
+
+	if (this.xmlHttp.readyState == 4 && (this.xmlHttp.status == 200 || !/^http/.test(window.location.href)))
+		//this.el.innerHTML = this.xmlHttp.responseText;
+		document.getElementById('ajax_reponse').innerHTML = this.xmlHttp.responseText;
 }
 
 var requestTime = function() {

--- a/app/registrations/registration_reload.php
+++ b/app/registrations/registration_reload.php
@@ -80,9 +80,17 @@
 	}
 
 	loadXmlHttp.prototype.stateChanged=function () {
-	if (this.xmlHttp.readyState == 4 && (this.xmlHttp.status == 200 || !/^http/.test(window.location.href)))
-		//this.el.innerHTML = this.xmlHttp.responseText;
-		document.getElementById('ajax_response').innerHTML = this.xmlHttp.responseText;
+		var url = new URL(this.xmlHttp.responseURL);
+		if (/login\.php$/.test(url.pathname)) {
+			// You are logged out. Stop refresh!
+			url.searchParams.set('path', '<?php echo $_SERVER['REQUEST_URI']; ?>');
+			window.location.href = url.href;
+			return;
+		}
+
+		if (this.xmlHttp.readyState == 4 && (this.xmlHttp.status == 200 || !/^http/.test(window.location.href)))
+			//this.el.innerHTML = this.xmlHttp.responseText;
+			document.getElementById('ajax_response').innerHTML = this.xmlHttp.responseText;
 	}
 
 	var requestTime = function() {


### PR DESCRIPTION
Responses to AJAX calls are now checked for a redirection to the login page and redirect the user to the login page if logged out.
This fixes an issue where fail2ban detects too many login tries when some users leave an "Operator Panel" tab open after logging out in an other tab. The "Operator Panel" tab keeps refreshing and requesting the login page.