### PR TITLE
Use epoch times for CDR Imports

### DIFF
--- a/app/xml_cdr/resources/classes/xml_cdr.php
+++ b/app/xml_cdr/resources/classes/xml_cdr.php
@@ -346,13 +346,15 @@ if (!class_exists('xml_cdr')) {
 						$this->array[$key]['pin_number'] = urldecode($xml->variables->pin_number);
 
 					//time
-						$this->array[$key]['start_epoch'] = urldecode($xml->variables->start_epoch);
-						$start_stamp = urldecode($xml->variables->start_stamp);
-						$this->array[$key]['start_stamp'] = $start_stamp;
-						$this->array[$key]['answer_stamp'] = urldecode($xml->variables->answer_stamp);
-						$this->array[$key]['answer_epoch'] = urldecode($xml->variables->answer_epoch);
-						$this->array[$key]['end_epoch'] = urldecode($xml->variables->end_epoch);
-						$this->array[$key]['end_stamp'] = urldecode($xml->variables->end_stamp);
+						$start_epoch = urldecode($xml->variables->start_epoch);
+						$this->array[$key]['start_epoch'] = $start_epoch;
+						$this->array[$key]['start_stamp'] = date('c', $start_epoch);
+						$answer_epoch = urldecode($xml->variables->answer_epoch);
+						$this->array[$key]['answer_epoch'] = $answer_epoch;
+						$this->array[$key]['answer_stamp'] = date('c', $answer_epoch);
+						$end_epoch = urldecode($xml->variables->end_epoch);
+						$this->array[$key]['end_epoch'] = $end_epoch;
+						$this->array[$key]['end_stamp'] = date('c', $end_epoch);
 						$this->array[$key]['duration'] = urldecode($xml->variables->duration);
 						$this->array[$key]['mduration'] = urldecode($xml->variables->mduration);
 						$this->array[$key]['billsec'] = urldecode($xml->variables->billsec);
@@ -424,6 +426,7 @@ if (!class_exists('xml_cdr')) {
 						$this->array[$key]['pdd_ms'] = urldecode($xml->variables->progress_mediamsec) + urldecode($xml->variables->progressmsec);
 
 					//get break down the date to year, month and day
+						$start_stamp = urldecode($xml->variables->start_stamp);
 						$start_time = strtotime($start_stamp);
 						$start_year = date("Y", $start_time);
 						$start_month = date("M", $start_time);

--- a/app/xml_cdr/resources/classes/xml_cdr.php
+++ b/app/xml_cdr/resources/classes/xml_cdr.php
@@ -638,7 +638,7 @@ if (!class_exists('xml_cdr')) {
 									$array['call_recordings'][$x]['call_recording_name'] = $record_name;
 									$array['call_recordings'][$x]['call_recording_path'] = $record_path;
 									$array['call_recordings'][$x]['call_recording_length'] = $record_length;
-									$array['call_recordings'][$x]['call_recording_date'] = urldecode($xml->variables->start_stamp);
+									$array['call_recordings'][$x]['call_recording_date'] = date('c', $start_epoch);
 									$array['call_recordings'][$x]['call_direction'] = urldecode($xml->variables->call_direction);
 									//$array['call_recordings'][$x]['call_recording_description']= $row['zzz'];
 									//$array['call_recordings'][$x]['call_recording_base64']= $row['zzz'];


### PR DESCRIPTION
There has been some discussion of edge cases for CDR Importing time zones/time stamps.

This modification makes the start_stamp, answer_stamp, and end_stamp values use the corresponding _epoch times for import into the v_xml_cdr table.

This prevents scenarios where the DB's default time zone is set differently than the switch's timezone. 

I believe this is the most flexible solution because it doesn't require a new setting, it doesn't require reading the system timezone (which isn't always the same system for postgres and freeswitch) and it prevents all possible timezone offset mistakes when setting the timestamptz columns, regardless if the admin is using a default fusionpbx install or any altered/custom installation this will work for all of those scenarios because it uses an absolute time instead of a formatted string that doesn't define its timezone (start_stamp from freeswitch doesn't tell you what time zone it used).



## Possible Improvements

- This leaves the timestamptz timezone in UTC. We could look up the time zone setting for the domain of the CDR and set the timezone accordingly so that the timestamp column will show the most commonly used view of the date. It won't impact how postgres stores the data, just what timezone postgres displays it in by default. As far as I can tell, all references to the date/time of a CDR elsewhere in fusionpbx are using the various _epoch fields or they are executing a query with a specific timezone using AT TIME ZONE in the SQL, so this won't have any impact on the display except when looking at the records in the DB manually.
- Update the other import script, 'v_xml_cdr_import.php' with these same improvements. 

## Edge Cases/Conflicts
I cannot find a situation or think of one where this will have any impact on anything else. Please speak up if you know of any objections to this change. The reason I made this PR is because I had 3 or 4 scenarios I can readily think of and one I personally encountered when using freeswitch's _stamp fields and I can't think of any problems with using the epoch.

