### PR TITLE
agent+ fix dialplan

### DIFF
--- a/app/dialplans/resources/switch/conf/dialplan/200_agent_status.xml
+++ b/app/dialplans/resources/switch/conf/dialplan/200_agent_status.xml
@@ -4,8 +4,8 @@
 			<action application="set" data="agent_id=${sip_from_user}"/>
 			<action application="lua" data="app.lua agent_status"/>
 		</condition>
-		<condition field="destination_number" expression="^(agent\+)(.*)$">
-			<action application="set" data="agent_id=${sip_from_user}"/>
+		<condition field="destination_number" expression="^agent\+(.*)$">
+			<action application="set" data="agent_id=$1"/>
 			<action application="lua" data="app.lua agent_status"/>
 		</condition>
 	</extension>


### PR DESCRIPTION
Taking the agent_id from sip_from_user doesn't allow tracking other agents