### PR TITLE
updated templates to include screensaver.wait_time

### DIFF
--- a/resources/templates/provision/yealink/t33g/y000000000124.cfg
+++ b/resources/templates/provision/yealink/t33g/y000000000124.cfg
@@ -1541,7 +1541,7 @@ features.blf_active_backlight.enable=
 screensaver.display_clock.enable=
 screensaver.clock_move_interval=
 screensaver.picture_change_interval=
-screensaver.wait_time=
+screensaver.wait_time= {$yealink_screensaver_wait}
 screensaver.xml_browser.url=
 
 

--- a/resources/templates/provision/yealink/t41s/y000000000068.cfg
+++ b/resources/templates/provision/yealink/t41s/y000000000068.cfg
@@ -1406,7 +1406,7 @@ features.blf_active_backlight.enable=
 screensaver.display_clock.enable=
 screensaver.clock_move_interval=
 screensaver.picture_change_interval=
-screensaver.wait_time=
+screensaver.wait_time= {$yealink_screensaver_wait}
 screensaver.xml_browser.url=
 
 

--- a/resources/templates/provision/yealink/t42s/y000000000067.cfg
+++ b/resources/templates/provision/yealink/t42s/y000000000067.cfg
@@ -1403,7 +1403,7 @@ features.blf_active_backlight.enable=
 screensaver.display_clock.enable=
 screensaver.clock_move_interval=
 screensaver.picture_change_interval=
-screensaver.wait_time=
+screensaver.wait_time= {$yealink_screensaver_wait}
 screensaver.xml_browser.url=
 
 

--- a/resources/templates/provision/yealink/t43u/y000000000107.cfg
+++ b/resources/templates/provision/yealink/t43u/y000000000107.cfg
@@ -1546,7 +1546,7 @@ features.blf_active_backlight.enable=
 screensaver.display_clock.enable=
 screensaver.clock_move_interval=
 screensaver.picture_change_interval=
-screensaver.wait_time=
+screensaver.wait_time= {$yealink_screensaver_wait}
 screensaver.xml_browser.url=
 
 

--- a/resources/templates/provision/yealink/t46s/y000000000066.cfg
+++ b/resources/templates/provision/yealink/t46s/y000000000066.cfg
@@ -1405,7 +1405,7 @@ features.blf_active_backlight.enable=
 screensaver.display_clock.enable=
 screensaver.clock_move_interval=
 screensaver.picture_change_interval=
-screensaver.wait_time=
+screensaver.wait_time= {$yealink_screensaver_wait}
 screensaver.xml_browser.url=
 
 

--- a/resources/templates/provision/yealink/t46u/y000000000108.cfg
+++ b/resources/templates/provision/yealink/t46u/y000000000108.cfg
@@ -1542,7 +1542,7 @@ features.blf_active_backlight.enable=
 screensaver.display_clock.enable=
 screensaver.clock_move_interval=
 screensaver.picture_change_interval=
-screensaver.wait_time=
+screensaver.wait_time= {$yealink_screensaver_wait}
 screensaver.xml_browser.url=
 
 

--- a/resources/templates/provision/yealink/t48s/y000000000065.cfg
+++ b/resources/templates/provision/yealink/t48s/y000000000065.cfg
@@ -1453,7 +1453,7 @@ features.blf_active_backlight.enable=
 screensaver.display_clock.enable=
 screensaver.clock_move_interval=
 screensaver.picture_change_interval=
-screensaver.wait_time=
+screensaver.wait_time= {$yealink_screensaver_wait}
 screensaver.xml_browser.url=
 
 

--- a/resources/templates/provision/yealink/t4x/y000000000065.cfg
+++ b/resources/templates/provision/yealink/t4x/y000000000065.cfg
@@ -1452,7 +1452,7 @@ features.blf_active_backlight.enable=
 screensaver.display_clock.enable=
 screensaver.clock_move_interval=
 screensaver.picture_change_interval=
-screensaver.wait_time=
+screensaver.wait_time= {$yealink_screensaver_wait}
 screensaver.xml_browser.url=
 
 

--- a/resources/templates/provision/yealink/t4x/y000000000066.cfg
+++ b/resources/templates/provision/yealink/t4x/y000000000066.cfg
@@ -1402,7 +1402,7 @@ features.blf_active_backlight.enable=
 screensaver.display_clock.enable=
 screensaver.clock_move_interval=
 screensaver.picture_change_interval=
-screensaver.wait_time=
+screensaver.wait_time= {$yealink_screensaver_wait}
 screensaver.xml_browser.url=
 
 

--- a/resources/templates/provision/yealink/t4x/y000000000067.cfg
+++ b/resources/templates/provision/yealink/t4x/y000000000067.cfg
@@ -1401,7 +1401,7 @@ features.blf_active_backlight.enable=
 screensaver.display_clock.enable=
 screensaver.clock_move_interval=
 screensaver.picture_change_interval=
-screensaver.wait_time=
+screensaver.wait_time= {$yealink_screensaver_wait}
 screensaver.xml_browser.url=
 
 

--- a/resources/templates/provision/yealink/t4x/y000000000068.cfg
+++ b/resources/templates/provision/yealink/t4x/y000000000068.cfg
@@ -1405,7 +1405,7 @@ features.blf_active_backlight.enable=
 screensaver.display_clock.enable=
 screensaver.clock_move_interval=
 screensaver.picture_change_interval=
-screensaver.wait_time=
+screensaver.wait_time= {$yealink_screensaver_wait}
 screensaver.xml_browser.url=
 
 

--- a/resources/templates/provision/yealink/t4x/y000000000107.cfg
+++ b/resources/templates/provision/yealink/t4x/y000000000107.cfg
@@ -1452,7 +1452,7 @@ features.blf_active_backlight.enable=
 screensaver.display_clock.enable=
 screensaver.clock_move_interval=
 screensaver.picture_change_interval=
-screensaver.wait_time=
+screensaver.wait_time= {$yealink_screensaver_wait}
 screensaver.xml_browser.url=
 
 

--- a/resources/templates/provision/yealink/t4x/y000000000108.cfg
+++ b/resources/templates/provision/yealink/t4x/y000000000108.cfg
@@ -1402,7 +1402,7 @@ features.blf_active_backlight.enable=
 screensaver.display_clock.enable=
 screensaver.clock_move_interval=
 screensaver.picture_change_interval=
-screensaver.wait_time=
+screensaver.wait_time= {$yealink_screensaver_wait}
 screensaver.xml_browser.url=
 
 

--- a/resources/templates/provision/yealink/t4x/y000000000109.cfg
+++ b/resources/templates/provision/yealink/t4x/y000000000109.cfg
@@ -1452,7 +1452,7 @@ features.blf_active_backlight.enable=
 screensaver.display_clock.enable=
 screensaver.clock_move_interval=
 screensaver.picture_change_interval=
-screensaver.wait_time=
+screensaver.wait_time= {$yealink_screensaver_wait}
 screensaver.xml_browser.url=
 
 

--- a/resources/templates/provision/yealink/t4x/y000000000116.cfg
+++ b/resources/templates/provision/yealink/t4x/y000000000116.cfg
@@ -1401,7 +1401,7 @@ features.blf_active_backlight.enable=
 screensaver.display_clock.enable=
 screensaver.clock_move_interval=
 screensaver.picture_change_interval=
-screensaver.wait_time=
+screensaver.wait_time= {$yealink_screensaver_wait}
 screensaver.xml_browser.url=
 
 

--- a/resources/templates/provision/yealink/vp59/y000000000091.cfg
+++ b/resources/templates/provision/yealink/vp59/y000000000091.cfg
@@ -1297,7 +1297,7 @@ features.power_saving.office_hour.thursday =
 features.power_saving.office_hour.friday  =
 features.power_saving.office_hour.saturday  =
 features.power_saving.office_hour.sunday =
-screensaver.wait_time=
+screensaver.wait_time= {$yealink_screensaver_wait}
 
 ##V83 Add
 features.power_saving.power_led_flash.off_time=


### PR DESCRIPTION
Not all device templates supported the screensaver wait time variable. I edited them all to include the variable.