### PR TITLE
[4.5] Make fool probe the CDR configuration (default setting)

### DIFF
--- a/app/xml_cdr/resources/classes/xml_cdr.php
+++ b/app/xml_cdr/resources/classes/xml_cdr.php
@@ -197,7 +197,7 @@ if (!class_exists('xml_cdr')) {
 			if (is_array($_SESSION['cdr']['field'])) {
 				foreach ($_SESSION['cdr']['field'] as $field) {
 					$field_name = end($field);
-					if (!in_array($field, $this->fields)){
+					if (!in_array($field, $this->fields))
 						$this->fields[] = $field_name;
 				}
 			}

--- a/app/xml_cdr/resources/classes/xml_cdr.php
+++ b/app/xml_cdr/resources/classes/xml_cdr.php
@@ -197,7 +197,8 @@ if (!class_exists('xml_cdr')) {
 			if (is_array($_SESSION['cdr']['field'])) {
 				foreach ($_SESSION['cdr']['field'] as $field) {
 					$field_name = end($field);
-					$this->fields[] = $field_name;
+					if (!in_array($field, $this->fields)){
+						$this->fields[] = $field_name;
 				}
 			}
 		}
@@ -479,21 +480,27 @@ if (!class_exists('xml_cdr')) {
 							foreach ($_SESSION['cdr']['field'] as $field) {
 								$fields = explode(",", $field);
 								$field_name = end($fields);
-								$this->fields[] = $field_name;
+								if (!in_array($field_name, $this->fields))
+									$this->fields[] = $field_name;
 								if (count($fields) == 1) {
-									$this->array[$key][$field_name] = urldecode($xml->variables->{$fields[0]});
+									if (is_null($this->array[$key][$field_name]))
+										$this->array[$key][$field_name] = urldecode($xml->variables->{$fields[0]});
 								}
 								if (count($fields) == 2) {
-									$this->array[$key][$field_name] = urldecode($xml->{$fields[0]}->{$fields[1]});
+									if (is_null($this->array[$key][$field_name]))
+										$this->array[$key][$field_name] = urldecode($xml->{$fields[0]}->{$fields[1]});
 								}
 								if (count($fields) == 3) {
-									$this->array[$key][$field_name] = urldecode($xml->{$fields[0]}->{$fields[1]}->{$fields[2]});
+									if (is_null($this->array[$key][$field_name]))
+										$this->array[$key][$field_name] = urldecode($xml->{$fields[0]}->{$fields[1]}->{$fields[2]});
 								}
 								if (count($fields) == 4) {
-									$this->array[$key][$field_name] = urldecode($xml->{$fields[0]}->{$fields[1]}->{$fields[2]}->{$fields[3]});
+									if (is_null($this->array[$key][$field_name]))
+										$this->array[$key][$field_name] = urldecode($xml->{$fields[0]}->{$fields[1]}->{$fields[2]}->{$fields[3]});
 								}
 								if (count($fields) == 5) {
-									$this->array[$key][$field_name] = urldecode($xml->{$fields[0]}->{$fields[1]}->{$fields[2]}->{$fields[3]}->{$fields[4]});
+									if (is_null($this->array[$key][$field_name]))
+										$this->array[$key][$field_name] = urldecode($xml->{$fields[0]}->{$fields[1]}->{$fields[2]}->{$fields[3]}->{$fields[4]});
 								}
 							}
 						}


### PR DESCRIPTION
the SQL query already has some fixed fields, if someone puts in the default settings those variables, you may end having a query like "select domain_name, .... domain_name from v_xml_cdr" which will break Pgsql and Mysql. This patch reviews before adding.