### PR TITLE
Yealink Dual Registration for T40P

### DIFF
--- a/resources/templates/provision/yealink/t40p/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t40p/{$mac}.cfg
@@ -78,8 +78,13 @@ account.1.sip_server.2.retry_counts = 3
 account.1.sip_server.2.failback_mode = 0
 account.1.sip_server.2.failback_timeout = 3600
 account.1.sip_server.2.register_on_enable = 0
-account.1.dns_cache_type = 1
+#Configure the transport type; 0-UDP (default), 1-TCP, 2-TLS, 3-DNS-NAPTR;
+{if $account.1.sip_transport == 'udp'}account.1.sip_server.2.transport_type = 0{/if}
+{if $account.1.sip_transport == 'tcp'}account.1.sip_server.2.transport_type = 1{/if}
+{if $account.1.sip_transport == 'tls'}account.1.sip_server.2.transport_type = 2{/if}
+{if $account.1.sip_transport == 'dns srv'}account.1.sip_server.2.transport_type = 3{/if}
 
+account.1.dns_cache_type = 1
 account.1.dns_cache_a.1.name =
 account.1.dns_cache_a.1.ip =
 account.1.dns_cache_a.1.ttl = 300
@@ -548,6 +553,12 @@ account.2.sip_listen_port = 5060
 {if $account.2.sip_transport == 'tls'}account.2.transport = 2{/if}
 {if $account.2.sip_transport == 'dns srv'}account.2.transport = 3{/if}
 
+#Configure the transport type; 0-UDP (default), 1-TCP, 2-TLS, 3-DNS-NAPTR;
+{if $account.1.sip_transport == 'udp'}account.1.sip_server.1.transport_type = 0{/if}
+{if $account.1.sip_transport == 'tcp'}account.1.sip_server.1.transport_type = 1{/if}
+{if $account.1.sip_transport == 'tls'}account.1.sip_server.1.transport_type = 2{/if}
+{if $account.1.sip_transport == 'dns srv'}account.1.sip_server.1.transport_type = 3{/if}
+
 account.2.outbound_proxy.1.address = {$account.2.outbound_proxy_primary}
 account.2.outbound_proxy.2.address = {$account.2.outbound_proxy_secondary}
 account.2.outbound_proxy_enable = {if isset($account.2.outbound_proxy_primary)}1{else}0{/if}
@@ -580,8 +591,13 @@ account.2.sip_server.2.retry_counts = 3
 account.2.sip_server.2.failback_mode = 0
 account.2.sip_server.2.failback_timeout = 3600
 account.2.sip_server.2.register_on_enable = 0
-account.2.dns_cache_type = 1
+#Configure the transport type; 0-UDP (default), 1-TCP, 2-TLS, 3-DNS-NAPTR;
+{if $account.2.sip_transport == 'udp'}account.2.sip_server.2.transport_type = 0{/if}
+{if $account.2.sip_transport == 'tcp'}account.2.sip_server.2.transport_type = 1{/if}
+{if $account.2.sip_transport == 'tls'}account.2.sip_server.2.transport_type = 2{/if}
+{if $account.2.sip_transport == 'dns srv'}account.2.sip_server.2.transport_type = 3{/if}
 
+account.2.dns_cache_type = 1
 account.2.dns_cache_a.1.name =
 account.2.dns_cache_a.1.ip =
 account.2.dns_cache_a.1.ttl = 300
@@ -1093,8 +1109,13 @@ account.3.sip_server.2.retry_counts = 3
 account.3.sip_server.2.failback_mode = 0
 account.3.sip_server.2.failback_timeout = 3600
 account.3.sip_server.2.register_on_enable = 0
-account.3.dns_cache_type = 1
+#Configure the transport type; 0-UDP (default), 1-TCP, 2-TLS, 3-DNS-NAPTR;
+{if $account.3.sip_transport == 'udp'}account.3.sip_server.2.transport_type = 0{/if}
+{if $account.3.sip_transport == 'tcp'}account.3.sip_server.2.transport_type = 1{/if}
+{if $account.3.sip_transport == 'tls'}account.3.sip_server.2.transport_type = 2{/if}
+{if $account.3.sip_transport == 'dns srv'}account.3.sip_server.2.transport_type = 3{/if}
 
+account.3.dns_cache_type = 1
 account.3.dns_cache_a.1.name =
 account.3.dns_cache_a.1.ip =
 account.3.dns_cache_a.1.ttl = 300
@@ -1589,8 +1610,13 @@ account.4.sip_server.2.retry_counts = 3
 account.4.sip_server.2.failback_mode = 0
 account.4.sip_server.2.failback_timeout = 3600
 account.4.sip_server.2.register_on_enable = 0
-account.4.dns_cache_type = 1
+#Configure the transport type; 0-UDP (default), 1-TCP, 2-TLS, 3-DNS-NAPTR;
+{if $account.4.sip_transport == 'udp'}account.4.sip_server.2.transport_type = 0{/if}
+{if $account.4.sip_transport == 'tcp'}account.4.sip_server.2.transport_type = 1{/if}
+{if $account.4.sip_transport == 'tls'}account.4.sip_server.2.transport_type = 2{/if}
+{if $account.4.sip_transport == 'dns srv'}account.4.sip_server.2.transport_type = 3{/if}
 
+account.4.dns_cache_type = 1
 account.4.dns_cache_a.1.name =
 account.4.dns_cache_a.1.ip =
 account.4.dns_cache_a.1.ttl = 300
@@ -2085,8 +2111,13 @@ account.5.sip_server.2.retry_counts = 3
 account.5.sip_server.2.failback_mode = 0
 account.5.sip_server.2.failback_timeout = 3600
 account.5.sip_server.2.register_on_enable = 0
-account.5.dns_cache_type = 1
+#Configure the transport type; 0-UDP (default), 1-TCP, 2-TLS, 3-DNS-NAPTR;
+{if $account.5.sip_transport == 'udp'}account.5.sip_server.2.transport_type = 0{/if}
+{if $account.5.sip_transport == 'tcp'}account.5.sip_server.2.transport_type = 1{/if}
+{if $account.5.sip_transport == 'tls'}account.5.sip_server.2.transport_type = 2{/if}
+{if $account.5.sip_transport == 'dns srv'}account.5.sip_server.2.transport_type = 3{/if}
 
+account.5.dns_cache_type = 1
 account.5.dns_cache_a.1.name =
 account.5.dns_cache_a.1.ip =
 account.5.dns_cache_a.1.ttl = 300
@@ -2581,8 +2612,13 @@ account.6.sip_server.2.retry_counts = 3
 account.6.sip_server.2.failback_mode = 0
 account.6.sip_server.2.failback_timeout = 3600
 account.6.sip_server.2.register_on_enable = 0
-account.6.dns_cache_type = 1
+#Configure the transport type; 0-UDP (default), 1-TCP, 2-TLS, 3-DNS-NAPTR;
+{if $account.6.sip_transport == 'udp'}account.6.sip_server.2.transport_type = 0{/if}
+{if $account.6.sip_transport == 'tcp'}account.6.sip_server.2.transport_type = 1{/if}
+{if $account.6.sip_transport == 'tls'}account.6.sip_server.2.transport_type = 2{/if}
+{if $account.6.sip_transport == 'dns srv'}account.6.sip_server.2.transport_type = 3{/if}
 
+account.6.dns_cache_type = 1
 account.6.dns_cache_a.1.name =
 account.6.dns_cache_a.1.ip =
 account.6.dns_cache_a.1.ttl = 300


### PR DESCRIPTION
The t40p template was missing the rules for setting the transport type for the secondary server for dual registration.


Related note, A lot of the T4xG series phones don't support dual registration with fusionpbx. They have a secondary server address, but the update that fixed the context to allow the user@domain format for the user name was never released for most of those phones, and they are now end of support (no new firmwares). 

Can anyone see any reason to keep the server.2 options in the T4xG phone templates? It just causes issues because the phone will be sending bad registrations constantly to the secondary server since it doesn't know how to send them properly and could trigger fail2ban.