### PR TITLE
Remove these as they break HTML emails.

### DIFF
--- a/app/scripts/resources/scripts/app/ring_groups/index.lua
+++ b/app/scripts/resources/scripts/app/ring_groups/index.lua
@@ -341,6 +341,12 @@
 						["X-FusionPBX-Email-Type"]  = 'missed';
 					}
 
+				--remove quotes from caller id name and number
+					caller_id_name = caller_id_name:gsub("'", "&#39;");
+					caller_id_name = caller_id_name:gsub([["]], "&#34;");
+					caller_id_number = caller_id_number:gsub("'", "&#39;");
+					caller_id_number = caller_id_number:gsub([["]], "&#34;");
+			
 				--prepare the subject
 					subject = subject:gsub("${caller_id_name}", caller_id_name);
 					subject = subject:gsub("${caller_id_number}", caller_id_number);
@@ -363,8 +369,6 @@
 					body = body:gsub("&nbsp;", " ");
 					body = body:gsub("\n", "");
 					body = body:gsub("\n", "");
-					body = body:gsub("'", "&#39;");
-					body = body:gsub([["]], "&#34;");
 					body = trim(body);
 
 				--send the email


### PR DESCRIPTION
* Remove these as they break HTML emails. 
* Remove quotes from Caller ID name and number. 

Same as following commits:

https://github.com/fusionpbx/fusionpbx/commit/29c1d52533fd95ce0b995122471b9b283962bc3f
https://github.com/fusionpbx/fusionpbx/commit/c93c20c4e10796e7b3e64c67565748e83f0a100c