### PR TITLE
[Extension] Don't null dial_string when enable/disable follow me or dnd

### DIFF
--- a/app/calls/call_edit.php
+++ b/app/calls/call_edit.php
@@ -197,7 +197,6 @@
 				$array['extensions'][0]['domain_uuid'] = $_SESSION['domain_uuid'];
 				$array['extensions'][0]['extension_uuid'] = $extension_uuid;
 				$array['extensions'][0]['do_not_disturb'] = $dnd_enabled;
-				$array['extensions'][0]['dial_string'] = $dnd_enabled == "true" ? "error/user_busy" : '';
 			}
 
 		//follow me config

--- a/app/calls/resources/classes/call_forward.php
+++ b/app/calls/resources/classes/call_forward.php
@@ -39,7 +39,6 @@ include "root.php";
 		private $number_alias;
 		public $forward_all_destination;
 		public $forward_all_enabled;
-		private $dial_string;
 		private $toll_allow;
 		public $accountcode;
 		public $outbound_caller_id_name;
@@ -68,11 +67,9 @@ include "root.php";
 				$array['extensions'][0]['extension_uuid'] = $this->extension_uuid;
 				$array['extensions'][0]['forward_all_destination'] = strlen($this->forward_all_destination) != 0 ? $this->forward_all_destination : null;
 				if (strlen($this->forward_all_destination) == 0 || $this->forward_all_enabled == "false") {
-					$array['extensions'][0]['dial_string'] = null;
 					$array['extensions'][0]['forward_all_enabled'] = 'false';
 				}
 				else {
-					$array['extensions'][0]['dial_string'] = $this->dial_string;
 					$array['extensions'][0]['forward_all_enabled'] = 'true';
 				}
 

--- a/app/calls/resources/classes/do_not_disturb.php
+++ b/app/calls/resources/classes/do_not_disturb.php
@@ -33,7 +33,6 @@ include "root.php";
 		public $extension_uuid;
 		public $extension;
 		public $enabled;
-		private $dial_string;
 
 		//update the user_status
 		public function user_status() {
@@ -92,12 +91,8 @@ include "root.php";
 				}
 				unset($sql, $parameters, $row);
 
-			//set the dial string
-				$this->dial_string = $this->enabled == "true" ? "error/user_busy" : '';
-
 			//build extension update array
 				$array['extensions'][0]['extension_uuid'] = $this->extension_uuid;
-				$array['extensions'][0]['dial_string'] = $this->dial_string;
 				$array['extensions'][0]['do_not_disturb'] = $this->enabled;
 
 			//grant temporary permissions

--- a/app/calls/resources/classes/follow_me.php
+++ b/app/calls/resources/classes/follow_me.php
@@ -242,12 +242,10 @@ include "root.php";
 			//add follow me to the array
 				$array['follow_me'][0]["follow_me_uuid"] = $this->follow_me_uuid;
 				$array['follow_me'][0]["domain_uuid"] = $this->domain_uuid;
-				$array['follow_me'][0]["dial_string"] = '';
 
 			//add extensions to the array
 				$array['extensions'][0]["extension_uuid"] = $extension_uuid;
 				$array['extensions'][0]["dial_domain"] = $this->domain_name;
-				$array['extensions'][0]["dial_string"] = '';
 				$array['extensions'][0]["follow_me_destinations"] = '';
 				$array['extensions'][0]["follow_me_enabled"] = $this->follow_me_enabled;
 

--- a/app/scripts/resources/scripts/app/xml_handler/resources/scripts/directory/directory.lua
+++ b/app/scripts/resources/scripts/app/xml_handler/resources/scripts/directory/directory.lua
@@ -380,7 +380,9 @@
 								presence_id = (NUMBER_AS_PRESENCE_ID and sip_from_number or sip_from_user) .. "@" .. domain_name;
 
 							--set the dial_string
-								if (string.len(row.dial_string) > 0) then
+								if (do_not_disturb == "true") then
+									dial_string = "error/USER_BUSY";
+								elseif (string.len(row.dial_string) > 0) then
 									dial_string = row.dial_string;
 								else
 										local destination = (DIAL_STRING_BASED_ON_USERID and sip_from_number or sip_from_user) .. "@" .. domain_name;


### PR DESCRIPTION
Until now, the behavior nulled the dial string every time a save was made on the call forward page that didn't allow for custom dial strings that can be useful in some cases.

The only place fusionpbx uses the dial string is for DND, which can be set in the XML handler.