### PR TITLE
update to fix array count of emails to determine if normal to: or bcc:

### DIFF
--- a/secure/v_mailto.php
+++ b/secure/v_mailto.php
@@ -266,7 +266,7 @@
 	$to = str_replace(" ", "", $to);
 	$to = str_replace(";", ",", $to);
 	$to_array = explode(",", $to);
-	if (count($to_array) == 0) {
+	if (count($to_array) == 1) {
 		$mail->AddAddress($to);
 	}
 	else {


### PR DESCRIPTION
at line 269 if this is set to ZERO all emails are bcc. this causes problems for normal recipients and scripts that depend on a TO field existing.

Setting to 1 will have it be a normal to: if its 1 email address and if its more than 1 it will do the BCC steps.