### PR TITLE
Fix some nway conference true/false variables

### DIFF
--- a/resources/templates/provision/flyingvoice/fip10/{$mac}.cfg
+++ b/resources/templates/provision/flyingvoice/fip10/{$mac}.cfg
@@ -198,7 +198,7 @@ account.1.session_timer.refresher=
 account.1.session_timer.expires=
 account.1.session_timer.enable= {$flyingvoice_session_timer}
 
-account.1.conf_type = {if $nway_conference == true}2{/if}
+account.1.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 account.1.sip_server_type=
 
 
@@ -389,7 +389,7 @@ account.1.refresh_remote_id.enable =
 #######################################################################################
 ##                                Network Conferene                                  ##       
 #######################################################################################
-account.1.conf_uri = {if $nway_conference == true}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
+account.1.conf_uri = {if $nway_conference == 'true'}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
 
 
 
@@ -575,7 +575,7 @@ account.2.session_timer.refresher=
 account.2.session_timer.expires=
 account.2.session_timer.enable= {$flyingvoice_session_timer}
 
-account.2.conf_type = {if $nway_conference == true}2{/if}
+account.2.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 account.2.sip_server_type=
 
 
@@ -766,7 +766,7 @@ account.2.refresh_remote_id.enable =
 #######################################################################################
 ##                                Network Conferene                                  ##       
 #######################################################################################
-account.2.conf_uri = {if $nway_conference == true}nway{$account.2.user_id}@{$account.2.server_address}{/if}
+account.2.conf_uri = {if $nway_conference == 'true'}nway{$account.2.user_id}@{$account.2.server_address}{/if}
 
 
 

--- a/resources/templates/provision/flyingvoice/fip11c/{$mac}.cfg
+++ b/resources/templates/provision/flyingvoice/fip11c/{$mac}.cfg
@@ -199,7 +199,7 @@ account.1.session_timer.refresher=
 account.1.session_timer.expires=
 account.1.session_timer.enable= {$flyingvoice_session_timer}
 
-account.1.conf_type = {if $nway_conference == true}2{/if}
+account.1.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 account.1.sip_server_type=
 
 
@@ -390,7 +390,7 @@ account.1.refresh_remote_id.enable =
 #######################################################################################
 ##                                Network Conferene                                  ##       
 #######################################################################################
-account.1.conf_uri = {if $nway_conference == true}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
+account.1.conf_uri = {if $nway_conference == 'true'}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
 
 
 
@@ -576,7 +576,7 @@ account.2.session_timer.refresher=
 account.2.session_timer.expires=
 account.2.session_timer.enable= {$flyingvoice_session_timer}
 
-account.2.conf_type = {if $nway_conference == true}2{/if}
+account.2.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 account.2.sip_server_type=
 
 
@@ -767,7 +767,7 @@ account.2.refresh_remote_id.enable =
 #######################################################################################
 ##                                Network Conferene                                  ##       
 #######################################################################################
-account.2.conf_uri = {if $nway_conference == true}nway{$account.2.user_id}@{$account.2.server_address}{/if}
+account.2.conf_uri = {if $nway_conference == 'true'}nway{$account.2.user_id}@{$account.2.server_address}{/if}
 
 
 
@@ -955,7 +955,7 @@ account.3.session_timer.refresher=
 account.3.session_timer.expires=
 account.3.session_timer.enable= {$flyingvoice_session_timer}
 
-account.3.conf_type = {if $nway_conference == true}2{/if}
+account.3.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 account.3.sip_server_type=
 
 
@@ -1160,7 +1160,7 @@ account.3.refresh_remote_id.enable =
 #######################################################################################
 ##                                Network Conferene                                  ##       
 #######################################################################################
-account.3.conf_uri = {if $nway_conference == true}nway{$account.3.user_id}@{$account.3.server_address}{/if}
+account.3.conf_uri = {if $nway_conference == 'true'}nway{$account.3.user_id}@{$account.3.server_address}{/if}
 
 
 

--- a/resources/templates/provision/flyingvoice/fip12wp/{$mac}.cfg
+++ b/resources/templates/provision/flyingvoice/fip12wp/{$mac}.cfg
@@ -199,7 +199,7 @@ account.1.session_timer.refresher=
 account.1.session_timer.expires=
 account.1.session_timer.enable= {$flyingvoice_session_timer}
 
-account.1.conf_type = {if $nway_conference == true}2{/if}
+account.1.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 account.1.sip_server_type=
 
 
@@ -390,7 +390,7 @@ account.1.refresh_remote_id.enable =
 #######################################################################################
 ##                                Network Conferene                                  ##       
 #######################################################################################
-account.1.conf_uri = {if $nway_conference == true}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
+account.1.conf_uri = {if $nway_conference == 'true'}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
 
 
 
@@ -576,7 +576,7 @@ account.2.session_timer.refresher=
 account.2.session_timer.expires=
 account.2.session_timer.enable= {$flyingvoice_session_timer}
 
-account.2.conf_type = {if $nway_conference == true}2{/if}
+account.2.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 account.2.sip_server_type=
 
 
@@ -767,7 +767,7 @@ account.2.refresh_remote_id.enable =
 #######################################################################################
 ##                                Network Conferene                                  ##       
 #######################################################################################
-account.2.conf_uri = {if $nway_conference == true}nway{$account.2.user_id}@{$account.2.server_address}{/if}
+account.2.conf_uri = {if $nway_conference == 'true'}nway{$account.2.user_id}@{$account.2.server_address}{/if}
 
 
 

--- a/resources/templates/provision/flyingvoice/fip13g/{$mac}.cfg
+++ b/resources/templates/provision/flyingvoice/fip13g/{$mac}.cfg
@@ -199,7 +199,7 @@ account.1.session_timer.refresher=
 account.1.session_timer.expires=
 account.1.session_timer.enable= {$flyingvoice_session_timer}
 
-account.1.conf_type = {if $nway_conference == true}2{/if}
+account.1.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 account.1.sip_server_type=
 
 
@@ -390,7 +390,7 @@ account.1.refresh_remote_id.enable =
 #######################################################################################
 ##                                Network Conferene                                  ##       
 #######################################################################################
-account.1.conf_uri = {if $nway_conference == true}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
+account.1.conf_uri = {if $nway_conference == 'true'}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
 
 
 
@@ -576,7 +576,7 @@ account.2.session_timer.refresher=
 account.2.session_timer.expires=
 account.2.session_timer.enable= {$flyingvoice_session_timer}
 
-account.2.conf_type = {if $nway_conference == true}2{/if}
+account.2.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 account.2.sip_server_type=
 
 
@@ -767,7 +767,7 @@ account.2.refresh_remote_id.enable =
 #######################################################################################
 ##                                Network Conferene                                  ##       
 #######################################################################################
-account.2.conf_uri = {if $nway_conference == true}nway{$account.2.user_id}@{$account.2.server_address}{/if}
+account.2.conf_uri = {if $nway_conference == 'true'}nway{$account.2.user_id}@{$account.2.server_address}{/if}
 
 
 
@@ -955,7 +955,7 @@ account.3.session_timer.refresher=
 account.3.session_timer.expires=
 account.3.session_timer.enable= {$flyingvoice_session_timer}
 
-account.3.conf_type = {if $nway_conference == true}2{/if}
+account.3.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 account.3.sip_server_type=
 
 
@@ -1160,7 +1160,7 @@ account.3.refresh_remote_id.enable =
 #######################################################################################
 ##                                Network Conferene                                  ##       
 #######################################################################################
-account.3.conf_uri = {if $nway_conference == true}nway{$account.3.user_id}@{$account.3.server_address}{/if}
+account.3.conf_uri = {if $nway_conference == 'true'}nway{$account.3.user_id}@{$account.3.server_address}{/if}
 
 
 
@@ -1348,7 +1348,7 @@ account.4.session_timer.refresher=
 account.4.session_timer.expires=
 account.4.session_timer.enable= {$flyingvoice_session_timer}
 
-account.4.conf_type = {if $nway_conference == true}2{/if} 
+account.4.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if} 
 account.4.sip_server_type=
 
 
@@ -1553,7 +1553,7 @@ account.4.refresh_remote_id.enable =
 #######################################################################################
 ##                                Network Conferene                                  ##       
 #######################################################################################
-account.4.conf_uri = {if $nway_conference == true}nway{$account.4.user_id}@{$account.4.server_address}{/if}
+account.4.conf_uri = {if $nway_conference == 'true'}nway{$account.4.user_id}@{$account.4.server_address}{/if}
 
 
 

--- a/resources/templates/provision/flyingvoice/fip14g/{$mac}.cfg
+++ b/resources/templates/provision/flyingvoice/fip14g/{$mac}.cfg
@@ -199,7 +199,7 @@ account.1.session_timer.refresher=
 account.1.session_timer.expires=
 account.1.session_timer.enable= {$flyingvoice_session_timer}
 
-account.1.conf_type = {if $nway_conference == true}2{/if}
+account.1.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 account.1.sip_server_type=
 
 
@@ -390,7 +390,7 @@ account.1.refresh_remote_id.enable =
 #######################################################################################
 ##                                Network Conferene                                  ##       
 #######################################################################################
-account.1.conf_uri = {if $nway_conference == true}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
+account.1.conf_uri = {if $nway_conference == 'true'}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
 
 
 
@@ -576,7 +576,7 @@ account.2.session_timer.refresher=
 account.2.session_timer.expires=
 account.2.session_timer.enable= {$flyingvoice_session_timer}
 
-account.2.conf_type = {if $nway_conference == true}2{/if}
+account.2.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 account.2.sip_server_type=
 
 
@@ -767,7 +767,7 @@ account.2.refresh_remote_id.enable =
 #######################################################################################
 ##                                Network Conferene                                  ##       
 #######################################################################################
-account.2.conf_uri = {if $nway_conference == true}nway{$account.2.user_id}@{$account.2.server_address}{/if}
+account.2.conf_uri = {if $nway_conference == 'true'}nway{$account.2.user_id}@{$account.2.server_address}{/if}
 
 
 
@@ -955,7 +955,7 @@ account.3.session_timer.refresher=
 account.3.session_timer.expires=
 account.3.session_timer.enable= {$flyingvoice_session_timer}
 
-account.3.conf_type = {if $nway_conference == true}2{/if}
+account.3.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 account.3.sip_server_type=
 
 
@@ -1160,7 +1160,7 @@ account.3.refresh_remote_id.enable =
 #######################################################################################
 ##                                Network Conferene                                  ##       
 #######################################################################################
-account.3.conf_uri = {if $nway_conference == true}nway{$account.3.user_id}@{$account.3.server_address}{/if}
+account.3.conf_uri = {if $nway_conference == 'true'}nway{$account.3.user_id}@{$account.3.server_address}{/if}
 
 
 
@@ -1348,7 +1348,7 @@ account.4.session_timer.refresher=
 account.4.session_timer.expires=
 account.4.session_timer.enable= {$flyingvoice_session_timer}
 
-account.4.conf_type = {if $nway_conference == true}2{/if} 
+account.4.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if} 
 account.4.sip_server_type=
 
 
@@ -1553,7 +1553,7 @@ account.4.refresh_remote_id.enable =
 #######################################################################################
 ##                                Network Conferene                                  ##       
 #######################################################################################
-account.4.conf_uri = {if $nway_conference == true}nway{$account.4.user_id}@{$account.4.server_address}{/if}
+account.4.conf_uri = {if $nway_conference == 'true'}nway{$account.4.user_id}@{$account.4.server_address}{/if}
 
 
 
@@ -1740,7 +1740,7 @@ account.5.session_timer.refresher=
 account.5.session_timer.expires=
 account.5.session_timer.enable= {$flyingvoice_session_timer}
 
-account.5.conf_type = {if $nway_conference == true}2{/if}
+account.5.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 account.5.sip_server_type=
 
 
@@ -1945,7 +1945,7 @@ account.5.refresh_remote_id.enable =
 #######################################################################################
 ##                                Network Conferene                                  ##       
 #######################################################################################
-account.5.conf_uri = {if $nway_conference == true}nway{$account.5.user_id}@{$account.5.server_address}{/if}
+account.5.conf_uri = {if $nway_conference == 'true'}nway{$account.5.user_id}@{$account.5.server_address}{/if}
 
 
 
@@ -2132,7 +2132,7 @@ account.6.session_timer.refresher=
 account.6.session_timer.expires=
 account.6.session_timer.enable= {$flyingvoice_session_timer}
 
-account.6.conf_type = {if $nway_conference == true}2{/if}
+account.6.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 account.6.sip_server_type=
 
 
@@ -2337,7 +2337,7 @@ account.6.refresh_remote_id.enable =
 #######################################################################################
 ##                                Network Conferene                                  ##       
 #######################################################################################
-account.6.conf_uri = {if $nway_conference == true}nway{$account.6.user_id}@{$account.6.server_address}{/if}
+account.6.conf_uri = {if $nway_conference == 'true'}nway{$account.6.user_id}@{$account.6.server_address}{/if}
 
 
 

--- a/resources/templates/provision/flyingvoice/fip15g/{$mac}.cfg
+++ b/resources/templates/provision/flyingvoice/fip15g/{$mac}.cfg
@@ -198,7 +198,7 @@ account.1.session_timer.refresher=
 account.1.session_timer.expires=
 account.1.session_timer.enable= {$flyingvoice_session_timer}
 
-account.1.conf_type = {if $nway_conference == true}2{/if}
+account.1.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 account.1.sip_server_type=
 
 
@@ -410,7 +410,7 @@ account.1.refresh_remote_id.enable =
 #######################################################################################
 ##                                Network Conferene                                  ##       
 #######################################################################################
-account.1.conf_uri = {if $nway_conference == true}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
+account.1.conf_uri = {if $nway_conference == 'true'}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
 
 
 
@@ -596,7 +596,7 @@ account.2.session_timer.refresher=
 account.2.session_timer.expires=
 account.2.session_timer.enable= {$flyingvoice_session_timer}
 
-account.2.conf_type = {if $nway_conference == true}2{/if}
+account.2.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 account.2.sip_server_type=
 
 
@@ -808,7 +808,7 @@ account.2.refresh_remote_id.enable =
 #######################################################################################
 ##                                Network Conferene                                  ##       
 #######################################################################################
-account.2.conf_uri = {if $nway_conference == true}nway{$account.2.user_id}@{$account.2.server_address}{/if}
+account.2.conf_uri = {if $nway_conference == 'true'}nway{$account.2.user_id}@{$account.2.server_address}{/if}
 
 
 
@@ -996,7 +996,7 @@ account.3.session_timer.refresher=
 account.3.session_timer.expires=
 account.3.session_timer.enable= {$flyingvoice_session_timer}
 
-account.3.conf_type = {if $nway_conference == true}2{/if}
+account.3.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 account.3.sip_server_type=
 
 
@@ -1222,7 +1222,7 @@ account.3.refresh_remote_id.enable =
 #######################################################################################
 ##                                Network Conferene                                  ##       
 #######################################################################################
-account.3.conf_uri = {if $nway_conference == true}nway{$account.3.user_id}@{$account.3.server_address}{/if}
+account.3.conf_uri = {if $nway_conference == 'true'}nway{$account.3.user_id}@{$account.3.server_address}{/if}
 
 
 
@@ -1410,7 +1410,7 @@ account.4.session_timer.refresher=
 account.4.session_timer.expires=
 account.4.session_timer.enable= {$flyingvoice_session_timer}
 
-account.4.conf_type = {if $nway_conference == true}2{/if} 
+account.4.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if} 
 account.4.sip_server_type=
 
 
@@ -1636,7 +1636,7 @@ account.4.refresh_remote_id.enable =
 #######################################################################################
 ##                                Network Conferene                                  ##       
 #######################################################################################
-account.4.conf_uri = {if $nway_conference == true}nway{$account.4.user_id}@{$account.4.server_address}{/if}
+account.4.conf_uri = {if $nway_conference == 'true'}nway{$account.4.user_id}@{$account.4.server_address}{/if}
 
 
 
@@ -1823,7 +1823,7 @@ account.5.session_timer.refresher=
 account.5.session_timer.expires=
 account.5.session_timer.enable= {$flyingvoice_session_timer}
 
-account.5.conf_type = {if $nway_conference == true}2{/if}
+account.5.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 account.5.sip_server_type=
 
 
@@ -2049,7 +2049,7 @@ account.5.refresh_remote_id.enable =
 #######################################################################################
 ##                                Network Conferene                                  ##       
 #######################################################################################
-account.5.conf_uri = {if $nway_conference == true}nway{$account.5.user_id}@{$account.5.server_address}{/if}
+account.5.conf_uri = {if $nway_conference == 'true'}nway{$account.5.user_id}@{$account.5.server_address}{/if}
 
 
 
@@ -2236,7 +2236,7 @@ account.6.session_timer.refresher=
 account.6.session_timer.expires=
 account.6.session_timer.enable= {$flyingvoice_session_timer}
 
-account.6.conf_type = {if $nway_conference == true}2{/if}
+account.6.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 account.6.sip_server_type=
 
 
@@ -2462,7 +2462,7 @@ account.6.refresh_remote_id.enable =
 #######################################################################################
 ##                                Network Conferene                                  ##       
 #######################################################################################
-account.6.conf_uri = {if $nway_conference == true}nway{$account.6.user_id}@{$account.6.server_address}{/if}
+account.6.conf_uri = {if $nway_conference == 'true'}nway{$account.6.user_id}@{$account.6.server_address}{/if}
 
 
 

--- a/resources/templates/provision/flyingvoice/fip16/{$mac}.cfg
+++ b/resources/templates/provision/flyingvoice/fip16/{$mac}.cfg
@@ -186,7 +186,7 @@ account.1.session_timer.refresher=
 account.1.session_timer.expires=
 account.1.session_timer.enable= {$flyingvoice_session_timer}
 
-account.1.conf_type = {if $nway_conference == true}2{/if}
+account.1.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 account.1.sip_server_type=
 
 
@@ -353,7 +353,7 @@ account.1.refresh_remote_id.enable =
 #######################################################################################
 ##                                Network Conferene                                  ##       
 #######################################################################################
-account.1.conf_uri = {if $nway_conference == true}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
+account.1.conf_uri = {if $nway_conference == 'true'}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
 
 
 
@@ -520,7 +520,7 @@ account.2.session_timer.refresher=
 account.2.session_timer.expires=
 account.2.session_timer.enable= {$flyingvoice_session_timer}
 
-account.2.conf_type = {if $nway_conference == true}2{/if}
+account.2.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 account.2.sip_server_type=
 
 
@@ -686,7 +686,7 @@ account.2.refresh_remote_id.enable =
 #######################################################################################
 ##                                Network Conferene                                  ##       
 #######################################################################################
-account.2.conf_uri = {if $nway_conference == true}nway{$account.2.user_id}@{$account.2.server_address}{/if}
+account.2.conf_uri = {if $nway_conference == 'true'}nway{$account.2.user_id}@{$account.2.server_address}{/if}
 
 
 

--- a/resources/templates/provision/flyingvoice/fip16plus/{$mac}.cfg
+++ b/resources/templates/provision/flyingvoice/fip16plus/{$mac}.cfg
@@ -186,7 +186,7 @@ account.1.session_timer.refresher=
 account.1.session_timer.expires=
 account.1.session_timer.enable= {$flyingvoice_session_timer}
 
-account.1.conf_type = {if $nway_conference == true}2{/if}
+account.1.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 account.1.sip_server_type=
 
 
@@ -353,7 +353,7 @@ account.1.refresh_remote_id.enable =
 #######################################################################################
 ##                                Network Conferene                                  ##       
 #######################################################################################
-account.1.conf_uri = {if $nway_conference == true}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
+account.1.conf_uri = {if $nway_conference == 'true'}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
 
 
 
@@ -520,7 +520,7 @@ account.2.session_timer.refresher=
 account.2.session_timer.expires=
 account.2.session_timer.enable= {$flyingvoice_session_timer}
 
-account.2.conf_type = {if $nway_conference == true}2{/if}
+account.2.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 account.2.sip_server_type=
 
 
@@ -686,7 +686,7 @@ account.2.refresh_remote_id.enable =
 #######################################################################################
 ##                                Network Conferene                                  ##       
 #######################################################################################
-account.2.conf_uri = {if $nway_conference == true}nway{$account.2.user_id}@{$account.2.server_address}{/if}
+account.2.conf_uri = {if $nway_conference == 'true'}nway{$account.2.user_id}@{$account.2.server_address}{/if}
 
 
 

--- a/resources/templates/provision/grandstream/gac2500/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gac2500/{$mac}.xml
@@ -488,7 +488,7 @@
 
     <!-- # Conference URI -->
     <!-- # String -->
-    <P2318>{if $nway_conference == true}nway{$account.1.user_id}@{$account.1.server_address}{/if}</P2318>
+    <P2318>{if $nway_conference == 'true'}nway{$account.1.user_id}@{$account.1.server_address}{/if}</P2318>
 
     <!-- # Account Ring Tone. See ring tone options and value in the Ring Tone Value Table below -->
    	{if isset($grandstream_account_ring_tone_1)}
@@ -1056,7 +1056,7 @@
 
     <!-- # Conference-URI -->
     <!-- # String -->
-    <P2418>{if $nway_conference == true}nway{$account.2.user_id}@{$account.2.server_address}{/if}</P2418>
+    <P2418>{if $nway_conference == 'true'}nway{$account.2.user_id}@{$account.2.server_address}{/if}</P2418>
 
     <!-- # No Answer Timeout (s). Default value is 20 -->
     <!-- # Number: 1 - 120. -->
@@ -1624,7 +1624,7 @@
 
     <!-- # Conference-URI -->
     <!-- # String -->
-    <P2518>{if $nway_conference == true}nway{$account.3.user_id}@{$account.3.server_address}{/if}</P2518>
+    <P2518>{if $nway_conference == 'true'}nway{$account.3.user_id}@{$account.3.server_address}{/if}</P2518>
 
     <!-- # No Answer Timeout (s). Default value is 20 -->
     <!-- # Number: 1 - 120 -->
@@ -2193,7 +2193,7 @@
 
     <!-- # Conference-URI -->
     <!-- # String -->
-    <P2618>{if $nway_conference == true}nway{$account.4.user_id}@{$account.4.server_address}{/if}</P2618>
+    <P2618>{if $nway_conference == 'true'}nway{$account.4.user_id}@{$account.4.server_address}{/if}</P2618>
 
     <!-- # Account Ring Tone. See ring tone options and value in the Ring Tone value table below -->
     
@@ -2764,7 +2764,7 @@
 
     <!-- # Conference-URI -->
     <!-- # String -->
-    <P2718>{if $nway_conference == true}nway{$account.5.user_id}@{$account.5.server_address}{/if}</P2718>
+    <P2718>{if $nway_conference == 'true'}nway{$account.5.user_id}@{$account.5.server_address}{/if}</P2718>
 
     <!-- # No Answer Timeout (s). Default value is 20 -->
     <!-- # Number: 1 - 120 -->
@@ -3335,7 +3335,7 @@
 
     <!-- # Conference-URI -->
     <!-- # String -->
-    <P2818>{if $nway_conference == true}nway{$account.6.user_id}@{$account.6.server_address}{/if}</P2818>
+    <P2818>{if $nway_conference == 'true'}nway{$account.6.user_id}@{$account.6.server_address}{/if}</P2818>
 
     <!-- # No Answer Timeout (s). Default value is 20 -->
     <!-- # Number: 1 - 120 -->

--- a/resources/templates/provision/grandstream/grp2612/{$mac}.xml
+++ b/resources/templates/provision/grandstream/grp2612/{$mac}.xml
@@ -358,7 +358,7 @@
 
     <!-- # Conference URI -->
     <!-- # String -->
-    <P2318>{if $nway_conference == true}nway{$account.1.user_id}@{$account.1.server_address}{/if}</P2318>
+    <P2318>{if $nway_conference == 'true'}nway{$account.1.user_id}@{$account.1.server_address}{/if}</P2318>
 
     <!-- # Music On Hold URI -->
     <!-- # String -->
@@ -1316,7 +1316,7 @@
 
     <!-- # Conference URI -->
     <!-- # String -->
-    <P2418>{if $nway_conference == true}nway{$account.2.user_id}@{$account.2.server_address}{/if}</P2418>
+    <P2418>{if $nway_conference == 'true'}nway{$account.2.user_id}@{$account.2.server_address}{/if}</P2418>
 
     <!-- # Music On Hold URI -->
     <!-- # String -->

--- a/resources/templates/provision/grandstream/grp2612w/{$mac}.xml
+++ b/resources/templates/provision/grandstream/grp2612w/{$mac}.xml
@@ -358,7 +358,7 @@
 
     <!-- # Conference URI -->
     <!-- # String -->
-    <P2318>{if $nway_conference == true}nway{$account.1.user_id}@{$account.1.server_address}{/if}</P2318>
+    <P2318>{if $nway_conference == 'true'}nway{$account.1.user_id}@{$account.1.server_address}{/if}</P2318>
 
     <!-- # Music On Hold URI -->
     <!-- # String -->
@@ -1316,7 +1316,7 @@
 
     <!-- # Conference URI -->
     <!-- # String -->
-    <P2418>{if $nway_conference == true}nway{$account.2.user_id}@{$account.2.server_address}{/if}</P2418>
+    <P2418>{if $nway_conference == 'true'}nway{$account.2.user_id}@{$account.2.server_address}{/if}</P2418>
 
     <!-- # Music On Hold URI -->
     <!-- # String -->

--- a/resources/templates/provision/grandstream/grp2613/{$mac}.xml
+++ b/resources/templates/provision/grandstream/grp2613/{$mac}.xml
@@ -358,7 +358,7 @@
 
     <!-- # Conference URI -->
     <!-- # String -->
-    <P2318>{if $nway_conference == true}nway{$account.1.user_id}@{$account.1.server_address}{/if}</P2318>
+    <P2318>{if $nway_conference == 'true'}nway{$account.1.user_id}@{$account.1.server_address}{/if}</P2318>
 
     <!-- # Music On Hold URI -->
     <!-- # String -->
@@ -1316,7 +1316,7 @@
 
     <!-- # Conference URI -->
     <!-- # String -->
-    <P2418>{if $nway_conference == true}nway{$account.2.user_id}@{$account.2.server_address}{/if}</P2418>
+    <P2418>{if $nway_conference == 'true'}nway{$account.2.user_id}@{$account.2.server_address}{/if}</P2418>
 
     <!-- # Music On Hold URI -->
     <!-- # String -->
@@ -2268,7 +2268,7 @@
 
     <!-- # Conference URI -->
     <!-- # String -->
-    <P2518>{if $nway_conference == true}nway{$account.3.user_id}@{$account.3.server_address}{/if}</P2518>
+    <P2518>{if $nway_conference == 'true'}nway{$account.3.user_id}@{$account.3.server_address}{/if}</P2518>
 
     <!-- # Music On Hold URI -->
     <!-- # String -->

--- a/resources/templates/provision/grandstream/grp2614/{$mac}.xml
+++ b/resources/templates/provision/grandstream/grp2614/{$mac}.xml
@@ -358,7 +358,7 @@
 
     <!-- # Conference URI -->
     <!-- # String -->
-    <P2318>{if $nway_conference == true}nway{$account.1.user_id}@{$account.1.server_address}{/if}</P2318>
+    <P2318>{if $nway_conference == 'true'}nway{$account.1.user_id}@{$account.1.server_address}{/if}</P2318>
 
     <!-- # Music On Hold URI -->
     <!-- # String -->
@@ -1316,7 +1316,7 @@
 
     <!-- # Conference URI -->
     <!-- # String -->
-    <P2418>{if $nway_conference == true}nway{$account.2.user_id}@{$account.2.server_address}{/if}</P2418>
+    <P2418>{if $nway_conference == 'true'}nway{$account.2.user_id}@{$account.2.server_address}{/if}</P2418>
 
     <!-- # Music On Hold URI -->
     <!-- # String -->
@@ -2268,7 +2268,7 @@
 
     <!-- # Conference URI -->
     <!-- # String -->
-    <P2518>{if $nway_conference == true}nway{$account.3.user_id}@{$account.3.server_address}{/if}</P2518>
+    <P2518>{if $nway_conference == 'true'}nway{$account.3.user_id}@{$account.3.server_address}{/if}</P2518>
 
     <!-- # Music On Hold URI -->
     <!-- # String -->
@@ -3221,7 +3221,7 @@
 
     <!-- # Conference URI -->
     <!-- # String -->
-    <P2618>{if $nway_conference == true}nway{$account.4.user_id}@{$account.4.server_address}{/if}</P2618>
+    <P2618>{if $nway_conference == 'true'}nway{$account.4.user_id}@{$account.4.server_address}{/if}</P2618>
 
     <!-- # Music On Hold URI -->
     <!-- # String -->

--- a/resources/templates/provision/grandstream/grp2615/{$mac}.xml
+++ b/resources/templates/provision/grandstream/grp2615/{$mac}.xml
@@ -358,7 +358,7 @@
 
     <!-- # Conference URI -->
     <!-- # String -->
-    <P2318>{if $nway_conference == true}nway{$account.1.user_id}@{$account.1.server_address}{/if}</P2318>
+    <P2318>{if $nway_conference == 'true'}nway{$account.1.user_id}@{$account.1.server_address}{/if}</P2318>
 
     <!-- # Music On Hold URI -->
     <!-- # String -->
@@ -1332,7 +1332,7 @@
 
     <!-- # Conference URI -->
     <!-- # String -->
-    <P2418>{if $nway_conference == true}nway{$account.2.user_id}@{$account.2.server_address}{/if}</P2418>
+    <P2418>{if $nway_conference == 'true'}nway{$account.2.user_id}@{$account.2.server_address}{/if}</P2418>
 
     <!-- # Music On Hold URI -->
     <!-- # String -->
@@ -2300,7 +2300,7 @@
 
     <!-- # Conference URI -->
     <!-- # String -->
-    <P2518>{if $nway_conference == true}nway{$account.3.user_id}@{$account.3.server_address}{/if}</P2518>
+    <P2518>{if $nway_conference == 'true'}nway{$account.3.user_id}@{$account.3.server_address}{/if}</P2518>
 
     <!-- # Music On Hold URI -->
     <!-- # String -->
@@ -3269,7 +3269,7 @@
 
     <!-- # Conference URI -->
     <!-- # String -->
-    <P2618>{if $nway_conference == true}nway{$account.4.user_id}@{$account.4.server_address}{/if}</P2618>
+    <P2618>{if $nway_conference == 'true'}nway{$account.4.user_id}@{$account.4.server_address}{/if}</P2618>
 
     <!-- # Music On Hold URI -->
     <!-- # String -->
@@ -4239,7 +4239,7 @@
 
     <!-- # Conference URI -->
     <!-- # String -->
-    <P2718>{if $nway_conference == true}nway{$account.5.user_id}@{$account.5.server_address}{/if}</P2718>
+    <P2718>{if $nway_conference == 'true'}nway{$account.5.user_id}@{$account.5.server_address}{/if}</P2718>
 
     <!-- # Music On Hold URI -->
     <!-- # String -->

--- a/resources/templates/provision/grandstream/grp2616/{$mac}.xml
+++ b/resources/templates/provision/grandstream/grp2616/{$mac}.xml
@@ -358,7 +358,7 @@
 
     <!-- # Conference URI -->
     <!-- # String -->
-    <P2318>{if $nway_conference == true}nway{$account.1.user_id}@{$account.1.server_address}{/if}</P2318>
+    <P2318>{if $nway_conference == 'true'}nway{$account.1.user_id}@{$account.1.server_address}{/if}</P2318>
 
     <!-- # Music On Hold URI -->
     <!-- # String -->
@@ -1316,7 +1316,7 @@
 
     <!-- # Conference URI -->
     <!-- # String -->
-    <P2418>{if $nway_conference == true}nway{$account.2.user_id}@{$account.2.server_address}{/if}</P2418>
+    <P2418>{if $nway_conference == 'true'}nway{$account.2.user_id}@{$account.2.server_address}{/if}</P2418>
 
     <!-- # Music On Hold URI -->
     <!-- # String -->
@@ -2268,7 +2268,7 @@
 
     <!-- # Conference URI -->
     <!-- # String -->
-    <P2518>{if $nway_conference == true}nway{$account.3.user_id}@{$account.3.server_address}{/if}</P2518>
+    <P2518>{if $nway_conference == 'true'}nway{$account.3.user_id}@{$account.3.server_address}{/if}</P2518>
 
     <!-- # Music On Hold URI -->
     <!-- # String -->
@@ -3221,7 +3221,7 @@
 
     <!-- # Conference URI -->
     <!-- # String -->
-    <P2618>{if $nway_conference == true}nway{$account.4.user_id}@{$account.4.server_address}{/if}</P2618>
+    <P2618>{if $nway_conference == 'true'}nway{$account.4.user_id}@{$account.4.server_address}{/if}</P2618>
 
     <!-- # Music On Hold URI -->
     <!-- # String -->
@@ -4175,7 +4175,7 @@
 
     <!-- # Conference URI -->
     <!-- # String -->
-    <P2718>{if $nway_conference == true}nway{$account.5.user_id}@{$account.5.server_address}{/if}</P2718>
+    <P2718>{if $nway_conference == 'true'}nway{$account.5.user_id}@{$account.5.server_address}{/if}</P2718>
 
     <!-- # Music On Hold URI -->
     <!-- # String -->
@@ -5129,7 +5129,7 @@
 
     <!-- # Conference URI -->
     <!-- # String -->
-    <P2818>{if $nway_conference == true}nway{$account.6.user_id}@{$account.6.server_address}{/if}</P2818>
+    <P2818>{if $nway_conference == 'true'}nway{$account.6.user_id}@{$account.6.server_address}{/if}</P2818>
 
     <!-- # Music On Hold URI -->
     <!-- # String -->

--- a/resources/templates/provision/grandstream/grp261x/{$mac}.xml
+++ b/resources/templates/provision/grandstream/grp261x/{$mac}.xml
@@ -249,7 +249,7 @@
 		<item name="account.{$line}.sip.blf.eventlist.autoProvision">Disabled</item>
 
 		<!-- Conference URI -->
-		<item name="account.{$line}.sip.conferenceUri">{if $nway_conference == true}nway{$row.user_id}@{$row.server_address}{/if}</item>
+		<item name="account.{$line}.sip.conferenceUri">{if $nway_conference == 'true'}nway{$row.user_id}@{$row.server_address}{/if}</item>
 
 		<!-- Music On Hold URI -->
 		<item name="account.{$line}.sip.musicOnHoldUri"></item>

--- a/resources/templates/provision/grandstream/grp26xx/{$mac}.xml
+++ b/resources/templates/provision/grandstream/grp26xx/{$mac}.xml
@@ -354,7 +354,7 @@
 
     <!-- # Conference URI -->
     <!-- # String -->
-    <P2318>{if $nway_conference == true}nway{$account.1.user_id}@{$account.1.server_address}{/if}</P2318>
+    <P2318>{if $nway_conference == 'true'}nway{$account.1.user_id}@{$account.1.server_address}{/if}</P2318>
 
     <!-- # Music On Hold URI -->
     <!-- # String -->
@@ -1334,7 +1334,7 @@
 
     <!-- # Conference URI -->
     <!-- # String -->
-    <P2418>{if $nway_conference == true}nway{$account.2.user_id}@{$account.2.server_address}{/if}</P2418>
+    <P2418>{if $nway_conference == 'true'}nway{$account.2.user_id}@{$account.2.server_address}{/if}</P2418>
 
     <!-- # Music On Hold URI -->
     <!-- # String -->
@@ -2305,7 +2305,7 @@
 
     <!-- # Conference URI -->
     <!-- # String -->
-    <P2518>{if $nway_conference == true}nway{$account.3.user_id}@{$account.3.server_address}{/if}</P2518>
+    <P2518>{if $nway_conference == 'true'}nway{$account.3.user_id}@{$account.3.server_address}{/if}</P2518>
 
     <!-- # Music On Hold URI -->
     <!-- # String -->
@@ -3278,7 +3278,7 @@
 
     <!-- # Conference URI -->
     <!-- # String -->
-    <P2618>{if $nway_conference == true}nway{$account.4.user_id}@{$account.4.server_address}{/if}</P2618>
+    <P2618>{if $nway_conference == 'true'}nway{$account.4.user_id}@{$account.4.server_address}{/if}</P2618>
 
     <!-- # Music On Hold URI -->
     <!-- # String -->
@@ -4253,7 +4253,7 @@
 
     <!-- # Conference URI -->
     <!-- # String -->
-    <P2718>{if $nway_conference == true}nway{$account.5.user_id}@{$account.5.server_address}{/if}</P2718>
+    <P2718>{if $nway_conference == 'true'}nway{$account.5.user_id}@{$account.5.server_address}{/if}</P2718>
 
     <!-- # Music On Hold URI -->
     <!-- # String -->

--- a/resources/templates/provision/grandstream/gswave/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gswave/{$mac}.xml
@@ -236,7 +236,7 @@
 
 <!-- # Conference URI -->
 <!-- # String -->
-<P2318>{if $nway_conference == true}nway{$account.1.user_id}@{$account.1.server_address}{/if}</P2318>
+<P2318>{if $nway_conference == 'true'}nway{$account.1.user_id}@{$account.1.server_address}{/if}</P2318>
 
 <!-- # BLF Call-pickup Prefix. Default is ** -->
 <!-- # String -->
@@ -645,7 +645,7 @@
 
 <!-- # Conference URI -->
 <!-- # String -->
-<P2418>{if $nway_conference == true}nway{$account.2.user_id}@{$account.2.server_address}{/if}</P2418>
+<P2418>{if $nway_conference == 'true'}nway{$account.2.user_id}@{$account.2.server_address}{/if}</P2418>
 
 <!-- # BLF Call-pickup Prefix. Default is ** -->
 <!-- # String -->
@@ -1054,7 +1054,7 @@
 
 <!-- # Conference URI -->
 <!-- # String -->
-<P2518>{if $nway_conference == true}nway{$account.3.user_id}@{$account.3.server_address}{/if}</P2518>
+<P2518>{if $nway_conference == 'true'}nway{$account.3.user_id}@{$account.3.server_address}{/if}</P2518>
 
 <!-- # BLF Call-pickup Prefix. Default is ** -->
 <!-- # String -->
@@ -1463,7 +1463,7 @@
 
 <!-- # Conference URI -->
 <!-- # String -->
-<P2618>{if $nway_conference == true}nway{$account.4.user_id}@{$account.4.server_address}{/if}</P2618>
+<P2618>{if $nway_conference == 'true'}nway{$account.4.user_id}@{$account.4.server_address}{/if}</P2618>
 
 <!-- # BLF Call-pickup Prefix. Default is ** -->
 <!-- # String -->
@@ -1872,7 +1872,7 @@
 
 <!-- # Conference URI -->
 <!-- # String -->
-<P2718>{if $nway_conference == true}nway{$account.5.user_id}@{$account.5.server_address}{/if}</P2718>
+<P2718>{if $nway_conference == 'true'}nway{$account.5.user_id}@{$account.5.server_address}{/if}</P2718>
 
 <!-- # BLF Call-pickup Prefix. Default is ** -->
 <!-- # String -->
@@ -2281,7 +2281,7 @@
 
 <!-- # Conference URI -->
 <!-- # String -->
-<P2818>{if $nway_conference == true}nway{$account.6.user_id}@{$account.6.server_address}{/if}</P2818>
+<P2818>{if $nway_conference == 'true'}nway{$account.6.user_id}@{$account.6.server_address}{/if}</P2818>
 
 <!-- # BLF Call-pickup Prefix. Default is ** -->
 <!-- # String -->

--- a/resources/templates/provision/grandstream/gxp110x/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp110x/{$mac}.xml
@@ -353,7 +353,7 @@
 
 <!-- Conference URI -->
 <!-- String -->
-<P2318>{if $nway_conference == true}nway{$account.1.user_id}@{$account.1.server_address}{/if}</P2318>
+<P2318>{if $nway_conference == 'true'}nway{$account.1.user_id}@{$account.1.server_address}{/if}</P2318>
 
 <!-- Music On Hold URI -->
 <!-- String -->

--- a/resources/templates/provision/grandstream/gxp116x/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp116x/{$mac}.xml
@@ -227,7 +227,7 @@
 
 <!--  Conference URI -->
 <!--  String -->
-<P2318>{if $nway_conference == true}nway{$account.1.user_id}@{$account.1.server_address}{/if}</P2318>
+<P2318>{if $nway_conference == 'true'}nway{$account.1.user_id}@{$account.1.server_address}{/if}</P2318>
 
 <!--  Music On Hold URI -->
 <!--  String -->

--- a/resources/templates/provision/grandstream/gxp140x/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp140x/{$mac}.xml
@@ -302,7 +302,7 @@
     <P134></P134>
     <!--  Conference URI -->
     <!--  String -->
-    <P2318>{if $nway_conference == true}nway{$account.1.user_id}@{$account.1.server_address}{/if}</P2318>
+    <P2318>{if $nway_conference == 'true'}nway{$account.1.user_id}@{$account.1.server_address}{/if}</P2318>
     <!--  Music On Hold URI -->
     <!--  String -->
     <P2350></P2350>
@@ -736,7 +736,7 @@
     <P444></P444>
     <!--  Conference URI -->
     <!--  String -->
-    <P2418>{if $nway_conference == true}nway{$account.2.user_id}@{$account.2.server_address}{/if}</P2418>
+    <P2418>{if $nway_conference == 'true'}nway{$account.2.user_id}@{$account.2.server_address}{/if}</P2418>
     <!--  Music On Hold URI -->
     <!--  String -->
     <P2450></P2450>

--- a/resources/templates/provision/grandstream/gxp140xbk/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp140xbk/{$mac}.xml
@@ -302,7 +302,7 @@
     <P134></P134>
     <!--  Conference URI -->
     <!--  String -->
-    <P2318>{if $nway_conference == true}nway{$account.1.user_id}@{$account.1.server_address}{/if}</P2318>
+    <P2318>{if $nway_conference == 'true'}nway{$account.1.user_id}@{$account.1.server_address}{/if}</P2318>
     <!--  Music On Hold URI -->
     <!--  String -->
     <P2350></P2350>
@@ -736,7 +736,7 @@
     <P444></P444>
     <!--  Conference URI -->
     <!--  String -->
-    <P2418>{if $nway_conference == true}nway{$account.2.user_id}@{$account.2.server_address}{/if}</P2418>
+    <P2418>{if $nway_conference == 'true'}nway{$account.2.user_id}@{$account.2.server_address}{/if}</P2418>
     <!--  Music On Hold URI -->
     <!--  String -->
     <P2450></P2450>

--- a/resources/templates/provision/grandstream/gxp1450/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp1450/{$mac}.xml
@@ -417,7 +417,7 @@
 
 <!-- Conference URI -->
 <!-- String -->
-<P2318>{if $nway_conference == true}nway{$account.1.user_id}@{$account.1.server_address}{/if}</P2318>
+<P2318>{if $nway_conference == 'true'}nway{$account.1.user_id}@{$account.1.server_address}{/if}</P2318>
 
 <!-- Music On Hold URI -->
 <!-- String -->
@@ -974,7 +974,7 @@
 
 <!-- Conference URI -->
 <!-- String -->
-<P2418>{if $nway_conference == true}nway{$account.2.user_id}@{$account.2.server_address}{/if}</P2418>
+<P2418>{if $nway_conference == 'true'}nway{$account.2.user_id}@{$account.2.server_address}{/if}</P2418>
 
 <!-- Music On Hold URI -->
 <!-- String -->

--- a/resources/templates/provision/grandstream/gxp1450bk/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp1450bk/{$mac}.xml
@@ -226,7 +226,7 @@
 
 <!-- Conference URI -->
 <!-- String -->
-<P2318>{if $nway_conference == true}nway{$account.1.user_id}@{$account.1.server_address}{/if}</P2318>
+<P2318>{if $nway_conference == 'true'}nway{$account.1.user_id}@{$account.1.server_address}{/if}</P2318>
 
 <!-- Music On Hold URI -->
 <!-- String -->
@@ -783,7 +783,7 @@
 
 <!-- Conference URI -->
 <!-- String -->
-<P2418>{if $nway_conference == true}nway{$account.2.user_id}@{$account.2.server_address}{/if}</P2418>
+<P2418>{if $nway_conference == 'true'}nway{$account.2.user_id}@{$account.2.server_address}{/if}</P2418>
 
 <!-- Music On Hold URI -->
 <!-- String -->

--- a/resources/templates/provision/grandstream/gxp16xx/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp16xx/{$mac}.xml
@@ -268,7 +268,7 @@
 <P188>0</P188>
 <!--  Conference URI -->
 <!--  String -->
-<P2318>{if $nway_conference == true}nway{$account.1.user_id}@{$account.1.server_address}{/if}</P2318>
+<P2318>{if $nway_conference == 'true'}nway{$account.1.user_id}@{$account.1.server_address}{/if}</P2318>
 <!--  Music On Hold URI -->
 <!--  String -->
 <P2350></P2350>
@@ -880,7 +880,7 @@
 <P488>0</P488>
 <!--  Conference URI -->
 <!--  String -->
-<P2418>{if $nway_conference == true}nway{$account.2.user_id}@{$account.2.server_address}{/if}</P2418>
+<P2418>{if $nway_conference == 'true'}nway{$account.2.user_id}@{$account.2.server_address}{/if}</P2418>
 <!--  Music On Hold URI -->
 <!--  String -->
 <P2450></P2450>
@@ -1457,7 +1457,7 @@
 <P2589>0</P2589>
 <!--  Conference URI -->
 <!--  String -->
-<P2518>{if $nway_conference == true}nway{$account.3.user_id}@{$account.3.server_address}{/if}</P2518>
+<P2518>{if $nway_conference == 'true'}nway{$account.3.user_id}@{$account.3.server_address}{/if}</P2518>
 <!--  Music On Hold URI -->
 <!--  String -->
 <P2550></P2550>

--- a/resources/templates/provision/grandstream/gxp17xx/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp17xx/{$mac}.xml
@@ -1038,7 +1038,7 @@
 
 <!-- # Conference URI -->
 <!-- # String -->
-<P2318>{if $nway_conference == true}nway{$account.1.user_id}@{$account.1.server_address}{/if}</P2318>
+<P2318>{if $nway_conference == 'true'}nway{$account.1.user_id}@{$account.1.server_address}{/if}</P2318>
 
 <!-- # Music On Hold URI -->
 <!-- # String -->
@@ -1753,7 +1753,7 @@
 
 <!-- # Conference URI -->
 <!-- # String -->
-<P2418>{if $nway_conference == true}nway{$account.2.user_id}@{$account.2.server_address}{/if}</P2418>
+<P2418>{if $nway_conference == 'true'}nway{$account.2.user_id}@{$account.2.server_address}{/if}</P2418>
 
 <!-- # Music On Hold URI -->
 <!-- # String -->
@@ -2457,7 +2457,7 @@
 
 <!-- # Conference URI -->
 <!-- # String -->
-<P2518>{if $nway_conference == true}nway{$account.3.user_id}@{$account.3.server_address}{/if}</P2518>
+<P2518>{if $nway_conference == 'true'}nway{$account.3.user_id}@{$account.3.server_address}{/if}</P2518>
 
 <!-- # Music On Hold URI -->
 <!-- # String -->

--- a/resources/templates/provision/grandstream/gxp2100/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp2100/{$mac}.xml
@@ -263,7 +263,7 @@
 
 <!--# Conference URI-->
 <!--# String-->
-    <P2318>{if $nway_conference == true}nway{$account.1.user_id}@{$account.1.server_address}{/if}</P2318>
+    <P2318>{if $nway_conference == 'true'}nway{$account.1.user_id}@{$account.1.server_address}{/if}</P2318>
 
 <!--# Music On Hold URI-->
 <!--# String-->
@@ -893,7 +893,7 @@
 
 <!--# Conference URI-->
 <!--# String-->
-    <P2418>{if $nway_conference == true}nway{$account.2.user_id}@{$account.2.server_address}{/if}</P2418>
+    <P2418>{if $nway_conference == 'true'}nway{$account.2.user_id}@{$account.2.server_address}{/if}</P2418>
 
 <!--# Music On Hold URI-->
 <!--# String-->
@@ -1521,7 +1521,7 @@
 
 <!--# Conference URI-->
 <!--# String-->
-    <P2518>{if $nway_conference == true}nway{$account.3.user_id}@{$account.3.server_address}{/if}</P2518>
+    <P2518>{if $nway_conference == 'true'}nway{$account.3.user_id}@{$account.3.server_address}{/if}</P2518>
 
 <!--# Music On Hold URI-->
 <!--# String-->
@@ -2147,7 +2147,7 @@
 
 <!--# Conference URI-->
 <!--# String-->
-    <P2618>{if $nway_conference == true}nway{$account.4.user_id}@{$account.4.server_address}{/if}</P2618>
+    <P2618>{if $nway_conference == 'true'}nway{$account.4.user_id}@{$account.4.server_address}{/if}</P2618>
 
 <!--# Music On Hold URI-->
 <!--# String-->

--- a/resources/templates/provision/grandstream/gxp2124/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp2124/{$mac}.xml
@@ -178,7 +178,7 @@
     <P134></P134>
     <!-- Conference URI -->
     <!-- String -->
-    <P2318>{if $nway_conference == true}nway{$account.1.user_id}@{$account.1.server_address}{/if}</P2318>
+    <P2318>{if $nway_conference == 'true'}nway{$account.1.user_id}@{$account.1.server_address}{/if}</P2318>
     <!-- Music On Hold URI -->
     <!-- String -->
     <P2350></P2350>
@@ -616,7 +616,7 @@
     <P444></P444>
     <!-- Conference URI-->
     <!-- String-->
-    <P2418>{if $nway_conference == true}nway{$account.2.user_id}@{$account.2.server_address}{/if}</P2418>
+    <P2418>{if $nway_conference == 'true'}nway{$account.2.user_id}@{$account.2.server_address}{/if}</P2418>
     <!-- Music On Hold URI-->
     <!-- String-->
     <P2450></P2450>
@@ -1049,7 +1049,7 @@
     <P544></P544>
     <!-- Conference URI -->
     <!-- String -->
-    <P2518>{if $nway_conference == true}nway{$account.3.user_id}@{$account.3.server_address}{/if}</P2518>
+    <P2518>{if $nway_conference == 'true'}nway{$account.3.user_id}@{$account.3.server_address}{/if}</P2518>
     <!-- Music On Hold URI -->
     <!-- String -->
     <P2550></P2550>
@@ -1480,7 +1480,7 @@
     <P644></P644>
     <!-- Conference URI -->
     <!-- String -->
-    <P2618>{if $nway_conference == true}nway{$account.4.user_id}@{$account.4.server_address}{/if}</P2618>
+    <P2618>{if $nway_conference == 'true'}nway{$account.4.user_id}@{$account.4.server_address}{/if}</P2618>
     <!-- Music On Hold -->
     <!-- String -->
     <P2650></P2650>

--- a/resources/templates/provision/grandstream/gxp2130/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp2130/{$mac}.xml
@@ -362,7 +362,7 @@
 
     <!-- # Conference URI -->
     <!-- # String -->
-    <P2318>{if $nway_conference == true}nway{$account.1.user_id}@{$account.1.server_address}{/if}</P2318>
+    <P2318>{if $nway_conference == 'true'}nway{$account.1.user_id}@{$account.1.server_address}{/if}</P2318>
 
     <!-- # Music On Hold URI -->
     <!-- # String -->
@@ -1320,7 +1320,7 @@
 
     <!-- # Conference URI -->
     <!-- # String -->
-    <P2418>{if $nway_conference == true}nway{$account.2.user_id}@{$account.2.server_address}{/if}</P2418>
+    <P2418>{if $nway_conference == 'true'}nway{$account.2.user_id}@{$account.2.server_address}{/if}</P2418>
 
     <!-- # Music On Hold URI -->
     <!-- # String -->
@@ -2272,7 +2272,7 @@
 
     <!-- # Conference URI -->
     <!-- # String -->
-    <P2518>{if $nway_conference == true}nway{$account.3.user_id}@{$account.3.server_address}{/if}</P2518>
+    <P2518>{if $nway_conference == 'true'}nway{$account.3.user_id}@{$account.3.server_address}{/if}</P2518>
 
     <!-- # Music On Hold URI -->
     <!-- # String -->
@@ -3224,7 +3224,7 @@
 
     <!-- # Conference URI -->
     <!-- # String -->
-    <P2618>{if $nway_conference == true}nway{$account.4.user_id}@{$account.4.server_address}{/if}</P2618>
+    <P2618>{if $nway_conference == 'true'}nway{$account.4.user_id}@{$account.4.server_address}{/if}</P2618>
 
     <!-- # Music On Hold URI -->
     <!-- # String -->
@@ -4178,7 +4178,7 @@
 
     <!-- # Conference URI -->
     <!-- # String -->
-    <P2718>{if $nway_conference == true}nway{$account.5.user_id}@{$account.5.server_address}{/if}</P2718>
+    <P2718>{if $nway_conference == 'true'}nway{$account.5.user_id}@{$account.5.server_address}{/if}</P2718>
 
     <!-- # Music On Hold URI -->
     <!-- # String -->
@@ -5132,7 +5132,7 @@
 
     <!-- # Conference URI -->
     <!-- # String -->
-    <P2818>{if $nway_conference == true}nway{$account.6.user_id}@{$account.6.server_address}{/if}</P2818>
+    <P2818>{if $nway_conference == 'true'}nway{$account.6.user_id}@{$account.6.server_address}{/if}</P2818>
 
     <!-- # Music On Hold URI -->
     <!-- # String -->

--- a/resources/templates/provision/grandstream/gxp2135/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp2135/{$mac}.xml
@@ -362,7 +362,7 @@
 
     <!-- # Conference URI -->
     <!-- # String -->
-    <P2318>{if $nway_conference == true}nway{$account.1.user_id}@{$account.1.server_address}{/if}</P2318>
+    <P2318>{if $nway_conference == 'true'}nway{$account.1.user_id}@{$account.1.server_address}{/if}</P2318>
 
     <!-- # Music On Hold URI -->
     <!-- # String -->
@@ -1320,7 +1320,7 @@
 
     <!-- # Conference URI -->
     <!-- # String -->
-    <P2418>{if $nway_conference == true}nway{$account.2.user_id}@{$account.2.server_address}{/if}</P2418>
+    <P2418>{if $nway_conference == 'true'}nway{$account.2.user_id}@{$account.2.server_address}{/if}</P2418>
 
     <!-- # Music On Hold URI -->
     <!-- # String -->
@@ -2272,7 +2272,7 @@
 
     <!-- # Conference URI -->
     <!-- # String -->
-    <P2518>{if $nway_conference == true}nway{$account.3.user_id}@{$account.3.server_address}{/if}</P2518>
+    <P2518>{if $nway_conference == 'true'}nway{$account.3.user_id}@{$account.3.server_address}{/if}</P2518>
 
     <!-- # Music On Hold URI -->
     <!-- # String -->
@@ -3224,7 +3224,7 @@
 
     <!-- # Conference URI -->
     <!-- # String -->
-    <P2618>{if $nway_conference == true}nway{$account.4.user_id}@{$account.4.server_address}{/if}</P2618>
+    <P2618>{if $nway_conference == 'true'}nway{$account.4.user_id}@{$account.4.server_address}{/if}</P2618>
 
     <!-- # Music On Hold URI -->
     <!-- # String -->
@@ -4178,7 +4178,7 @@
 
     <!-- # Conference URI -->
     <!-- # String -->
-    <P2718>{if $nway_conference == true}nway{$account.5.user_id}@{$account.5.server_address}{/if}</P2718>
+    <P2718>{if $nway_conference == 'true'}nway{$account.5.user_id}@{$account.5.server_address}{/if}</P2718>
 
     <!-- # Music On Hold URI -->
     <!-- # String -->
@@ -5132,7 +5132,7 @@
 
     <!-- # Conference URI -->
     <!-- # String -->
-    <P2818>{if $nway_conference == true}nway{$account.6.user_id}@{$account.6.server_address}{/if}</P2818>
+    <P2818>{if $nway_conference == 'true'}nway{$account.6.user_id}@{$account.6.server_address}{/if}</P2818>
 
     <!-- # Music On Hold URI -->
     <!-- # String -->

--- a/resources/templates/provision/grandstream/gxp2140/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp2140/{$mac}.xml
@@ -362,7 +362,7 @@
 
     <!-- # Conference URI -->
     <!-- # String -->
-    <P2318>{if $nway_conference == true}nway{$account.1.user_id}@{$account.1.server_address}{/if}</P2318>
+    <P2318>{if $nway_conference == 'true'}nway{$account.1.user_id}@{$account.1.server_address}{/if}</P2318>
 
     <!-- # Music On Hold URI -->
     <!-- # String -->
@@ -1320,7 +1320,7 @@
 
     <!-- # Conference URI -->
     <!-- # String -->
-    <P2418>{if $nway_conference == true}nway{$account.2.user_id}@{$account.2.server_address}{/if}</P2418>
+    <P2418>{if $nway_conference == 'true'}nway{$account.2.user_id}@{$account.2.server_address}{/if}</P2418>
 
     <!-- # Music On Hold URI -->
     <!-- # String -->
@@ -2272,7 +2272,7 @@
 
     <!-- # Conference URI -->
     <!-- # String -->
-    <P2518>{if $nway_conference == true}nway{$account.3.user_id}@{$account.3.server_address}{/if}</P2518>
+    <P2518>{if $nway_conference == 'true'}nway{$account.3.user_id}@{$account.3.server_address}{/if}</P2518>
 
     <!-- # Music On Hold URI -->
     <!-- # String -->
@@ -3224,7 +3224,7 @@
 
     <!-- # Conference URI -->
     <!-- # String -->
-    <P2618>{if $nway_conference == true}nway{$account.4.user_id}@{$account.4.server_address}{/if}</P2618>
+    <P2618>{if $nway_conference == 'true'}nway{$account.4.user_id}@{$account.4.server_address}{/if}</P2618>
 
     <!-- # Music On Hold URI -->
     <!-- # String -->
@@ -4178,7 +4178,7 @@
 
     <!-- # Conference URI -->
     <!-- # String -->
-    <P2718>{if $nway_conference == true}nway{$account.5.user_id}@{$account.5.server_address}{/if}</P2718>
+    <P2718>{if $nway_conference == 'true'}nway{$account.5.user_id}@{$account.5.server_address}{/if}</P2718>
 
     <!-- # Music On Hold URI -->
     <!-- # String -->
@@ -5132,7 +5132,7 @@
 
     <!-- # Conference URI -->
     <!-- # String -->
-    <P2818>{if $nway_conference == true}nway{$account.6.user_id}@{$account.6.server_address}{/if}</P2818>
+    <P2818>{if $nway_conference == 'true'}nway{$account.6.user_id}@{$account.6.server_address}{/if}</P2818>
 
     <!-- # Music On Hold URI -->
     <!-- # String -->

--- a/resources/templates/provision/grandstream/gxp2160/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp2160/{$mac}.xml
@@ -362,7 +362,7 @@
 
     <!-- # Conference URI -->
     <!-- # String -->
-    <P2318>{if $nway_conference == true}nway{$account.1.user_id}@{$account.1.server_address}{/if}</P2318>
+    <P2318>{if $nway_conference == 'true'}nway{$account.1.user_id}@{$account.1.server_address}{/if}</P2318>
 
     <!-- # Music On Hold URI -->
     <!-- # String -->
@@ -1320,7 +1320,7 @@
 
     <!-- # Conference URI -->
     <!-- # String -->
-    <P2418>{if $nway_conference == true}nway{$account.2.user_id}@{$account.2.server_address}{/if}</P2418>
+    <P2418>{if $nway_conference == 'true'}nway{$account.2.user_id}@{$account.2.server_address}{/if}</P2418>
 
     <!-- # Music On Hold URI -->
     <!-- # String -->
@@ -2272,7 +2272,7 @@
 
     <!-- # Conference URI -->
     <!-- # String -->
-    <P2518>{if $nway_conference == true}nway{$account.3.user_id}@{$account.3.server_address}{/if}</P2518>
+    <P2518>{if $nway_conference == 'true'}nway{$account.3.user_id}@{$account.3.server_address}{/if}</P2518>
 
     <!-- # Music On Hold URI -->
     <!-- # String -->
@@ -3224,7 +3224,7 @@
 
     <!-- # Conference URI -->
     <!-- # String -->
-    <P2618>{if $nway_conference == true}nway{$account.4.user_id}@{$account.4.server_address}{/if}</P2618>
+    <P2618>{if $nway_conference == 'true'}nway{$account.4.user_id}@{$account.4.server_address}{/if}</P2618>
 
     <!-- # Music On Hold URI -->
     <!-- # String -->
@@ -4178,7 +4178,7 @@
 
     <!-- # Conference URI -->
     <!-- # String -->
-    <P2718>{if $nway_conference == true}nway{$account.5.user_id}@{$account.5.server_address}{/if}</P2718>
+    <P2718>{if $nway_conference == 'true'}nway{$account.5.user_id}@{$account.5.server_address}{/if}</P2718>
 
     <!-- # Music On Hold URI -->
     <!-- # String -->
@@ -5132,7 +5132,7 @@
 
     <!-- # Conference URI -->
     <!-- # String -->
-    <P2818>{if $nway_conference == true}nway{$account.6.user_id}@{$account.6.server_address}{/if}</P2818>
+    <P2818>{if $nway_conference == 'true'}nway{$account.6.user_id}@{$account.6.server_address}{/if}</P2818>
 
     <!-- # Music On Hold URI -->
     <!-- # String -->

--- a/resources/templates/provision/grandstream/gxp2170/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp2170/{$mac}.xml
@@ -362,7 +362,7 @@
 
     <!-- # Conference URI -->
     <!-- # String -->
-    <P2318>{if $nway_conference == true}nway{$account.1.user_id}@{$account.1.server_address}{/if}</P2318>
+    <P2318>{if $nway_conference == 'true'}nway{$account.1.user_id}@{$account.1.server_address}{/if}</P2318>
 
     <!-- # Music On Hold URI -->
     <!-- # String -->
@@ -1320,7 +1320,7 @@
 
     <!-- # Conference URI -->
     <!-- # String -->
-    <P2418>{if $nway_conference == true}nway{$account.2.user_id}@{$account.2.server_address}{/if}</P2418>
+    <P2418>{if $nway_conference == 'true'}nway{$account.2.user_id}@{$account.2.server_address}{/if}</P2418>
 
     <!-- # Music On Hold URI -->
     <!-- # String -->
@@ -2272,7 +2272,7 @@
 
     <!-- # Conference URI -->
     <!-- # String -->
-    <P2518>{if $nway_conference == true}nway{$account.3.user_id}@{$account.3.server_address}{/if}</P2518>
+    <P2518>{if $nway_conference == 'true'}nway{$account.3.user_id}@{$account.3.server_address}{/if}</P2518>
 
     <!-- # Music On Hold URI -->
     <!-- # String -->
@@ -3224,7 +3224,7 @@
 
     <!-- # Conference URI -->
     <!-- # String -->
-    <P2618>{if $nway_conference == true}nway{$account.4.user_id}@{$account.4.server_address}{/if}</P2618>
+    <P2618>{if $nway_conference == 'true'}nway{$account.4.user_id}@{$account.4.server_address}{/if}</P2618>
 
     <!-- # Music On Hold URI -->
     <!-- # String -->
@@ -4178,7 +4178,7 @@
 
     <!-- # Conference URI -->
     <!-- # String -->
-    <P2718>{if $nway_conference == true}nway{$account.5.user_id}@{$account.5.server_address}{/if}</P2718>
+    <P2718>{if $nway_conference == 'true'}nway{$account.5.user_id}@{$account.5.server_address}{/if}</P2718>
 
     <!-- # Music On Hold URI -->
     <!-- # String -->
@@ -5132,7 +5132,7 @@
 
     <!-- # Conference URI -->
     <!-- # String -->
-    <P2818>{if $nway_conference == true}nway{$account.6.user_id}@{$account.6.server_address}{/if}</P2818>
+    <P2818>{if $nway_conference == 'true'}nway{$account.6.user_id}@{$account.6.server_address}{/if}</P2818>
 
     <!-- # Music On Hold URI -->
     <!-- # String -->

--- a/resources/templates/provision/grandstream/gxp21xx/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp21xx/{$mac}.xml
@@ -122,7 +122,7 @@
     <P134></P134>
     <!-- Conference URI -->
     <!-- String -->
-    <P2318>{if $nway_conference == true}nway{$account.1.user_id}@{$account.1.server_address}{/if}</P2318>
+    <P2318>{if $nway_conference == 'true'}nway{$account.1.user_id}@{$account.1.server_address}{/if}</P2318>
     <!-- Music On Hold URI -->
     <!-- String -->
     <P2350></P2350>
@@ -559,7 +559,7 @@
     <P444></P444>
     <!-- Conference URI -->
     <!-- String -->
-    <P2418>{if $nway_conference == true}nway{$account.2.user_id}@{$account.2.server_address}{/if}</P2418>
+    <P2418>{if $nway_conference == 'true'}nway{$account.2.user_id}@{$account.2.server_address}{/if}</P2418>
     <!-- Music On Hold URI -->
     <!-- String -->
     <P2450></P2450>
@@ -991,7 +991,7 @@
     <P544></P544>
     <!-- Conference URI -->
     <!-- String -->
-    <P2518>{if $nway_conference == true}nway{$account.3.user_id}@{$account.3.server_address}{/if}</P2518>
+    <P2518>{if $nway_conference == 'true'}nway{$account.3.user_id}@{$account.3.server_address}{/if}</P2518>
     <!-- Music On Hold URI -->
     <!-- String -->
     <P2550></P2550>
@@ -1421,7 +1421,7 @@
     <P644></P644>
     <!-- Conference URI -->
     <!-- String -->
-    <P2618>{if $nway_conference == true}nway{$account.4.user_id}@{$account.4.server_address}{/if}</P2618>
+    <P2618>{if $nway_conference == 'true'}nway{$account.4.user_id}@{$account.4.server_address}{/if}</P2618>
     <!-- Music On Hold URI -->
     <!-- String -->
     <P2650></P2650>
@@ -1845,7 +1845,7 @@
     <P1744></P1744>
     <!-- Conference URI -->
     <!-- String -->
-    <P2718>{if $nway_conference == true}nway{$account.5.user_id}@{$account.5.server_address}{/if}</P2718>
+    <P2718>{if $nway_conference == 'true'}nway{$account.5.user_id}@{$account.5.server_address}{/if}</P2718>
     <!-- Music On Hold URI -->
     <!-- String -->
     <P2750></P2750>
@@ -2276,7 +2276,7 @@
     <P1844></P1844>
     <!-- Conference URI -->
     <!-- String -->
-    <P2818>{if $nway_conference == true}nway{$account.6.user_id}@{$account.6.server_address}{/if}</P2818>
+    <P2818>{if $nway_conference == 'true'}nway{$account.6.user_id}@{$account.6.server_address}{/if}</P2818>
     <!-- Music On Hold URI -->
     <!-- String -->
     <P2850></P2850>

--- a/resources/templates/provision/grandstream/gxp21xxbk/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp21xxbk/{$mac}.xml
@@ -272,7 +272,7 @@
 
 <!-- Conference URI -->
 <!-- String -->
-<P2318>{if $nway_conference == true}nway{$account.1.user_id}@{$account.1.server_address}{/if}</P2318>
+<P2318>{if $nway_conference == 'true'}nway{$account.1.user_id}@{$account.1.server_address}{/if}</P2318>
 
 <!-- Music On Hold URI -->
 <!-- String -->
@@ -836,7 +836,7 @@
 
 <!-- Conference URI -->
 <!-- String -->
-<P2418>{if $nway_conference == true}nway{$account.2.user_id}@{$account.2.server_address}{/if}</P2418>
+<P2418>{if $nway_conference == 'true'}nway{$account.2.user_id}@{$account.2.server_address}{/if}</P2418>
 
 <!-- Music On Hold URI -->
 <!-- String -->
@@ -1399,7 +1399,7 @@
 
 <!-- Conference URI -->
 <!-- String -->
-<P2518>{if $nway_conference == true}nway{$account.3.user_id}@{$account.3.server_address}{/if}</P2518>
+<P2518>{if $nway_conference == 'true'}nway{$account.3.user_id}@{$account.3.server_address}{/if}</P2518>
 
 <!-- Music On Hold URI -->
 <!-- String -->
@@ -1955,7 +1955,7 @@
 
 <!-- Conference URI -->
 <!-- String -->
-<P2618>{if $nway_conference == true}nway{$account.4.user_id}@{$account.4.server_address}{/if}</P2618>
+<P2618>{if $nway_conference == 'true'}nway{$account.4.user_id}@{$account.4.server_address}{/if}</P2618>
 
 <!-- Music On Hold URI -->
 <!-- String -->
@@ -2505,7 +2505,7 @@
 
 <!-- Conference URI -->
 <!-- String -->
-<P2718>{if $nway_conference == true}nway{$account.5.user_id}@{$account.5.server_address}{/if}</P2718>
+<P2718>{if $nway_conference == 'true'}nway{$account.5.user_id}@{$account.5.server_address}{/if}</P2718>
 
 <!-- Music On Hold URI -->
 <!-- String -->
@@ -3062,7 +3062,7 @@
 
 <!-- Conference URI -->
 <!-- String -->
-<P2818>{if $nway_conference == true}nway{$account.6.user_id}@{$account.6.server_address}{/if}</P2818>
+<P2818>{if $nway_conference == 'true'}nway{$account.6.user_id}@{$account.6.server_address}{/if}</P2818>
 
 <!-- Music On Hold URI -->
 <!-- String -->

--- a/resources/templates/provision/grandstream/gxp2200/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp2200/{$mac}.xml
@@ -344,7 +344,7 @@
 
 <!-- Conference-URI -->
 <!-- String -->
-<P2318>{if $nway_conference == true}nway{$account.1.user_id}@{$account.1.server_address}{/if}</P2318>
+<P2318>{if $nway_conference == 'true'}nway{$account.1.user_id}@{$account.1.server_address}{/if}</P2318>
 
 <!-- Broadsoft Call Center. 0 - No, 1 - Yes. Default value is 0 -->
 <!-- Number: 0, 1 -->
@@ -762,7 +762,7 @@
 
 <!-- Conference-URI -->
 <!-- String -->
-<P2418>{if $nway_conference == true}nway{$account.2.user_id}@{$account.2.server_address}{/if}</P2418>
+<P2418>{if $nway_conference == 'true'}nway{$account.2.user_id}@{$account.2.server_address}{/if}</P2418>
 
 <!-- Broadsoft Call Center. 0 - No, 1 - Yes. Default value is 0 -->
 <!-- Number: 0, 1 -->
@@ -1190,7 +1190,7 @@ VNumber: 0, 1, 2. -->
 
 <!-- Conference-URI -->
 <!-- String -->
-<P2518>{if $nway_conference == true}nway{$account.3.user_id}@{$account.3.server_address}{/if}</P2518>
+<P2518>{if $nway_conference == 'true'}nway{$account.3.user_id}@{$account.3.server_address}{/if}</P2518>
 
 <!-- Broadsoft Call Center. 0 - No, 1 - Yes. Default value is 0 -->
 <!-- Number: 0, 1 -->
@@ -1620,7 +1620,7 @@ VNumber: 0, 1, 2. -->
 
 <!-- Conference-URI -->
 <!-- String -->
-<P2618>{if $nway_conference == true}nway{$account.4.user_id}@{$account.4.server_address}{/if}</P2618>
+<P2618>{if $nway_conference == 'true'}nway{$account.4.user_id}@{$account.4.server_address}{/if}</P2618>
 
 <!-- Account Ring Tone. See ring tone options and value in the Ring Tone value table below -->
 <P623>content://settings/system/ringtone</P623>
@@ -2045,7 +2045,7 @@ Account 5 Codec Settings
 
 <!-- Conference-URI -->
 <!-- String -->
-<P2718>{if $nway_conference == true}nway{$account.5.user_id}@{$account.5.server_address}{/if}</P2718>
+<P2718>{if $nway_conference == 'true'}nway{$account.5.user_id}@{$account.5.server_address}{/if}</P2718>
 
 <!-- Broadsoft Call Center. 0 - No, 1 - Yes. Default value is 0 -->
 <!-- Number: 0, 1 -->
@@ -2471,7 +2471,7 @@ Account 5 Codec Settings
 
 <!-- Conference-URI -->
 <!-- String -->
-<P2818>{if $nway_conference == true}nway{$account.6.user_id}@{$account.6.server_address}{/if}</P2818>
+<P2818>{if $nway_conference == 'true'}nway{$account.6.user_id}@{$account.6.server_address}{/if}</P2818>
 
 <!-- Broadsoft Call Center. 0 - No, 1 - Yes. Default value is 0 -->
 <!-- Number: 0, 1 -->

--- a/resources/templates/provision/grandstream/gxp3240/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp3240/{$mac}.xml
@@ -555,7 +555,7 @@
 
 <!-- Conference-URI -->
 <!-- String -->
-<P2318>{if $nway_conference == true}nway{$account.1.user_id}@{$account.1.server_address}{/if}</P2318>
+<P2318>{if $nway_conference == 'true'}nway{$account.1.user_id}@{$account.1.server_address}{/if}</P2318>
 
 <!-- Broadsoft Call Center. 0 - No, 1 - Yes. Default value is 0 -->
 <!-- Number: 0, 1 -->
@@ -973,7 +973,7 @@
 
 <!-- Conference-URI -->
 <!-- String -->
-<P2418>{if $nway_conference == true}nway{$account.2.user_id}@{$account.2.server_address}{/if}</P2418>
+<P2418>{if $nway_conference == 'true'}nway{$account.2.user_id}@{$account.2.server_address}{/if}</P2418>
 
 <!-- Broadsoft Call Center. 0 - No, 1 - Yes. Default value is 0 -->
 <!-- Number: 0, 1 -->
@@ -1401,7 +1401,7 @@ VNumber: 0, 1, 2. -->
 
 <!-- Conference-URI -->
 <!-- String -->
-<P2518>{if $nway_conference == true}nway{$account.3.user_id}@{$account.3.server_address}{/if}</P2518>
+<P2518>{if $nway_conference == 'true'}nway{$account.3.user_id}@{$account.3.server_address}{/if}</P2518>
 
 <!-- Broadsoft Call Center. 0 - No, 1 - Yes. Default value is 0 -->
 <!-- Number: 0, 1 -->
@@ -1831,7 +1831,7 @@ VNumber: 0, 1, 2. -->
 
 <!-- Conference-URI -->
 <!-- String -->
-<P2618>{if $nway_conference == true}nway{$account.4.user_id}@{$account.4.server_address}{/if}</P2618>
+<P2618>{if $nway_conference == 'true'}nway{$account.4.user_id}@{$account.4.server_address}{/if}</P2618>
 
 <!-- Account Ring Tone. See ring tone options and value in the Ring Tone value table below -->
 <P623>content://settings/system/ringtone</P623>
@@ -2256,7 +2256,7 @@ Account 5 Codec Settings
 
 <!-- Conference-URI -->
 <!-- String -->
-<P2718>{if $nway_conference == true}nway{$account.5.user_id}@{$account.5.server_address}{/if}</P2718>
+<P2718>{if $nway_conference == 'true'}nway{$account.5.user_id}@{$account.5.server_address}{/if}</P2718>
 
 <!-- Broadsoft Call Center. 0 - No, 1 - Yes. Default value is 0 -->
 <!-- Number: 0, 1 -->
@@ -2682,7 +2682,7 @@ Account 5 Codec Settings
 
 <!-- Conference-URI -->
 <!-- String -->
-<P2818>{if $nway_conference == true}nway{$account.6.user_id}@{$account.6.server_address}{/if}</P2818>
+<P2818>{if $nway_conference == 'true'}nway{$account.6.user_id}@{$account.6.server_address}{/if}</P2818>
 
 <!-- Broadsoft Call Center. 0 - No, 1 - Yes. Default value is 0 -->
 <!-- Number: 0, 1 -->

--- a/resources/templates/provision/grandstream/gxv3240/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxv3240/{$mac}.xml
@@ -600,7 +600,7 @@
 
 <!-- Conference URI -->
 <!-- String -->
-<P2318>{if $nway_conference == true}nway{$account.1.user_id}@{$account.1.server_address}{/if}</P2318>
+<P2318>{if $nway_conference == 'true'}nway{$account.1.user_id}@{$account.1.server_address}{/if}</P2318>
 
 <!-- Broadsoft Call Center. 0 - No, 1 - Yes. Default value is 0 -->
 <!-- Number: 0, 1 -->
@@ -1255,7 +1255,7 @@
 
 <!-- Conference-URI -->
 <!-- String -->
-<P2418>{if $nway_conference == true}nway{$account.2.user_id}@{$account.2.server_address}{/if}</P2418>
+<P2418>{if $nway_conference == 'true'}nway{$account.2.user_id}@{$account.2.server_address}{/if}</P2418>
 
 <!-- Broadsoft Call Center. 0 - No, 1 - Yes. Default value is 0 -->
 <!-- Number: 0, 1 -->
@@ -1893,7 +1893,7 @@
 
 <!-- Conference-URI -->
 <!-- String -->
-<P2518>{if $nway_conference == true}nway{$account.3.user_id}@{$account.3.server_address}{/if}</P2518>
+<P2518>{if $nway_conference == 'true'}nway{$account.3.user_id}@{$account.3.server_address}{/if}</P2518>
 
 <!-- Broadsoft Call Center. 0 - No, 1 - Yes. Default value is 0 -->
 <!-- Number: 0, 1 -->
@@ -2534,7 +2534,7 @@
 
 <!-- Conference-URI -->
 <!-- String -->
-<P2618>{if $nway_conference == true}nway{$account.4.user_id}@{$account.4.server_address}{/if}</P2618>
+<P2618>{if $nway_conference == 'true'}nway{$account.4.user_id}@{$account.4.server_address}{/if}</P2618>
 
 <!-- Broadsoft Call Center. 0 - No, 1 - Yes. Default value is 0 -->
 <!-- Number: 0, 1 -->
@@ -3173,7 +3173,7 @@
 
 <!-- Conference-URI -->
 <!-- String -->
-<P2718>{if $nway_conference == true}nway{$account.5.user_id}@{$account.5.server_address}{/if}</P2718>
+<P2718>{if $nway_conference == 'true'}nway{$account.5.user_id}@{$account.5.server_address}{/if}</P2718>
 
 <!-- Broadsoft Call Center. 0 - No, 1 - Yes. Default value is 0 -->
 <!-- Number: 0, 1 -->
@@ -3814,7 +3814,7 @@
 
 <!-- Conference-URI -->
 <!-- String -->
-<P2818>{if $nway_conference == true}nway{$account.6.user_id}@{$account.6.server_address}{/if}</P2818>
+<P2818>{if $nway_conference == 'true'}nway{$account.6.user_id}@{$account.6.server_address}{/if}</P2818>
 
 <!-- Broadsoft Call Center. 0 - No, 1 - Yes. Default value is 0 -->
 <!-- Number: 0, 1 -->

--- a/resources/templates/provision/grandstream/gxv3275/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxv3275/{$mac}.xml
@@ -579,7 +579,7 @@
 
 <!-- Conference-URI -->
 <!-- String -->
-<P2318>{if $nway_conference == true}nway{$account.1.user_id}@{$account.1.server_address}{/if}</P2318>
+<P2318>{if $nway_conference == 'true'}nway{$account.1.user_id}@{$account.1.server_address}{/if}</P2318>
 
 <!-- Broadsoft Call Center. 0 - No, 1 - Yes. Default value is 0 -->
 <!-- Number: 0, 1 -->
@@ -1028,7 +1028,7 @@
 
 <!-- Conference-URI -->
 <!-- String -->
-<P2418>{if $nway_conference == true}nway{$account.2.user_id}@{$account.2.server_address}{/if}</P2418>
+<P2418>{if $nway_conference == 'true'}nway{$account.2.user_id}@{$account.2.server_address}{/if}</P2418>
 
 <!-- Broadsoft Call Center. 0 - No, 1 - Yes. Default value is 0 -->
 <!-- Number: 0, 1 -->
@@ -1474,7 +1474,7 @@
 
 <!-- Conference-URI -->
 <!-- String -->
-<P2518>{if $nway_conference == true}nway{$account.3.user_id}@{$account.3.server_address}{/if}</P2518>
+<P2518>{if $nway_conference == 'true'}nway{$account.3.user_id}@{$account.3.server_address}{/if}</P2518>
 
 <!-- Broadsoft Call Center. 0 - No, 1 - Yes. Default value is 0 -->
 <!-- Number: 0, 1 -->
@@ -1921,7 +1921,7 @@
 
 <!-- Conference-URI -->
 <!-- String -->
-<P2618>{if $nway_conference == true}nway{$account.4.user_id}@{$account.4.server_address}{/if}</P2618>
+<P2618>{if $nway_conference == 'true'}nway{$account.4.user_id}@{$account.4.server_address}{/if}</P2618>
 
 <!-- Account Ring Tone. See ring tone options and value in the Ring Tone value table below -->
 <P623>content://settings/system/ringtone</P623>
@@ -2363,7 +2363,7 @@
 
 <!-- Conference-URI -->
 <!-- String -->
-<P2718>{if $nway_conference == true}nway{$account.5.user_id}@{$account.5.server_address}{/if}</P2718>
+<P2718>{if $nway_conference == 'true'}nway{$account.5.user_id}@{$account.5.server_address}{/if}</P2718>
 
 <!-- Broadsoft Call Center. 0 - No, 1 - Yes. Default value is 0 -->
 <!-- Number: 0, 1 -->
@@ -2806,7 +2806,7 @@
 
 <!-- Conference-URI -->
 <!-- String -->
-<P2818>{if $nway_conference == true}nway{$account.6.user_id}@{$account.6.server_address}{/if}</P2818>
+<P2818>{if $nway_conference == 'true'}nway{$account.6.user_id}@{$account.6.server_address}{/if}</P2818>
 
 <!-- Broadsoft Call Center. 0 - No, 1 - Yes. Default value is 0 -->
 <!-- Number: 0, 1 -->

--- a/resources/templates/provision/grandstream/ht801/{$mac}.xml
+++ b/resources/templates/provision/grandstream/ht801/{$mac}.xml
@@ -1113,7 +1113,7 @@
     <P2359>0</P2359>
 
     <!-- # Conference URI -->
-    <P2318>{if $nway_conference == true}nway{$account.1.user_id}@{$account.1.server_address}{/if}</P2318>
+    <P2318>{if $nway_conference == 'true'}nway{$account.1.user_id}@{$account.1.server_address}{/if}</P2318>
 
     <!-- ################################################################################# -->
     <!-- # Codec/Voice Quality settings                                                  # -->

--- a/resources/templates/provision/grandstream/ht802/{$mac}.xml
+++ b/resources/templates/provision/grandstream/ht802/{$mac}.xml
@@ -1113,7 +1113,7 @@
     <P2359>0</P2359>
 
     <!-- # Conference URI -->
-    <P2318>{if $nway_conference == true}nway{$account.1.user_id}@{$account.1.server_address}{/if}</P2318>
+    <P2318>{if $nway_conference == 'true'}nway{$account.1.user_id}@{$account.1.server_address}{/if}</P2318>
 
     <!-- ################################################################################# -->
     <!-- # Codec/Voice Quality settings                                                  # -->
@@ -1999,7 +1999,7 @@
     <P2459>0</P2459>
 
     <!-- #Conference URI -->
-    <P2418>{if $nway_conference == true}nway{$account.2.user_id}@{$account.2.server_address}{/if}</P2418>
+    <P2418>{if $nway_conference == 'true'}nway{$account.2.user_id}@{$account.2.server_address}{/if}</P2418>
 
     <!-- ################################################################################# -->
     <!-- # Codec/Voice Quality settings                                                  # -->

--- a/resources/templates/provision/grandstream/ht818/{$mac}.xml
+++ b/resources/templates/provision/grandstream/ht818/{$mac}.xml
@@ -1048,7 +1048,7 @@
     <P2359>0</P2359>
 
     <!-- # Conference URI -->
-    <P2318>{if $nway_conference == true}nway{$account.1.user_id}@{$account.1.server_address}{/if}</P2318>
+    <P2318>{if $nway_conference == 'true'}nway{$account.1.user_id}@{$account.1.server_address}{/if}</P2318>
 
     <!-- ################################################################################# -->
     <!-- # Codec/Voice Quality settings                                                  # -->

--- a/resources/templates/provision/yealink/cp860/{$mac}.cfg
+++ b/resources/templates/provision/yealink/cp860/{$mac}.cfg
@@ -381,10 +381,10 @@ account.1.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.1.conf_type = {if $nway_conference == true}2{/if}
+account.1.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.1.conf_uri = {if $nway_conference == true}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
+account.1.conf_uri = {if $nway_conference == 'true'}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
 
 #######################################################################################
 ##                            cid_source                                             ##
@@ -852,10 +852,10 @@ account.2.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.2.conf_type = {if $nway_conference == true}2{/if}
+account.2.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.2.conf_uri = {if $nway_conference == true}nway{$account.2.user_id}@{$account.2.server_address}{/if}
+account.2.conf_uri = {if $nway_conference == 'true'}nway{$account.2.user_id}@{$account.2.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -1367,10 +1367,10 @@ account.3.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.3.conf_type = {if $nway_conference == true}2{/if}
+account.3.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.3.conf_uri = {if $nway_conference == true}nway{$account.3.user_id}@{$account.3.server_address}{/if}
+account.3.conf_uri = {if $nway_conference == 'true'}nway{$account.3.user_id}@{$account.3.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -1867,10 +1867,10 @@ account.4.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.4.conf_type = {if $nway_conference == true}2{/if}
+account.4.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.4.conf_uri = {if $nway_conference == true}nway{$account.4.user_id}@{$account.4.server_address}{/if}
+account.4.conf_uri = {if $nway_conference == 'true'}nway{$account.4.user_id}@{$account.4.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -2364,10 +2364,10 @@ account.5.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.5.conf_type = {if $nway_conference == true}2{/if}
+account.5.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.5.conf_uri = {if $nway_conference == true}nway{$account.5.user_id}@{$account.5.server_address}{/if}
+account.5.conf_uri = {if $nway_conference == 'true'}nway{$account.5.user_id}@{$account.5.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -2860,10 +2860,10 @@ account.6.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.6.conf_type = {if $nway_conference == true}2{/if}
+account.6.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.6.conf_uri = {if $nway_conference == true}nway{$account.6.user_id}@{$account.6.server_address}{/if}
+account.6.conf_uri = {if $nway_conference == 'true'}nway{$account.6.user_id}@{$account.6.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##

--- a/resources/templates/provision/yealink/cp920/{$mac}.cfg
+++ b/resources/templates/provision/yealink/cp920/{$mac}.cfg
@@ -380,10 +380,10 @@ account.1.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.1.conf_type = {if $nway_conference == true}2{/if}
+account.1.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.1.conf_uri = {if $nway_conference == true}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
+account.1.conf_uri = {if $nway_conference == 'true'}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
 
 #######################################################################################
 ##                            cid_source                                             ##
@@ -851,10 +851,10 @@ account.2.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.2.conf_type = {if $nway_conference == true}2{/if}
+account.2.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.2.conf_uri = {if $nway_conference == true}nway{$account.2.user_id}@{$account.2.server_address}{/if}
+account.2.conf_uri = {if $nway_conference == 'true'}nway{$account.2.user_id}@{$account.2.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -1367,10 +1367,10 @@ account.3.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.3.conf_type = {if $nway_conference == true}2{/if}
+account.3.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.3.conf_uri = {if $nway_conference == true}nway{$account.3.user_id}@{$account.3.server_address}{/if}
+account.3.conf_uri = {if $nway_conference == 'true'}nway{$account.3.user_id}@{$account.3.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -1869,10 +1869,10 @@ account.4.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.4.conf_type = {if $nway_conference == true}2{/if}
+account.4.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.4.conf_uri = {if $nway_conference == true}nway{$account.4.user_id}@{$account.4.server_address}{/if}
+account.4.conf_uri = {if $nway_conference == 'true'}nway{$account.4.user_id}@{$account.4.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -2367,10 +2367,10 @@ account.5.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.5.conf_type = {if $nway_conference == true}2{/if}
+account.5.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.5.conf_uri = {if $nway_conference == true}nway{$account.5.user_id}@{$account.5.server_address}{/if}
+account.5.conf_uri = {if $nway_conference == 'true'}nway{$account.5.user_id}@{$account.5.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -2864,10 +2864,10 @@ account.6.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.6.conf_type = {if $nway_conference == true}2{/if}
+account.6.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.6.conf_uri = {if $nway_conference == true}nway{$account.6.user_id}@{$account.6.server_address}{/if}
+account.6.conf_uri = {if $nway_conference == 'true'}nway{$account.6.user_id}@{$account.6.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##

--- a/resources/templates/provision/yealink/cp960/{$mac}.cfg
+++ b/resources/templates/provision/yealink/cp960/{$mac}.cfg
@@ -382,10 +382,10 @@ account.1.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.1.conf_type = {if $nway_conference == true}2{/if}
+account.1.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.1.conf_uri = {if $nway_conference == true}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
+account.1.conf_uri = {if $nway_conference == 'true'}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
 
 #######################################################################################
 ##                            cid_source                                             ##
@@ -853,10 +853,10 @@ account.2.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.2.conf_type = {if $nway_conference == true}2{/if}
+account.2.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.2.conf_uri = {if $nway_conference == true}nway{$account.2.user_id}@{$account.2.server_address}{/if}
+account.2.conf_uri = {if $nway_conference == 'true'}nway{$account.2.user_id}@{$account.2.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -1368,10 +1368,10 @@ account.3.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.3.conf_type = {if $nway_conference == true}2{/if}
+account.3.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.3.conf_uri = {if $nway_conference == true}nway{$account.3.user_id}@{$account.3.server_address}{/if}
+account.3.conf_uri = {if $nway_conference == 'true'}nway{$account.3.user_id}@{$account.3.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -1867,10 +1867,10 @@ account.4.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.4.conf_type = {if $nway_conference == true}2{/if}
+account.4.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.4.conf_uri = {if $nway_conference == true}nway{$account.4.user_id}@{$account.4.server_address}{/if}
+account.4.conf_uri = {if $nway_conference == 'true'}nway{$account.4.user_id}@{$account.4.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -2364,10 +2364,10 @@ account.5.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.5.conf_type = {if $nway_conference == true}2{/if}
+account.5.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.5.conf_uri = {if $nway_conference == true}nway{$account.5.user_id}@{$account.5.server_address}{/if}
+account.5.conf_uri = {if $nway_conference == 'true'}nway{$account.5.user_id}@{$account.5.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -2860,10 +2860,10 @@ account.6.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.6.conf_type = {if $nway_conference == true}2{/if}
+account.6.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.6.conf_uri = {if $nway_conference == true}nway{$account.6.user_id}@{$account.6.server_address}{/if}
+account.6.conf_uri = {if $nway_conference == 'true'}nway{$account.6.user_id}@{$account.6.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##

--- a/resources/templates/provision/yealink/t19p/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t19p/{$mac}.cfg
@@ -186,10 +186,10 @@ account.1.register_line =
 account.1.reg_fail_retry_interval =
 
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.1.conf_type = {if $nway_conference == true}2{/if}
+account.1.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.1.conf_uri = {if $nway_conference == true}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
+account.1.conf_uri = {if $nway_conference == 'true'}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
 
 #Configure the BLF list URI (a SIP URI, or use part of the SIP URI). For example, "2300_blflist@domain.com" or "2300_blflist".
 account.1.blf.blf_list_uri =
@@ -539,10 +539,10 @@ account.2.register_line =
 account.2.reg_fail_retry_interval =
 
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.2.conf_type = {if $nway_conference == true}2{/if}
+account.2.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.2.conf_uri = {if $nway_conference == true}nway{$account.2.user_id}@{$account.2.server_address}{/if}
+account.2.conf_uri = {if $nway_conference == 'true'}nway{$account.2.user_id}@{$account.2.server_address}{/if}
 
 #Configure the BLF list URI (a SIP URI, or use part of the SIP URI). For example, "2300_blflist@domain.com" or "2300_blflist".
 account.2.blf.blf_list_uri =
@@ -864,10 +864,10 @@ account.3.register_line =
 account.3.reg_fail_retry_interval =
 
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.3.conf_type = {if $nway_conference == true}2{/if}
+account.3.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.3.conf_uri = {if $nway_conference == true}nway{$account.3.user_id}@{$account.3.server_address}{/if}
+account.3.conf_uri = {if $nway_conference == 'true'}nway{$account.3.user_id}@{$account.3.server_address}{/if}
 
 #Configure the BLF list URI (a SIP URI, or use part of the SIP URI). For example, "2300_blflist@domain.com" or "2300_blflist".
 account.3.blf.blf_list_uri =
@@ -1190,10 +1190,10 @@ account.4.register_line =
 account.4.reg_fail_retry_interval =
 
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.4.conf_type = {if $nway_conference == true}2{/if}
+account.4.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.4.conf_uri = {if $nway_conference == true}nway{$account.4.user_id}@{$account.4.server_address}{/if}
+account.4.conf_uri = {if $nway_conference == 'true'}nway{$account.4.user_id}@{$account.4.server_address}{/if}
 
 #Configure the BLF list URI (a SIP URI, or use part of the SIP URI). For example, "2300_blflist@domain.com" or "2300_blflist".
 account.4.blf.blf_list_uri =
@@ -1516,10 +1516,10 @@ account.5.register_line =
 account.5.reg_fail_retry_interval =
 
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.5.conf_type = {if $nway_conference == true}2{/if}
+account.5.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.5.conf_uri = {if $nway_conference == true}nway{$account.5.user_id}@{$account.5.server_address}{/if}
+account.5.conf_uri = {if $nway_conference == 'true'}nway{$account.5.user_id}@{$account.5.server_address}{/if}
 
 #Configure the BLF list URI (a SIP URI, or use part of the SIP URI). For example, "2300_blflist@domain.com" or "2300_blflist".
 account.5.blf.blf_list_uri =
@@ -1839,10 +1839,10 @@ account.6.register_line =
 account.6.reg_fail_retry_interval =
 
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.6.conf_type = {if $nway_conference == true}2{/if}
+account.6.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.6.conf_uri = {if $nway_conference == true}nway{$account.6.user_id}@{$account.6.server_address}{/if}
+account.6.conf_uri = {if $nway_conference == 'true'}nway{$account.6.user_id}@{$account.6.server_address}{/if}
 
 #Configure the BLF list URI (a SIP URI, or use part of the SIP URI). For example, "2300_blflist@domain.com" or "2300_blflist".
 account.6.blf.blf_list_uri =

--- a/resources/templates/provision/yealink/t20p/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t20p/{$mac}.cfg
@@ -186,10 +186,10 @@ account.1.register_line =
 account.1.reg_fail_retry_interval =
 
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.1.conf_type = {if $nway_conference == true}2{/if}
+account.1.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.1.conf_uri = {if $nway_conference == true}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
+account.1.conf_uri = {if $nway_conference == 'true'}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
 
 #Configure the BLF list URI (a SIP URI, or use part of the SIP URI). For example, "2300_blflist@domain.com" or "2300_blflist".
 account.1.blf.blf_list_uri =
@@ -541,10 +541,10 @@ account.2.register_line =
 account.2.reg_fail_retry_interval =
 
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.2.conf_type = {if $nway_conference == true}2{/if}
+account.2.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.2.conf_uri = {if $nway_conference == true}nway{$account.2.user_id}@{$account.2.server_address}{/if}
+account.2.conf_uri = {if $nway_conference == 'true'}nway{$account.2.user_id}@{$account.2.server_address}{/if}
 
 #Configure the BLF list URI (a SIP URI, or use part of the SIP URI). For example, "2300_blflist@domain.com" or "2300_blflist".
 account.2.blf.blf_list_uri =
@@ -866,10 +866,10 @@ account.3.register_line =
 account.3.reg_fail_retry_interval =
 
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.3.conf_type = {if $nway_conference == true}2{/if}
+account.3.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.3.conf_uri = {if $nway_conference == true}nway{$account.3.user_id}@{$account.3.server_address}{/if}
+account.3.conf_uri = {if $nway_conference == 'true'}nway{$account.3.user_id}@{$account.3.server_address}{/if}
 
 #Configure the BLF list URI (a SIP URI, or use part of the SIP URI). For example, "2300_blflist@domain.com" or "2300_blflist".
 account.3.blf.blf_list_uri =
@@ -1191,10 +1191,10 @@ account.4.register_line =
 account.4.reg_fail_retry_interval =
 
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.4.conf_type = {if $nway_conference == true}2{/if}
+account.4.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.4.conf_uri = {if $nway_conference == true}nway{$account.4.user_id}@{$account.4.server_address}{/if}
+account.4.conf_uri = {if $nway_conference == 'true'}nway{$account.4.user_id}@{$account.4.server_address}{/if}
 
 #Configure the BLF list URI (a SIP URI, or use part of the SIP URI). For example, "2300_blflist@domain.com" or "2300_blflist".
 account.4.blf.blf_list_uri =
@@ -1517,10 +1517,10 @@ account.5.register_line =
 account.5.reg_fail_retry_interval =
 
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.5.conf_type = {if $nway_conference == true}2{/if}
+account.5.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.5.conf_uri = {if $nway_conference == true}nway{$account.5.user_id}@{$account.5.server_address}{/if}
+account.5.conf_uri = {if $nway_conference == 'true'}nway{$account.5.user_id}@{$account.5.server_address}{/if}
 
 #Configure the BLF list URI (a SIP URI, or use part of the SIP URI). For example, "2300_blflist@domain.com" or "2300_blflist".
 account.5.blf.blf_list_uri =
@@ -1840,10 +1840,10 @@ account.6.register_line =
 account.6.reg_fail_retry_interval =
 
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.6.conf_type = {if $nway_conference == true}2{/if}
+account.6.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.6.conf_uri = {if $nway_conference == true}nway{$account.6.user_id}@{$account.6.server_address}{/if}
+account.6.conf_uri = {if $nway_conference == 'true'}nway{$account.6.user_id}@{$account.6.server_address}{/if}
 
 #Configure the BLF list URI (a SIP URI, or use part of the SIP URI). For example, "2300_blflist@domain.com" or "2300_blflist".
 account.6.blf.blf_list_uri =

--- a/resources/templates/provision/yealink/t21p/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t21p/{$mac}.cfg
@@ -382,10 +382,10 @@ account.1.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.1.conf_type = {if $nway_conference == true}2{/if}
+account.1.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.1.conf_uri = {if $nway_conference == true}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
+account.1.conf_uri = {if $nway_conference == 'true'}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
 
 #######################################################################################
 ##                            cid_source                                             ##
@@ -851,10 +851,10 @@ account.2.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.2.conf_type = {if $nway_conference == true}2{/if}
+account.2.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.2.conf_uri = {if $nway_conference == true}nway{$account.2.user_id}@{$account.2.server_address}{/if}
+account.2.conf_uri = {if $nway_conference == 'true'}nway{$account.2.user_id}@{$account.2.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -1364,10 +1364,10 @@ account.3.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.3.conf_type = {if $nway_conference == true}2{/if}
+account.3.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.3.conf_uri = {if $nway_conference == true}nway{$account.3.user_id}@{$account.3.server_address}{/if}
+account.3.conf_uri = {if $nway_conference == 'true'}nway{$account.3.user_id}@{$account.3.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -1860,10 +1860,10 @@ account.4.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.4.conf_type = {if $nway_conference == true}2{/if}
+account.4.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.4.conf_uri = {if $nway_conference == true}nway{$account.4.user_id}@{$account.4.server_address}{/if}
+account.4.conf_uri = {if $nway_conference == 'true'}nway{$account.4.user_id}@{$account.4.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -2356,10 +2356,10 @@ account.5.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.5.conf_type = {if $nway_conference == true}2{/if}
+account.5.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.5.conf_uri = {if $nway_conference == true}nway{$account.5.user_id}@{$account.5.server_address}{/if}
+account.5.conf_uri = {if $nway_conference == 'true'}nway{$account.5.user_id}@{$account.5.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -2851,10 +2851,10 @@ account.6.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.6.conf_type = {if $nway_conference == true}2{/if}
+account.6.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.6.conf_uri = {if $nway_conference == true}nway{$account.6.user_id}@{$account.6.server_address}{/if}
+account.6.conf_uri = {if $nway_conference == 'true'}nway{$account.6.user_id}@{$account.6.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##

--- a/resources/templates/provision/yealink/t22p/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t22p/{$mac}.cfg
@@ -186,10 +186,10 @@ account.1.register_line =
 account.1.reg_fail_retry_interval =
 
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.1.conf_type = {if $nway_conference == true}2{/if}
+account.1.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.1.conf_uri = {if $nway_conference == true}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
+account.1.conf_uri = {if $nway_conference == 'true'}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
 
 #Configure the BLF list URI (a SIP URI, or use part of the SIP URI). For example, "2300_blflist@domain.com" or "2300_blflist".
 account.1.blf.blf_list_uri =
@@ -539,10 +539,10 @@ account.2.register_line =
 account.2.reg_fail_retry_interval =
 
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.2.conf_type = {if $nway_conference == true}2{/if}
+account.2.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.2.conf_uri = {if $nway_conference == true}nway{$account.2.user_id}@{$account.2.server_address}{/if}
+account.2.conf_uri = {if $nway_conference == 'true'}nway{$account.2.user_id}@{$account.2.server_address}{/if}
 
 #Configure the BLF list URI (a SIP URI, or use part of the SIP URI). For example, "2300_blflist@domain.com" or "2300_blflist".
 account.2.blf.blf_list_uri =
@@ -864,10 +864,10 @@ account.3.register_line =
 account.3.reg_fail_retry_interval =
 
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.3.conf_type = {if $nway_conference == true}2{/if}
+account.3.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.3.conf_uri = {if $nway_conference == true}nway{$account.3.user_id}@{$account.3.server_address}{/if}
+account.3.conf_uri = {if $nway_conference == 'true'}nway{$account.3.user_id}@{$account.3.server_address}{/if}
 
 #Configure the BLF list URI (a SIP URI, or use part of the SIP URI). For example, "2300_blflist@domain.com" or "2300_blflist".
 account.3.blf.blf_list_uri =
@@ -1190,10 +1190,10 @@ account.4.register_line =
 account.4.reg_fail_retry_interval =
 
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.4.conf_type = {if $nway_conference == true}2{/if}
+account.4.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.4.conf_uri = {if $nway_conference == true}nway{$account.4.user_id}@{$account.4.server_address}{/if}
+account.4.conf_uri = {if $nway_conference == 'true'}nway{$account.4.user_id}@{$account.4.server_address}{/if}
 
 #Configure the BLF list URI (a SIP URI, or use part of the SIP URI). For example, "2300_blflist@domain.com" or "2300_blflist".
 account.4.blf.blf_list_uri =
@@ -1516,10 +1516,10 @@ account.5.register_line =
 account.5.reg_fail_retry_interval =
 
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.5.conf_type = {if $nway_conference == true}2{/if}
+account.5.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.5.conf_uri = {if $nway_conference == true}nway{$account.5.user_id}@{$account.5.server_address}{/if}
+account.5.conf_uri = {if $nway_conference == 'true'}nway{$account.5.user_id}@{$account.5.server_address}{/if}
 
 #Configure the BLF list URI (a SIP URI, or use part of the SIP URI). For example, "2300_blflist@domain.com" or "2300_blflist".
 account.5.blf.blf_list_uri =
@@ -1839,10 +1839,10 @@ account.6.register_line =
 account.6.reg_fail_retry_interval =
 
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.6.conf_type = {if $nway_conference == true}2{/if}
+account.6.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.6.conf_uri = {if $nway_conference == true}nway{$account.6.user_id}@{$account.6.server_address}{/if}
+account.6.conf_uri = {if $nway_conference == 'true'}nway{$account.6.user_id}@{$account.6.server_address}{/if}
 
 #Configure the BLF list URI (a SIP URI, or use part of the SIP URI). For example, "2300_blflist@domain.com" or "2300_blflist".
 account.6.blf.blf_list_uri =

--- a/resources/templates/provision/yealink/t23g/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t23g/{$mac}.cfg
@@ -395,10 +395,10 @@ account.1.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.1.conf_type = {if $nway_conference == true}2{/if}
+account.1.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.1.conf_uri = {if $nway_conference == true}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
+account.1.conf_uri = {if $nway_conference == 'true'}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
 
 #######################################################################################
 ##                            cid_source                                             ##
@@ -867,10 +867,10 @@ account.2.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.2.conf_type = {if $nway_conference == true}2{/if}
+account.2.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.2.conf_uri = {if $nway_conference == true}nway{$account.2.user_id}@{$account.2.server_address}{/if}
+account.2.conf_uri = {if $nway_conference == 'true'}nway{$account.2.user_id}@{$account.2.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -1353,10 +1353,10 @@ account.3.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.3.conf_type = {if $nway_conference == true}2{/if}
+account.3.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.3.conf_uri = {if $nway_conference == true}nway{$account.3.user_id}@{$account.3.server_address}{/if}
+account.3.conf_uri = {if $nway_conference == 'true'}nway{$account.3.user_id}@{$account.3.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -1829,10 +1829,10 @@ account.4.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.4.conf_type = {if $nway_conference == true}2{/if}
+account.4.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.4.conf_uri = {if $nway_conference == true}nway{$account.4.user_id}@{$account.4.server_address}{/if}
+account.4.conf_uri = {if $nway_conference == 'true'}nway{$account.4.user_id}@{$account.4.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -2305,10 +2305,10 @@ account.5.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.5.conf_type = {if $nway_conference == true}2{/if}
+account.5.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.5.conf_uri = {if $nway_conference == true}nway{$account.5.user_id}@{$account.5.server_address}{/if}
+account.5.conf_uri = {if $nway_conference == 'true'}nway{$account.5.user_id}@{$account.5.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -2780,10 +2780,10 @@ account.6.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.6.conf_type = {if $nway_conference == true}2{/if}
+account.6.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.6.conf_uri = {if $nway_conference == true}nway{$account.6.user_id}@{$account.6.server_address}{/if}
+account.6.conf_uri = {if $nway_conference == 'true'}nway{$account.6.user_id}@{$account.6.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##

--- a/resources/templates/provision/yealink/t23p/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t23p/{$mac}.cfg
@@ -381,10 +381,10 @@ account.1.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.1.conf_type = {if $nway_conference == true}2{/if}
+account.1.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.1.conf_uri = {if $nway_conference == true}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
+account.1.conf_uri = {if $nway_conference == 'true'}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
 
 #######################################################################################
 ##                            cid_source                                             ##
@@ -853,10 +853,10 @@ account.2.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.2.conf_type = {if $nway_conference == true}2{/if}
+account.2.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.2.conf_uri = {if $nway_conference == true}nway{$account.2.user_id}@{$account.2.server_address}{/if}
+account.2.conf_uri = {if $nway_conference == 'true'}nway{$account.2.user_id}@{$account.2.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -1339,10 +1339,10 @@ account.3.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.3.conf_type = {if $nway_conference == true}2{/if}
+account.3.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.3.conf_uri = {if $nway_conference == true}nway{$account.3.user_id}@{$account.3.server_address}{/if}
+account.3.conf_uri = {if $nway_conference == 'true'}nway{$account.3.user_id}@{$account.3.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -1815,10 +1815,10 @@ account.4.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.4.conf_type = {if $nway_conference == true}2{/if}
+account.4.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.4.conf_uri = {if $nway_conference == true}nway{$account.4.user_id}@{$account.4.server_address}{/if}
+account.4.conf_uri = {if $nway_conference == 'true'}nway{$account.4.user_id}@{$account.4.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -2291,10 +2291,10 @@ account.5.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.5.conf_type = {if $nway_conference == true}2{/if}
+account.5.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.5.conf_uri = {if $nway_conference == true}nway{$account.5.user_id}@{$account.5.server_address}{/if}
+account.5.conf_uri = {if $nway_conference == 'true'}nway{$account.5.user_id}@{$account.5.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -2766,10 +2766,10 @@ account.6.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.6.conf_type = {if $nway_conference == true}2{/if}
+account.6.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.6.conf_uri = {if $nway_conference == true}nway{$account.6.user_id}@{$account.6.server_address}{/if}
+account.6.conf_uri = {if $nway_conference == 'true'}nway{$account.6.user_id}@{$account.6.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##

--- a/resources/templates/provision/yealink/t26p/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t26p/{$mac}.cfg
@@ -186,10 +186,10 @@ account.1.register_line =
 account.1.reg_fail_retry_interval =
 
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.1.conf_type = {if $nway_conference == true}2{/if}
+account.1.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.1.conf_uri = {if $nway_conference == true}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
+account.1.conf_uri = {if $nway_conference == 'true'}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
 
 #Configure the BLF list URI (a SIP URI, or use part of the SIP URI). For example, "2300_blflist@domain.com" or "2300_blflist".
 account.1.blf.blf_list_uri =
@@ -539,10 +539,10 @@ account.2.register_line =
 account.2.reg_fail_retry_interval =
 
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.2.conf_type = {if $nway_conference == true}2{/if}
+account.2.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.2.conf_uri = {if $nway_conference == true}nway{$account.2.user_id}@{$account.2.server_address}{/if}
+account.2.conf_uri = {if $nway_conference == 'true'}nway{$account.2.user_id}@{$account.2.server_address}{/if}
 
 #Configure the BLF list URI (a SIP URI, or use part of the SIP URI). For example, "2300_blflist@domain.com" or "2300_blflist".
 account.2.blf.blf_list_uri =
@@ -865,10 +865,10 @@ account.3.register_line =
 account.3.reg_fail_retry_interval =
 
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.3.conf_type = {if $nway_conference == true}2{/if}
+account.3.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.3.conf_uri = {if $nway_conference == true}nway{$account.3.user_id}@{$account.3.server_address}{/if}
+account.3.conf_uri = {if $nway_conference == 'true'}nway{$account.3.user_id}@{$account.3.server_address}{/if}
 
 #Configure the BLF list URI (a SIP URI, or use part of the SIP URI). For example, "2300_blflist@domain.com" or "2300_blflist".
 account.3.blf.blf_list_uri =
@@ -1190,10 +1190,10 @@ account.4.register_line =
 account.4.reg_fail_retry_interval =
 
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.4.conf_type = {if $nway_conference == true}2{/if}
+account.4.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.4.conf_uri = {if $nway_conference == true}nway{$account.4.user_id}@{$account.4.server_address}{/if}
+account.4.conf_uri = {if $nway_conference == 'true'}nway{$account.4.user_id}@{$account.4.server_address}{/if}
 
 #Configure the BLF list URI (a SIP URI, or use part of the SIP URI). For example, "2300_blflist@domain.com" or "2300_blflist".
 account.4.blf.blf_list_uri =
@@ -1516,10 +1516,10 @@ account.5.register_line =
 account.5.reg_fail_retry_interval =
 
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.5.conf_type = {if $nway_conference == true}2{/if}
+account.5.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.5.conf_uri = {if $nway_conference == true}nway{$account.5.user_id}@{$account.5.server_address}{/if}
+account.5.conf_uri = {if $nway_conference == 'true'}nway{$account.5.user_id}@{$account.5.server_address}{/if}
 
 #Configure the BLF list URI (a SIP URI, or use part of the SIP URI). For example, "2300_blflist@domain.com" or "2300_blflist".
 account.5.blf.blf_list_uri =
@@ -1839,10 +1839,10 @@ account.6.register_line =
 account.6.reg_fail_retry_interval =
 
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.6.conf_type = {if $nway_conference == true}2{/if}
+account.6.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.6.conf_uri = {if $nway_conference == true}nway{$account.6.user_id}@{$account.6.server_address}{/if}
+account.6.conf_uri = {if $nway_conference == 'true'}nway{$account.6.user_id}@{$account.6.server_address}{/if}
 
 #Configure the BLF list URI (a SIP URI, or use part of the SIP URI). For example, "2300_blflist@domain.com" or "2300_blflist".
 account.6.blf.blf_list_uri =

--- a/resources/templates/provision/yealink/t27g/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t27g/{$mac}.cfg
@@ -395,10 +395,10 @@ account.1.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.1.conf_type = {if $nway_conference == true}2{/if}
+account.1.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.1.conf_uri = {if $nway_conference == true}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
+account.1.conf_uri = {if $nway_conference == 'true'}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
 
 #######################################################################################
 ##                            cid_source                                             ##
@@ -866,10 +866,10 @@ account.2.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.2.conf_type = {if $nway_conference == true}2{/if}
+account.2.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.2.conf_uri = {if $nway_conference == true}nway{$account.2.user_id}@{$account.2.server_address}{/if}
+account.2.conf_uri = {if $nway_conference == 'true'}nway{$account.2.user_id}@{$account.2.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -1351,10 +1351,10 @@ account.3.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.3.conf_type = {if $nway_conference == true}2{/if}
+account.3.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.3.conf_uri = {if $nway_conference == true}nway{$account.3.user_id}@{$account.3.server_address}{/if}
+account.3.conf_uri = {if $nway_conference == 'true'}nway{$account.3.user_id}@{$account.3.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -1826,10 +1826,10 @@ account.4.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.4.conf_type = {if $nway_conference == true}2{/if}
+account.4.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.4.conf_uri = {if $nway_conference == true}nway{$account.4.user_id}@{$account.4.server_address}{/if}
+account.4.conf_uri = {if $nway_conference == 'true'}nway{$account.4.user_id}@{$account.4.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -2301,10 +2301,10 @@ account.5.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.5.conf_type = {if $nway_conference == true}2{/if}
+account.5.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.5.conf_uri = {if $nway_conference == true}nway{$account.5.user_id}@{$account.5.server_address}{/if}
+account.5.conf_uri = {if $nway_conference == 'true'}nway{$account.5.user_id}@{$account.5.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -2775,10 +2775,10 @@ account.6.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.6.conf_type = {if $nway_conference == true}2{/if}
+account.6.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.6.conf_uri = {if $nway_conference == true}nway{$account.6.user_id}@{$account.6.server_address}{/if}
+account.6.conf_uri = {if $nway_conference == 'true'}nway{$account.6.user_id}@{$account.6.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##

--- a/resources/templates/provision/yealink/t27p/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t27p/{$mac}.cfg
@@ -395,10 +395,10 @@ account.1.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.1.conf_type = {if $nway_conference == true}2{/if}
+account.1.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.1.conf_uri = {if $nway_conference == true}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
+account.1.conf_uri = {if $nway_conference == 'true'}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
 
 #######################################################################################
 ##                            cid_source                                             ##
@@ -866,10 +866,10 @@ account.2.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.2.conf_type = {if $nway_conference == true}2{/if}
+account.2.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.2.conf_uri = {if $nway_conference == true}nway{$account.2.user_id}@{$account.2.server_address}{/if}
+account.2.conf_uri = {if $nway_conference == 'true'}nway{$account.2.user_id}@{$account.2.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -1351,10 +1351,10 @@ account.3.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.3.conf_type = {if $nway_conference == true}2{/if}
+account.3.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.3.conf_uri = {if $nway_conference == true}nway{$account.3.user_id}@{$account.3.server_address}{/if}
+account.3.conf_uri = {if $nway_conference == 'true'}nway{$account.3.user_id}@{$account.3.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -1826,10 +1826,10 @@ account.4.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.4.conf_type = {if $nway_conference == true}2{/if}
+account.4.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.4.conf_uri = {if $nway_conference == true}nway{$account.4.user_id}@{$account.4.server_address}{/if}
+account.4.conf_uri = {if $nway_conference == 'true'}nway{$account.4.user_id}@{$account.4.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -2301,10 +2301,10 @@ account.5.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.5.conf_type = {if $nway_conference == true}2{/if}
+account.5.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.5.conf_uri = {if $nway_conference == true}nway{$account.5.user_id}@{$account.5.server_address}{/if}
+account.5.conf_uri = {if $nway_conference == 'true'}nway{$account.5.user_id}@{$account.5.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -2775,10 +2775,10 @@ account.6.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.6.conf_type = {if $nway_conference == true}2{/if}
+account.6.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.6.conf_uri = {if $nway_conference == true}nway{$account.6.user_id}@{$account.6.server_address}{/if}
+account.6.conf_uri = {if $nway_conference == 'true'}nway{$account.6.user_id}@{$account.6.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##

--- a/resources/templates/provision/yealink/t28p/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t28p/{$mac}.cfg
@@ -186,10 +186,10 @@ account.1.register_line =
 account.1.reg_fail_retry_interval =
 
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.1.conf_type = {if $nway_conference == true}2{/if}
+account.1.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.1.conf_uri = {if $nway_conference == true}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
+account.1.conf_uri = {if $nway_conference == 'true'}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
 
 #Configure the BLF list URI (a SIP URI, or use part of the SIP URI). For example, "2300_blflist@domain.com" or "2300_blflist".
 account.1.blf.blf_list_uri =
@@ -539,10 +539,10 @@ account.2.register_line =
 account.2.reg_fail_retry_interval =
 
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.2.conf_type = {if $nway_conference == true}2{/if}
+account.2.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.2.conf_uri = {if $nway_conference == true}nway{$account.2.user_id}@{$account.2.server_address}{/if}
+account.2.conf_uri = {if $nway_conference == 'true'}nway{$account.2.user_id}@{$account.2.server_address}{/if}
 
 #Configure the BLF list URI (a SIP URI, or use part of the SIP URI). For example, "2300_blflist@domain.com" or "2300_blflist".
 account.2.blf.blf_list_uri =
@@ -865,10 +865,10 @@ account.3.register_line =
 account.3.reg_fail_retry_interval =
 
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.3.conf_type = {if $nway_conference == true}2{/if}
+account.3.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.3.conf_uri = {if $nway_conference == true}nway{$account.3.user_id}@{$account.3.server_address}{/if}
+account.3.conf_uri = {if $nway_conference == 'true'}nway{$account.3.user_id}@{$account.3.server_address}{/if}
 
 #Configure the BLF list URI (a SIP URI, or use part of the SIP URI). For example, "2300_blflist@domain.com" or "2300_blflist".
 account.3.blf.blf_list_uri =
@@ -1190,10 +1190,10 @@ account.4.register_line =
 account.4.reg_fail_retry_interval =
 
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.4.conf_type = {if $nway_conference == true}2{/if}
+account.4.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.4.conf_uri = {if $nway_conference == true}nway{$account.4.user_id}@{$account.4.server_address}{/if}
+account.4.conf_uri = {if $nway_conference == 'true'}nway{$account.4.user_id}@{$account.4.server_address}{/if}
 
 #Configure the BLF list URI (a SIP URI, or use part of the SIP URI). For example, "2300_blflist@domain.com" or "2300_blflist".
 account.4.blf.blf_list_uri =
@@ -1516,10 +1516,10 @@ account.5.register_line =
 account.5.reg_fail_retry_interval =
 
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.5.conf_type = {if $nway_conference == true}2{/if}
+account.5.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.5.conf_uri = {if $nway_conference == true}nway{$account.5.user_id}@{$account.5.server_address}{/if}
+account.5.conf_uri = {if $nway_conference == 'true'}nway{$account.5.user_id}@{$account.5.server_address}{/if}
 
 #Configure the BLF list URI (a SIP URI, or use part of the SIP URI). For example, "2300_blflist@domain.com" or "2300_blflist".
 account.5.blf.blf_list_uri =
@@ -1839,10 +1839,10 @@ account.6.register_line =
 account.6.reg_fail_retry_interval =
 
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.6.conf_type = {if $nway_conference == true}2{/if}
+account.6.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.6.conf_uri = {if $nway_conference == true}nway{$account.6.user_id}@{$account.6.server_address}{/if}
+account.6.conf_uri = {if $nway_conference == 'true'}nway{$account.6.user_id}@{$account.6.server_address}{/if}
 
 #Configure the BLF list URI (a SIP URI, or use part of the SIP URI). For example, "2300_blflist@domain.com" or "2300_blflist".
 account.6.blf.blf_list_uri =

--- a/resources/templates/provision/yealink/t29g/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t29g/{$mac}.cfg
@@ -395,10 +395,10 @@ account.1.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.1.conf_type = {if $nway_conference == true}2{/if}
+account.1.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.1.conf_uri = {if $nway_conference == true}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
+account.1.conf_uri = {if $nway_conference == 'true'}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
 
 #######################################################################################
 ##                            cid_source                                             ##
@@ -867,10 +867,10 @@ account.2.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.2.conf_type = {if $nway_conference == true}2{/if}
+account.2.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.2.conf_uri = {if $nway_conference == true}nway{$account.2.user_id}@{$account.2.server_address}{/if}
+account.2.conf_uri = {if $nway_conference == 'true'}nway{$account.2.user_id}@{$account.2.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -1353,10 +1353,10 @@ account.3.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.3.conf_type = {if $nway_conference == true}2{/if}
+account.3.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.3.conf_uri = {if $nway_conference == true}nway{$account.3.user_id}@{$account.3.server_address}{/if}
+account.3.conf_uri = {if $nway_conference == 'true'}nway{$account.3.user_id}@{$account.3.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -1829,10 +1829,10 @@ account.4.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.4.conf_type = {if $nway_conference == true}2{/if}
+account.4.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.4.conf_uri = {if $nway_conference == true}nway{$account.4.user_id}@{$account.4.server_address}{/if}
+account.4.conf_uri = {if $nway_conference == 'true'}nway{$account.4.user_id}@{$account.4.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -2305,10 +2305,10 @@ account.5.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.5.conf_type = {if $nway_conference == true}2{/if}
+account.5.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.5.conf_uri = {if $nway_conference == true}nway{$account.5.user_id}@{$account.5.server_address}{/if}
+account.5.conf_uri = {if $nway_conference == 'true'}nway{$account.5.user_id}@{$account.5.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -2780,10 +2780,10 @@ account.6.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.6.conf_type = {if $nway_conference == true}2{/if}
+account.6.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.6.conf_uri = {if $nway_conference == true}nway{$account.6.user_id}@{$account.6.server_address}{/if}
+account.6.conf_uri = {if $nway_conference == 'true'}nway{$account.6.user_id}@{$account.6.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##

--- a/resources/templates/provision/yealink/t2x/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t2x/{$mac}.cfg
@@ -342,10 +342,10 @@ account.{$row.line_number}.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type 0-Local (default), 2-Network Conference
-account.{$row.line_number}.conf_type = {if $nway_conference == true}2{/if}
+account.{$row.line_number}.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.{$row.line_number}.conf_uri = {if $nway_conference == true}nway{$account.{$row.line_number}.user_id}@{$account.{$row.line_number}.server_address}{/if}
+account.{$row.line_number}.conf_uri = {if $nway_conference == 'true'}nway{$account.{$row.line_number}.user_id}@{$account.{$row.line_number}.server_address}{/if}
 
 #######################################################################################
 ##                            cid_source                                             ##

--- a/resources/templates/provision/yealink/t31g/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t31g/{$mac}.cfg
@@ -177,10 +177,10 @@ account.1.register_line =
 account.1.reg_fail_retry_interval =
 
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.1.conf_type = {if $nway_conference == true}2{/if}
+account.1.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.1.conf_uri = {if $nway_conference == true}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
+account.1.conf_uri = {if $nway_conference == 'true'}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
 
 #Configure the BLF list URI (a SIP URI, or use part of the SIP URI). For example, "2300_blflist@domain.com" or "2300_blflist".
 account.1.blf.blf_list_uri =
@@ -522,10 +522,10 @@ account.2.register_line =
 account.2.reg_fail_retry_interval =
 
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.2.conf_type = {if $nway_conference == true}2{/if}
+account.2.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.2.conf_uri = {if $nway_conference == true}nway{$account.2.user_id}@{$account.2.server_address}{/if}
+account.2.conf_uri = {if $nway_conference == 'true'}nway{$account.2.user_id}@{$account.2.server_address}{/if}
 
 #Configure the BLF list URI (a SIP URI, or use part of the SIP URI). For example, "2300_blflist@domain.com" or "2300_blflist".
 account.2.blf.blf_list_uri =
@@ -839,10 +839,10 @@ account.3.register_line =
 account.3.reg_fail_retry_interval =
 
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.3.conf_type = {if $nway_conference == true}2{/if}
+account.3.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.3.conf_uri = {if $nway_conference == true}nway{$account.3.user_id}@{$account.3.server_address}{/if}
+account.3.conf_uri = {if $nway_conference == 'true'}nway{$account.3.user_id}@{$account.3.server_address}{/if}
 
 #Configure the BLF list URI (a SIP URI, or use part of the SIP URI). For example, "2300_blflist@domain.com" or "2300_blflist".
 account.3.blf.blf_list_uri =
@@ -1156,10 +1156,10 @@ account.4.register_line =
 account.4.reg_fail_retry_interval =
 
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.4.conf_type = {if $nway_conference == true}2{/if}
+account.4.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.4.conf_uri = {if $nway_conference == true}nway{$account.4.user_id}@{$account.4.server_address}{/if}
+account.4.conf_uri = {if $nway_conference == 'true'}nway{$account.4.user_id}@{$account.4.server_address}{/if}
 
 #Configure the BLF list URI (a SIP URI, or use part of the SIP URI). For example, "2300_blflist@domain.com" or "2300_blflist".
 account.4.blf.blf_list_uri =
@@ -1474,10 +1474,10 @@ account.5.register_line =
 account.5.reg_fail_retry_interval =
 
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.5.conf_type = {if $nway_conference == true}2{/if}
+account.5.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.5.conf_uri = {if $nway_conference == true}nway{$account.5.user_id}@{$account.5.server_address}{/if}
+account.5.conf_uri = {if $nway_conference == 'true'}nway{$account.5.user_id}@{$account.5.server_address}{/if}
 
 #Configure the BLF list URI (a SIP URI, or use part of the SIP URI). For example, "2300_blflist@domain.com" or "2300_blflist".
 account.5.blf.blf_list_uri =
@@ -1789,10 +1789,10 @@ account.6.register_line =
 account.6.reg_fail_retry_interval =
 
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.6.conf_type = {if $nway_conference == true}2{/if}
+account.6.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.6.conf_uri = {if $nway_conference == true}nway{$account.6.user_id}@{$account.6.server_address}{/if}
+account.6.conf_uri = {if $nway_conference == 'true'}nway{$account.6.user_id}@{$account.6.server_address}{/if}
 
 #Configure the BLF list URI (a SIP URI, or use part of the SIP URI). For example, "2300_blflist@domain.com" or "2300_blflist".
 account.6.blf.blf_list_uri =

--- a/resources/templates/provision/yealink/t32g/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t32g/{$mac}.cfg
@@ -177,10 +177,10 @@ account.1.register_line =
 account.1.reg_fail_retry_interval =
 
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.1.conf_type = {if $nway_conference == true}2{/if}
+account.1.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.1.conf_uri = {if $nway_conference == true}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
+account.1.conf_uri = {if $nway_conference == 'true'}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
 
 #Configure the BLF list URI (a SIP URI, or use part of the SIP URI). For example, "2300_blflist@domain.com" or "2300_blflist".
 account.1.blf.blf_list_uri =
@@ -522,10 +522,10 @@ account.2.register_line =
 account.2.reg_fail_retry_interval =
 
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.2.conf_type = {if $nway_conference == true}2{/if}
+account.2.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.2.conf_uri = {if $nway_conference == true}nway{$account.2.user_id}@{$account.2.server_address}{/if}
+account.2.conf_uri = {if $nway_conference == 'true'}nway{$account.2.user_id}@{$account.2.server_address}{/if}
 
 #Configure the BLF list URI (a SIP URI, or use part of the SIP URI). For example, "2300_blflist@domain.com" or "2300_blflist".
 account.2.blf.blf_list_uri =
@@ -839,10 +839,10 @@ account.3.register_line =
 account.3.reg_fail_retry_interval =
 
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.3.conf_type = {if $nway_conference == true}2{/if}
+account.3.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.3.conf_uri = {if $nway_conference == true}nway{$account.3.user_id}@{$account.3.server_address}{/if}
+account.3.conf_uri = {if $nway_conference == 'true'}nway{$account.3.user_id}@{$account.3.server_address}{/if}
 
 #Configure the BLF list URI (a SIP URI, or use part of the SIP URI). For example, "2300_blflist@domain.com" or "2300_blflist".
 account.3.blf.blf_list_uri =
@@ -1156,10 +1156,10 @@ account.4.register_line =
 account.4.reg_fail_retry_interval =
 
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.4.conf_type = {if $nway_conference == true}2{/if}
+account.4.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.4.conf_uri = {if $nway_conference == true}nway{$account.4.user_id}@{$account.4.server_address}{/if}
+account.4.conf_uri = {if $nway_conference == 'true'}nway{$account.4.user_id}@{$account.4.server_address}{/if}
 
 #Configure the BLF list URI (a SIP URI, or use part of the SIP URI). For example, "2300_blflist@domain.com" or "2300_blflist".
 account.4.blf.blf_list_uri =
@@ -1474,10 +1474,10 @@ account.5.register_line =
 account.5.reg_fail_retry_interval =
 
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.5.conf_type = {if $nway_conference == true}2{/if}
+account.5.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.5.conf_uri = {if $nway_conference == true}nway{$account.5.user_id}@{$account.5.server_address}{/if}
+account.5.conf_uri = {if $nway_conference == 'true'}nway{$account.5.user_id}@{$account.5.server_address}{/if}
 
 #Configure the BLF list URI (a SIP URI, or use part of the SIP URI). For example, "2300_blflist@domain.com" or "2300_blflist".
 account.5.blf.blf_list_uri =
@@ -1789,10 +1789,10 @@ account.6.register_line =
 account.6.reg_fail_retry_interval =
 
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.6.conf_type = {if $nway_conference == true}2{/if}
+account.6.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.6.conf_uri = {if $nway_conference == true}nway{$account.6.user_id}@{$account.6.server_address}{/if}
+account.6.conf_uri = {if $nway_conference == 'true'}nway{$account.6.user_id}@{$account.6.server_address}{/if}
 
 #Configure the BLF list URI (a SIP URI, or use part of the SIP URI). For example, "2300_blflist@domain.com" or "2300_blflist".
 account.6.blf.blf_list_uri =

--- a/resources/templates/provision/yealink/t33g/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t33g/{$mac}.cfg
@@ -210,7 +210,7 @@ account.1.session_timer.refresher=
 account.1.session_timer.expires=
 account.1.session_timer.enable= {$yealink_session_timer}
 
-account.1.conf_type = {if $nway_conference == true}2{/if}
+account.1.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 account.1.sip_server_type=
 
 ##V83 Add
@@ -516,7 +516,7 @@ account.1.call_recording.enable=
 #######################################################################################
 ##                                Network Conference                                  ##
 #######################################################################################
-account.1.conf_uri = {if $nway_conference == true}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
+account.1.conf_uri = {if $nway_conference == 'true'}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
 
 
 #######################################################################################
@@ -781,7 +781,7 @@ account.2.session_timer.refresher=
 account.2.session_timer.expires=
 account.2.session_timer.enable= {$yealink_session_timer}
 
-account.2.conf_type = {if $nway_conference == true}2{/if}
+account.2.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 account.2.sip_server_type=
 
 ##V83 Add
@@ -1084,7 +1084,7 @@ account.2.call_recording.enable=
 #######################################################################################
 ##                                Network Conference                                  ##
 #######################################################################################
-account.2.conf_uri = {if $nway_conference == true}nway{$account.2.user_id}@{$account.2.server_address}{/if}
+account.2.conf_uri = {if $nway_conference == 'true'}nway{$account.2.user_id}@{$account.2.server_address}{/if}
 
 
 #######################################################################################
@@ -1349,7 +1349,7 @@ account.3.session_timer.refresher=
 account.3.session_timer.expires=
 account.3.session_timer.enable= {$yealink_session_timer}
 
-account.3.conf_type = {if $nway_conference == true}2{/if}
+account.3.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 account.3.sip_server_type=
 
 ##V83 Add
@@ -1652,7 +1652,7 @@ account.3.call_recording.enable=
 #######################################################################################
 ##                                Network Conference                                  ##
 #######################################################################################
-account.3.conf_uri = {if $nway_conference == true}nway{$account.3.user_id}@{$account.3.server_address}{/if}
+account.3.conf_uri = {if $nway_conference == 'true'}nway{$account.3.user_id}@{$account.3.server_address}{/if}
 
 
 #######################################################################################
@@ -1917,7 +1917,7 @@ account.4.session_timer.refresher=
 account.4.session_timer.expires=
 account.4.session_timer.enable= {$yealink_session_timer}
 
-account.4.conf_type = {if $nway_conference == true}2{/if} 
+account.4.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if} 
 account.4.sip_server_type=
 
 ##V83 Add
@@ -2220,7 +2220,7 @@ account.4.call_recording.enable=
 #######################################################################################
 ##                                Network Conference                                  ##
 #######################################################################################
-account.4.conf_uri = {if $nway_conference == true}nway{$account.4.user_id}@{$account.4.server_address}{/if}
+account.4.conf_uri = {if $nway_conference == 'true'}nway{$account.4.user_id}@{$account.4.server_address}{/if}
 
 
 #######################################################################################

--- a/resources/templates/provision/yealink/t38g/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t38g/{$mac}.cfg
@@ -177,10 +177,10 @@ account.1.register_line =
 account.1.reg_fail_retry_interval =
 
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.1.conf_type = {if $nway_conference == true}2{/if}
+account.1.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.1.conf_uri = {if $nway_conference == true}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
+account.1.conf_uri = {if $nway_conference == 'true'}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
 
 #Configure the BLF list URI (a SIP URI, or use part of the SIP URI). For example, "2300_blflist@domain.com" or "2300_blflist".
 account.1.blf.blf_list_uri =
@@ -522,10 +522,10 @@ account.2.register_line =
 account.2.reg_fail_retry_interval =
 
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.2.conf_type = {if $nway_conference == true}2{/if}
+account.2.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.2.conf_uri = {if $nway_conference == true}nway{$account.2.user_id}@{$account.2.server_address}{/if}
+account.2.conf_uri = {if $nway_conference == 'true'}nway{$account.2.user_id}@{$account.2.server_address}{/if}
 
 #Configure the BLF list URI (a SIP URI, or use part of the SIP URI). For example, "2300_blflist@domain.com" or "2300_blflist".
 account.2.blf.blf_list_uri =
@@ -839,10 +839,10 @@ account.3.register_line =
 account.3.reg_fail_retry_interval =
 
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.3.conf_type = {if $nway_conference == true}2{/if}
+account.3.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.3.conf_uri = {if $nway_conference == true}nway{$account.3.user_id}@{$account.3.server_address}{/if}
+account.3.conf_uri = {if $nway_conference == 'true'}nway{$account.3.user_id}@{$account.3.server_address}{/if}
 
 #Configure the BLF list URI (a SIP URI, or use part of the SIP URI). For example, "2300_blflist@domain.com" or "2300_blflist".
 account.3.blf.blf_list_uri =
@@ -1156,10 +1156,10 @@ account.4.register_line =
 account.4.reg_fail_retry_interval =
 
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.4.conf_type = {if $nway_conference == true}2{/if}
+account.4.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.4.conf_uri = {if $nway_conference == true}nway{$account.4.user_id}@{$account.4.server_address}{/if}
+account.4.conf_uri = {if $nway_conference == 'true'}nway{$account.4.user_id}@{$account.4.server_address}{/if}
 
 #Configure the BLF list URI (a SIP URI, or use part of the SIP URI). For example, "2300_blflist@domain.com" or "2300_blflist".
 account.4.blf.blf_list_uri =
@@ -1474,10 +1474,10 @@ account.5.register_line =
 account.5.reg_fail_retry_interval =
 
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.5.conf_type = {if $nway_conference == true}2{/if}
+account.5.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.5.conf_uri = {if $nway_conference == true}nway{$account.5.user_id}@{$account.5.server_address}{/if}
+account.5.conf_uri = {if $nway_conference == 'true'}nway{$account.5.user_id}@{$account.5.server_address}{/if}
 
 #Configure the BLF list URI (a SIP URI, or use part of the SIP URI). For example, "2300_blflist@domain.com" or "2300_blflist".
 account.5.blf.blf_list_uri =
@@ -1789,10 +1789,10 @@ account.6.register_line =
 account.6.reg_fail_retry_interval =
 
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.6.conf_type = {if $nway_conference == true}2{/if}
+account.6.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.6.conf_uri = {if $nway_conference == true}nway{$account.6.user_id}@{$account.6.server_address}{/if}
+account.6.conf_uri = {if $nway_conference == 'true'}nway{$account.6.user_id}@{$account.6.server_address}{/if}
 
 #Configure the BLF list URI (a SIP URI, or use part of the SIP URI). For example, "2300_blflist@domain.com" or "2300_blflist".
 account.6.blf.blf_list_uri =

--- a/resources/templates/provision/yealink/t40g/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t40g/{$mac}.cfg
@@ -395,10 +395,10 @@ account.1.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.1.conf_type = {if $nway_conference == true}2{/if}
+account.1.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.1.conf_uri = {if $nway_conference == true}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
+account.1.conf_uri = {if $nway_conference == 'true'}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
 
 #######################################################################################
 ##                            cid_source                                             ##
@@ -867,10 +867,10 @@ account.2.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.2.conf_type = {if $nway_conference == true}2{/if}
+account.2.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.2.conf_uri = {if $nway_conference == true}nway{$account.2.user_id}@{$account.2.server_address}{/if}
+account.2.conf_uri = {if $nway_conference == 'true'}nway{$account.2.user_id}@{$account.2.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -1383,10 +1383,10 @@ account.3.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.3.conf_type = {if $nway_conference == true}2{/if}
+account.3.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.3.conf_uri = {if $nway_conference == true}nway{$account.3.user_id}@{$account.3.server_address}{/if}
+account.3.conf_uri = {if $nway_conference == 'true'}nway{$account.3.user_id}@{$account.3.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -1882,10 +1882,10 @@ account.4.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.4.conf_type = {if $nway_conference == true}2{/if}
+account.4.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.4.conf_uri = {if $nway_conference == true}nway{$account.4.user_id}@{$account.4.server_address}{/if}
+account.4.conf_uri = {if $nway_conference == 'true'}nway{$account.4.user_id}@{$account.4.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -2381,10 +2381,10 @@ account.5.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.5.conf_type = {if $nway_conference == true}2{/if}
+account.5.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.5.conf_uri = {if $nway_conference == true}nway{$account.5.user_id}@{$account.5.server_address}{/if}
+account.5.conf_uri = {if $nway_conference == 'true'}nway{$account.5.user_id}@{$account.5.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -2879,10 +2879,10 @@ account.6.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.6.conf_type = {if $nway_conference == true}2{/if}
+account.6.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.6.conf_uri = {if $nway_conference == true}nway{$account.6.user_id}@{$account.6.server_address}{/if}
+account.6.conf_uri = {if $nway_conference == 'true'}nway{$account.6.user_id}@{$account.6.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##

--- a/resources/templates/provision/yealink/t40p/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t40p/{$mac}.cfg
@@ -387,10 +387,10 @@ account.1.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.1.conf_type = {if $nway_conference == true}2{/if}
+account.1.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.1.conf_uri = {if $nway_conference == true}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
+account.1.conf_uri = {if $nway_conference == 'true'}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
 
 #######################################################################################
 ##                            cid_source                                             ##
@@ -867,10 +867,10 @@ account.2.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.2.conf_type = {if $nway_conference == true}2{/if}
+account.2.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.2.conf_uri = {if $nway_conference == true}nway{$account.2.user_id}@{$account.2.server_address}{/if}
+account.2.conf_uri = {if $nway_conference == 'true'}nway{$account.2.user_id}@{$account.2.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -1385,10 +1385,10 @@ account.3.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.3.conf_type = {if $nway_conference == true}2{/if}
+account.3.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.3.conf_uri = {if $nway_conference == true}nway{$account.3.user_id}@{$account.3.server_address}{/if}
+account.3.conf_uri = {if $nway_conference == 'true'}nway{$account.3.user_id}@{$account.3.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -1886,10 +1886,10 @@ account.4.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.4.conf_type = {if $nway_conference == true}2{/if}
+account.4.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.4.conf_uri = {if $nway_conference == true}nway{$account.4.user_id}@{$account.4.server_address}{/if}
+account.4.conf_uri = {if $nway_conference == 'true'}nway{$account.4.user_id}@{$account.4.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -2387,10 +2387,10 @@ account.5.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.5.conf_type = {if $nway_conference == true}2{/if}
+account.5.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.5.conf_uri = {if $nway_conference == true}nway{$account.5.user_id}@{$account.5.server_address}{/if}
+account.5.conf_uri = {if $nway_conference == 'true'}nway{$account.5.user_id}@{$account.5.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -2887,10 +2887,10 @@ account.6.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.6.conf_type = {if $nway_conference == true}2{/if}
+account.6.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.6.conf_uri = {if $nway_conference == true}nway{$account.6.user_id}@{$account.6.server_address}{/if}
+account.6.conf_uri = {if $nway_conference == 'true'}nway{$account.6.user_id}@{$account.6.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##

--- a/resources/templates/provision/yealink/t41p/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t41p/{$mac}.cfg
@@ -381,10 +381,10 @@ account.1.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.1.conf_type = {if $nway_conference == true}2{/if}
+account.1.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.1.conf_uri = {if $nway_conference == true}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
+account.1.conf_uri = {if $nway_conference == 'true'}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
 
 #######################################################################################
 ##                            cid_source                                             ##
@@ -850,10 +850,10 @@ account.2.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.2.conf_type = {if $nway_conference == true}2{/if}
+account.2.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.2.conf_uri = {if $nway_conference == true}nway{$account.2.user_id}@{$account.2.server_address}{/if}
+account.2.conf_uri = {if $nway_conference == 'true'}nway{$account.2.user_id}@{$account.2.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -1363,10 +1363,10 @@ account.3.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.3.conf_type = {if $nway_conference == true}2{/if}
+account.3.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.3.conf_uri = {if $nway_conference == true}nway{$account.3.user_id}@{$account.3.server_address}{/if}
+account.3.conf_uri = {if $nway_conference == 'true'}nway{$account.3.user_id}@{$account.3.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -1859,10 +1859,10 @@ account.4.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.4.conf_type = {if $nway_conference == true}2{/if}
+account.4.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.4.conf_uri = {if $nway_conference == true}nway{$account.4.user_id}@{$account.4.server_address}{/if}
+account.4.conf_uri = {if $nway_conference == 'true'}nway{$account.4.user_id}@{$account.4.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -2355,10 +2355,10 @@ account.5.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.5.conf_type = {if $nway_conference == true}2{/if}
+account.5.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.5.conf_uri = {if $nway_conference == true}nway{$account.5.user_id}@{$account.5.server_address}{/if}
+account.5.conf_uri = {if $nway_conference == 'true'}nway{$account.5.user_id}@{$account.5.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -2850,10 +2850,10 @@ account.6.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.6.conf_type = {if $nway_conference == true}2{/if}
+account.6.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.6.conf_uri = {if $nway_conference == true}nway{$account.6.user_id}@{$account.6.server_address}{/if}
+account.6.conf_uri = {if $nway_conference == 'true'}nway{$account.6.user_id}@{$account.6.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##

--- a/resources/templates/provision/yealink/t41s/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t41s/{$mac}.cfg
@@ -395,10 +395,10 @@ account.{$row.line_number}.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.{$row.line_number}.conf_type = {if $nway_conference == true}2{/if}
+account.{$row.line_number}.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.{$row.line_number}.conf_uri = {if $nway_conference == true}nway{$account.{$row.line_number}.auth_id}@{$account.{$row.line_number}.server_address}{/if}
+account.{$row.line_number}.conf_uri = {if $nway_conference == 'true'}nway{$account.{$row.line_number}.auth_id}@{$account.{$row.line_number}.server_address}{/if}
 
 
 #######################################################################################

--- a/resources/templates/provision/yealink/t42g/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t42g/{$mac}.cfg
@@ -395,10 +395,10 @@ account.1.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.1.conf_type = {if $nway_conference == true}2{/if}
+account.1.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.1.conf_uri = {if $nway_conference == true}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
+account.1.conf_uri = {if $nway_conference == 'true'}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
 
 #######################################################################################
 ##                            cid_source                                             ##
@@ -867,10 +867,10 @@ account.2.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.2.conf_type = {if $nway_conference == true}2{/if}
+account.2.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.2.conf_uri = {if $nway_conference == true}nway{$account.2.user_id}@{$account.2.server_address}{/if}
+account.2.conf_uri = {if $nway_conference == 'true'}nway{$account.2.user_id}@{$account.2.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -1353,10 +1353,10 @@ account.3.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.3.conf_type = {if $nway_conference == true}2{/if}
+account.3.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.3.conf_uri = {if $nway_conference == true}nway{$account.3.user_id}@{$account.3.server_address}{/if}
+account.3.conf_uri = {if $nway_conference == 'true'}nway{$account.3.user_id}@{$account.3.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -1829,10 +1829,10 @@ account.4.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.4.conf_type = {if $nway_conference == true}2{/if}
+account.4.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.4.conf_uri = {if $nway_conference == true}nway{$account.4.user_id}@{$account.4.server_address}{/if}
+account.4.conf_uri = {if $nway_conference == 'true'}nway{$account.4.user_id}@{$account.4.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -2305,10 +2305,10 @@ account.5.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.5.conf_type = {if $nway_conference == true}2{/if}
+account.5.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.5.conf_uri = {if $nway_conference == true}nway{$account.5.user_id}@{$account.5.server_address}{/if}
+account.5.conf_uri = {if $nway_conference == 'true'}nway{$account.5.user_id}@{$account.5.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -2780,10 +2780,10 @@ account.6.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.6.conf_type = {if $nway_conference == true}2{/if}
+account.6.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.6.conf_uri = {if $nway_conference == true}nway{$account.6.user_id}@{$account.6.server_address}{/if}
+account.6.conf_uri = {if $nway_conference == 'true'}nway{$account.6.user_id}@{$account.6.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##

--- a/resources/templates/provision/yealink/t42s/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t42s/{$mac}.cfg
@@ -394,10 +394,10 @@ account.1.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.1.conf_type = {if $nway_conference == true}2{/if}
+account.1.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.1.conf_uri = {if $nway_conference == true}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
+account.1.conf_uri = {if $nway_conference == 'true'}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
 
 #######################################################################################
 ##                            cid_source                                             ##
@@ -870,10 +870,10 @@ account.2.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.2.conf_type = {if $nway_conference == true}2{/if}
+account.2.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.2.conf_uri = {if $nway_conference == true}nway{$account.2.user_id}@{$account.2.server_address}{/if}
+account.2.conf_uri = {if $nway_conference == 'true'}nway{$account.2.user_id}@{$account.2.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -1358,10 +1358,10 @@ account.3.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.3.conf_type = {if $nway_conference == true}2{/if}
+account.3.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.3.conf_uri = {if $nway_conference == true}nway{$account.3.user_id}@{$account.3.server_address}{/if}
+account.3.conf_uri = {if $nway_conference == 'true'}nway{$account.3.user_id}@{$account.3.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -1829,10 +1829,10 @@ account.4.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.4.conf_type = {if $nway_conference == true}2{/if}
+account.4.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.4.conf_uri = {if $nway_conference == true}nway{$account.4.user_id}@{$account.4.server_address}{/if}
+account.4.conf_uri = {if $nway_conference == 'true'}nway{$account.4.user_id}@{$account.4.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -2300,10 +2300,10 @@ account.5.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.5.conf_type = {if $nway_conference == true}2{/if}
+account.5.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.5.conf_uri = {if $nway_conference == true}nway{$account.5.user_id}@{$account.5.server_address}{/if}
+account.5.conf_uri = {if $nway_conference == 'true'}nway{$account.5.user_id}@{$account.5.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -2770,10 +2770,10 @@ account.6.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.6.conf_type = {if $nway_conference == true}2{/if}
+account.6.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.6.conf_uri = {if $nway_conference == true}nway{$account.6.user_id}@{$account.6.server_address}{/if}
+account.6.conf_uri = {if $nway_conference == 'true'}nway{$account.6.user_id}@{$account.6.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##

--- a/resources/templates/provision/yealink/t43u/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t43u/{$mac}.cfg
@@ -206,7 +206,7 @@ account.1.session_timer.refresher=
 account.1.session_timer.expires=
 account.1.session_timer.enable= {$yealink_session_timer}
 
-account.1.conf_type = {if $nway_conference == true}2{/if}
+account.1.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 account.1.sip_server_type=
 
 ##V83 Add
@@ -509,7 +509,7 @@ account.1.call_recording.enable=
 #######################################################################################
 ##                                Network Conference                                  ##
 #######################################################################################
-account.1.conf_uri = {if $nway_conference == true}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
+account.1.conf_uri = {if $nway_conference == 'true'}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
 
 
 #######################################################################################
@@ -774,7 +774,7 @@ account.2.session_timer.refresher=
 account.2.session_timer.expires=
 account.2.session_timer.enable= {$yealink_session_timer}
 
-account.2.conf_type = {if $nway_conference == true}2{/if}
+account.2.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 account.2.sip_server_type=
 
 ##V83 Add
@@ -1077,7 +1077,7 @@ account.2.call_recording.enable=
 #######################################################################################
 ##                                Network Conference                                  ##
 #######################################################################################
-account.2.conf_uri = {if $nway_conference == true}nway{$account.2.user_id}@{$account.2.server_address}{/if}
+account.2.conf_uri = {if $nway_conference == 'true'}nway{$account.2.user_id}@{$account.2.server_address}{/if}
 
 
 #######################################################################################
@@ -1342,7 +1342,7 @@ account.3.session_timer.refresher=
 account.3.session_timer.expires=
 account.3.session_timer.enable= {$yealink_session_timer}
 
-account.3.conf_type = {if $nway_conference == true}2{/if}
+account.3.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 account.3.sip_server_type=
 
 ##V83 Add
@@ -1645,7 +1645,7 @@ account.3.call_recording.enable=
 #######################################################################################
 ##                                Network Conference                                  ##
 #######################################################################################
-account.3.conf_uri = {if $nway_conference == true}nway{$account.3.user_id}@{$account.3.server_address}{/if}
+account.3.conf_uri = {if $nway_conference == 'true'}nway{$account.3.user_id}@{$account.3.server_address}{/if}
 
 
 #######################################################################################
@@ -1910,7 +1910,7 @@ account.4.session_timer.refresher=
 account.4.session_timer.expires=
 account.4.session_timer.enable= {$yealink_session_timer}
 
-account.4.conf_type = {if $nway_conference == true}2{/if} 
+account.4.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if} 
 account.4.sip_server_type=
 
 ##V83 Add
@@ -2213,7 +2213,7 @@ account.4.call_recording.enable=
 #######################################################################################
 ##                                Network Conference                                  ##
 #######################################################################################
-account.4.conf_uri = {if $nway_conference == true}nway{$account.4.user_id}@{$account.4.server_address}{/if}
+account.4.conf_uri = {if $nway_conference == 'true'}nway{$account.4.user_id}@{$account.4.server_address}{/if}
 
 
 #######################################################################################
@@ -2478,7 +2478,7 @@ account.5.session_timer.refresher=
 account.5.session_timer.expires=
 account.5.session_timer.enable= {$yealink_session_timer}
 
-account.5.conf_type = {if $nway_conference == true}2{/if}
+account.5.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 account.5.sip_server_type=
 
 ##V83 Add
@@ -2781,7 +2781,7 @@ account.5.call_recording.enable=
 #######################################################################################
 ##                                Network Conference                                  ##
 #######################################################################################
-account.5.conf_uri = {if $nway_conference == true}nway{$account.5.user_id}@{$account.5.server_address}{/if}
+account.5.conf_uri = {if $nway_conference == 'true'}nway{$account.5.user_id}@{$account.5.server_address}{/if}
 
 
 #######################################################################################
@@ -3046,7 +3046,7 @@ account.6.session_timer.refresher=
 account.6.session_timer.expires=
 account.6.session_timer.enable= {$yealink_session_timer}
 
-account.6.conf_type = {if $nway_conference == true}2{/if}
+account.6.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 account.6.sip_server_type=
 
 ##V83 Add
@@ -3349,7 +3349,7 @@ account.6.call_recording.enable=
 #######################################################################################
 ##                                Network Conference                                  ##
 #######################################################################################
-account.6.conf_uri = {if $nway_conference == true}nway{$account.6.user_id}@{$account.6.server_address}{/if}
+account.6.conf_uri = {if $nway_conference == 'true'}nway{$account.6.user_id}@{$account.6.server_address}{/if}
 
 
 #######################################################################################

--- a/resources/templates/provision/yealink/t46g/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t46g/{$mac}.cfg
@@ -396,10 +396,10 @@ account.1.picture_info_enable = 1
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
 
-account.1.conf_type = {if $nway_conference == true}2{/if}
+account.1.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.1.conf_uri = {if $nway_conference == true}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
+account.1.conf_uri = {if $nway_conference == 'true'}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
 
 #######################################################################################
 ##                            cid_source                                             ##
@@ -868,10 +868,10 @@ account.2.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.2.conf_type = {if $nway_conference == true}2{/if}
+account.2.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.2.conf_uri = {if $nway_conference == true}nway{$account.2.user_id}@{$account.2.server_address}{/if}
+account.2.conf_uri = {if $nway_conference == 'true'}nway{$account.2.user_id}@{$account.2.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -1354,10 +1354,10 @@ account.3.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.3.conf_type = {if $nway_conference == true}2{/if}
+account.3.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.3.conf_uri = {if $nway_conference == true}nway{$account.3.user_id}@{$account.3.server_address}{/if}
+account.3.conf_uri = {if $nway_conference == 'true'}nway{$account.3.user_id}@{$account.3.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -1830,10 +1830,10 @@ account.4.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.4.conf_type = {if $nway_conference == true}2{/if}
+account.4.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.4.conf_uri = {if $nway_conference == true}nway{$account.4.user_id}@{$account.4.server_address}{/if}
+account.4.conf_uri = {if $nway_conference == 'true'}nway{$account.4.user_id}@{$account.4.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -2306,10 +2306,10 @@ account.5.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.5.conf_type = {if $nway_conference == true}2{/if}
+account.5.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.5.conf_uri = {if $nway_conference == true}nway{$account.5.user_id}@{$account.5.server_address}{/if}
+account.5.conf_uri = {if $nway_conference == 'true'}nway{$account.5.user_id}@{$account.5.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -2781,10 +2781,10 @@ account.6.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.6.conf_type = {if $nway_conference == true}2{/if}
+account.6.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.6.conf_uri = {if $nway_conference == true}nway{$account.6.user_id}@{$account.6.server_address}{/if}
+account.6.conf_uri = {if $nway_conference == 'true'}nway{$account.6.user_id}@{$account.6.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##

--- a/resources/templates/provision/yealink/t46s/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t46s/{$mac}.cfg
@@ -394,10 +394,10 @@ account.1.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.1.conf_type = {if $nway_conference == true}2{/if}
+account.1.conf_type = {if isset($nway_conference)}{$nway_conference}{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.1.conf_uri = {if $nway_conference == true}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
+account.1.conf_uri = {if $nway_conference == 'true'}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
 
 #######################################################################################
 ##                            cid_source                                             ##
@@ -870,10 +870,10 @@ account.2.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.2.conf_type = {if $nway_conference == true}2{/if}
+account.2.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.2.conf_uri = {if $nway_conference == true}nway{$account.2.user_id}@{$account.2.server_address}{/if}
+account.2.conf_uri = {if $nway_conference == 'true'}nway{$account.2.user_id}@{$account.2.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -1361,10 +1361,10 @@ account.3.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.3.conf_type = {if $nway_conference == true}2{/if}
+account.3.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.3.conf_uri = {if $nway_conference == true}nway{$account.3.user_id}@{$account.3.server_address}{/if}
+account.3.conf_uri = {if $nway_conference == 'true'}nway{$account.3.user_id}@{$account.3.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -1837,10 +1837,10 @@ account.4.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.4.conf_type = {if $nway_conference == true}2{/if}
+account.4.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.4.conf_uri = {if $nway_conference == true}nway{$account.4.user_id}@{$account.4.server_address}{/if}
+account.4.conf_uri = {if $nway_conference == 'true'}nway{$account.4.user_id}@{$account.4.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -2313,10 +2313,10 @@ account.5.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.5.conf_type = {if $nway_conference == true}2{/if}
+account.5.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.5.conf_uri = {if $nway_conference == true}nway{$account.5.user_id}@{$account.5.server_address}{/if}
+account.5.conf_uri = {if $nway_conference == 'true'}nway{$account.5.user_id}@{$account.5.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -2788,10 +2788,10 @@ account.6.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.6.conf_type = {if $nway_conference == true}2{/if}
+account.6.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.6.conf_uri = {if $nway_conference == true}nway{$account.6.user_id}@{$account.6.server_address}{/if}
+account.6.conf_uri = {if $nway_conference == 'true'}nway{$account.6.user_id}@{$account.6.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##

--- a/resources/templates/provision/yealink/t46u/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t46u/{$mac}.cfg
@@ -206,7 +206,7 @@ account.1.session_timer.refresher=
 account.1.session_timer.expires=
 account.1.session_timer.enable= {$yealink_session_timer}
 
-account.1.conf_type = {if $nway_conference == true}2{/if}
+account.1.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 account.1.sip_server_type=
 
 ##V83 Add
@@ -509,7 +509,7 @@ account.1.call_recording.enable=
 #######################################################################################
 ##                                Network Conference                                  ##
 #######################################################################################
-account.1.conf_uri = {if $nway_conference == true}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
+account.1.conf_uri = {if $nway_conference == 'true'}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
 
 
 #######################################################################################
@@ -769,7 +769,7 @@ account.2.session_timer.refresher=
 account.2.session_timer.expires=
 account.2.session_timer.enable= {$yealink_session_timer}
 
-account.2.conf_type = {if $nway_conference == true}2{/if}
+account.2.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 account.2.sip_server_type=
 
 ##V83 Add
@@ -1072,7 +1072,7 @@ account.2.call_recording.enable=
 #######################################################################################
 ##                                Network Conference                                  ##
 #######################################################################################
-account.2.conf_uri = {if $nway_conference == true}nway{$account.2.user_id}@{$account.2.server_address}{/if}
+account.2.conf_uri = {if $nway_conference == 'true'}nway{$account.2.user_id}@{$account.2.server_address}{/if}
 
 
 #######################################################################################
@@ -1332,7 +1332,7 @@ account.3.session_timer.refresher=
 account.3.session_timer.expires=
 account.3.session_timer.enable= {$yealink_session_timer}
 
-account.3.conf_type = {if $nway_conference == true}2{/if}
+account.3.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 account.3.sip_server_type=
 
 ##V83 Add
@@ -1635,7 +1635,7 @@ account.3.call_recording.enable=
 #######################################################################################
 ##                                Network Conference                                  ##
 #######################################################################################
-account.3.conf_uri = {if $nway_conference == true}nway{$account.3.user_id}@{$account.3.server_address}{/if}
+account.3.conf_uri = {if $nway_conference == 'true'}nway{$account.3.user_id}@{$account.3.server_address}{/if}
 
 
 #######################################################################################
@@ -1895,7 +1895,7 @@ account.4.session_timer.refresher=
 account.4.session_timer.expires=
 account.4.session_timer.enable= {$yealink_session_timer}
 
-account.4.conf_type = {if $nway_conference == true}2{/if} 
+account.4.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if} 
 account.4.sip_server_type=
 
 ##V83 Add
@@ -2198,7 +2198,7 @@ account.4.call_recording.enable=
 #######################################################################################
 ##                                Network Conference                                  ##
 #######################################################################################
-account.4.conf_uri = {if $nway_conference == true}nway{$account.4.user_id}@{$account.4.server_address}{/if}
+account.4.conf_uri = {if $nway_conference == 'true'}nway{$account.4.user_id}@{$account.4.server_address}{/if}
 
 
 #######################################################################################
@@ -2458,7 +2458,7 @@ account.5.session_timer.refresher=
 account.5.session_timer.expires=
 account.5.session_timer.enable= {$yealink_session_timer}
 
-account.5.conf_type = {if $nway_conference == true}2{/if}
+account.5.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 account.5.sip_server_type=
 
 ##V83 Add
@@ -2761,7 +2761,7 @@ account.5.call_recording.enable=
 #######################################################################################
 ##                                Network Conference                                  ##
 #######################################################################################
-account.5.conf_uri = {if $nway_conference == true}nway{$account.5.user_id}@{$account.5.server_address}{/if}
+account.5.conf_uri = {if $nway_conference == 'true'}nway{$account.5.user_id}@{$account.5.server_address}{/if}
 
 
 #######################################################################################
@@ -3021,7 +3021,7 @@ account.6.session_timer.refresher=
 account.6.session_timer.expires=
 account.6.session_timer.enable= {$yealink_session_timer}
 
-account.6.conf_type = {if $nway_conference == true}2{/if}
+account.6.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 account.6.sip_server_type=
 
 ##V83 Add
@@ -3324,7 +3324,7 @@ account.6.call_recording.enable=
 #######################################################################################
 ##                                Network Conference                                  ##
 #######################################################################################
-account.6.conf_uri = {if $nway_conference == true}nway{$account.6.user_id}@{$account.6.server_address}{/if}
+account.6.conf_uri = {if $nway_conference == 'true'}nway{$account.6.user_id}@{$account.6.server_address}{/if}
 
 
 #######################################################################################

--- a/resources/templates/provision/yealink/t48g/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t48g/{$mac}.cfg
@@ -395,10 +395,10 @@ account.1.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.1.conf_type = {if $nway_conference == true}2{/if}
+account.1.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.1.conf_uri = {if $nway_conference == true}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
+account.1.conf_uri = {if $nway_conference == 'true'}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
 
 #######################################################################################
 ##                            cid_source                                             ##
@@ -867,10 +867,10 @@ account.2.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.2.conf_type = {if $nway_conference == true}2{/if}
+account.2.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.2.conf_uri = {if $nway_conference == true}nway{$account.2.user_id}@{$account.2.server_address}{/if}
+account.2.conf_uri = {if $nway_conference == 'true'}nway{$account.2.user_id}@{$account.2.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -1353,10 +1353,10 @@ account.3.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.3.conf_type = {if $nway_conference == true}2{/if}
+account.3.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.3.conf_uri = {if $nway_conference == true}nway{$account.3.user_id}@{$account.3.server_address}{/if}
+account.3.conf_uri = {if $nway_conference == 'true'}nway{$account.3.user_id}@{$account.3.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -1829,10 +1829,10 @@ account.4.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.4.conf_type = {if $nway_conference == true}2{/if}
+account.4.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.4.conf_uri = {if $nway_conference == true}nway{$account.4.user_id}@{$account.4.server_address}{/if}
+account.4.conf_uri = {if $nway_conference == 'true'}nway{$account.4.user_id}@{$account.4.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -2305,10 +2305,10 @@ account.5.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.5.conf_type = {if $nway_conference == true}2{/if}
+account.5.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.5.conf_uri = {if $nway_conference == true}nway{$account.5.user_id}@{$account.5.server_address}{/if}
+account.5.conf_uri = {if $nway_conference == 'true'}nway{$account.5.user_id}@{$account.5.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -2780,10 +2780,10 @@ account.6.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.6.conf_type = {if $nway_conference == true}2{/if}
+account.6.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.6.conf_uri = {if $nway_conference == true}nway{$account.6.user_id}@{$account.6.server_address}{/if}
+account.6.conf_uri = {if $nway_conference == 'true'}nway{$account.6.user_id}@{$account.6.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##

--- a/resources/templates/provision/yealink/t48s/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t48s/{$mac}.cfg
@@ -394,10 +394,10 @@ account.1.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.1.conf_type = {if $nway_conference == true}2{/if}
+account.1.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.1.conf_uri = {if $nway_conference == true}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
+account.1.conf_uri = {if $nway_conference == 'true'}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
 
 #######################################################################################
 ##                            cid_source                                             ##
@@ -870,10 +870,10 @@ account.2.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.2.conf_type = {if $nway_conference == true}2{/if}
+account.2.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.2.conf_uri = {if $nway_conference == true}nway{$account.2.user_id}@{$account.2.server_address}{/if}
+account.2.conf_uri = {if $nway_conference == 'true'}nway{$account.2.user_id}@{$account.2.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -1357,10 +1357,10 @@ account.3.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.3.conf_type = {if $nway_conference == true}2{/if}
+account.3.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.3.conf_uri = {if $nway_conference == true}nway{$account.3.user_id}@{$account.3.server_address}{/if}
+account.3.conf_uri = {if $nway_conference == 'true'}nway{$account.3.user_id}@{$account.3.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -1829,10 +1829,10 @@ account.4.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.4.conf_type = {if $nway_conference == true}2{/if}
+account.4.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.4.conf_uri = {if $nway_conference == true}nway{$account.4.user_id}@{$account.4.server_address}{/if}
+account.4.conf_uri = {if $nway_conference == 'true'}nway{$account.4.user_id}@{$account.4.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -2301,10 +2301,10 @@ account.5.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.5.conf_type = {if $nway_conference == true}2{/if}
+account.5.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.5.conf_uri = {if $nway_conference == true}nway{$account.5.user_id}@{$account.5.server_address}{/if}
+account.5.conf_uri = {if $nway_conference == 'true'}nway{$account.5.user_id}@{$account.5.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -2772,10 +2772,10 @@ account.6.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.6.conf_type = {if $nway_conference == true}2{/if}
+account.6.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.6.conf_uri = {if $nway_conference == true}nway{$account.6.user_id}@{$account.6.server_address}{/if}
+account.6.conf_uri = {if $nway_conference == 'true'}nway{$account.6.user_id}@{$account.6.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##

--- a/resources/templates/provision/yealink/t49g/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t49g/{$mac}.cfg
@@ -395,10 +395,10 @@ account.1.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.1.conf_type = {if $nway_conference == true}2{/if}
+account.1.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.1.conf_uri = {if $nway_conference == true}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
+account.1.conf_uri = {if $nway_conference == 'true'}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
 
 #######################################################################################
 ##                            cid_source                                             ##
@@ -867,10 +867,10 @@ account.2.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.2.conf_type = {if $nway_conference == true}2{/if}
+account.2.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.2.conf_uri = {if $nway_conference == true}nway{$account.2.user_id}@{$account.2.server_address}{/if}
+account.2.conf_uri = {if $nway_conference == 'true'}nway{$account.2.user_id}@{$account.2.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -1392,10 +1392,10 @@ account.3.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.3.conf_type = {if $nway_conference == true}2{/if}
+account.3.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.3.conf_uri = {if $nway_conference == true}nway{$account.3.user_id}@{$account.3.server_address}{/if}
+account.3.conf_uri = {if $nway_conference == 'true'}nway{$account.3.user_id}@{$account.3.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -1891,10 +1891,10 @@ account.4.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.4.conf_type = {if $nway_conference == true}2{/if}
+account.4.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.4.conf_uri = {if $nway_conference == true}nway{$account.4.user_id}@{$account.4.server_address}{/if}
+account.4.conf_uri = {if $nway_conference == 'true'}nway{$account.4.user_id}@{$account.4.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -2390,10 +2390,10 @@ account.5.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.5.conf_type = {if $nway_conference == true}2{/if}
+account.5.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.5.conf_uri = {if $nway_conference == true}nway{$account.5.user_id}@{$account.5.server_address}{/if}
+account.5.conf_uri = {if $nway_conference == 'true'}nway{$account.5.user_id}@{$account.5.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -2888,10 +2888,10 @@ account.6.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.6.conf_type = {if $nway_conference == true}2{/if}
+account.6.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.6.conf_uri = {if $nway_conference == true}nway{$account.6.user_id}@{$account.6.server_address}{/if}
+account.6.conf_uri = {if $nway_conference == 'true'}nway{$account.6.user_id}@{$account.6.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##

--- a/resources/templates/provision/yealink/t4x/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t4x/{$mac}.cfg
@@ -347,10 +347,10 @@ account.{$row.line_number}.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type 0-Local (default), 2-Network Conference
-account.{$row.line_number}.conf_type = {if $nway_conference == true}2{/if}
+account.{$row.line_number}.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.{$row.line_number}.conf_uri = {if $nway_conference == true}nway{$account.{$row.line_number}.user_id}@{$account.{$row.line_number}.server_address}{/if}
+account.{$row.line_number}.conf_uri = {if $nway_conference == 'true'}nway{$account.{$row.line_number}.user_id}@{$account.{$row.line_number}.server_address}{/if}
 
 #######################################################################################
 ##                            cid_source                                             ##

--- a/resources/templates/provision/yealink/t52s/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t52s/{$mac}.cfg
@@ -361,7 +361,7 @@ account.1.session_timer.refresher=
 account.1.session_timer.expires=
 account.1.session_timer.enable= {$yealink_session_timer}
 
-account.1.conf_type = {if $nway_conference == true}2{/if}
+account.1.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 account.1.sip_server_type=
 
 account.2.nat.udp_update_enable= 3
@@ -387,8 +387,8 @@ account.2.session_timer.refresher=
 account.2.session_timer.expires=
 account.2.session_timer.enable= {$yealink_session_timer}
 
-account.2.conf_type = {if $nway_conference == true}2{/if}
-account.2.conf_uri = {if $nway_conference == true}nway{$account.2.user_id}@{$account.2.server_address}{/if}
+account.2.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
+account.2.conf_uri = {if $nway_conference == 'true'}nway{$account.2.user_id}@{$account.2.server_address}{/if}
 account.2.sip_server_type=
 
 
@@ -669,7 +669,7 @@ account.1.refresh_remote_id.enable =
 #######################################################################################
 ##                                Network Conferene                                  ##       
 #######################################################################################
-account.1.conf_uri = {if $nway_conference == true}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
+account.1.conf_uri = {if $nway_conference == 'true'}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
 
 
 #######################################################################################

--- a/resources/templates/provision/yealink/t53/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t53/{$mac}.cfg
@@ -205,7 +205,7 @@ account.1.session_timer.refresher=
 account.1.session_timer.expires=
 account.1.session_timer.enable= {$yealink_session_timer}
 
-account.1.conf_type = {if $nway_conference == true}2{/if}
+account.1.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 account.1.sip_server_type=
 
 ##V83 Add
@@ -499,7 +499,7 @@ account.1.call_recording.enable=
 #######################################################################################
 ##                                Network Conferene                                  ##       
 #######################################################################################
-account.1.conf_uri = {if $nway_conference == true}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
+account.1.conf_uri = {if $nway_conference == 'true'}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
 
 
 #######################################################################################
@@ -744,7 +744,7 @@ account.2.session_timer.refresher=
 account.2.session_timer.expires=
 account.2.session_timer.enable= {$yealink_session_timer}
 
-account.2.conf_type = {if $nway_conference == true}2{/if}
+account.2.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 account.2.sip_server_type=
 
 ##V83 Add
@@ -1038,7 +1038,7 @@ account.2.call_recording.enable=
 #######################################################################################
 ##                                Network Conferene                                  ##       
 #######################################################################################
-account.2.conf_uri = {if $nway_conference == true}nway{$account.2.user_id}@{$account.2.server_address}{/if}
+account.2.conf_uri = {if $nway_conference == 'true'}nway{$account.2.user_id}@{$account.2.server_address}{/if}
 
 
 #######################################################################################
@@ -1271,7 +1271,7 @@ account.3.session_timer.refresher=
 account.3.session_timer.expires=
 account.3.session_timer.enable= {$yealink_session_timer}
 
-account.3.conf_type = {if $nway_conference == true}2{/if}
+account.3.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 account.3.sip_server_type=
 
 ##V83 Add
@@ -1565,7 +1565,7 @@ account.3.call_recording.enable=
 #######################################################################################
 ##                                Network Conferene                                  ##       
 #######################################################################################
-account.3.conf_uri = {if $nway_conference == true}nway{$account.3.user_id}@{$account.3.server_address}{/if}
+account.3.conf_uri = {if $nway_conference == 'true'}nway{$account.3.user_id}@{$account.3.server_address}{/if}
 
 
 #######################################################################################
@@ -1798,7 +1798,7 @@ account.4.session_timer.refresher=
 account.4.session_timer.expires=
 account.4.session_timer.enable= {$yealink_session_timer}
 
-account.4.conf_type = {if $nway_conference == true}2{/if} 
+account.4.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if} 
 account.4.sip_server_type=
 
 ##V83 Add
@@ -2092,7 +2092,7 @@ account.4.call_recording.enable=
 #######################################################################################
 ##                                Network Conferene                                  ##       
 #######################################################################################
-account.4.conf_uri = {if $nway_conference == true}nway{$account.4.user_id}@{$account.4.server_address}{/if}
+account.4.conf_uri = {if $nway_conference == 'true'}nway{$account.4.user_id}@{$account.4.server_address}{/if}
 
 
 #######################################################################################
@@ -2324,7 +2324,7 @@ account.5.session_timer.refresher=
 account.5.session_timer.expires=
 account.5.session_timer.enable= {$yealink_session_timer}
 
-account.5.conf_type = {if $nway_conference == true}2{/if}
+account.5.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 account.5.sip_server_type=
 
 ##V83 Add
@@ -2618,7 +2618,7 @@ account.5.call_recording.enable=
 #######################################################################################
 ##                                Network Conferene                                  ##       
 #######################################################################################
-account.5.conf_uri = {if $nway_conference == true}nway{$account.5.user_id}@{$account.5.server_address}{/if}
+account.5.conf_uri = {if $nway_conference == 'true'}nway{$account.5.user_id}@{$account.5.server_address}{/if}
 
 
 #######################################################################################
@@ -2864,7 +2864,7 @@ account.6.session_timer.refresher=
 account.6.session_timer.expires=
 account.6.session_timer.enable= {$yealink_session_timer}
 
-account.6.conf_type = {if $nway_conference == true}2{/if}
+account.6.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 account.6.sip_server_type=
 
 ##V83 Add
@@ -3158,7 +3158,7 @@ account.6.call_recording.enable=
 #######################################################################################
 ##                                Network Conferene                                  ##       
 #######################################################################################
-account.6.conf_uri = {if $nway_conference == true}nway{$account.6.user_id}@{$account.6.server_address}{/if}
+account.6.conf_uri = {if $nway_conference == 'true'}nway{$account.6.user_id}@{$account.6.server_address}{/if}
 
 
 #######################################################################################

--- a/resources/templates/provision/yealink/t53w/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t53w/{$mac}.cfg
@@ -206,7 +206,7 @@ account.1.session_timer.refresher=
 account.1.session_timer.expires=
 account.1.session_timer.enable= {$yealink_session_timer}
 
-account.1.conf_type = {if $nway_conference == true}2{/if}
+account.1.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 account.1.sip_server_type=
 
 ##V83 Add
@@ -500,7 +500,7 @@ account.1.call_recording.enable=
 #######################################################################################
 ##                                Network Conferene                                  ##       
 #######################################################################################
-account.1.conf_uri = {if $nway_conference == true}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
+account.1.conf_uri = {if $nway_conference == 'true'}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
 
 
 #######################################################################################
@@ -746,7 +746,7 @@ account.2.session_timer.refresher=
 account.2.session_timer.expires=
 account.2.session_timer.enable= {$yealink_session_timer}
 
-account.2.conf_type = {if $nway_conference == true}2{/if}
+account.2.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 account.2.sip_server_type=
 
 ##V83 Add
@@ -1040,7 +1040,7 @@ account.2.call_recording.enable=
 #######################################################################################
 ##                                Network Conferene                                  ##       
 #######################################################################################
-account.2.conf_uri = {if $nway_conference == true}nway{$account.2.user_id}@{$account.2.server_address}{/if}
+account.2.conf_uri = {if $nway_conference == 'true'}nway{$account.2.user_id}@{$account.2.server_address}{/if}
 
 
 #######################################################################################
@@ -1274,7 +1274,7 @@ account.3.session_timer.refresher=
 account.3.session_timer.expires=
 account.3.session_timer.enable= {$yealink_session_timer}
 
-account.3.conf_type = {if $nway_conference == true}2{/if}
+account.3.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 account.3.sip_server_type=
 
 ##V83 Add
@@ -1568,7 +1568,7 @@ account.3.call_recording.enable=
 #######################################################################################
 ##                                Network Conferene                                  ##       
 #######################################################################################
-account.3.conf_uri = {if $nway_conference == true}nway{$account.3.user_id}@{$account.3.server_address}{/if}
+account.3.conf_uri = {if $nway_conference == 'true'}nway{$account.3.user_id}@{$account.3.server_address}{/if}
 
 
 #######################################################################################
@@ -1802,7 +1802,7 @@ account.4.session_timer.refresher=
 account.4.session_timer.expires=
 account.4.session_timer.enable= {$yealink_session_timer}
 
-account.4.conf_type = {if $nway_conference == true}2{/if} 
+account.4.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if} 
 account.4.sip_server_type=
 
 ##V83 Add
@@ -2096,7 +2096,7 @@ account.4.call_recording.enable=
 #######################################################################################
 ##                                Network Conferene                                  ##       
 #######################################################################################
-account.4.conf_uri = {if $nway_conference == true}nway{$account.4.user_id}@{$account.4.server_address}{/if}
+account.4.conf_uri = {if $nway_conference == 'true'}nway{$account.4.user_id}@{$account.4.server_address}{/if}
 
 
 #######################################################################################
@@ -2329,7 +2329,7 @@ account.5.session_timer.refresher=
 account.5.session_timer.expires=
 account.5.session_timer.enable= {$yealink_session_timer}
 
-account.5.conf_type = {if $nway_conference == true}2{/if}
+account.5.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 account.5.sip_server_type=
 
 ##V83 Add
@@ -2623,7 +2623,7 @@ account.5.call_recording.enable=
 #######################################################################################
 ##                                Network Conferene                                  ##       
 #######################################################################################
-account.5.conf_uri = {if $nway_conference == true}nway{$account.5.user_id}@{$account.5.server_address}{/if}
+account.5.conf_uri = {if $nway_conference == 'true'}nway{$account.5.user_id}@{$account.5.server_address}{/if}
 
 
 #######################################################################################
@@ -2870,7 +2870,7 @@ account.6.session_timer.refresher=
 account.6.session_timer.expires=
 account.6.session_timer.enable= {$yealink_session_timer}
 
-account.6.conf_type = {if $nway_conference == true}2{/if}
+account.6.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 account.6.sip_server_type=
 
 ##V83 Add
@@ -3164,7 +3164,7 @@ account.6.call_recording.enable=
 #######################################################################################
 ##                                Network Conferene                                  ##       
 #######################################################################################
-account.6.conf_uri = {if $nway_conference == true}nway{$account.6.user_id}@{$account.6.server_address}{/if}
+account.6.conf_uri = {if $nway_conference == 'true'}nway{$account.6.user_id}@{$account.6.server_address}{/if}
 
 
 #######################################################################################

--- a/resources/templates/provision/yealink/t54s/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t54s/{$mac}.cfg
@@ -362,7 +362,7 @@ account.1.session_timer.refresher=
 account.1.session_timer.expires=
 account.1.session_timer.enable= {$yealink_session_timer}
 
-account.1.conf_type = {if $nway_conference == true}2{/if}
+account.1.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 account.1.sip_server_type=
 
 account.2.nat.udp_update_enable= 3
@@ -388,8 +388,8 @@ account.2.session_timer.refresher=
 account.2.session_timer.expires=
 account.2.session_timer.enable= {$yealink_session_timer}
 
-account.2.conf_type = {if $nway_conference == true}2{/if}
-account.2.conf_uri = {if $nway_conference == true}nway{$account.2.user_id}@{$account.2.server_address}{/if}
+account.2.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
+account.2.conf_uri = {if $nway_conference == 'true'}nway{$account.2.user_id}@{$account.2.server_address}{/if}
 account.2.sip_server_type=
 
 
@@ -670,7 +670,7 @@ account.1.refresh_remote_id.enable =
 #######################################################################################
 ##                                Network Conferene                                  ##       
 #######################################################################################
-account.1.conf_uri = {if $nway_conference == true}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
+account.1.conf_uri = {if $nway_conference == 'true'}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
 
 
 #######################################################################################

--- a/resources/templates/provision/yealink/t54w/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t54w/{$mac}.cfg
@@ -209,7 +209,7 @@ account.{$row.line_number}.session_timer.refresher=
 account.{$row.line_number}.session_timer.expires=
 account.{$row.line_number}.session_timer.enable= {$yealink_session_timer}
 
-account.{$row.line_number}.conf_type = {if $nway_conference == true}2{/if}
+account.{$row.line_number}.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 account.{$row.line_number}.sip_server_type=
 
 ##V83 Add
@@ -487,7 +487,7 @@ account.{$row.line_number}.call_recording.enable=
 #######################################################################################
 ##                                Network Conferene                                  ##       
 #######################################################################################
-account.{$row.line_number}.conf_uri = {if $nway_conference == true}nway{$row.auth_id}@{$row.server_address}{/if}
+account.{$row.line_number}.conf_uri = {if $nway_conference == 'true'}nway{$row.auth_id}@{$row.server_address}{/if}
 
 #######################################################################################
 ##                              Broadsoft Call Decline                               ##       

--- a/resources/templates/provision/yealink/t56a/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t56a/{$mac}.cfg
@@ -369,11 +369,11 @@ account.1.picture_info_enable =
 #######################################################################################
 ##It configures the conference type for account X.0-Local Conference,2-Network Conference.
 ##The default value is 0.
-account.1.conf_type = {if $nway_conference == true}2{/if} 
+account.1.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if} 
 
 ##It configures the network conference URI for account X.
 ##The default value is blank.
-account.1.conf_uri = {if $nway_conference == true}nway{$account.1.auth_id}@{$account.1.server_address}{/if} 
+account.1.conf_uri = {if $nway_conference == 'true'}nway{$account.1.auth_id}@{$account.1.server_address}{/if} 
 
 
 #######################################################################################
@@ -833,10 +833,10 @@ account.2.picture_info_enable =
 #######################################################################################
 ##It configures the conference type for account X.0-Local Conference,2-Network Conference.
 ##The default value is 0.
-account.2.conf_type = {if $nway_conference == true}2{/if} 
+account.2.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if} 
 ##It configures the network conference URI for account X.
 ##The default value is blank.
-account.2.conf_uri = {if $nway_conference == true}nway{$account.2.user_id}@{$account.2.server_address}{/if} 
+account.2.conf_uri = {if $nway_conference == 'true'}nway{$account.2.user_id}@{$account.2.server_address}{/if} 
 
 
 #######################################################################################
@@ -1296,10 +1296,10 @@ account.3.picture_info_enable =
 #######################################################################################
 ##It configures the conference type for account X.0-Local Conference,2-Network Conference.
 ##The default value is 0.
-account.3.conf_type = {if $nway_conference == true}2{/if} 
+account.3.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if} 
 ##It configures the network conference URI for account X.
 ##The default value is blank.
-account.3.conf_uri = {if $nway_conference == true}nway{$account.3.user_id}@{$account.3.server_address}{/if} 
+account.3.conf_uri = {if $nway_conference == 'true'}nway{$account.3.user_id}@{$account.3.server_address}{/if} 
 
 
 #######################################################################################
@@ -1762,11 +1762,11 @@ account.4.picture_info_enable =
 #######################################################################################
 ##It configures the conference type for account X.0-Local Conference,2-Network Conference.
 ##The default value is 0.
-account.4.conf_type = {if $nway_conference == true}2{/if} 
+account.4.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if} 
 
 ##It configures the network conference URI for account X.
 ##The default value is blank.
-account.4.conf_uri = {if $nway_conference == true}nway{$account.4.user_id}@{$account.4.server_address}{/if} 
+account.4.conf_uri = {if $nway_conference == 'true'}nway{$account.4.user_id}@{$account.4.server_address}{/if} 
 
 
 #######################################################################################
@@ -2230,11 +2230,11 @@ account.5.picture_info_enable =
 #######################################################################################
 ##It configures the conference type for account X.0-Local Conference,2-Network Conference.
 ##The default value is 0.
-account.5.conf_type = {if $nway_conference == true}2{/if} 
+account.5.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if} 
 
 ##It configures the network conference URI for account X.
 ##The default value is blank.
-account.5.conf_uri = {if $nway_conference == true}nway{$account.5.user_id}@{$account.5.server_address}{/if}
+account.5.conf_uri = {if $nway_conference == 'true'}nway{$account.5.user_id}@{$account.5.server_address}{/if}
 
 
 #######################################################################################
@@ -2701,10 +2701,10 @@ account.6.picture_info_enable =
 #######################################################################################
 ##It configures the conference type for account X.0-Local Conference,2-Network Conference.
 ##The default value is 0.
-account.6.conf_type = {if $nway_conference == true}2{/if} 
+account.6.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if} 
 ##It configures the network conference URI for account X.
 ##The default value is blank.
-account.6.conf_uri = {if $nway_conference == true}nway{$account.6.user_id}@{$account.6.server_address}{/if} 
+account.6.conf_uri = {if $nway_conference == 'true'}nway{$account.6.user_id}@{$account.6.server_address}{/if} 
 
 
 #######################################################################################

--- a/resources/templates/provision/yealink/t57w/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t57w/{$mac}.cfg
@@ -206,7 +206,7 @@ account.1.session_timer.refresher=
 account.1.session_timer.expires=
 account.1.session_timer.enable= {$yealink_session_timer}
 
-account.1.conf_type = {if $nway_conference == true}2{/if}
+account.1.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 account.1.sip_server_type=
 
 ##V83 Add
@@ -500,7 +500,7 @@ account.1.call_recording.enable=
 #######################################################################################
 ##                                Network Conferene                                  ##       
 #######################################################################################
-account.1.conf_uri = {if $nway_conference == true}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
+account.1.conf_uri = {if $nway_conference == 'true'}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
 
 
 #######################################################################################
@@ -745,7 +745,7 @@ account.2.session_timer.refresher=
 account.2.session_timer.expires=
 account.2.session_timer.enable= {$yealink_session_timer}
 
-account.2.conf_type = {if $nway_conference == true}2{/if}
+account.2.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 account.2.sip_server_type=
 
 ##V83 Add
@@ -1039,7 +1039,7 @@ account.2.call_recording.enable=
 #######################################################################################
 ##                                Network Conferene                                  ##       
 #######################################################################################
-account.2.conf_uri = {if $nway_conference == true}nway{$account.2.user_id}@{$account.2.server_address}{/if}
+account.2.conf_uri = {if $nway_conference == 'true'}nway{$account.2.user_id}@{$account.2.server_address}{/if}
 
 
 #######################################################################################
@@ -1272,7 +1272,7 @@ account.3.session_timer.refresher=
 account.3.session_timer.expires=
 account.3.session_timer.enable= {$yealink_session_timer}
 
-account.3.conf_type = {if $nway_conference == true}2{/if}
+account.3.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 account.3.sip_server_type=
 
 ##V83 Add
@@ -1566,7 +1566,7 @@ account.3.call_recording.enable=
 #######################################################################################
 ##                                Network Conferene                                  ##       
 #######################################################################################
-account.3.conf_uri = {if $nway_conference == true}nway{$account.3.user_id}@{$account.3.server_address}{/if}
+account.3.conf_uri = {if $nway_conference == 'true'}nway{$account.3.user_id}@{$account.3.server_address}{/if}
 
 
 #######################################################################################
@@ -1799,7 +1799,7 @@ account.4.session_timer.refresher=
 account.4.session_timer.expires=
 account.4.session_timer.enable= {$yealink_session_timer}
 
-account.4.conf_type = {if $nway_conference == true}2{/if} 
+account.4.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if} 
 account.4.sip_server_type=
 
 ##V83 Add
@@ -2093,7 +2093,7 @@ account.4.call_recording.enable=
 #######################################################################################
 ##                                Network Conferene                                  ##       
 #######################################################################################
-account.4.conf_uri = {if $nway_conference == true}nway{$account.4.user_id}@{$account.4.server_address}{/if}
+account.4.conf_uri = {if $nway_conference == 'true'}nway{$account.4.user_id}@{$account.4.server_address}{/if}
 
 
 #######################################################################################
@@ -2325,7 +2325,7 @@ account.5.session_timer.refresher=
 account.5.session_timer.expires=
 account.5.session_timer.enable= {$yealink_session_timer}
 
-account.5.conf_type = {if $nway_conference == true}2{/if}
+account.5.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 account.5.sip_server_type=
 
 ##V83 Add
@@ -2619,7 +2619,7 @@ account.5.call_recording.enable=
 #######################################################################################
 ##                                Network Conferene                                  ##       
 #######################################################################################
-account.5.conf_uri = {if $nway_conference == true}nway{$account.5.user_id}@{$account.5.server_address}{/if}
+account.5.conf_uri = {if $nway_conference == 'true'}nway{$account.5.user_id}@{$account.5.server_address}{/if}
 
 
 #######################################################################################
@@ -2865,7 +2865,7 @@ account.6.session_timer.refresher=
 account.6.session_timer.expires=
 account.6.session_timer.enable= {$yealink_session_timer}
 
-account.6.conf_type = {if $nway_conference == true}2{/if}
+account.6.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 account.6.sip_server_type=
 
 ##V83 Add
@@ -3159,7 +3159,7 @@ account.6.call_recording.enable=
 #######################################################################################
 ##                                Network Conferene                                  ##       
 #######################################################################################
-account.6.conf_uri = {if $nway_conference == true}nway{$account.6.user_id}@{$account.6.server_address}{/if}
+account.6.conf_uri = {if $nway_conference == 'true'}nway{$account.6.user_id}@{$account.6.server_address}{/if}
 
 
 #######################################################################################

--- a/resources/templates/provision/yealink/t58a/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t58a/{$mac}.cfg
@@ -369,11 +369,11 @@ account.1.picture_info_enable =
 #######################################################################################
 ##It configures the conference type for account X.0-Local Conference,2-Network Conference.
 ##The default value is 0.
-account.1.conf_type = {if $nway_conference == true}2{/if} 
+account.1.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if} 
 
 ##It configures the network conference URI for account X.
 ##The default value is blank.
-account.1.conf_uri = {if $nway_conference == true}nway{$account.1.auth_id}@{$account.1.server_address}{/if} 
+account.1.conf_uri = {if $nway_conference == 'true'}nway{$account.1.auth_id}@{$account.1.server_address}{/if} 
 
 
 #######################################################################################
@@ -833,10 +833,10 @@ account.2.picture_info_enable =
 #######################################################################################
 ##It configures the conference type for account X.0-Local Conference,2-Network Conference.
 ##The default value is 0.
-account.2.conf_type = {if $nway_conference == true}2{/if} 
+account.2.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if} 
 ##It configures the network conference URI for account X.
 ##The default value is blank.
-account.2.conf_uri = {if $nway_conference == true}nway{$account.2.user_id}@{$account.2.server_address}{/if} 
+account.2.conf_uri = {if $nway_conference == 'true'}nway{$account.2.user_id}@{$account.2.server_address}{/if} 
 
 
 #######################################################################################
@@ -1296,10 +1296,10 @@ account.3.picture_info_enable =
 #######################################################################################
 ##It configures the conference type for account X.0-Local Conference,2-Network Conference.
 ##The default value is 0.
-account.3.conf_type = {if $nway_conference == true}2{/if} 
+account.3.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if} 
 ##It configures the network conference URI for account X.
 ##The default value is blank.
-account.3.conf_uri = {if $nway_conference == true}nway{$account.3.user_id}@{$account.3.server_address}{/if} 
+account.3.conf_uri = {if $nway_conference == 'true'}nway{$account.3.user_id}@{$account.3.server_address}{/if} 
 
 
 #######################################################################################
@@ -1762,11 +1762,11 @@ account.4.picture_info_enable =
 #######################################################################################
 ##It configures the conference type for account X.0-Local Conference,2-Network Conference.
 ##The default value is 0.
-account.4.conf_type = {if $nway_conference == true}2{/if} 
+account.4.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if} 
 
 ##It configures the network conference URI for account X.
 ##The default value is blank.
-account.4.conf_uri = {if $nway_conference == true}nway{$account.4.user_id}@{$account.4.server_address}{/if} 
+account.4.conf_uri = {if $nway_conference == 'true'}nway{$account.4.user_id}@{$account.4.server_address}{/if} 
 
 
 #######################################################################################
@@ -2230,11 +2230,11 @@ account.5.picture_info_enable =
 #######################################################################################
 ##It configures the conference type for account X.0-Local Conference,2-Network Conference.
 ##The default value is 0.
-account.5.conf_type = {if $nway_conference == true}2{/if} 
+account.5.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if} 
 
 ##It configures the network conference URI for account X.
 ##The default value is blank.
-account.5.conf_uri = {if $nway_conference == true}nway{$account.5.user_id}@{$account.5.server_address}{/if}
+account.5.conf_uri = {if $nway_conference == 'true'}nway{$account.5.user_id}@{$account.5.server_address}{/if}
 
 
 #######################################################################################
@@ -2701,10 +2701,10 @@ account.6.picture_info_enable =
 #######################################################################################
 ##It configures the conference type for account X.0-Local Conference,2-Network Conference.
 ##The default value is 0.
-account.6.conf_type = {if $nway_conference == true}2{/if} 
+account.6.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if} 
 ##It configures the network conference URI for account X.
 ##The default value is blank.
-account.6.conf_uri = {if $nway_conference == true}nway{$account.6.user_id}@{$account.6.server_address}{/if} 
+account.6.conf_uri = {if $nway_conference == 'true'}nway{$account.6.user_id}@{$account.6.server_address}{/if} 
 
 
 #######################################################################################

--- a/resources/templates/provision/yealink/t58v/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t58v/{$mac}.cfg
@@ -369,11 +369,11 @@ account.1.picture_info_enable =
 #######################################################################################
 ##It configures the conference type for account X.0-Local Conference,2-Network Conference.
 ##The default value is 0.
-account.1.conf_type = {if $nway_conference == true}2{/if} 
+account.1.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if} 
 
 ##It configures the network conference URI for account X.
 ##The default value is blank.
-account.1.conf_uri = {if $nway_conference == true}nway{$account.1.auth_id}@{$account.1.server_address}{/if} 
+account.1.conf_uri = {if $nway_conference == 'true'}nway{$account.1.auth_id}@{$account.1.server_address}{/if} 
 
 
 #######################################################################################
@@ -833,10 +833,10 @@ account.2.picture_info_enable =
 #######################################################################################
 ##It configures the conference type for account X.0-Local Conference,2-Network Conference.
 ##The default value is 0.
-account.2.conf_type = {if $nway_conference == true}2{/if} 
+account.2.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if} 
 ##It configures the network conference URI for account X.
 ##The default value is blank.
-account.2.conf_uri = {if $nway_conference == true}nway{$account.2.user_id}@{$account.2.server_address}{/if} 
+account.2.conf_uri = {if $nway_conference == 'true'}nway{$account.2.user_id}@{$account.2.server_address}{/if} 
 
 
 #######################################################################################
@@ -1296,10 +1296,10 @@ account.3.picture_info_enable =
 #######################################################################################
 ##It configures the conference type for account X.0-Local Conference,2-Network Conference.
 ##The default value is 0.
-account.3.conf_type = {if $nway_conference == true}2{/if} 
+account.3.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if} 
 ##It configures the network conference URI for account X.
 ##The default value is blank.
-account.3.conf_uri = {if $nway_conference == true}nway{$account.3.user_id}@{$account.3.server_address}{/if} 
+account.3.conf_uri = {if $nway_conference == 'true'}nway{$account.3.user_id}@{$account.3.server_address}{/if} 
 
 
 #######################################################################################
@@ -1762,11 +1762,11 @@ account.4.picture_info_enable =
 #######################################################################################
 ##It configures the conference type for account X.0-Local Conference,2-Network Conference.
 ##The default value is 0.
-account.4.conf_type = {if $nway_conference == true}2{/if} 
+account.4.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if} 
 
 ##It configures the network conference URI for account X.
 ##The default value is blank.
-account.4.conf_uri = {if $nway_conference == true}nway{$account.4.user_id}@{$account.4.server_address}{/if} 
+account.4.conf_uri = {if $nway_conference == 'true'}nway{$account.4.user_id}@{$account.4.server_address}{/if} 
 
 
 #######################################################################################
@@ -2230,11 +2230,11 @@ account.5.picture_info_enable =
 #######################################################################################
 ##It configures the conference type for account X.0-Local Conference,2-Network Conference.
 ##The default value is 0.
-account.5.conf_type = {if $nway_conference == true}2{/if} 
+account.5.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if} 
 
 ##It configures the network conference URI for account X.
 ##The default value is blank.
-account.5.conf_uri = {if $nway_conference == true}nway{$account.5.user_id}@{$account.5.server_address}{/if}
+account.5.conf_uri = {if $nway_conference == 'true'}nway{$account.5.user_id}@{$account.5.server_address}{/if}
 
 
 #######################################################################################
@@ -2701,10 +2701,10 @@ account.6.picture_info_enable =
 #######################################################################################
 ##It configures the conference type for account X.0-Local Conference,2-Network Conference.
 ##The default value is 0.
-account.6.conf_type = {if $nway_conference == true}2{/if} 
+account.6.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if} 
 ##It configures the network conference URI for account X.
 ##The default value is blank.
-account.6.conf_uri = {if $nway_conference == true}nway{$account.6.user_id}@{$account.6.server_address}{/if} 
+account.6.conf_uri = {if $nway_conference == 'true'}nway{$account.6.user_id}@{$account.6.server_address}{/if} 
 
 
 #######################################################################################

--- a/resources/templates/provision/yealink/t5x/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t5x/{$mac}.cfg
@@ -325,10 +325,10 @@ account.{$row.line_number}.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type 0-Local (default), 2-Network Conference
-account.{$row.line_number}.conf_type = {if $nway_conference == true}2{/if}
+account.{$row.line_number}.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.{$row.line_number}.conf_uri = {if $nway_conference == true}nway{$row.user_id}@{$row.server_address}{/if}
+account.{$row.line_number}.conf_uri = {if $nway_conference == 'true'}nway{$row.user_id}@{$row.server_address}{/if}
 
 #######################################################################################
 ##                            cid_source                                             ##

--- a/resources/templates/provision/yealink/vp530/{$mac}.cfg
+++ b/resources/templates/provision/yealink/vp530/{$mac}.cfg
@@ -376,10 +376,10 @@ account.1.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.1.conf_type = {if $nway_conference == true}2{/if}
+account.1.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.1.conf_uri = {if $nway_conference == true}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
+account.1.conf_uri = {if $nway_conference == 'true'}nway{$account.1.auth_id}@{$account.1.server_address}{/if}
 
 #######################################################################################
 ##                            cid_source                                             ##
@@ -841,10 +841,10 @@ account.2.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.2.conf_type = {if $nway_conference == true}2{/if}
+account.2.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.2.conf_uri = {if $nway_conference == true}nway{$account.2.user_id}@{$account.2.server_address}{/if}
+account.2.conf_uri = {if $nway_conference == 'true'}nway{$account.2.user_id}@{$account.2.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -1350,10 +1350,10 @@ account.3.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.3.conf_type = {if $nway_conference == true}2{/if}
+account.3.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.3.conf_uri = {if $nway_conference == true}nway{$account.3.user_id}@{$account.3.server_address}{/if}
+account.3.conf_uri = {if $nway_conference == 'true'}nway{$account.3.user_id}@{$account.3.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -1842,10 +1842,10 @@ account.4.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.4.conf_type = {if $nway_conference == true}2{/if}
+account.4.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.4.conf_uri = {if $nway_conference == true}nway{$account.4.user_id}@{$account.4.server_address}{/if}
+account.4.conf_uri = {if $nway_conference == 'true'}nway{$account.4.user_id}@{$account.4.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -2334,10 +2334,10 @@ account.5.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.5.conf_type = {if $nway_conference == true}2{/if}
+account.5.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.5.conf_uri = {if $nway_conference == true}nway{$account.5.user_id}@{$account.5.server_address}{/if}
+account.5.conf_uri = {if $nway_conference == 'true'}nway{$account.5.user_id}@{$account.5.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##
@@ -2825,10 +2825,10 @@ account.6.picture_info_enable = 1
 ##                            Conference                                             ##
 #######################################################################################
 #Configure the conference type; 0-Local (default), 2-Network Conference;
-account.6.conf_type = {if $nway_conference == true}2{/if}
+account.6.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 
 #Configure the conference URI (a SIP URI, or use part of the SIP URI). For example, "conference@domain.com" or "conference".
-account.6.conf_uri = {if $nway_conference == true}nway{$account.6.user_id}@{$account.6.server_address}{/if}
+account.6.conf_uri = {if $nway_conference == 'true'}nway{$account.6.user_id}@{$account.6.server_address}{/if}
 
 #######################################################################################
 ##                            cid source                                             ##


### PR DESCRIPTION
nway_conference == true was evaluating as true regardless if nway_conference was set to true or false, just as long as it had a value of any kind.
This also fixes it so that you can set nway_conference to false in the default settings and it will disable the network conference feature, previously once it was enabled on yealink phones it could not be disabled without manually changing it in the phone or a factory default.