### PR TITLE
Add grandstream_disable_active_mpk_page variable

### DIFF
--- a/resources/templates/provision/grandstream/gxp2170/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp2170/{$mac}.xml
@@ -7498,7 +7498,11 @@
     <!-- # Disable Active MPK Page. 0 - No, 1 - Yes. Default is 0 -->
     <!-- # Number: 0, 1 -->
     <!-- # Mandatory -->
+{if isset($grandstream_disable_active_mpk_page)}
+    <P6764>{$grandstream_disable_active_mpk_page}</P6764>
+{else}
     <P6764>0</P6764>
+{/if}
 
     <!-- # Enable Active VPK Page. 0 - No, 1 - Yes. Default is 0 -->
     <!-- # Number: 0, 1 -->


### PR DESCRIPTION
Allows active mpk page on expansion module (GXP2200EXT) to be disabled.