### PR TITLE
Add grandstream_disable_active_mpk_page variable

### DIFF
--- a/resources/templates/provision/grandstream/grp2613/{$mac}.xml
+++ b/resources/templates/provision/grandstream/grp2613/{$mac}.xml
@@ -4365,7 +4365,11 @@
     <!-- # Disable Active MPK Page. 0 - No, 1 - Yes. Default is 0 -->
     <!-- # Number: 0, 1 -->
     <!-- # Mandatory -->
+{if isset($grandstream_disable_active_mpk_page)}
+    <P6764>{$grandstream_disable_active_mpk_page}</P6764>
+{else}
     <P6764>0</P6764>
+{/if}
 
     <!-- # Enable Active VPK Page. 0 - No, 1 - Yes. Default is 0 -->
     <!-- # Number: 0, 1 -->


### PR DESCRIPTION
Allows the active mpk page to be disabled on expansion modules