### PR TITLE
Use effective_caller_id_name for origination_callee_id_name

### DIFF
--- a/app/dialplans/resources/switch/conf/dialplan/020_domain-variables.xml
+++ b/app/dialplans/resources/switch/conf/dialplan/020_domain-variables.xml
@@ -1,7 +1,8 @@
 <context name="{v_context}">
 	<extension name="domain-variables" number="" continue="true" app_uuid="9f356fe7-8cf8-4c14-8fe2-6daf89304458" order="20">
-		<condition>
-			<action application="export" data="origination_callee_id_name=${destination_number}"/>
-		</condition>
+	<condition field="${user_data ${destination_number}@${domain_name} var effective_caller_id_name}" expression="^.+$">
+		<action application="export" data="origination_callee_id_name=${user_data ${destination_number}@${domain_name} var effective_caller_id_name}"/>
+		<anti-action application="export" data="origination_callee_id_name=${destination_number}"/>
+	</condition>
 	</extension>
 </context>


### PR DESCRIPTION
The current dialplan has the destination number used as the callee ID
name for display updates.  If the call is local, we should look for
effective_caller_id_name to make the information more complete.