### PR TITLE
Use effective_caller_id_name for origination_callee_id_name

### DIFF
--- a/app/dialplans/resources/switch/conf/dialplan/020_domain-variables.xml
+++ b/app/dialplans/resources/switch/conf/dialplan/020_domain-variables.xml
@@ -3,5 +3,8 @@
 		<condition>
 			<action application="export" data="origination_callee_id_name=${destination_number}"/>
 		</condition>
+		<condition field="${user_data ${destination_number}@${domain_name} var effective_caller_id_name}" expression="^.+$">
+			<action application="export" data="origination_callee_id_name=${user_data ${destination_number}@${domain_name} var effective_caller_id_name}"/>
+		</condition>
 	</extension>
 </context>


### PR DESCRIPTION
Currently, we use the destination number for
origination_callee_id_name.  If available, we should
use effective_caller_id_name so that display name
is available to the caller.