### PR TITLE
Add some snom-variables that are already used in the templates.

### DIFF
--- a/app/snom/app_config.php
+++ b/app/snom/app_config.php
@@ -230,5 +230,29 @@
 		$apps[$x]['default_settings'][$y]['default_setting_value'] = "off";
 		$apps[$x]['default_settings'][$y]['default_setting_enabled'] = "true";
 		$apps[$x]['default_settings'][$y]['default_setting_description'] = "Enables/Disables sending Supported:100Rel and by this whether early-dialogs by PRACK will be offered. valid values: on,off";
+		$y++;
+		$apps[$x]['default_settings'][$y]['default_setting_uuid'] = "c85c9b44-c56e-4aac-aa88-98663771645a";
+		$apps[$x]['default_settings'][$y]['default_setting_category'] = "provision";
+		$apps[$x]['default_settings'][$y]['default_setting_subcategory'] = "snom_language";
+		$apps[$x]['default_settings'][$y]['default_setting_name'] = "text";
+		$apps[$x]['default_settings'][$y]['default_setting_value'] = "English";
+		$apps[$x]['default_settings'][$y]['default_setting_enabled'] = "true";
+		$apps[$x]['default_settings'][$y]['default_setting_description'] = "Sets the default display-language on snom-phones. See https://service.snom.com/display/wiki/language";
+		$y++;
+		$apps[$x]['default_settings'][$y]['default_setting_uuid'] = "974bad52-b793-4901-ae7d-8bfb561970f5";
+		$apps[$x]['default_settings'][$y]['default_setting_category'] = "provision";
+		$apps[$x]['default_settings'][$y]['default_setting_subcategory'] = "snom_ntp_server";
+		$apps[$x]['default_settings'][$y]['default_setting_name'] = "text";
+		$apps[$x]['default_settings'][$y]['default_setting_value'] = "0.pool.ntp.org";
+		$apps[$x]['default_settings'][$y]['default_setting_enabled'] = "false";
+		$apps[$x]['default_settings'][$y]['default_setting_description'] = "Sets the ntp server on snom-phones.";
+		$y++;
+		$apps[$x]['default_settings'][$y]['default_setting_uuid'] = "ad42166c-af84-46bb-b4f4-8d18eceaf65d";
+		$apps[$x]['default_settings'][$y]['default_setting_category'] = "provision";
+		$apps[$x]['default_settings'][$y]['default_setting_subcategory'] = "snom_tone_scheme";
+		$apps[$x]['default_settings'][$y]['default_setting_name'] = "text";
+		$apps[$x]['default_settings'][$y]['default_setting_value'] = "USA";
+		$apps[$x]['default_settings'][$y]['default_setting_enabled'] = "false";
+		$apps[$x]['default_settings'][$y]['default_setting_description'] = "Sets the tone scheme on snom-phones. See https://service.snom.com/display/wiki/tone_scheme";
 
 ?>


### PR DESCRIPTION
This commit adds some snom-variables that are already used in the templates.
See https://github.com/fusionpbx/fusionpbx/blob/d7cc26a51df7dae1e464dc883d3ac61788a6826b/resources/templates/provision/snom/D745/%7B%24mac%7D.xml#L6-L8