### PR TITLE
[4.4] Fixes many SQL NOW() queries

### DIFF
--- a/resources/classes/database.php
+++ b/resources/classes/database.php
@@ -1489,8 +1489,8 @@ include "root.php";
 													if (strlen($array_value) == 0) {
 														$sql .= "null, ";
 													}
-													elseif ($array_value === "now()") {
-														$sql .= "now(), ";
+													elseif (strtolower(substr($array_value, 0, 5)) === "now()") {
+														$sql .= "$array_value, ";
 													}
 													else {
 														//$sql .= "'".check_str($array_value)."', ";


### PR DESCRIPTION
You have NOW()  AT TIME ZONE XXX which is not handled correctly. Happily, this only breaks Postgresql. MySQL/MariaDB users are safe.