### PR TITLE
use application tag to enable firmware updates

### DIFF
--- a/app/polycom/app_config.php
+++ b/app/polycom/app_config.php
@@ -550,5 +550,37 @@
 		$apps[$x]['default_settings'][$y]['default_setting_value'] = "04:00";
 		$apps[$x]['default_settings'][$y]['default_setting_enabled'] = "false";
 		$apps[$x]['default_settings'][$y]['default_setting_description'] = "Set the time to stop polling when using random mode";
+		$y++;
+		$apps[$x]['default_settings'][$y]['default_setting_uuid'] = "fb4fe110-bb83-4b64-a39b-c879ebcc8af7";
+		$apps[$x]['default_settings'][$y]['default_setting_category'] = "provision";
+		$apps[$x]['default_settings'][$y]['default_setting_subcategory'] = "polycom_provision_app_file_path_4x";
+		$apps[$x]['default_settings'][$y]['default_setting_name'] = "text";
+		$apps[$x]['default_settings'][$y]['default_setting_value'] = "4.0.15/";
+		$apps[$x]['default_settings'][$y]['default_setting_enabled'] = "true";
+		$apps[$x]['default_settings'][$y]['default_setting_description'] = "4.x firmware is stored in this subdirectory of /app/polycom/resources/firmware/, ex:/app/polycom/resources/firmware/4.0.15/";
+		$y++;
+		$apps[$x]['default_settings'][$y]['default_setting_uuid'] = "134483f0-aa0c-44a9-9a4f-eb03be30c1c2";
+		$apps[$x]['default_settings'][$y]['default_setting_category'] = "provision";
+		$apps[$x]['default_settings'][$y]['default_setting_subcategory'] = "polycom_provision_app_file_path_5x";
+		$apps[$x]['default_settings'][$y]['default_setting_name'] = "text";
+		$apps[$x]['default_settings'][$y]['default_setting_value'] = "5.9.7/";
+		$apps[$x]['default_settings'][$y]['default_setting_enabled'] = "true";
+		$apps[$x]['default_settings'][$y]['default_setting_description'] = "5.x firmware is stored in this subdirectory of /app/polycom/resources/firmware/, ex:/app/polycom/resources/firmware/5.9.6/";
+		$y++;
+		$apps[$x]['default_settings'][$y]['default_setting_uuid'] = "cc3fcaa0-a809-4235-9a95-f5d6426fcafa";
+		$apps[$x]['default_settings'][$y]['default_setting_category'] = "provision";
+		$apps[$x]['default_settings'][$y]['default_setting_subcategory'] = "polycom_provision_app_file_path_6x";
+		$apps[$x]['default_settings'][$y]['default_setting_name'] = "text";
+		$apps[$x]['default_settings'][$y]['default_setting_value'] = "6.4.1/";
+		$apps[$x]['default_settings'][$y]['default_setting_enabled'] = "true";
+		$apps[$x]['default_settings'][$y]['default_setting_description'] = "6.x firmware is stored in this subdirectory of /app/polycom/resources/firmware/, ex:/app/polycom/resources/firmware/6.4.1/";
+		$y++;
+		$apps[$x]['default_settings'][$y]['default_setting_uuid'] = "828f52cf-4ac8-403c-95f1-34c71cdcd046";
+		$apps[$x]['default_settings'][$y]['default_setting_category'] = "provision";
+		$apps[$x]['default_settings'][$y]['default_setting_subcategory'] = "polycom_provision_app_include";
+		$apps[$x]['default_settings'][$y]['default_setting_name'] = "boolean";
+		$apps[$x]['default_settings'][$y]['default_setting_value'] = "true";
+		$apps[$x]['default_settings'][$y]['default_setting_enabled'] = "false";
+		$apps[$x]['default_settings'][$y]['default_setting_description'] = "if enabled, renders the APPLICATION tag in provisioning file. This allows polycom phones to load firmware files from the server.";
 
 ?>

--- a/resources/templates/provision/polycom/4.x/{$mac}.cfg
+++ b/resources/templates/provision/polycom/4.x/{$mac}.cfg
@@ -1,5 +1,28 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <PHONE>
+	{if $polycom_provision_app_include == "true"}
+	{*
+
+	Be sure to add a rewrite directive in the nginx site under the #polycom section if one is not already present. Example:
+
+		#polycom
+		rewrite "^.*/provision/000000000000.cfg$" "/app/provision/?mac=$1&file={%24mac}.cfg";
+		rewrite "^.*/provision/polycom/firmware/(.+)$" /app/polycom/resources/firmware/$1; ### add if missing
+
+	Unzip the UC software from polycom into /var/www/fusionpbx/app/polycom/resources/frimware/4.x.x/, and be sure to set the polycom_app_file_path_4x to match, e.g. "4.0.15/"
+
+	*}<APPLICATION
+		APP_FILE_PATH="polycom/firmware/{$polycom_provision_app_file_path_4x}sip.ld"
+		CONFIG_FILES=""
+		MISC_FILES=""
+		LOG_FILE_DIRECTORY=""
+		OVERRIDES_DIRECTORY=""
+		CONTACTS_DIRECTORY=""
+		LICENSE_DIRECTORY=""
+		USER_PROFILES_DIRECTORY=""
+		CALL_LISTS_DIRECTORY=""
+	/>
+	{/if}
 	<REGISTRATION
 
 		{foreach $lines as $row}reg.{$row.line_number}.displayName="{$row.display_name}"

--- a/resources/templates/provision/polycom/5.x/{$mac}.cfg
+++ b/resources/templates/provision/polycom/5.x/{$mac}.cfg
@@ -1,5 +1,33 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <PHONE>
+	{if $polycom_provision_app_include == "true"}
+	{*
+
+	Be sure to add a rewrite directive in the nginx site under the #polycom section if one is not already present. Example:
+
+		#polycom
+		rewrite "^.*/provision/000000000000.cfg$" "/app/provision/?mac=$1&file={%24mac}.cfg";
+		rewrite "^.*/provision/polycom/firmware/(.+)$" /app/polycom/resources/firmware/$1; ### add if missing
+
+	Unzip the UC software from polycom into /var/www/fusionpbx/app/polycom/resources/frimware/5.x.x/, and be sure to set the polycom_app_file_path_5x to match, e.g. "5.9.7/"
+
+	*}<APPLICATION
+		APP_FILE_PATH="polycom/firmware/{$polycom_provision_app_file_path_5x}sip.ld"
+		DECT_FILE_PATH="polycom/firmware/{$polycom_provision_app_file_path_5x}3111-17823-001.dect.ld"
+		CONFIG_FILES=""
+		SERVICE_FILES=""
+		MISC_FILES=""
+		LOG_FILE_DIRECTORY=""
+		OVERRIDES_DIRECTORY=""
+		CONTACTS_DIRECTORY=""
+		LICENSE_DIRECTORY=""
+		USER_PROFILES_DIRECTORY=""
+		CALL_LISTS_DIRECTORY=""
+		COREFILE_DIRECTORY=""
+		CERTIFICATE_DIRECTORY=""
+		FLK_DIRECTORY=""
+	/>
+	{/if}
 	<REGISTRATION
 	{foreach $lines as $row}reg.{$row.line_number}.displayName="{$row.display_name}"
 		reg.{$row.line_number}.address="{$row.user_id}@{$row.server_address}"

--- a/resources/templates/provision/polycom/6.x/{$mac}.cfg
+++ b/resources/templates/provision/polycom/6.x/{$mac}.cfg
@@ -1,5 +1,33 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <PHONE>
+	{if $polycom_provision_app_include == "true"}
+	{*
+
+	Be sure to add a rewrite directive in the nginx site under the #polycom section if one is not already present. Example:
+
+		#polycom
+		rewrite "^.*/provision/000000000000.cfg$" "/app/provision/?mac=$1&file={%24mac}.cfg";
+		rewrite "^.*/provision/polycom/firmware/(.+)$" /app/polycom/resources/firmware/$1; ### add if missing
+
+	Unzip the UC software from polycom into /var/www/fusionpbx/app/polycom/resources/frimware/6.x.x/, and be sure to set the polycom_app_file_path_6x to match, e.g. "6.4.1/"
+
+	*}<APPLICATION
+		APP_FILE_PATH="polycom/firmware/{$polycom_provision_app_file_path_6x}sip.ld"
+		DECT_FILE_PATH="polycom/firmware/{$polycom_provision_app_file_path_6x}3111-17823-001.dect.ld"
+		CONFIG_FILES=""
+		SERVICE_FILES=""
+		MISC_FILES=""
+		LOG_FILE_DIRECTORY=""
+		OVERRIDES_DIRECTORY=""
+		CONTACTS_DIRECTORY=""
+		LICENSE_DIRECTORY=""
+		USER_PROFILES_DIRECTORY=""
+		CALL_LISTS_DIRECTORY=""
+		COREFILE_DIRECTORY=""
+		CERTIFICATE_DIRECTORY=""
+		FLK_DIRECTORY=""
+	/>
+	{/if}
 	<REGISTRATION
 	{foreach $lines as $row}reg.{$row.line_number}.displayName="{$row.display_name}"
 		reg.{$row.line_number}.address="{$row.user_id}@{$row.server_address}"


### PR DESCRIPTION
I've been struggling to get FusionPBX to host firmware upgrades for my polycom phones. I've found a solution that works for me and would like to merge my changes.

This adds four default settings, and some logic to the polycom 4.x, 5.x, and 6.x provisioning file templates to handle the settings.

The new default settings are:
- polycom_provision_app_include - a boolean to enable/disable the new code in the provisioning template. defaults to **disabled**.
- polycom_provision_app_file_path_4x - a text string representing a portion of a URL/directory path; only used in the 4.x provisioning template.
- polycom_provision_app_file_path_5x - a text string representing a portion of a URL/directory path; only used in the 5.x provisioning template.
- polycom_provision_app_file_path_6x - a text string representing a portion of a URL/directory path; only used in the 6.x provisioning template.

An Nginx rewrite rule is required to allow the phones to download the firmware. I may open a pull request on the fusionpbx-install.sh repository to get the rewrite rule included in new installations if there is interest. The rewrite rule I have had success with so far (this could probably be improved) is:

`rewrite "^.*/provision/polycom/firmware/(.+)$" /app/polycom/resources/firmware/$1;`

Firmware files should be obtained from Polycom and placed in /var/www/fusionpbx/app/polycom/resources/firmware/x.y.z/ where x.y.z matches the version number (by convention).

For example, If I want to use UC version 6.4.1 on my 6.x provisioned phones, I would unzip the firmware files into `/var/www/fusionpbx/app/polycom/resources/firmware/6.4.1`. I would then make sure that the polycom_provision_app_file_path_6x setting has a value of `6.4.1/`

Example scenario: when a VVX250 phone is provisioned, the phone will do an HTTP request for /app/provision/polycom/firmware/6.4.1/3111-48820-001.sip.ld, and the rewrite will pass the request to the local file stored at /var/www/fusionpbx/app/polycom/resources/firmware/6.4.1/3111-48820-001.sip.ld. The phone will download and install the firmware, rebooting in the process. 






