### PR TITLE
add ability to disable/enable polycom boot status popup messages

### DIFF
--- a/app/polycom/app_config.php
+++ b/app/polycom/app_config.php
@@ -838,5 +838,13 @@
 		$apps[$x]['default_settings'][$y]['default_setting_value'] = "933";
 		$apps[$x]['default_settings'][$y]['default_setting_enabled'] = "true";
 		$apps[$x]['default_settings'][$y]['default_setting_description'] = "933 service";
+		$y++;
+		$apps[$x]['default_settings'][$y]['default_setting_uuid'] = "d243151a-8120-464d-bdf5-91d9dc57bfc4";
+		$apps[$x]['default_settings'][$y]['default_setting_category'] = "provision";
+		$apps[$x]['default_settings'][$y]['default_setting_subcategory'] = "polycom_boot_status_popup_enabled";
+		$apps[$x]['default_settings'][$y]['default_setting_name'] = "numeric";
+		$apps[$x]['default_settings'][$y]['default_setting_value'] = "0";
+		$apps[$x]['default_settings'][$y]['default_setting_enabled'] = "true";
+		$apps[$x]['default_settings'][$y]['default_setting_description'] = "Disable boot status popup by default";
 
 ?>

--- a/resources/templates/provision/polycom/5.x/{$mac}.cfg
+++ b/resources/templates/provision/polycom/5.x/{$mac}.cfg
@@ -243,6 +243,7 @@
 		call.callWaiting.ring="beep"
 		call.callsPerLineKey="{$polycom_calls_per_line_key}"
 		up.OffHookLineView.enabled="{$polycom_offhook_line_view_enabled}"
+		up.phoneBootStatusPopupEnabled="{$polycom_boot_status_popup_enabled}"
 		prov.polling.enabled="{$polycom_provision_polling_enabled}"
 		prov.polling.mode="{$polycom_provision_polling_mode}"
 		prov.polling.period="{$polycom_provision_polling_period}"

--- a/resources/templates/provision/polycom/6.x/{$mac}.cfg
+++ b/resources/templates/provision/polycom/6.x/{$mac}.cfg
@@ -239,6 +239,7 @@
 		call.callWaiting.ring="beep"
 		call.callsPerLineKey="{$polycom_calls_per_line_key}"
 		up.OffHookLineView.enabled="{$polycom_offhook_line_view_enabled}"
+		up.phoneBootStatusPopupEnabled="{$polycom_boot_status_popup_enabled}"
 		prov.polling.enabled="{$polycom_provision_polling_enabled}"
 		prov.polling.mode="{$polycom_provision_polling_mode}"
 		prov.polling.period="{$polycom_provision_polling_period}"

--- a/resources/templates/provision/polycom/vvx101/{$mac}.cfg
+++ b/resources/templates/provision/polycom/vvx101/{$mac}.cfg
@@ -239,6 +239,7 @@
 		call.callWaiting.ring="beep"
 		call.callsPerLineKey="{$polycom_calls_per_line_key}"
 		up.OffHookLineView.enabled="{$polycom_offhook_line_view_enabled}"
+		up.phoneBootStatusPopupEnabled="{$polycom_boot_status_popup_enabled}"
 		prov.polling.enabled="{$polycom_provision_polling_enabled}"
 		prov.polling.mode="{$polycom_provision_polling_mode}"
 		prov.polling.period="{$polycom_provision_polling_period}"

--- a/resources/templates/provision/polycom/vvx150/{$mac}.cfg
+++ b/resources/templates/provision/polycom/vvx150/{$mac}.cfg
@@ -239,6 +239,7 @@
 		call.callWaiting.ring="beep"
 		call.callsPerLineKey="{$polycom_calls_per_line_key}"
 		up.OffHookLineView.enabled="{$polycom_offhook_line_view_enabled}"
+		up.phoneBootStatusPopupEnabled="{$polycom_boot_status_popup_enabled}"
 		prov.polling.enabled="{$polycom_provision_polling_enabled}"
 		prov.polling.mode="{$polycom_provision_polling_mode}"
 		prov.polling.period="{$polycom_provision_polling_period}"

--- a/resources/templates/provision/polycom/vvx1500/{$mac}.cfg
+++ b/resources/templates/provision/polycom/vvx1500/{$mac}.cfg
@@ -243,6 +243,7 @@
 		call.callWaiting.ring="beep"
 		call.callsPerLineKey="{$polycom_calls_per_line_key}"
 		up.OffHookLineView.enabled="{$polycom_offhook_line_view_enabled}"
+		up.phoneBootStatusPopupEnabled="{$polycom_boot_status_popup_enabled}"
 		prov.polling.enabled="{$polycom_provision_polling_enabled}"
 		prov.polling.mode="{$polycom_provision_polling_mode}"
 		prov.polling.period="{$polycom_provision_polling_period}"

--- a/resources/templates/provision/polycom/vvx201/{$mac}.cfg
+++ b/resources/templates/provision/polycom/vvx201/{$mac}.cfg
@@ -239,6 +239,7 @@
 		call.callWaiting.ring="beep"
 		call.callsPerLineKey="{$polycom_calls_per_line_key}"
 		up.OffHookLineView.enabled="{$polycom_offhook_line_view_enabled}"
+		up.phoneBootStatusPopupEnabled="{$polycom_boot_status_popup_enabled}"
 		prov.polling.enabled="{$polycom_provision_polling_enabled}"
 		prov.polling.mode="{$polycom_provision_polling_mode}"
 		prov.polling.period="{$polycom_provision_polling_period}"

--- a/resources/templates/provision/polycom/vvx250/{$mac}.cfg
+++ b/resources/templates/provision/polycom/vvx250/{$mac}.cfg
@@ -239,6 +239,7 @@
 		call.callWaiting.ring="beep"
 		call.callsPerLineKey="{$polycom_calls_per_line_key}"
 		up.OffHookLineView.enabled="{$polycom_offhook_line_view_enabled}"
+		up.phoneBootStatusPopupEnabled="{$polycom_boot_status_popup_enabled}"
 		prov.polling.enabled="{$polycom_provision_polling_enabled}"
 		prov.polling.mode="{$polycom_provision_polling_mode}"
 		prov.polling.period="{$polycom_provision_polling_period}"

--- a/resources/templates/provision/polycom/vvx300/{$mac}.cfg
+++ b/resources/templates/provision/polycom/vvx300/{$mac}.cfg
@@ -243,6 +243,7 @@
 		call.callWaiting.ring="beep"
 		call.callsPerLineKey="{$polycom_calls_per_line_key}"
 		up.OffHookLineView.enabled="{$polycom_offhook_line_view_enabled}"
+		up.phoneBootStatusPopupEnabled="{$polycom_boot_status_popup_enabled}"
 		prov.polling.enabled="{$polycom_provision_polling_enabled}"
 		prov.polling.mode="{$polycom_provision_polling_mode}"
 		prov.polling.period="{$polycom_provision_polling_period}"

--- a/resources/templates/provision/polycom/vvx301/{$mac}.cfg
+++ b/resources/templates/provision/polycom/vvx301/{$mac}.cfg
@@ -239,6 +239,7 @@
 		call.callWaiting.ring="beep"
 		call.callsPerLineKey="{$polycom_calls_per_line_key}"
 		up.OffHookLineView.enabled="{$polycom_offhook_line_view_enabled}"
+		up.phoneBootStatusPopupEnabled="{$polycom_boot_status_popup_enabled}"
 		prov.polling.enabled="{$polycom_provision_polling_enabled}"
 		prov.polling.mode="{$polycom_provision_polling_mode}"
 		prov.polling.period="{$polycom_provision_polling_period}"

--- a/resources/templates/provision/polycom/vvx310/{$mac}.cfg
+++ b/resources/templates/provision/polycom/vvx310/{$mac}.cfg
@@ -243,6 +243,7 @@
 		call.callWaiting.ring="beep"
 		call.callsPerLineKey="{$polycom_calls_per_line_key}"
 		up.OffHookLineView.enabled="{$polycom_offhook_line_view_enabled}"
+		up.phoneBootStatusPopupEnabled="{$polycom_boot_status_popup_enabled}"
 		prov.polling.enabled="{$polycom_provision_polling_enabled}"
 		prov.polling.mode="{$polycom_provision_polling_mode}"
 		prov.polling.period="{$polycom_provision_polling_period}"

--- a/resources/templates/provision/polycom/vvx311/{$mac}.cfg
+++ b/resources/templates/provision/polycom/vvx311/{$mac}.cfg
@@ -239,6 +239,7 @@
 		call.callWaiting.ring="beep"
 		call.callsPerLineKey="{$polycom_calls_per_line_key}"
 		up.OffHookLineView.enabled="{$polycom_offhook_line_view_enabled}"
+		up.phoneBootStatusPopupEnabled="{$polycom_boot_status_popup_enabled}"
 		prov.polling.enabled="{$polycom_provision_polling_enabled}"
 		prov.polling.mode="{$polycom_provision_polling_mode}"
 		prov.polling.period="{$polycom_provision_polling_period}"

--- a/resources/templates/provision/polycom/vvx350/{$mac}.cfg
+++ b/resources/templates/provision/polycom/vvx350/{$mac}.cfg
@@ -239,6 +239,7 @@
 		call.callWaiting.ring="beep"
 		call.callsPerLineKey="{$polycom_calls_per_line_key}"
 		up.OffHookLineView.enabled="{$polycom_offhook_line_view_enabled}"
+		up.phoneBootStatusPopupEnabled="{$polycom_boot_status_popup_enabled}"
 		prov.polling.enabled="{$polycom_provision_polling_enabled}"
 		prov.polling.mode="{$polycom_provision_polling_mode}"
 		prov.polling.period="{$polycom_provision_polling_period}"

--- a/resources/templates/provision/polycom/vvx400/{$mac}.cfg
+++ b/resources/templates/provision/polycom/vvx400/{$mac}.cfg
@@ -243,6 +243,7 @@
 		call.callWaiting.ring="beep"
 		call.callsPerLineKey="{$polycom_calls_per_line_key}"
 		up.OffHookLineView.enabled="{$polycom_offhook_line_view_enabled}"
+		up.phoneBootStatusPopupEnabled="{$polycom_boot_status_popup_enabled}"
 		prov.polling.enabled="{$polycom_provision_polling_enabled}"
 		prov.polling.mode="{$polycom_provision_polling_mode}"
 		prov.polling.period="{$polycom_provision_polling_period}"

--- a/resources/templates/provision/polycom/vvx401/{$mac}.cfg
+++ b/resources/templates/provision/polycom/vvx401/{$mac}.cfg
@@ -239,6 +239,7 @@
 		call.callWaiting.ring="beep"
 		call.callsPerLineKey="{$polycom_calls_per_line_key}"
 		up.OffHookLineView.enabled="{$polycom_offhook_line_view_enabled}"
+		up.phoneBootStatusPopupEnabled="{$polycom_boot_status_popup_enabled}"
 		prov.polling.enabled="{$polycom_provision_polling_enabled}"
 		prov.polling.mode="{$polycom_provision_polling_mode}"
 		prov.polling.period="{$polycom_provision_polling_period}"

--- a/resources/templates/provision/polycom/vvx410/{$mac}.cfg
+++ b/resources/templates/provision/polycom/vvx410/{$mac}.cfg
@@ -243,6 +243,7 @@
 		call.callWaiting.ring="beep"
 		call.callsPerLineKey="{$polycom_calls_per_line_key}"
 		up.OffHookLineView.enabled="{$polycom_offhook_line_view_enabled}"
+		up.phoneBootStatusPopupEnabled="{$polycom_boot_status_popup_enabled}"
 		prov.polling.enabled="{$polycom_provision_polling_enabled}"
 		prov.polling.mode="{$polycom_provision_polling_mode}"
 		prov.polling.period="{$polycom_provision_polling_period}"

--- a/resources/templates/provision/polycom/vvx411/{$mac}.cfg
+++ b/resources/templates/provision/polycom/vvx411/{$mac}.cfg
@@ -239,6 +239,7 @@
 		call.callWaiting.ring="beep"
 		call.callsPerLineKey="{$polycom_calls_per_line_key}"
 		up.OffHookLineView.enabled="{$polycom_offhook_line_view_enabled}"
+		up.phoneBootStatusPopupEnabled="{$polycom_boot_status_popup_enabled}"
 		prov.polling.enabled="{$polycom_provision_polling_enabled}"
 		prov.polling.mode="{$polycom_provision_polling_mode}"
 		prov.polling.period="{$polycom_provision_polling_period}"

--- a/resources/templates/provision/polycom/vvx450/{$mac}.cfg
+++ b/resources/templates/provision/polycom/vvx450/{$mac}.cfg
@@ -239,6 +239,7 @@
 		call.callWaiting.ring="beep"
 		call.callsPerLineKey="{$polycom_calls_per_line_key}"
 		up.OffHookLineView.enabled="{$polycom_offhook_line_view_enabled}"
+		up.phoneBootStatusPopupEnabled="{$polycom_boot_status_popup_enabled}"
 		prov.polling.enabled="{$polycom_provision_polling_enabled}"
 		prov.polling.mode="{$polycom_provision_polling_mode}"
 		prov.polling.period="{$polycom_provision_polling_period}"

--- a/resources/templates/provision/polycom/vvx500/{$mac}.cfg
+++ b/resources/templates/provision/polycom/vvx500/{$mac}.cfg
@@ -243,6 +243,7 @@
 		call.callWaiting.ring="beep"
 		call.callsPerLineKey="{$polycom_calls_per_line_key}"
 		up.OffHookLineView.enabled="{$polycom_offhook_line_view_enabled}"
+		up.phoneBootStatusPopupEnabled="{$polycom_boot_status_popup_enabled}"
 		prov.polling.enabled="{$polycom_provision_polling_enabled}"
 		prov.polling.mode="{$polycom_provision_polling_mode}"
 		prov.polling.period="{$polycom_provision_polling_period}"

--- a/resources/templates/provision/polycom/vvx501/{$mac}.cfg
+++ b/resources/templates/provision/polycom/vvx501/{$mac}.cfg
@@ -239,6 +239,7 @@
 		call.callWaiting.ring="beep"
 		call.callsPerLineKey="{$polycom_calls_per_line_key}"
 		up.OffHookLineView.enabled="{$polycom_offhook_line_view_enabled}"
+		up.phoneBootStatusPopupEnabled="{$polycom_boot_status_popup_enabled}"
 		prov.polling.enabled="{$polycom_provision_polling_enabled}"
 		prov.polling.mode="{$polycom_provision_polling_mode}"
 		prov.polling.period="{$polycom_provision_polling_period}"

--- a/resources/templates/provision/polycom/vvx600/{$mac}.cfg
+++ b/resources/templates/provision/polycom/vvx600/{$mac}.cfg
@@ -243,6 +243,7 @@
 		call.callWaiting.ring="beep"
 		call.callsPerLineKey="{$polycom_calls_per_line_key}"
 		up.OffHookLineView.enabled="{$polycom_offhook_line_view_enabled}"
+		up.phoneBootStatusPopupEnabled="{$polycom_boot_status_popup_enabled}"
 		prov.polling.enabled="{$polycom_provision_polling_enabled}"
 		prov.polling.mode="{$polycom_provision_polling_mode}"
 		prov.polling.period="{$polycom_provision_polling_period}"

--- a/resources/templates/provision/polycom/vvx601/{$mac}.cfg
+++ b/resources/templates/provision/polycom/vvx601/{$mac}.cfg
@@ -239,6 +239,7 @@
 		call.callWaiting.ring="beep"
 		call.callsPerLineKey="{$polycom_calls_per_line_key}"
 		up.OffHookLineView.enabled="{$polycom_offhook_line_view_enabled}"
+		up.phoneBootStatusPopupEnabled="{$polycom_boot_status_popup_enabled}"
 		prov.polling.enabled="{$polycom_provision_polling_enabled}"
 		prov.polling.mode="{$polycom_provision_polling_mode}"
 		prov.polling.period="{$polycom_provision_polling_period}"


### PR DESCRIPTION
This code enables the ability to enable/disable Polycom boot-time status popup message feature. The feature is disabled by default. Prior to this code, the phones that support the feature have it enabled by default.

Polycom documentation can be seen at https://knowledgebase-iframe.polycom.com/kb/viewContent.do;jsessionid=1EE04DA884586F4187CC86D1B4D3329A?externalId=37102

To quote the above page:
> UC Software 5.9.0 introduced a new feature that during the boot up process would display useful information like the VLAN etc.
> 
> This feature displays the phone’s status pop up information for IP Address, VLAN ID, Provisioning and SNTP status upon every reboot/restart. This feature is enabled by default.