### PR TITLE
Fix permissions on inband feature codes

### DIFF
--- a/app/dialplans/resources/switch/conf/dialplan/085_bind_digit_action.xml
+++ b/app/dialplans/resources/switch/conf/dialplan/085_bind_digit_action.xml
@@ -1,17 +1,19 @@
 
 <context name="{v_context}">
 	<extension name="bind_digit_action" number="" continue="true" app_uuid="7e007a4d-886b-4cdf-81f4-da9eb4689f1c" enabled="false" order="85">
-		<condition field="${sip_authorized}" expression="true" break="never">
-			<action application="set" data="bind_target=both" inline="true"/>
-			<!-- set to peer to prevent manipulate of call by caller -->
+		<condition field="${from_user_exists}" expression="true" break="never">
+			<action application="set" data="bind_target=self" inline="true"/>
+			<action application="set" data="bind_action_target=self" inline="true"/>
+			<!-- The caller here is remote so only assign feature codes to internal recipient -->
 			<anti-action application="set" data="bind_target=peer" inline="true"/>
+			<anti-action application="set" data="bind_action_target=peer" inline="true"/>
 		</condition>
 		<condition>
 			<!-- <action application="export" data="conf_xfer_number=xfer-${create_uuid foo}-${domain_name}"/>-->
-			<action application="bind_digit_action" data="local,*1,exec:execute_extension,dx XML ${context},${bind_target}"/>
-			<action application="bind_digit_action" data="local,*3,exec:execute_extension,cf XML ${context},${bind_target}"/>
-			<action application="bind_digit_action" data="local,*4,exec:execute_extension,att_xfer XML ${context},${bind_target}"/>
-			<!-- <action application="bind_digit_action" data="local,*0,exec:execute_extension,conf_xfer_from_dialplan XML conf-xfer@${domain_name},${bind_target}"/> -->
+			<action application="bind_digit_action" data="local,*1,exec:execute_extension,dx XML ${context},${bind_target},${bind_action_target}"/>
+			<action application="bind_digit_action" data="local,*3,exec:execute_extension,cf XML ${context},${bind_target},${bind_action_target}"/>
+			<action application="bind_digit_action" data="local,*4,exec:execute_extension,att_xfer XML ${context},${bind_target},${bind_action_target}"/>
+			<!-- <action application="bind_digit_action" data="local,*0,exec:execute_extension,conf_xfer_from_dialplan XML conf-xfer@${domain_name},${bind_target},${bind_action_target}"/> -->
 			<action application="digit_action_set_realm" data="local"/>
 		</condition>
 	</extension>


### PR DESCRIPTION
Using ${sip_authorized} is not effective since the inbound
call often has authorization to call into the PBX, either via
ACL or registration.  Instead, use ${from_user_exists} to test
if this user exists on the system.

We also fix a condition that the local user types *1 and the
remote user receives the dial tone.