### PR TITLE
bind_digit_action for B-leg during internal call

### DIFF
--- a/app/dialplans/resources/switch/conf/dialplan/085_bind_digit_action.xml
+++ b/app/dialplans/resources/switch/conf/dialplan/085_bind_digit_action.xml
@@ -16,5 +16,10 @@
 			<!-- <action application="bind_digit_action" data="local,*0,exec:execute_extension,conf_xfer_from_dialplan XML conf-xfer@${domain_name},${bind_target},${bind_action_target}"/> -->
 			<action application="digit_action_set_realm" data="local"/>
 		</condition>
+		<condition field="${user_exists}" expression="true"/>
+		<condition field="${from_user_exists}" expression="true">
+			<action application="set" data="bridge_pre_execute_bleg_app=lua"/>
+			<action application="set" data="bridge_pre_execute_bleg_data=bind_digit_bleg.lua ${context}"/>
+		</condition>
 	</extension>
 </context>

--- a/app/scripts/resources/scripts/bind_digit_bleg.lua
+++ b/app/scripts/resources/scripts/bind_digit_bleg.lua
@@ -1,0 +1,39 @@
+--
+--	FusionPBX
+--	Version: MPL 1.1
+--
+--	The contents of this file are subject to the Mozilla Public License Version
+--	1.1 (the "License"); you may not use this file except in compliance with
+--	the License. You may obtain a copy of the License at
+--	http://www.mozilla.org/MPL/
+--
+--	Software distributed under the License is distributed on an "AS IS" basis,
+--	WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License
+--	for the specific language governing rights and limitations under the
+--	License.
+--
+--	The Original Code is FusionPBX
+--
+--	The Initial Developer of the Original Code is
+--	Mark J Crane <markjcrane@fusionpbx.com>
+--	Copyright (C) 2021
+--	the Initial Developer. All Rights Reserved.
+--
+--	Contributor(s):
+--	Joseph A Nadiv <ynadiv@corpit.xyz>
+
+--include config.lua
+	require "resources.functions.config";
+
+--create the api object
+	api = freeswitch.API();
+	require "resources.functions.channel_utils";
+
+--get context variable
+	local context = argv[1];
+
+--bind to bleg
+	session:execute("bind_digit_action", "local,*1,exec:execute_extension,dx XML ".. context .. ",self,self");
+	session:execute("bind_digit_action", "local,*3,exec:execute_extension,cf XML ".. context .. ",self,self");
+	session:execute("bind_digit_action", "local,*4,exec:execute_extension,att_xfer XML ".. context .. ",self,self");
+	session:execute("digit_action_set_realm", "local");


### PR DESCRIPTION
The existing code only binds properly when one leg
is not internal.  Here we use LUA to bind the bleg
for internal calls.