### PR TITLE
Better detection of trailing '/' in path

### DIFF
--- a/app/recordings/recordings.php
+++ b/app/recordings/recordings.php
@@ -66,7 +66,7 @@
 				}
 
 			// build full path
-				if (substr($recording_filename,0,1) == '/'){
+				if (substr($recording_filename,-1) == '/'){
 					$full_recording_path = $path.$recording_filename;
 				}
 				else {


### PR DESCRIPTION
Currently the substr method may return an invalid path if the $recording_filename starts with a '/'. This will correct it by looking at the string in reverse.