### PR TITLE
Close PHP session to prevent page locking

### DIFF
--- a/resources/classes/domains.php
+++ b/resources/classes/domains.php
@@ -25,6 +25,8 @@
 	sreis
 */
 
+// close session to prevent php locking
+session_write_close();
 
 /**
  * domains class


### PR DESCRIPTION
This change closes the PHP session before executing the app defaults changes. This allows other pages to load while an app defaults is being run from the GUI.

See here: https://stackoverflow.com/questions/28151982/php-page-stuck-at-loading-while-another-php-script-is-running

I am proposing this change because it work to solve a specific problem. However, I can't be 100% sure there wouldn't be other impacts to other parts of the GUI. I searched for the use of this class, and it appears to really only be used when doing an upgrade so I suspect it is safe. There should be no need to update session variables on the upgrade page once an app defaults is running anyways.'

So while I'm quite certain this solves the page locking problem and it is safe, if anyone knows better please chime in!