### PR TITLE
[directory] Use effective_caller_id_name when directory_first_name blank

### DIFF
--- a/app/scripts/resources/scripts/directory.lua
+++ b/app/scripts/resources/scripts/directory.lua
@@ -393,7 +393,7 @@
 			--directory[x] = row;
 		--variables
 			effective_caller_id_name = row.effective_caller_id_name;
-			if (row.directory_first_name) then
+			if (row.directory_first_name ~= nil) and (row.directory_first_name ~= "") then
 				first_name = row.directory_first_name;
 				last_name = row.directory_last_name;
 			else


### PR DESCRIPTION
The database contains directory_first_name entries that are blank, and the
table does not populate properly.  Use effective_caller_id_name when a
nil or blank entry is found.