### PR TITLE
updated the snom timezone description

### DIFF
--- a/app/snom/app_config.php
+++ b/app/snom/app_config.php
@@ -37,7 +37,7 @@
 		$apps[$x]['default_settings'][$y]['default_setting_name'] = "text";
 		$apps[$x]['default_settings'][$y]['default_setting_value'] = "USA-7";
 		$apps[$x]['default_settings'][$y]['default_setting_enabled'] = "false";
-		$apps[$x]['default_settings'][$y]['default_setting_description'] = "http://wiki.snom.com/Settings/timezone";
+		$apps[$x]['default_settings'][$y]['default_setting_description'] = "https://service.snom.com/display/wiki/timezone";
 		$y++;
 		$apps[$x]['default_settings'][$y]['default_setting_uuid'] = "9945982a-f366-11e9-a713-2a2ae2dbcce4";
 		$apps[$x]['default_settings'][$y]['default_setting_category'] = "provision";


### PR DESCRIPTION
The old timezone URL is no longer valid. I've updated the default description with the new correct URL.