### PR TITLE
Removing {$row.display_name} from the line button

### DIFF
--- a/resources/templates/provision/snom/D785/{$mac}.xml
+++ b/resources/templates/provision/snom/D785/{$mac}.xml
@@ -79,7 +79,7 @@
   <!-- Function Keys. View Key Types here: https://service.snom.com/display/wiki/Function+Key+Types -->
   <functionKeys e="2"> {assign var="maxKeys" value=77 - count($lines)}
     {foreach $lines as $row}
-      <fkey idx="{$row.line_number-1}" context="{$row.line_number}" label="{$row.display_name}" perm="RW">line</fkey>
+      <fkey idx="{$row.line_number-1}" context="{$row.line_number}" label="" perm="RW">line</fkey>
       {if $row@index eq 11}{break}{/if}
     {/foreach}
     {foreach $keys["line"] as $row}


### PR DESCRIPTION
The reason I think this should be removed is because setting the label on this model of phone removes the ability to see status of the line button.

For example (without the label), if I have a call on hold on my first line button, it will show the caller's number and the state of that call. For example: "4165551234 holding"

When you put the label, it removes that great feature. When the label is left blank, it defaults to "Line".

## Here is a pic of the current way things work and what the user sees with a call from extension 101 on hold
<details>
  <summary>Click to view image</summary>

![20220109_214917](https://user-images.githubusercontent.com/5287266/148713192-84251d04-cbde-4356-8c11-907dbea7178a.jpg)

</details>

## Here is a pic of the way I am proposing be default
<details>
  <summary>Click to view image</summary>

![20220109_214901](https://user-images.githubusercontent.com/5287266/148713201-c97c147a-3793-4cd5-95a5-8f1ba27f1c5d.jpg)

 </details>