### PR TITLE
Always authorize vm when voicemail authorized=true

### DIFF
--- a/app/scripts/resources/scripts/app/voicemail/index.lua
+++ b/app/scripts/resources/scripts/app/voicemail/index.lua
@@ -383,16 +383,8 @@
 		if (session ~= nil and session:ready()) then
 			--check the voicemail password
 				if (voicemail_id) then
-					if (voicemail_authorized) then
-						if (voicemail_authorized == "true") then
-							if (voicemail_id == user_name or voicemail_id == sip_number_alias) then
-								--skip the password check
-							else
-								check_password(voicemail_id, password_tries);
-							end
-						else
-							check_password(voicemail_id, password_tries);
-						end
+					if (voicemail_authorized == "true") then
+						--skip the password check
 					else
 						check_password(voicemail_id, password_tries);
 					end


### PR DESCRIPTION
To major changes have been made:

* Removed redundant check for the existence of the voicemail_authorized variable since in this logic it is not needed
* Removed additional check to see if voicemail_id or user_name matches the vm box

Purpose being that it prevents use cases such as setting voicemail_authorized=true to disable password prompt with *95[ext] dialplan. In other words, it makes it possible to disable voicemail password check through dialplans under any condition, which I suspect is the intended purpose of the voicemail_authorized variable in the first place.