### PR TITLE
Update {$mac}.cfg

### DIFF
--- a/resources/templates/provision/yealink/t56a/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t56a/{$mac}.cfg
@@ -102,6 +102,10 @@ account.1.register_mac =
 account.1.register_line = 
 account.1.reg_fail_retry_interval = 
 
+#set encryption
+account.1.srtp_encryption= {$yealink_srtp_encryption}
+#this is a dirty way to do this, ideally this entire template needs to be brought in line with the t54w template which has more options for settings and doesn't have account.1,2,3,etc 
+
 
 ######################################################################################
 ##                     NAT Settings                                                 ##


### PR DESCRIPTION
I added a line to set SRTP encryption. the default setting yealink_srtp_encryption was not setting properly to my T56a devices. I downloaded my config files and did not find an entry for srtp at all.

compared with the t54w template and it did have a srtp setting. So I pretty much stole the line from the T54w template and dumped it in here.

this is dirty and tbh the t54w template is vastly superior to this one and this probably needs a rewrite to bring it in line.


tested on my T56a and it at least gets the job done.