### PR TITLE
Provisioning Template Updates for Grandstream GXP2130+, Yealink T46S & Polycom 4.x

### DIFF
--- a/resources/templates/provision/grandstream/dp750/{$mac}.xml
+++ b/resources/templates/provision/grandstream/dp750/{$mac}.xml
@@ -2691,7 +2691,7 @@
 <!-- Number: 0, 1 -->
 <!-- Mandatory -->
 {if isset($grandstream_lan_port_vlan) }
-<P27004>1</P27004>
+<P27004>{$grandstream_lan_port_vlan}</P27004>
 {else}
 <P27004>0</P27004>
 {/if}
@@ -2850,12 +2850,12 @@
 <!-- When set to Yes(1), it will override the configured provision path and method -->
 <!-- Number: 0, 1 -->
 <!-- Mandatory -->
-<P20719>1</P20719>
+{if isset($grandstream_dhcp_option_override)}<P20719>{$grandstream_dhcp_option_override}</P20719>{else}<P20719>1</P20719>{/if}
 
 <!-- Automatic Upgrade. 0 - No, 1 - Check daily, 2 - Check weekly, 3 - Check every () minutes. Default is No. -->
 <!-- Number: 0,1,2,3 -->
 <!-- Mandatory -->
-<P20721>0</P20721>
+<P20721>1</P20721>
 
 <!-- Automatic Upgrade. Check for new firmware/config file every () minutes, unit is in minute, minimum 60 minutes, default is 7 days. P20721=3 -->
 <!-- Number: 60 to 5256000 -->
@@ -3209,7 +3209,7 @@
 <!-- Allow DHCP Option 2 to override time zone (If DHCP Option 2 is enabled, the timezone can be offset.) -->
 <!-- Number: 0, 1 -->
 <!-- Mandatory -->
-<P143>1</P143>
+{if isset($grandstream_dhcp_option_2_timezone_override) }<P143>{$grandstream_dhcp_option_2_timezone_override}</P143>{else}<P143>0</P143>{/if}
 
 <!-- ######################### -->
 <!-- #  Maintenance/Syslog  ## -->
@@ -3268,11 +3268,7 @@
 <!-- Enable Phonebook XML Download. # 0 - No, 1 - YES, HTTP, 2 - YES, TFTP, 3 - Yes, HTTPS. Default is 0 -->
 <!-- Number: 0, 1, 2, 3 -->
 <!-- Mandatory -->
-{if isset($contact_grandstream)}
-<P330>1</P330>
-{else}
-<P330>0</P330>
-{/if}
+<P330>{$grandstream_phonebook_download}</P330>
 
 <!-- HTTP/HTTPS User Name -->
 <!-- String -->
@@ -3286,23 +3282,25 @@
 <!-- This is a string of up to 256 characters that should contain a path to the XML file. It MUST be in the host/path format. -->
 <!-- For example: directory.grandstream.com/engineering -->
 <!-- String -->
-{if isset($contact_grandstream)}
-<P331>{$grandstream_phonebook_xml_server_path}{$mac}/</P331>
-{elseif isset($grandstream_phonebook_xml_server_path)}
-<P331>{$grandstream_phonebook_xml_server_path}</P331>
+{if isset($grandstream_phonebook_xml_server_path)}
+    <P331>{$grandstream_phonebook_xml_server_path}/{$mac}</P331>
 {else}
-<P331></P331>
+    <P331></P331>
 {/if}
 
 <!-- Phonebook Download Interval (in minutes) -->
 <!-- Valid value range is 5-720. Default is 0 for disabled -->
 <!-- Number: 0, 5-720;  -->
-<P332>120</P332>
+{if isset($grandstream_phonebook_download_interval)}
+    <P332>{$grandstream_phonebook_download_interval}</P332>
+{else}
+    <P332>0</P332>
+{/if}
 
 <!-- Remove Manually-edited entries on Download. 0 - No, 1 - Yes. Default is 1 -->
 <!-- Number: 0, 1 -->
 <!-- Mandatory -->
-<P333>1</P333>
+<P333>0</P333>
 
 <!-- ############################################### -->
 <!-- #  Phonebook/Global Phonebook LDAP Settings  ## -->

--- a/resources/templates/provision/grandstream/gxp2130/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp2130/{$mac}.xml
@@ -631,8 +631,12 @@
     <!-- # Jitter Buffer Type. 0 - Fixed, 1 - Adaptive. Default is 1 -->
     <!-- # Number: 0, 1 -->
     <!-- # Mandatory -->
+    {if isset ($grandstream_jitter_adapt)}
+    <P133>{$grandstream_jitter_adapt}</P133>
+    {else}
     <P133>1</P133>
-
+    {/if}
+    
     <!-- # Jitter Buffer Length. 0 - 100ms, 1 - 200ms, 2 - 300ms, 3 - 400ms, 4 - 500ms, 5 - 600ms, 6 - 700ms, 7 - 800ms -->
     <!-- # Default is 2 -->
     <!-- # Number: 0, 1, 2, 3, 4, 5, 6, 7 -->
@@ -8433,11 +8437,13 @@
     <!-- ############################################################################## -->
     <!-- # Server Path -->
     <!-- # String -->
-    <P337></P337>
-
-    <!-- # Softkey Label -->
-    <!-- # String -->
-    <P352>XMLApp</P352>
+{if isset($xmlappurl)}
+    <P337>{$xmlappurl}?token={$xmlapptoken}</P337>
+    <P352>{$xmlapp}</P352>
+{elseif isset($xmlapp)}
+    <P337>https://{$server_address_1}/app/change-caller-id/app.php?token={$xmlapptoken}</P337>
+    <P352>{$xmlapp}</P352>
+{/if}
 
     <!-- # Default Background Color -->
     <!-- # String -->
@@ -8469,8 +8475,12 @@
     <!-- # Key Mode. 1 - Line Mode, 2 - Account Mode. Default is 1 -->
     <!-- # Number: 1, 2 -->
     <!-- # Mandatory -->
+    {if isset ($grandstream_key_mode)}
+    <P8369>{$grandstream_key_mode}</P8369>
+    {else}
     <P8369>1</P8369>
-
+    {/if}
+    
     <!-- # Transfer Mode via VPK. 0 - Blind Transfer, 1 - Attended Transfer, 2 - New Call. Default is 0 -->
     <!-- # Number: 0, 1, 2 -->
     <!-- # Mandatory -->

--- a/resources/templates/provision/grandstream/gxp2135/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp2135/{$mac}.xml
@@ -631,8 +631,12 @@
     <!-- # Jitter Buffer Type. 0 - Fixed, 1 - Adaptive. Default is 1 -->
     <!-- # Number: 0, 1 -->
     <!-- # Mandatory -->
+    {if isset ($grandstream_jitter_adapt)}
+    <P133>{$grandstream_jitter_adapt}</P133>
+    {else}
     <P133>1</P133>
-
+    {/if}
+    
     <!-- # Jitter Buffer Length. 0 - 100ms, 1 - 200ms, 2 - 300ms, 3 - 400ms, 4 - 500ms, 5 - 600ms, 6 - 700ms, 7 - 800ms -->
     <!-- # Default is 2 -->
     <!-- # Number: 0, 1, 2, 3, 4, 5, 6, 7 -->
@@ -8433,11 +8437,13 @@
     <!-- ############################################################################## -->
     <!-- # Server Path -->
     <!-- # String -->
-    <P337></P337>
-
-    <!-- # Softkey Label -->
-    <!-- # String -->
-    <P352>XMLApp</P352>
+{if isset($xmlappurl)}
+    <P337>{$xmlappurl}?token={$xmlapptoken}</P337>
+    <P352>{$xmlapp}</P352>
+{elseif isset($xmlapp)}
+    <P337>https://{$server_address_1}/app/change-caller-id/app.php?token={$xmlapptoken}</P337>
+    <P352>{$xmlapp}</P352>
+{/if}
 
     <!-- # Default Background Color -->
     <!-- # String -->
@@ -8469,8 +8475,12 @@
     <!-- # Key Mode. 1 - Line Mode, 2 - Account Mode. Default is 1 -->
     <!-- # Number: 1, 2 -->
     <!-- # Mandatory -->
+    {if isset ($grandstream_key_mode)}
+    <P8369>{$grandstream_key_mode}</P8369>
+    {else}
     <P8369>1</P8369>
-
+    {/if}
+    
     <!-- # Transfer Mode via VPK. 0 - Blind Transfer, 1 - Attended Transfer, 2 - New Call. Default is 0 -->
     <!-- # Number: 0, 1, 2 -->
     <!-- # Mandatory -->

--- a/resources/templates/provision/grandstream/gxp2140/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp2140/{$mac}.xml
@@ -631,8 +631,12 @@
     <!-- # Jitter Buffer Type. 0 - Fixed, 1 - Adaptive. Default is 1 -->
     <!-- # Number: 0, 1 -->
     <!-- # Mandatory -->
+    {if isset ($grandstream_jitter_adapt)}
+    <P133>{$grandstream_jitter_adapt}</P133>
+    {else}
     <P133>1</P133>
-
+    {/if}
+    
     <!-- # Jitter Buffer Length. 0 - 100ms, 1 - 200ms, 2 - 300ms, 3 - 400ms, 4 - 500ms, 5 - 600ms, 6 - 700ms, 7 - 800ms -->
     <!-- # Default is 2 -->
     <!-- # Number: 0, 1, 2, 3, 4, 5, 6, 7 -->
@@ -8433,11 +8437,13 @@
     <!-- ############################################################################## -->
     <!-- # Server Path -->
     <!-- # String -->
-    <P337></P337>
-
-    <!-- # Softkey Label -->
-    <!-- # String -->
-    <P352>XMLApp</P352>
+{if isset($xmlappurl)}
+    <P337>{$xmlappurl}?token={$xmlapptoken}</P337>
+    <P352>{$xmlapp}</P352>
+{elseif isset($xmlapp)}
+    <P337>https://{$server_address_1}/app/change-caller-id/app.php?token={$xmlapptoken}</P337>
+    <P352>{$xmlapp}</P352>
+{/if}
 
     <!-- # Default Background Color -->
     <!-- # String -->
@@ -8469,8 +8475,12 @@
     <!-- # Key Mode. 1 - Line Mode, 2 - Account Mode. Default is 1 -->
     <!-- # Number: 1, 2 -->
     <!-- # Mandatory -->
+    {if isset ($grandstream_key_mode)}
+    <P8369>{$grandstream_key_mode}</P8369>
+    {else}
     <P8369>1</P8369>
-
+    {/if}
+    
     <!-- # Transfer Mode via VPK. 0 - Blind Transfer, 1 - Attended Transfer, 2 - New Call. Default is 0 -->
     <!-- # Number: 0, 1, 2 -->
     <!-- # Mandatory -->

--- a/resources/templates/provision/grandstream/gxp2160/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp2160/{$mac}.xml
@@ -631,7 +631,11 @@
     <!-- # Jitter Buffer Type. 0 - Fixed, 1 - Adaptive. Default is 1 -->
     <!-- # Number: 0, 1 -->
     <!-- # Mandatory -->
+    {if isset ($grandstream_jitter_adapt)}
+    <P133>{$grandstream_jitter_adapt}</P133>
+    {else}
     <P133>1</P133>
+    {/if}
 
     <!-- # Jitter Buffer Length. 0 - 100ms, 1 - 200ms, 2 - 300ms, 3 - 400ms, 4 - 500ms, 5 - 600ms, 6 - 700ms, 7 - 800ms -->
     <!-- # Default is 2 -->
@@ -8433,11 +8437,13 @@
     <!-- ############################################################################## -->
     <!-- # Server Path -->
     <!-- # String -->
-    <P337></P337>
-
-    <!-- # Softkey Label -->
-    <!-- # String -->
-    <P352>XMLApp</P352>
+{if isset($xmlappurl)}
+    <P337>{$xmlappurl}?token={$xmlapptoken}</P337>
+    <P352>{$xmlapp}</P352>
+{elseif isset($xmlapp)}
+    <P337>https://{$server_address_1}/app/change-caller-id/app.php?token={$xmlapptoken}</P337>
+    <P352>{$xmlapp}</P352>
+{/if}
 
     <!-- # Default Background Color -->
     <!-- # String -->
@@ -8469,8 +8475,12 @@
     <!-- # Key Mode. 1 - Line Mode, 2 - Account Mode. Default is 1 -->
     <!-- # Number: 1, 2 -->
     <!-- # Mandatory -->
+    {if isset ($grandstream_key_mode)}
+    <P8369>{$grandstream_key_mode}</P8369>
+    {else}
     <P8369>1</P8369>
-
+    {/if}
+    
     <!-- # Transfer Mode via VPK. 0 - Blind Transfer, 1 - Attended Transfer, 2 - New Call. Default is 0 -->
     <!-- # Number: 0, 1, 2 -->
     <!-- # Mandatory -->

--- a/resources/templates/provision/grandstream/gxp2170/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp2170/{$mac}.xml
@@ -8175,7 +8175,11 @@
     <!-- # When set to Yes(1), it will override the configured Time Zone setting if available  -->
     <!-- # Number: 0, 1 -->
     <!-- # Mandatory -->
-    <P143>1</P143>
+{if isset($grandstream_dhcp_option_2_timezone_override) }
+    <P143>{$grandstream_dhcp_option_2_timezone_override}</P143>
+{else}
+    <P143>0</P143>
+{/if}
 
     <!-- # Self Defined Time zone. Max length allowed is 64 characters -->
     <!-- # String -->

--- a/resources/templates/provision/grandstream/gxp2170/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp2170/{$mac}.xml
@@ -631,7 +631,11 @@
     <!-- # Jitter Buffer Type. 0 - Fixed, 1 - Adaptive. Default is 1 -->
     <!-- # Number: 0, 1 -->
     <!-- # Mandatory -->
+    {if isset ($grandstream_jitter_adapt)}
+    <P133>{$grandstream_jitter_adapt}</P133>
+    {else}
     <P133>1</P133>
+    {/if}
 
     <!-- # Jitter Buffer Length. 0 - 100ms, 1 - 200ms, 2 - 300ms, 3 - 400ms, 4 - 500ms, 5 - 600ms, 6 - 700ms, 7 - 800ms -->
     <!-- # Default is 2 -->
@@ -8437,11 +8441,13 @@
     <!-- ############################################################################## -->
     <!-- # Server Path -->
     <!-- # String -->
-    <P337></P337>
-
-    <!-- # Softkey Label -->
-    <!-- # String -->
-    <P352>XMLApp</P352>
+{if isset($xmlappurl)}
+    <P337>{$xmlappurl}?token={$xmlapptoken}</P337>
+    <P352>{$xmlapp}</P352>
+{elseif isset($xmlapp)}
+    <P337>https://{$server_address_1}/app/change-caller-id/app.php?token={$xmlapptoken}</P337>
+    <P352>{$xmlapp}</P352>
+{/if}
 
     <!-- # Default Background Color -->
     <!-- # String -->
@@ -8473,7 +8479,11 @@
     <!-- # Key Mode. 1 - Line Mode, 2 - Account Mode. Default is 1 -->
     <!-- # Number: 1, 2 -->
     <!-- # Mandatory -->
+    {if isset ($grandstream_key_mode)}
+    <P8369>{$grandstream_key_mode}</P8369>
+    {else}
     <P8369>1</P8369>
+    {/if}
 
     <!-- # Transfer Mode via VPK. 0 - Blind Transfer, 1 - Attended Transfer, 2 - New Call. Default is 0 -->
     <!-- # Number: 0, 1, 2 -->

--- a/resources/templates/provision/grandstream/gxw42xx/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxw42xx/{$mac}.xml
@@ -3896,12 +3896,12 @@
 <P21641>5060</P21641>
 
 <!-- FXS 35 -->
-<P21002>{$account.34.user_id}</P21002>
-<P21066>{$account.34.user_id}</P21066>
-<P21130>{$account.34.password}</P21130>
-<P21194>{$account.34.display_name}</P21194>
+<P21002>{$account.35.user_id}</P21002>
+<P21066>{$account.35.user_id}</P21066>
+<P21130>{$account.35.password}</P21130>
+<P21194>{$account.35.display_name}</P21194>
 <P21258>0</P21258>
-{if !isset($account.34.user_id) && $grandstream_fxs_enabled == 0}
+{if !isset($account.35.user_id) && $grandstream_fxs_enabled == 0}
 <P21386>0</P21386>
 {else}
 <P21386>1</P21386>
@@ -3993,7 +3993,7 @@
 <!-- FXS 40 -->
 <P21007>{$account.40.user_id}</P21007>
 <P21071>{$account.40.user_id}</P21071>
-<P21145>{$account.40.password}</P21145>
+<P21135>{$account.40.password}</P21135>
 <P21199>{$account.40.display_name}</P21199>
 <P21263>0</P21263>
 {if !isset($account.40.user_id) && $grandstream_fxs_enabled == 0}
@@ -4012,7 +4012,7 @@
 <!-- FXS 41 -->
 <P21008>{$account.41.user_id}</P21008>
 <P21072>{$account.41.user_id}</P21072>
-<P21146>{$account.41.password}</P21146>
+<P21136>{$account.41.password}</P21136>
 <P21200>{$account.41.display_name}</P21200>
 <P21264>0</P21264>
 {if !isset($account.41.user_id) && $grandstream_fxs_enabled == 0}
@@ -4031,7 +4031,7 @@
 <!-- FXS 42 -->
 <P21009>{$account.42.user_id}</P21009>
 <P21073>{$account.42.user_id}</P21073>
-<P21147>{$account.42.password}</P21147>
+<P21137>{$account.42.password}</P21137>
 <P21201>{$account.42.display_name}</P21201>
 <P21265>0</P21265>
 {if !isset($account.42.user_id) && $grandstream_fxs_enabled == 0}
@@ -4050,7 +4050,7 @@
 <!-- FXS 43 -->
 <P21010>{$account.43.user_id}</P21010>
 <P21074>{$account.43.user_id}</P21074>
-<P21148>{$account.43.password}</P21148>
+<P21138>{$account.43.password}</P21138>
 <P21202>{$account.43.display_name}</P21202>
 <P21266>0</P21266>
 {if !isset($account.43.user_id) && $grandstream_fxs_enabled == 0}

--- a/resources/templates/provision/polycom/4.x/{$mac}.cfg
+++ b/resources/templates/provision/polycom/4.x/{$mac}.cfg
@@ -79,6 +79,10 @@
 		device.sntp.gmtOffset="{$polycom_gmt_offset}"
 		device.prov.upgradeServer.set="1"
 		device.prov.upgradeServer="{$polycom_firmware_url}"
+		{if isset($polycom_cdp_enabled)}
+		device.net.cdpEnabled.set="1"
+		device.net.cdpEnabled="{$polycom_cdp_enabled}"
+		{/if}
 
 		{if isset($admin_password)}
 		device.auth.localUserPassword.set="1" 

--- a/resources/templates/provision/yealink/t46s/y000000000066.cfg
+++ b/resources/templates/provision/yealink/t46s/y000000000066.cfg
@@ -1054,7 +1054,7 @@ features.voice_mail_alert.enable=
 features.voice_mail_popup.enable = {$yealink_voice_mail_popup_enable}
 features.voice_mail_tone_enable=
 features.hide_feature_access_codes.enable = {$yealink_hide_feature_access_codes_enable}
-voice_mail.number.1=
+voice_mail.number.1 = {$voicemail_number}
 
 
 #######################################################################################  
@@ -1093,7 +1093,7 @@ voice.handset_send=
 voice.handfree_send =
 voice.headset_send =
 features.intercom.headset_prior.enable=
-features.ringer_device.is_use_headset=
+features.ringer_device.is_use_headset = {$yealink_headset_ringer}
 
 
 #######################################################################################  


### PR DESCRIPTION
Hello Mark,

Per our call I have modified 9 templates, adding the following things:
**Grandstream**
- Fixed grandstream_lan_port_vlan
- Backported grandstream_dhcp_option_override and grandstream_phonebook_download and grandstream_phonebook_download_interval
- Added grandstream_key_mode (Key Mode. 1 - Line Mode, 2 - Account Mode. Default is 1)
- Added grandstream_dhcp_option_2_timezone_override (When set to Yes(1), it will override the configured Time Zone setting if available)
- Added grandstream_jitter_adapt
- Added xmlappurl and xmlapp ([Grandstream thread](https://forums.grandstream.com/t/writing-an-xml-application/15888/6))

**Yealink**
- Backported voicemail_number
- Added yealink_headset_ringer (Configures the ringer device for the IP phone, 0-Use Speaker, 1-Use Headset, 2-Use Headset & Speaker)

**Polycom 4.x**
- Backported the polycom_cdp_enabled variable