### PR TITLE
Yealink template consistency

### DIFF
--- a/resources/templates/provision/yealink/cp860/{$mac}.cfg
+++ b/resources/templates/provision/yealink/cp860/{$mac}.cfg
@@ -143,7 +143,7 @@ account.1.nat.stun_server = {$stun_server}
 account.1.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.1.nat.udp_update_enable = 3
+account.1.nat.udp_update_enable = {if isset($account.1.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
 account.1.nat.udp_update_time = 30
@@ -646,7 +646,7 @@ account.2.nat.stun_server = {$stun_server}
 account.2.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.2.nat.udp_update_enable = 1
+account.2.nat.udp_update_enable = {if isset($account.2.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
 account.2.nat.udp_update_time = 30
@@ -1161,7 +1161,7 @@ account.3.nat.stun_server = {$stun_server}
 account.3.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.3.nat.udp_update_enable = 1
+account.3.nat.udp_update_enable = {if isset($account.3.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
 account.3.nat.udp_update_time = 30
@@ -1661,7 +1661,7 @@ account.4.nat.stun_server = {$stun_server}
 account.4.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.4.nat.udp_update_enable = 1
+account.4.nat.udp_update_enable = {if isset($account.4.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
 account.4.nat.udp_update_time = 30
@@ -2158,7 +2158,7 @@ account.5.nat.stun_server = {$stun_server}
 account.5.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.5.nat.udp_update_enable = 1
+account.5.nat.udp_update_enable = {if isset($account.5.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
 account.5.nat.udp_update_time = 30
@@ -2654,7 +2654,7 @@ account.6.nat.stun_server =
 account.6.nat.stun_port = 3478
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.6.nat.udp_update_enable = 1
+account.6.nat.udp_update_enable = {if isset($account.6.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
 account.6.nat.udp_update_time = 30

--- a/resources/templates/provision/yealink/cp920/{$mac}.cfg
+++ b/resources/templates/provision/yealink/cp920/{$mac}.cfg
@@ -142,7 +142,7 @@ account.1.nat.stun_server = {$stun_server}
 account.1.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.1.nat.udp_update_enable = 3
+account.1.nat.udp_update_enable = {if isset($account.1.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
 account.1.nat.udp_update_time = 30
@@ -645,7 +645,7 @@ account.2.nat.stun_server = {$stun_server}
 account.2.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.2.nat.udp_update_enable = 1
+account.2.nat.udp_update_enable = {if isset($account.2.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
 account.2.nat.udp_update_time = 30
@@ -1161,7 +1161,7 @@ account.3.nat.stun_server = {$stun_server}
 account.3.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.3.nat.udp_update_enable = 1
+account.3.nat.udp_update_enable = {if isset($account.3.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
 account.3.nat.udp_update_time = 30
@@ -1663,7 +1663,7 @@ account.4.nat.stun_server = {$stun_server}
 account.4.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.4.nat.udp_update_enable = 1
+account.4.nat.udp_update_enable = {if isset($account.4.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
 account.4.nat.udp_update_time = 30
@@ -2161,7 +2161,7 @@ account.5.nat.stun_server = {$stun_server}
 account.5.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.5.nat.udp_update_enable = 1
+account.5.nat.udp_update_enable = {if isset($account.5.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
 account.5.nat.udp_update_time = 30
@@ -2658,7 +2658,7 @@ account.6.nat.stun_server =
 account.6.nat.stun_port = 3478
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.6.nat.udp_update_enable = 1
+account.6.nat.udp_update_enable = {if isset($account.6.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
 account.6.nat.udp_update_time = 30

--- a/resources/templates/provision/yealink/cp960/{$mac}.cfg
+++ b/resources/templates/provision/yealink/cp960/{$mac}.cfg
@@ -143,7 +143,7 @@ account.1.nat.stun_server = {$stun_server}
 account.1.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.1.nat.udp_update_enable = 3
+account.1.nat.udp_update_enable = {if isset($account.1.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
 account.1.nat.udp_update_time = 30
@@ -647,7 +647,7 @@ account.2.nat.stun_server = {$stun_server}
 account.2.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.2.nat.udp_update_enable = 1
+account.2.nat.udp_update_enable = {if isset($account.2.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
 account.2.nat.udp_update_time = 30
@@ -1162,7 +1162,7 @@ account.3.nat.stun_server = {$stun_server}
 account.3.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.3.nat.udp_update_enable = 1
+account.3.nat.udp_update_enable = {if isset($account.3.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
 account.3.nat.udp_update_time = 30
@@ -1661,7 +1661,7 @@ account.4.nat.stun_server = {$stun_server}
 account.4.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.4.nat.udp_update_enable = 1
+account.4.nat.udp_update_enable = {if isset($account.4.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
 account.4.nat.udp_update_time = 30
@@ -2158,7 +2158,7 @@ account.5.nat.stun_server = {$stun_server}
 account.5.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.5.nat.udp_update_enable = 1
+account.5.nat.udp_update_enable = {if isset($account.5.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
 account.5.nat.udp_update_time = 30
@@ -2654,7 +2654,7 @@ account.6.nat.stun_server =
 account.6.nat.stun_port = 3478
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.6.nat.udp_update_enable = 1
+account.6.nat.udp_update_enable = {if isset($account.6.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
 account.6.nat.udp_update_time = 30

--- a/resources/templates/provision/yealink/t19p/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t19p/{$mac}.cfg
@@ -247,10 +247,10 @@ account.1.nat.stun_server = {$stun_server}
 account.1.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.1.nat.udp_update_enable = 3
+account.1.nat.udp_update_enable = {if isset($account.1.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
-account.1.nat.udp_update_time =
+account.1.nat.udp_update_time = 30
 
 #Enable or disable the NAT Rport; 0-Disabled (default), 1-Enabled;
 account.1.nat.rport = {$yealink_rport}
@@ -599,11 +599,11 @@ account.2.nat.stun_server = {$stun_server}
 #Configure the STUN server port, the default value is 3478.
 account.2.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
-#Enable or disable the NAT keep-alive; 0-Disabled, 1-Enabled (default);
-account.2.nat.udp_update_enable =
+#Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
+account.2.nat.udp_update_enable = {if isset($account.2.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
-account.2.nat.udp_update_time =
+account.2.nat.udp_update_time = 30
 
 #Enable or disable the NAT Rport; 0-Disabled (default), 1-Enabled;
 account.2.nat.rport = {$yealink_rport}
@@ -924,11 +924,11 @@ account.3.nat.stun_server = {$stun_server}
 #Configure the STUN server port, the default value is 3478.
 account.3.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
-#Enable or disable the NAT keep-alive; 0-Disabled, 1-Enabled (default);
-account.3.nat.udp_update_enable =
+#Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
+account.3.nat.udp_update_enable = {if isset($account.3.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
-account.3.nat.udp_update_time =
+account.3.nat.udp_update_time = 30
 
 #Enable or disable the NAT Rport; 0-Disabled (default), 1-Enabled;
 account.3.nat.rport = {$yealink_rport}
@@ -1250,11 +1250,11 @@ account.4.nat.stun_server = {$stun_server}
 #Configure the STUN server port, the default value is 3478.
 account.4.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
-#Enable or disable the NAT keep-alive; 0-Disabled, 1-Enabled (default);
-account.4.nat.udp_update_enable =
+#Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
+account.4.nat.udp_update_enable = {if isset($account.4.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
-account.4.nat.udp_update_time =
+account.4.nat.udp_update_time = 30
 
 #Enable or disable the NAT Rport; 0-Disabled (default), 1-Enabled;
 account.4.nat.rport = {$yealink_rport}
@@ -1576,11 +1576,11 @@ account.5.nat.stun_server = {$stun_server}
 #Configure the STUN server port, the default value is 3478.
 account.5.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
-#Enable or disable the NAT keep-alive; 0-Disabled, 1-Enabled (default);
-account.5.nat.udp_update_enable =
+#Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
+account.5.nat.udp_update_enable = {if isset($account.5.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
-account.5.nat.udp_update_time =
+account.5.nat.udp_update_time = 30
 
 #Enable or disable the NAT Rport; 0-Disabled (default), 1-Enabled;
 account.5.nat.rport = {$yealink_rport}
@@ -1899,11 +1899,11 @@ account.6.nat.stun_server =
 #Configure the STUN server port, the default value is 3478.
 account.6.nat.stun_port =
 
-#Enable or disable the NAT keep-alive; 0-Disabled, 1-Enabled (default);
-account.6.nat.udp_update_enable =
+#Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
+account.6.nat.udp_update_enable = {if isset($account.6.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
-account.6.nat.udp_update_time =
+account.6.nat.udp_update_time = 30
 
 #Enable or disable the NAT Rport; 0-Disabled (default), 1-Enabled;
 account.6.nat.rport = {$yealink_rport}

--- a/resources/templates/provision/yealink/t20p/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t20p/{$mac}.cfg
@@ -247,10 +247,10 @@ account.1.nat.stun_server = {$stun_server}
 account.1.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.1.nat.udp_update_enable = 3
+account.1.nat.udp_update_enable = {if isset($account.1.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
-account.1.nat.udp_update_time =
+account.1.nat.udp_update_time = 30
 
 #Enable or disable the NAT Rport; 0-Disabled (default), 1-Enabled;
 account.1.nat.rport = {$yealink_rport}
@@ -601,11 +601,11 @@ account.2.nat.stun_server = {$stun_server}
 #Configure the STUN server port, the default value is 3478.
 account.2.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
-#Enable or disable the NAT keep-alive; 0-Disabled, 1-Enabled (default);
-account.2.nat.udp_update_enable =
+#Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
+account.2.nat.udp_update_enable = {if isset($account.2.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
-account.2.nat.udp_update_time =
+account.2.nat.udp_update_time = 30
 
 #Enable or disable the NAT Rport; 0-Disabled (default), 1-Enabled;
 account.2.nat.rport = {$yealink_rport}
@@ -926,11 +926,11 @@ account.3.nat.stun_server = {$stun_server}
 #Configure the STUN server port, the default value is 3478.
 account.3.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
-#Enable or disable the NAT keep-alive; 0-Disabled, 1-Enabled (default);
-account.3.nat.udp_update_enable =
+#Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
+account.3.nat.udp_update_enable = {if isset($account.3.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
-account.3.nat.udp_update_time =
+account.3.nat.udp_update_time = 30
 
 #Enable or disable the NAT Rport; 0-Disabled (default), 1-Enabled;
 account.3.nat.rport = {$yealink_rport}
@@ -1251,11 +1251,11 @@ account.4.nat.stun_server = {$stun_server}
 #Configure the STUN server port, the default value is 3478.
 account.4.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
-#Enable or disable the NAT keep-alive; 0-Disabled, 1-Enabled (default);
-account.4.nat.udp_update_enable =
+#Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
+account.4.nat.udp_update_enable = {if isset($account.4.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
-account.4.nat.udp_update_time =
+account.4.nat.udp_update_time = 30
 
 #Enable or disable the NAT Rport; 0-Disabled (default), 1-Enabled;
 account.4.nat.rport = {$yealink_rport}
@@ -1577,11 +1577,11 @@ account.5.nat.stun_server = {$stun_server}
 #Configure the STUN server port, the default value is 3478.
 account.5.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
-#Enable or disable the NAT keep-alive; 0-Disabled, 1-Enabled (default);
-account.5.nat.udp_update_enable =
+#Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
+account.5.nat.udp_update_enable = {if isset($account.5.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
-account.5.nat.udp_update_time =
+account.5.nat.udp_update_time = 30
 
 #Enable or disable the NAT Rport; 0-Disabled (default), 1-Enabled;
 account.5.nat.rport = {$yealink_rport}
@@ -1900,11 +1900,11 @@ account.6.nat.stun_server =
 #Configure the STUN server port, the default value is 3478.
 account.6.nat.stun_port =
 
-#Enable or disable the NAT keep-alive; 0-Disabled, 1-Enabled (default);
-account.6.nat.udp_update_enable =
+#Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
+account.6.nat.udp_update_enable = {if isset($account.6.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
-account.6.nat.udp_update_time =
+account.6.nat.udp_update_time = 30
 
 #Enable or disable the NAT Rport; 0-Disabled (default), 1-Enabled;
 account.6.nat.rport = {$yealink_rport}

--- a/resources/templates/provision/yealink/t21p/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t21p/{$mac}.cfg
@@ -143,7 +143,7 @@ account.1.nat.stun_server = {$stun_server}
 account.1.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.1.nat.udp_update_enable = 3
+account.1.nat.udp_update_enable = {if isset($account.1.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
 account.1.nat.udp_update_time = 30
@@ -645,7 +645,7 @@ account.2.nat.stun_server = {$stun_server}
 account.2.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.2.nat.udp_update_enable = 1
+account.2.nat.udp_update_enable = {if isset($account.2.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
 account.2.nat.udp_update_time = 30
@@ -1158,7 +1158,7 @@ account.3.nat.stun_server = {$stun_server}
 account.3.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.3.nat.udp_update_enable = 1
+account.3.nat.udp_update_enable = {if isset($account.3.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
 account.3.nat.udp_update_time = 30
@@ -1654,7 +1654,7 @@ account.4.nat.stun_server = {$stun_server}
 account.4.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.4.nat.udp_update_enable = 1
+account.4.nat.udp_update_enable = {if isset($account.4.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
 account.4.nat.udp_update_time = 30
@@ -2150,7 +2150,7 @@ account.5.nat.stun_server = {$stun_server}
 account.5.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.5.nat.udp_update_enable = 1
+account.5.nat.udp_update_enable = {if isset($account.5.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
 account.5.nat.udp_update_time = 30
@@ -2645,7 +2645,7 @@ account.6.nat.stun_server =
 account.6.nat.stun_port = 3478
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.6.nat.udp_update_enable = 1
+account.6.nat.udp_update_enable = {if isset($account.6.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
 account.6.nat.udp_update_time = 30

--- a/resources/templates/provision/yealink/t22p/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t22p/{$mac}.cfg
@@ -247,10 +247,10 @@ account.1.nat.stun_server = {$stun_server}
 account.1.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.1.nat.udp_update_enable = 3
+account.1.nat.udp_update_enable = {if isset($account.1.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
-account.1.nat.udp_update_time =
+account.1.nat.udp_update_time = 30
 
 #Enable or disable the NAT Rport; 0-Disabled (default), 1-Enabled;
 account.1.nat.rport = {$yealink_rport}
@@ -599,11 +599,11 @@ account.2.nat.stun_server = {$stun_server}
 #Configure the STUN server port, the default value is 3478.
 account.2.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
-#Enable or disable the NAT keep-alive; 0-Disabled, 1-Enabled (default);
-account.2.nat.udp_update_enable =
+#Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
+account.2.nat.udp_update_enable = {if isset($account.2.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
-account.2.nat.udp_update_time =
+account.2.nat.udp_update_time = 30
 
 #Enable or disable the NAT Rport; 0-Disabled (default), 1-Enabled;
 account.2.nat.rport = {$yealink_rport}
@@ -924,11 +924,11 @@ account.3.nat.stun_server = {$stun_server}
 #Configure the STUN server port, the default value is 3478.
 account.3.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
-#Enable or disable the NAT keep-alive; 0-Disabled, 1-Enabled (default);
-account.3.nat.udp_update_enable =
+#Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
+account.3.nat.udp_update_enable = {if isset($account.3.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
-account.3.nat.udp_update_time =
+account.3.nat.udp_update_time = 30
 
 #Enable or disable the NAT Rport; 0-Disabled (default), 1-Enabled;
 account.3.nat.rport = {$yealink_rport}
@@ -1250,11 +1250,11 @@ account.4.nat.stun_server = {$stun_server}
 #Configure the STUN server port, the default value is 3478.
 account.4.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
-#Enable or disable the NAT keep-alive; 0-Disabled, 1-Enabled (default);
-account.4.nat.udp_update_enable =
+#Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
+account.4.nat.udp_update_enable = {if isset($account.4.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
-account.4.nat.udp_update_time =
+account.4.nat.udp_update_time = 30
 
 #Enable or disable the NAT Rport; 0-Disabled (default), 1-Enabled;
 account.4.nat.rport = {$yealink_rport}
@@ -1576,11 +1576,11 @@ account.5.nat.stun_server = {$stun_server}
 #Configure the STUN server port, the default value is 3478.
 account.5.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
-#Enable or disable the NAT keep-alive; 0-Disabled, 1-Enabled (default);
-account.5.nat.udp_update_enable =
+#Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
+account.5.nat.udp_update_enable = {if isset($account.5.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
-account.5.nat.udp_update_time =
+account.5.nat.udp_update_time = 30
 
 #Enable or disable the NAT Rport; 0-Disabled (default), 1-Enabled;
 account.5.nat.rport = {$yealink_rport}
@@ -1899,11 +1899,11 @@ account.6.nat.stun_server =
 #Configure the STUN server port, the default value is 3478.
 account.6.nat.stun_port =
 
-#Enable or disable the NAT keep-alive; 0-Disabled, 1-Enabled (default);
-account.6.nat.udp_update_enable =
+#Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
+account.6.nat.udp_update_enable = {if isset($account.6.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
-account.6.nat.udp_update_time =
+account.6.nat.udp_update_time = 30
 
 #Enable or disable the NAT Rport; 0-Disabled (default), 1-Enabled;
 account.6.nat.rport = {$yealink_rport}

--- a/resources/templates/provision/yealink/t23g/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t23g/{$mac}.cfg
@@ -156,7 +156,7 @@ account.1.nat.stun_server = {$stun_server}
 account.1.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.1.nat.udp_update_enable = 3
+account.1.nat.udp_update_enable = {if isset($account.1.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
 account.1.nat.udp_update_time = 30
@@ -661,7 +661,7 @@ account.2.nat.stun_server = {$stun_server}
 account.2.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.2.nat.udp_update_enable = 1
+account.2.nat.udp_update_enable = {if isset($account.2.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
 account.2.nat.udp_update_time = 30
@@ -1147,7 +1147,7 @@ account.3.nat.stun_server = {$stun_server}
 account.3.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.3.nat.udp_update_enable = 1
+account.3.nat.udp_update_enable = {if isset($account.3.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
 account.3.nat.udp_update_time = 30
@@ -1623,7 +1623,7 @@ account.4.nat.stun_server = {$stun_server}
 account.4.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.4.nat.udp_update_enable = 1
+account.4.nat.udp_update_enable = {if isset($account.4.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
 account.4.nat.udp_update_time = 30
@@ -2099,7 +2099,7 @@ account.5.nat.stun_server = {$stun_server}
 account.5.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.5.nat.udp_update_enable = 1
+account.5.nat.udp_update_enable = {if isset($account.5.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
 account.5.nat.udp_update_time = 30
@@ -2574,7 +2574,7 @@ account.6.nat.stun_server =
 account.6.nat.stun_port = 3478
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.6.nat.udp_update_enable = 1
+account.6.nat.udp_update_enable = {if isset($account.6.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
 account.6.nat.udp_update_time = 30

--- a/resources/templates/provision/yealink/t23p/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t23p/{$mac}.cfg
@@ -142,7 +142,7 @@ account.1.nat.stun_server = {$stun_server}
 account.1.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.1.nat.udp_update_enable = 3
+account.1.nat.udp_update_enable = {if isset($account.1.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
 account.1.nat.udp_update_time = 30
@@ -647,7 +647,7 @@ account.2.nat.stun_server = {$stun_server}
 account.2.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.2.nat.udp_update_enable = 1
+account.2.nat.udp_update_enable = {if isset($account.2.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
 account.2.nat.udp_update_time = 30
@@ -1133,7 +1133,7 @@ account.3.nat.stun_server = {$stun_server}
 account.3.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.3.nat.udp_update_enable = 1
+account.3.nat.udp_update_enable = {if isset($account.3.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
 account.3.nat.udp_update_time = 30
@@ -1609,7 +1609,7 @@ account.4.nat.stun_server = {$stun_server}
 account.4.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.4.nat.udp_update_enable = 1
+account.4.nat.udp_update_enable = {if isset($account.4.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
 account.4.nat.udp_update_time = 30
@@ -2085,7 +2085,7 @@ account.5.nat.stun_server = {$stun_server}
 account.5.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.5.nat.udp_update_enable = 1
+account.5.nat.udp_update_enable = {if isset($account.5.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
 account.5.nat.udp_update_time = 30
@@ -2560,7 +2560,7 @@ account.6.nat.stun_server =
 account.6.nat.stun_port = 3478
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.6.nat.udp_update_enable = 1
+account.6.nat.udp_update_enable = {if isset($account.6.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
 account.6.nat.udp_update_time = 30

--- a/resources/templates/provision/yealink/t26p/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t26p/{$mac}.cfg
@@ -247,10 +247,10 @@ account.1.nat.stun_server = {$stun_server}
 account.1.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.1.nat.udp_update_enable = 3
+account.1.nat.udp_update_enable = {if isset($account.1.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
-account.1.nat.udp_update_time =
+account.1.nat.udp_update_time = 30
 
 #Enable or disable the NAT Rport; 0-Disabled (default), 1-Enabled;
 account.1.nat.rport = {$yealink_rport}
@@ -599,11 +599,11 @@ account.2.nat.stun_server = {$stun_server}
 #Configure the STUN server port, the default value is 3478.
 account.2.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
-#Enable or disable the NAT keep-alive; 0-Disabled, 1-Enabled (default);
-account.2.nat.udp_update_enable =
+#Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
+account.2.nat.udp_update_enable = {if isset($account.2.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
-account.2.nat.udp_update_time =
+account.2.nat.udp_update_time = 30
 
 #Enable or disable the NAT Rport; 0-Disabled (default), 1-Enabled;
 account.2.nat.rport = {$yealink_rport}
@@ -925,11 +925,11 @@ account.3.nat.stun_server = {$stun_server}
 #Configure the STUN server port, the default value is 3478.
 account.3.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
-#Enable or disable the NAT keep-alive; 0-Disabled, 1-Enabled (default);
-account.3.nat.udp_update_enable =
+#Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
+account.3.nat.udp_update_enable = {if isset($account.3.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
-account.3.nat.udp_update_time =
+account.3.nat.udp_update_time = 30
 
 #Enable or disable the NAT Rport; 0-Disabled (default), 1-Enabled;
 account.3.nat.rport = {$yealink_rport}
@@ -1250,11 +1250,11 @@ account.4.nat.stun_server = {$stun_server}
 #Configure the STUN server port, the default value is 3478.
 account.4.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
-#Enable or disable the NAT keep-alive; 0-Disabled, 1-Enabled (default);
-account.4.nat.udp_update_enable =
+#Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
+account.4.nat.udp_update_enable = {if isset($account.4.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
-account.4.nat.udp_update_time =
+account.4.nat.udp_update_time = 30
 
 #Enable or disable the NAT Rport; 0-Disabled (default), 1-Enabled;
 account.4.nat.rport = {$yealink_rport}
@@ -1576,11 +1576,11 @@ account.5.nat.stun_server = {$stun_server}
 #Configure the STUN server port, the default value is 3478.
 account.5.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
-#Enable or disable the NAT keep-alive; 0-Disabled, 1-Enabled (default);
-account.5.nat.udp_update_enable =
+#Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
+account.5.nat.udp_update_enable = {if isset($account.5.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
-account.5.nat.udp_update_time =
+account.5.nat.udp_update_time = 30
 
 #Enable or disable the NAT Rport; 0-Disabled (default), 1-Enabled;
 account.5.nat.rport = {$yealink_rport}
@@ -1899,11 +1899,11 @@ account.6.nat.stun_server =
 #Configure the STUN server port, the default value is 3478.
 account.6.nat.stun_port =
 
-#Enable or disable the NAT keep-alive; 0-Disabled, 1-Enabled (default);
-account.6.nat.udp_update_enable =
+#Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
+account.6.nat.udp_update_enable = {if isset($account.6.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
-account.6.nat.udp_update_time =
+account.6.nat.udp_update_time = 30
 
 #Enable or disable the NAT Rport; 0-Disabled (default), 1-Enabled;
 account.6.nat.rport = {$yealink_rport}

--- a/resources/templates/provision/yealink/t27g/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t27g/{$mac}.cfg
@@ -156,7 +156,7 @@ account.1.nat.stun_server = {$stun_server}
 account.1.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.1.nat.udp_update_enable = 3
+account.1.nat.udp_update_enable = {if isset($account.1.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
 account.1.nat.udp_update_time = 30
@@ -660,7 +660,7 @@ account.2.nat.stun_server = {$stun_server}
 account.2.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.2.nat.udp_update_enable = 1
+account.2.nat.udp_update_enable = {if isset($account.2.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
 account.2.nat.udp_update_time = 30
@@ -1145,7 +1145,7 @@ account.3.nat.stun_server = {$stun_server}
 account.3.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.3.nat.udp_update_enable = 1
+account.3.nat.udp_update_enable = {if isset($account.3.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
 account.3.nat.udp_update_time = 30
@@ -1620,7 +1620,7 @@ account.4.nat.stun_server = {$stun_server}
 account.4.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.4.nat.udp_update_enable = 1
+account.4.nat.udp_update_enable = {if isset($account.4.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
 account.4.nat.udp_update_time = 30
@@ -2095,7 +2095,7 @@ account.5.nat.stun_server = {$stun_server}
 account.5.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.5.nat.udp_update_enable = 1
+account.5.nat.udp_update_enable = {if isset($account.5.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
 account.5.nat.udp_update_time = 30
@@ -2569,7 +2569,7 @@ account.6.nat.stun_server =
 account.6.nat.stun_port = 3478
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.6.nat.udp_update_enable = 1
+account.6.nat.udp_update_enable = {if isset($account.6.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
 account.6.nat.udp_update_time = 30

--- a/resources/templates/provision/yealink/t27p/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t27p/{$mac}.cfg
@@ -156,7 +156,7 @@ account.1.nat.stun_server = {$stun_server}
 account.1.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.1.nat.udp_update_enable = 3
+account.1.nat.udp_update_enable = {if isset($account.1.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
 account.1.nat.udp_update_time = 30
@@ -660,7 +660,7 @@ account.2.nat.stun_server = {$stun_server}
 account.2.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.2.nat.udp_update_enable = 1
+account.2.nat.udp_update_enable = {if isset($account.2.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
 account.2.nat.udp_update_time = 30
@@ -1145,7 +1145,7 @@ account.3.nat.stun_server = {$stun_server}
 account.3.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.3.nat.udp_update_enable = 1
+account.3.nat.udp_update_enable = {if isset($account.3.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
 account.3.nat.udp_update_time = 30
@@ -1620,7 +1620,7 @@ account.4.nat.stun_server = {$stun_server}
 account.4.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.4.nat.udp_update_enable = 1
+account.4.nat.udp_update_enable = {if isset($account.4.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
 account.4.nat.udp_update_time = 30
@@ -2095,7 +2095,7 @@ account.5.nat.stun_server = {$stun_server}
 account.5.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.5.nat.udp_update_enable = 1
+account.5.nat.udp_update_enable = {if isset($account.5.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
 account.5.nat.udp_update_time = 30
@@ -2569,7 +2569,7 @@ account.6.nat.stun_server =
 account.6.nat.stun_port = 3478
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.6.nat.udp_update_enable = 1
+account.6.nat.udp_update_enable = {if isset($account.6.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
 account.6.nat.udp_update_time = 30

--- a/resources/templates/provision/yealink/t28p/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t28p/{$mac}.cfg
@@ -247,10 +247,10 @@ account.1.nat.stun_server = {$stun_server}
 account.1.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.1.nat.udp_update_enable = 3
+account.1.nat.udp_update_enable = {if isset($account.1.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
-account.1.nat.udp_update_time =
+account.1.nat.udp_update_time = 30
 
 #Enable or disable the NAT Rport; 0-Disabled (default), 1-Enabled;
 account.1.nat.rport = {$yealink_rport}
@@ -599,11 +599,11 @@ account.2.nat.stun_server = {$stun_server}
 #Configure the STUN server port, the default value is 3478.
 account.2.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
-#Enable or disable the NAT keep-alive; 0-Disabled, 1-Enabled (default);
-account.2.nat.udp_update_enable =
+#Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
+account.2.nat.udp_update_enable = {if isset($account.2.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
-account.2.nat.udp_update_time =
+account.2.nat.udp_update_time = 30
 
 #Enable or disable the NAT Rport; 0-Disabled (default), 1-Enabled;
 account.2.nat.rport = {$yealink_rport}
@@ -925,11 +925,11 @@ account.3.nat.stun_server = {$stun_server}
 #Configure the STUN server port, the default value is 3478.
 account.3.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
-#Enable or disable the NAT keep-alive; 0-Disabled, 1-Enabled (default);
-account.3.nat.udp_update_enable =
+#Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
+account.3.nat.udp_update_enable = {if isset($account.3.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
-account.3.nat.udp_update_time =
+account.3.nat.udp_update_time = 30
 
 #Enable or disable the NAT Rport; 0-Disabled (default), 1-Enabled;
 account.3.nat.rport = {$yealink_rport}
@@ -1250,11 +1250,11 @@ account.4.nat.stun_server = {$stun_server}
 #Configure the STUN server port, the default value is 3478.
 account.4.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
-#Enable or disable the NAT keep-alive; 0-Disabled, 1-Enabled (default);
-account.4.nat.udp_update_enable =
+#Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
+account.4.nat.udp_update_enable = {if isset($account.4.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
-account.4.nat.udp_update_time =
+account.4.nat.udp_update_time = 30
 
 #Enable or disable the NAT Rport; 0-Disabled (default), 1-Enabled;
 account.4.nat.rport = {$yealink_rport}
@@ -1576,11 +1576,11 @@ account.5.nat.stun_server = {$stun_server}
 #Configure the STUN server port, the default value is 3478.
 account.5.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
-#Enable or disable the NAT keep-alive; 0-Disabled, 1-Enabled (default);
-account.5.nat.udp_update_enable =
+#Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
+account.5.nat.udp_update_enable = {if isset($account.5.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
-account.5.nat.udp_update_time =
+account.5.nat.udp_update_time = 30
 
 #Enable or disable the NAT Rport; 0-Disabled (default), 1-Enabled;
 account.5.nat.rport = {$yealink_rport}
@@ -1899,11 +1899,11 @@ account.6.nat.stun_server =
 #Configure the STUN server port, the default value is 3478.
 account.6.nat.stun_port =
 
-#Enable or disable the NAT keep-alive; 0-Disabled, 1-Enabled (default);
-account.6.nat.udp_update_enable =
+#Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
+account.6.nat.udp_update_enable = {if isset($account.6.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
-account.6.nat.udp_update_time =
+account.6.nat.udp_update_time = 30
 
 #Enable or disable the NAT Rport; 0-Disabled (default), 1-Enabled;
 account.6.nat.rport = {$yealink_rport}

--- a/resources/templates/provision/yealink/t29g/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t29g/{$mac}.cfg
@@ -156,7 +156,7 @@ account.1.nat.stun_server = {$stun_server}
 account.1.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.1.nat.udp_update_enable = 3
+account.1.nat.udp_update_enable = {if isset($account.1.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
 account.1.nat.udp_update_time = 30
@@ -661,7 +661,7 @@ account.2.nat.stun_server = {$stun_server}
 account.2.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.2.nat.udp_update_enable = 1
+account.2.nat.udp_update_enable = {if isset($account.2.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
 account.2.nat.udp_update_time = 30
@@ -1147,7 +1147,7 @@ account.3.nat.stun_server = {$stun_server}
 account.3.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.3.nat.udp_update_enable = 1
+account.3.nat.udp_update_enable = {if isset($account.3.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
 account.3.nat.udp_update_time = 30
@@ -1623,7 +1623,7 @@ account.4.nat.stun_server = {$stun_server}
 account.4.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.4.nat.udp_update_enable = 1
+account.4.nat.udp_update_enable = {if isset($account.4.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
 account.4.nat.udp_update_time = 30
@@ -2099,7 +2099,7 @@ account.5.nat.stun_server = {$stun_server}
 account.5.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.5.nat.udp_update_enable = 1
+account.5.nat.udp_update_enable = {if isset($account.5.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
 account.5.nat.udp_update_time = 30
@@ -2574,7 +2574,7 @@ account.6.nat.stun_server =
 account.6.nat.stun_port = 3478
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.6.nat.udp_update_enable = 1
+account.6.nat.udp_update_enable = {if isset($account.6.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
 account.6.nat.udp_update_time = 30

--- a/resources/templates/provision/yealink/t31g/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t31g/{$mac}.cfg
@@ -238,10 +238,10 @@ account.1.nat.stun_server = {$stun_server}
 account.1.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.1.nat.udp_update_enable = 3
+account.1.nat.udp_update_enable = {if isset($account.1.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
-account.1.nat.udp_update_time =
+account.1.nat.udp_update_time = 30
 
 #Enable or disable the NAT Rport; 0-Disabled (default), 1-Enabled;
 account.1.nat.rport = {$yealink_rport}
@@ -582,11 +582,11 @@ account.2.nat.stun_server = {$stun_server}
 #Configure the STUN server port, the default value is 3478.
 account.2.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
-#Enable or disable the NAT keep-alive; 0-Disabled, 1-Enabled (default);
-account.2.nat.udp_update_enable =
+#Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
+account.2.nat.udp_update_enable = {if isset($account.2.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
-account.2.nat.udp_update_time =
+account.2.nat.udp_update_time = 30
 
 #Enable or disable the NAT Rport; 0-Disabled (default), 1-Enabled;
 account.2.nat.rport = {$yealink_rport}
@@ -899,11 +899,11 @@ account.3.nat.stun_server = {$stun_server}
 #Configure the STUN server port, the default value is 3478.
 account.3.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
-#Enable or disable the NAT keep-alive; 0-Disabled, 1-Enabled (default);
-account.3.nat.udp_update_enable =
+#Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
+account.3.nat.udp_update_enable = {if isset($account.3.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
-account.3.nat.udp_update_time =
+account.3.nat.udp_update_time = 30
 
 #Enable or disable the NAT Rport; 0-Disabled (default), 1-Enabled;
 account.3.nat.rport = {$yealink_rport}
@@ -1216,11 +1216,11 @@ account.4.nat.stun_server = {$stun_server}
 #Configure the STUN server port, the default value is 3478.
 account.4.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
-#Enable or disable the NAT keep-alive; 0-Disabled, 1-Enabled (default);
-account.4.nat.udp_update_enable =
+#Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
+account.4.nat.udp_update_enable = {if isset($account.4.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
-account.4.nat.udp_update_time =
+account.4.nat.udp_update_time = 30
 
 #Enable or disable the NAT Rport; 0-Disabled (default), 1-Enabled;
 account.4.nat.rport = {$yealink_rport}
@@ -1534,11 +1534,11 @@ account.5.nat.stun_server = {$stun_server}
 #Configure the STUN server port, the default value is 3478.
 account.5.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
-#Enable or disable the NAT keep-alive; 0-Disabled, 1-Enabled (default);
-account.5.nat.udp_update_enable =
+#Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
+account.5.nat.udp_update_enable = {if isset($account.5.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
-account.5.nat.udp_update_time =
+account.5.nat.udp_update_time = 30
 
 #Enable or disable the NAT Rport; 0-Disabled (default), 1-Enabled;
 account.5.nat.rport = {$yealink_rport}
@@ -1849,11 +1849,11 @@ account.6.nat.stun_server =
 #Configure the STUN server port, the default value is 3478.
 account.6.nat.stun_port =
 
-#Enable or disable the NAT keep-alive; 0-Disabled, 1-Enabled (default);
-account.6.nat.udp_update_enable =
+#Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
+account.6.nat.udp_update_enable = {if isset($account.6.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
-account.6.nat.udp_update_time =
+account.6.nat.udp_update_time = 30
 
 #Enable or disable the NAT Rport; 0-Disabled (default), 1-Enabled;
 account.6.nat.rport = {$yealink_rport}

--- a/resources/templates/provision/yealink/t32g/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t32g/{$mac}.cfg
@@ -238,10 +238,10 @@ account.1.nat.stun_server = {$stun_server}
 account.1.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.1.nat.udp_update_enable = 3
+account.1.nat.udp_update_enable = {if isset($account.1.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
-account.1.nat.udp_update_time =
+account.1.nat.udp_update_time = 30
 
 #Enable or disable the NAT Rport; 0-Disabled (default), 1-Enabled;
 account.1.nat.rport = {$yealink_rport}
@@ -582,11 +582,11 @@ account.2.nat.stun_server = {$stun_server}
 #Configure the STUN server port, the default value is 3478.
 account.2.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
-#Enable or disable the NAT keep-alive; 0-Disabled, 1-Enabled (default);
-account.2.nat.udp_update_enable =
+#Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
+account.2.nat.udp_update_enable = {if isset($account.2.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
-account.2.nat.udp_update_time =
+account.2.nat.udp_update_time = 30
 
 #Enable or disable the NAT Rport; 0-Disabled (default), 1-Enabled;
 account.2.nat.rport = {$yealink_rport}
@@ -899,11 +899,11 @@ account.3.nat.stun_server = {$stun_server}
 #Configure the STUN server port, the default value is 3478.
 account.3.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
-#Enable or disable the NAT keep-alive; 0-Disabled, 1-Enabled (default);
-account.3.nat.udp_update_enable =
+#Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
+account.3.nat.udp_update_enable = {if isset($account.3.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
-account.3.nat.udp_update_time =
+account.3.nat.udp_update_time = 30
 
 #Enable or disable the NAT Rport; 0-Disabled (default), 1-Enabled;
 account.3.nat.rport = {$yealink_rport}
@@ -1216,11 +1216,11 @@ account.4.nat.stun_server = {$stun_server}
 #Configure the STUN server port, the default value is 3478.
 account.4.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
-#Enable or disable the NAT keep-alive; 0-Disabled, 1-Enabled (default);
-account.4.nat.udp_update_enable =
+#Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
+account.4.nat.udp_update_enable = {if isset($account.4.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
-account.4.nat.udp_update_time =
+account.4.nat.udp_update_time = 30
 
 #Enable or disable the NAT Rport; 0-Disabled (default), 1-Enabled;
 account.4.nat.rport = {$yealink_rport}
@@ -1534,11 +1534,11 @@ account.5.nat.stun_server = {$stun_server}
 #Configure the STUN server port, the default value is 3478.
 account.5.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
-#Enable or disable the NAT keep-alive; 0-Disabled, 1-Enabled (default);
-account.5.nat.udp_update_enable =
+#Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
+account.5.nat.udp_update_enable = {if isset($account.5.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
-account.5.nat.udp_update_time =
+account.5.nat.udp_update_time = 30
 
 #Enable or disable the NAT Rport; 0-Disabled (default), 1-Enabled;
 account.5.nat.rport = {$yealink_rport}
@@ -1849,11 +1849,11 @@ account.6.nat.stun_server =
 #Configure the STUN server port, the default value is 3478.
 account.6.nat.stun_port =
 
-#Enable or disable the NAT keep-alive; 0-Disabled, 1-Enabled (default);
-account.6.nat.udp_update_enable =
+#Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
+account.6.nat.udp_update_enable = {if isset($account.6.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
-account.6.nat.udp_update_time =
+account.6.nat.udp_update_time = 30
 
 #Enable or disable the NAT Rport; 0-Disabled (default), 1-Enabled;
 account.6.nat.rport = {$yealink_rport}

--- a/resources/templates/provision/yealink/t33g/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t33g/{$mac}.cfg
@@ -187,8 +187,8 @@ account.1.auto_answer=
 ################################################################
 #                      Account Advanced                       ##
 ################################################################
-account.1.nat.udp_update_enable=
-account.1.nat.udp_update_time=
+account.1.nat.udp_update_enable = {if isset($account.1.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
+account.1.nat.udp_update_time = 30
 account.1.nat.rport= {$yealink_rport}
 
 account.1.dtmf.type= {$yealink_dtmf_type}
@@ -758,8 +758,8 @@ account.2.auto_answer=
 ################################################################
 #                      Account Advanced                       ##
 ################################################################
-account.2.nat.udp_update_enable=
-account.2.nat.udp_update_time=
+account.2.nat.udp_update_enable = {if isset($account.2.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
+account.2.nat.udp_update_time = 30
 account.2.nat.rport=  {$yealink_rport}
 
 account.2.dtmf.type= {$yealink_dtmf_type}
@@ -1326,8 +1326,8 @@ account.3.auto_answer=
 ################################################################
 #                      Account Advanced                       ##
 ################################################################
-account.3.nat.udp_update_enable=
-account.3.nat.udp_update_time=
+account.3.nat.udp_update_enable = {if isset($account.3.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
+account.3.nat.udp_update_time = 30
 account.3.nat.rport= {$yealink_rport}
 
 account.3.dtmf.type= {$yealink_dtmf_type}
@@ -1894,8 +1894,8 @@ account.4.auto_answer=
 ################################################################
 #                      Account Advanced                       ##
 ################################################################
-account.4.nat.udp_update_enable=
-account.4.nat.udp_update_time=
+account.4.nat.udp_update_enable = {if isset($account.4.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
+account.4.nat.udp_update_time = 30
 account.4.nat.rport= {$yealink_rport}
 
 account.4.dtmf.type= {$yealink_dtmf_type}

--- a/resources/templates/provision/yealink/t38g/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t38g/{$mac}.cfg
@@ -238,10 +238,10 @@ account.1.nat.stun_server = {$stun_server}
 account.1.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.1.nat.udp_update_enable = 3
+account.1.nat.udp_update_enable = {if isset($account.1.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
-account.1.nat.udp_update_time =
+account.1.nat.udp_update_time = 30
 
 #Enable or disable the NAT Rport; 0-Disabled (default), 1-Enabled;
 account.1.nat.rport = {$yealink_rport}
@@ -582,11 +582,11 @@ account.2.nat.stun_server = {$stun_server}
 #Configure the STUN server port, the default value is 3478.
 account.2.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
-#Enable or disable the NAT keep-alive; 0-Disabled, 1-Enabled (default);
-account.2.nat.udp_update_enable =
+#Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
+account.2.nat.udp_update_enable = {if isset($account.2.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
-account.2.nat.udp_update_time =
+account.2.nat.udp_update_time = 30
 
 #Enable or disable the NAT Rport; 0-Disabled (default), 1-Enabled;
 account.2.nat.rport = {$yealink_rport}
@@ -899,11 +899,11 @@ account.3.nat.stun_server = {$stun_server}
 #Configure the STUN server port, the default value is 3478.
 account.3.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
-#Enable or disable the NAT keep-alive; 0-Disabled, 1-Enabled (default);
-account.3.nat.udp_update_enable =
+#Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
+account.3.nat.udp_update_enable = {if isset($account.3.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
-account.3.nat.udp_update_time =
+account.3.nat.udp_update_time = 30
 
 #Enable or disable the NAT Rport; 0-Disabled (default), 1-Enabled;
 account.3.nat.rport = {$yealink_rport}
@@ -1216,11 +1216,11 @@ account.4.nat.stun_server = {$stun_server}
 #Configure the STUN server port, the default value is 3478.
 account.4.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
-#Enable or disable the NAT keep-alive; 0-Disabled, 1-Enabled (default);
-account.4.nat.udp_update_enable =
+#Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
+account.4.nat.udp_update_enable = {if isset($account.4.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
-account.4.nat.udp_update_time =
+account.4.nat.udp_update_time = 30
 
 #Enable or disable the NAT Rport; 0-Disabled (default), 1-Enabled;
 account.4.nat.rport = {$yealink_rport}
@@ -1534,11 +1534,11 @@ account.5.nat.stun_server = {$stun_server}
 #Configure the STUN server port, the default value is 3478.
 account.5.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
-#Enable or disable the NAT keep-alive; 0-Disabled, 1-Enabled (default);
-account.5.nat.udp_update_enable =
+#Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
+account.5.nat.udp_update_enable = {if isset($account.5.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
-account.5.nat.udp_update_time =
+account.5.nat.udp_update_time = 30
 
 #Enable or disable the NAT Rport; 0-Disabled (default), 1-Enabled;
 account.5.nat.rport = {$yealink_rport}
@@ -1849,11 +1849,11 @@ account.6.nat.stun_server =
 #Configure the STUN server port, the default value is 3478.
 account.6.nat.stun_port =
 
-#Enable or disable the NAT keep-alive; 0-Disabled, 1-Enabled (default);
-account.6.nat.udp_update_enable =
+#Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
+account.6.nat.udp_update_enable = {if isset($account.6.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
-account.6.nat.udp_update_time =
+account.6.nat.udp_update_time = 30
 
 #Enable or disable the NAT Rport; 0-Disabled (default), 1-Enabled;
 account.6.nat.rport = {$yealink_rport}

--- a/resources/templates/provision/yealink/t40g/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t40g/{$mac}.cfg
@@ -156,7 +156,7 @@ account.1.nat.stun_server = {$stun_server}
 account.1.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.1.nat.udp_update_enable = 3
+account.1.nat.udp_update_enable = {if isset($account.1.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
 account.1.nat.udp_update_time = 30
@@ -661,7 +661,7 @@ account.2.nat.stun_server = {$stun_server}
 account.2.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.2.nat.udp_update_enable = 1
+account.2.nat.udp_update_enable = {if isset($account.2.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
 account.2.nat.udp_update_time = 30
@@ -1177,7 +1177,7 @@ account.3.nat.stun_server = {$stun_server}
 account.3.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.3.nat.udp_update_enable = 1
+account.3.nat.udp_update_enable = {if isset($account.3.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
 account.3.nat.udp_update_time = 30
@@ -1676,7 +1676,7 @@ account.4.nat.stun_server = {$stun_server}
 account.4.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.4.nat.udp_update_enable = 1
+account.4.nat.udp_update_enable = {if isset($account.4.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
 account.4.nat.udp_update_time = 30
@@ -2175,7 +2175,7 @@ account.5.nat.stun_server = {$stun_server}
 account.5.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.5.nat.udp_update_enable = 1
+account.5.nat.udp_update_enable = {if isset($account.5.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
 account.5.nat.udp_update_time = 30
@@ -2673,7 +2673,7 @@ account.6.nat.stun_server =
 account.6.nat.stun_port = 3478
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.6.nat.udp_update_enable = 1
+account.6.nat.udp_update_enable = {if isset($account.6.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
 account.6.nat.udp_update_time = 30

--- a/resources/templates/provision/yealink/t40p/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t40p/{$mac}.cfg
@@ -148,7 +148,7 @@ account.1.nat.stun_server = {$stun_server}
 account.1.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.1.nat.udp_update_enable = 3
+account.1.nat.udp_update_enable = {if isset($account.1.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
 account.1.nat.udp_update_time = 30
@@ -661,7 +661,7 @@ account.2.nat.stun_server = {$stun_server}
 account.2.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.2.nat.udp_update_enable = 1
+account.2.nat.udp_update_enable = {if isset($account.2.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
 account.2.nat.udp_update_time = 30
@@ -1179,7 +1179,7 @@ account.3.nat.stun_server = {$stun_server}
 account.3.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.3.nat.udp_update_enable = 1
+account.3.nat.udp_update_enable = {if isset($account.3.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
 account.3.nat.udp_update_time = 30
@@ -1680,7 +1680,7 @@ account.4.nat.stun_server = {$stun_server}
 account.4.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.4.nat.udp_update_enable = 1
+account.4.nat.udp_update_enable = {if isset($account.4.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
 account.4.nat.udp_update_time = 30
@@ -2181,7 +2181,7 @@ account.5.nat.stun_server = {$stun_server}
 account.5.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.5.nat.udp_update_enable = 1
+account.5.nat.udp_update_enable = {if isset($account.5.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
 account.5.nat.udp_update_time = 30
@@ -2681,7 +2681,7 @@ account.6.nat.stun_server =
 account.6.nat.stun_port = 3478
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.6.nat.udp_update_enable = 1
+account.6.nat.udp_update_enable = {if isset($account.6.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
 account.6.nat.udp_update_time = 30

--- a/resources/templates/provision/yealink/t41p/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t41p/{$mac}.cfg
@@ -142,7 +142,7 @@ account.1.nat.stun_server = {$stun_server}
 account.1.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.1.nat.udp_update_enable = 3
+account.1.nat.udp_update_enable = {if isset($account.1.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
 account.1.nat.udp_update_time = 30
@@ -644,7 +644,7 @@ account.2.nat.stun_server = {$stun_server}
 account.2.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.2.nat.udp_update_enable = 1
+account.2.nat.udp_update_enable = {if isset($account.2.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
 account.2.nat.udp_update_time = 30
@@ -1157,7 +1157,7 @@ account.3.nat.stun_server = {$stun_server}
 account.3.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.3.nat.udp_update_enable = 1
+account.3.nat.udp_update_enable = {if isset($account.3.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
 account.3.nat.udp_update_time = 30
@@ -1653,7 +1653,7 @@ account.4.nat.stun_server = {$stun_server}
 account.4.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.4.nat.udp_update_enable = 1
+account.4.nat.udp_update_enable = {if isset($account.4.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
 account.4.nat.udp_update_time = 30
@@ -2149,7 +2149,7 @@ account.5.nat.stun_server = {$stun_server}
 account.5.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.5.nat.udp_update_enable = 1
+account.5.nat.udp_update_enable = {if isset($account.5.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
 account.5.nat.udp_update_time = 30
@@ -2644,7 +2644,7 @@ account.6.nat.stun_server =
 account.6.nat.stun_port = 3478
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.6.nat.udp_update_enable = 1
+account.6.nat.udp_update_enable = {if isset($account.6.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
 account.6.nat.udp_update_time = 30

--- a/resources/templates/provision/yealink/t42g/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t42g/{$mac}.cfg
@@ -156,7 +156,7 @@ account.1.nat.stun_server = {$stun_server}
 account.1.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.1.nat.udp_update_enable = 3
+account.1.nat.udp_update_enable = {if isset($account.1.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
 account.1.nat.udp_update_time = 30
@@ -661,7 +661,7 @@ account.2.nat.stun_server = {$stun_server}
 account.2.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.2.nat.udp_update_enable = 1
+account.2.nat.udp_update_enable = {if isset($account.2.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
 account.2.nat.udp_update_time = 30
@@ -1147,7 +1147,7 @@ account.3.nat.stun_server = {$stun_server}
 account.3.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.3.nat.udp_update_enable = 1
+account.3.nat.udp_update_enable = {if isset($account.3.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
 account.3.nat.udp_update_time = 30
@@ -1623,7 +1623,7 @@ account.4.nat.stun_server = {$stun_server}
 account.4.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.4.nat.udp_update_enable = 1
+account.4.nat.udp_update_enable = {if isset($account.4.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
 account.4.nat.udp_update_time = 30
@@ -2099,7 +2099,7 @@ account.5.nat.stun_server = {$stun_server}
 account.5.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.5.nat.udp_update_enable = 1
+account.5.nat.udp_update_enable = {if isset($account.5.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
 account.5.nat.udp_update_time = 30
@@ -2574,7 +2574,7 @@ account.6.nat.stun_server =
 account.6.nat.stun_port = 3478
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.6.nat.udp_update_enable = 1
+account.6.nat.udp_update_enable = {if isset($account.6.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
 account.6.nat.udp_update_time = 30

--- a/resources/templates/provision/yealink/t42s/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t42s/{$mac}.cfg
@@ -156,7 +156,7 @@ account.1.nat.stun_server = {$stun_server}
 account.1.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.1.nat.udp_update_enable = 3
+account.1.nat.udp_update_enable = {if isset($account.1.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
 account.1.nat.udp_update_time = 30
@@ -660,7 +660,7 @@ account.2.nat.stun_server = {$stun_server}
 account.2.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.2.nat.udp_update_enable = 1
+account.2.nat.udp_update_enable = {if isset($account.2.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
 account.2.nat.udp_update_time = 30
@@ -1147,7 +1147,7 @@ account.3.nat.stun_server = {$stun_server}
 account.3.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.3.nat.udp_update_enable = 1
+account.3.nat.udp_update_enable = {if isset($account.3.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
 account.3.nat.udp_update_time = 30
@@ -1623,7 +1623,7 @@ account.4.nat.stun_server = {$stun_server}
 account.4.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.4.nat.udp_update_enable = 1
+account.4.nat.udp_update_enable = {if isset($account.4.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
 account.4.nat.udp_update_time = 30
@@ -2094,7 +2094,7 @@ account.5.nat.stun_server = {$stun_server}
 account.5.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.5.nat.udp_update_enable = 1
+account.5.nat.udp_update_enable = {if isset($account.5.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
 account.5.nat.udp_update_time = 30
@@ -2564,7 +2564,7 @@ account.6.nat.stun_server =
 account.6.nat.stun_port = 3478
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.6.nat.udp_update_enable = 1
+account.6.nat.udp_update_enable = {if isset($account.6.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
 account.6.nat.udp_update_time = 30

--- a/resources/templates/provision/yealink/t43u/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t43u/{$mac}.cfg
@@ -183,8 +183,8 @@ account.1.auto_answer=
 ################################################################
 #                      Account Advanced                       ##
 ################################################################
-account.1.nat.udp_update_enable=
-account.1.nat.udp_update_time=
+account.1.nat.udp_update_enable = {if isset($account.1.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
+account.1.nat.udp_update_time = 30
 account.1.nat.rport= {$yealink_rport}
 
 account.1.dtmf.type= {$yealink_dtmf_type}
@@ -751,8 +751,8 @@ account.2.auto_answer=
 ################################################################
 #                      Account Advanced                       ##
 ################################################################
-account.2.nat.udp_update_enable=
-account.2.nat.udp_update_time=
+account.2.nat.udp_update_enable = {if isset($account.2.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
+account.2.nat.udp_update_time = 30
 account.2.nat.rport=  {$yealink_rport}
 
 account.2.dtmf.type= {$yealink_dtmf_type}
@@ -1319,8 +1319,8 @@ account.3.auto_answer=
 ################################################################
 #                      Account Advanced                       ##
 ################################################################
-account.3.nat.udp_update_enable=
-account.3.nat.udp_update_time=
+account.3.nat.udp_update_enable = {if isset($account.3.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
+account.3.nat.udp_update_time = 30
 account.3.nat.rport= {$yealink_rport}
 
 account.3.dtmf.type= {$yealink_dtmf_type}
@@ -1887,8 +1887,8 @@ account.4.auto_answer=
 ################################################################
 #                      Account Advanced                       ##
 ################################################################
-account.4.nat.udp_update_enable=
-account.4.nat.udp_update_time=
+account.4.nat.udp_update_enable = {if isset($account.4.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
+account.4.nat.udp_update_time = 30
 account.4.nat.rport= {$yealink_rport}
 
 account.4.dtmf.type= {$yealink_dtmf_type}
@@ -2455,8 +2455,8 @@ account.5.auto_answer=
 ################################################################
 #                      Account Advanced                       ##
 ################################################################
-account.5.nat.udp_update_enable=
-account.5.nat.udp_update_time=
+account.5.nat.udp_update_enable = {if isset($account.5.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
+account.5.nat.udp_update_time = 30
 account.5.nat.rport= {$yealink_rport}
 
 account.5.dtmf.type= {$yealink_dtmf_type}
@@ -3023,8 +3023,8 @@ account.6.auto_answer=
 ################################################################
 #                      Account Advanced                       ##
 ################################################################
-account.6.nat.udp_update_enable=
-account.6.nat.udp_update_time=
+account.6.nat.udp_update_enable = {if isset($account.6.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
+account.6.nat.udp_update_time = 30
 account.6.nat.rport= {$yealink_rport}
 
 account.6.dtmf.type= {$yealink_dtmf_type}

--- a/resources/templates/provision/yealink/t46g/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t46g/{$mac}.cfg
@@ -156,7 +156,7 @@ account.1.nat.stun_server = {$stun_server}
 account.1.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.1.nat.udp_update_enable = 3
+account.1.nat.udp_update_enable = {if isset($account.1.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
 account.1.nat.udp_update_time = 30
@@ -662,7 +662,7 @@ account.2.nat.stun_server = {$stun_server}
 account.2.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.2.nat.udp_update_enable = 1
+account.2.nat.udp_update_enable = {if isset($account.2.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
 account.2.nat.udp_update_time = 30
@@ -1148,7 +1148,7 @@ account.3.nat.stun_server = {$stun_server}
 account.3.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.3.nat.udp_update_enable = 1
+account.3.nat.udp_update_enable = {if isset($account.3.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
 account.3.nat.udp_update_time = 30
@@ -1624,7 +1624,7 @@ account.4.nat.stun_server = {$stun_server}
 account.4.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.4.nat.udp_update_enable = 1
+account.4.nat.udp_update_enable = {if isset($account.4.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
 account.4.nat.udp_update_time = 30
@@ -2100,7 +2100,7 @@ account.5.nat.stun_server = {$stun_server}
 account.5.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.5.nat.udp_update_enable = 1
+account.5.nat.udp_update_enable = {if isset($account.5.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
 account.5.nat.udp_update_time = 30
@@ -2575,7 +2575,7 @@ account.6.nat.stun_server =
 account.6.nat.stun_port = 3478
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.6.nat.udp_update_enable = 1
+account.6.nat.udp_update_enable = {if isset($account.6.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
 account.6.nat.udp_update_time = 30

--- a/resources/templates/provision/yealink/t46s/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t46s/{$mac}.cfg
@@ -156,7 +156,7 @@ account.1.nat.stun_server = {$stun_server}
 account.1.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.1.nat.udp_update_enable = 3
+account.1.nat.udp_update_enable = {if isset($account.1.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
 account.1.nat.udp_update_time = 30
@@ -660,7 +660,7 @@ account.2.nat.stun_server = {$stun_server}
 account.2.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.2.nat.udp_update_enable = 1
+account.2.nat.udp_update_enable = {if isset($account.2.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
 account.2.nat.udp_update_time = 30
@@ -1150,7 +1150,7 @@ account.3.nat.stun_server = {$stun_server}
 account.3.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.3.nat.udp_update_enable = 1
+account.3.nat.udp_update_enable = {if isset($account.3.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
 account.3.nat.udp_update_time = 30
@@ -1631,7 +1631,7 @@ account.4.nat.stun_server = {$stun_server}
 account.4.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.4.nat.udp_update_enable = 1
+account.4.nat.udp_update_enable = {if isset($account.4.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
 account.4.nat.udp_update_time = 30
@@ -2107,7 +2107,7 @@ account.5.nat.stun_server = {$stun_server}
 account.5.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.5.nat.udp_update_enable = 1
+account.5.nat.udp_update_enable = {if isset($account.5.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
 account.5.nat.udp_update_time = 30
@@ -2582,7 +2582,7 @@ account.6.nat.stun_server =
 account.6.nat.stun_port = 3478
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.6.nat.udp_update_enable = 1
+account.6.nat.udp_update_enable = {if isset($account.6.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
 account.6.nat.udp_update_time = 30

--- a/resources/templates/provision/yealink/t46u/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t46u/{$mac}.cfg
@@ -183,8 +183,8 @@ account.1.auto_answer=
 ################################################################
 #                      Account Advanced                       ##
 ################################################################
-account.1.nat.udp_update_enable=
-account.1.nat.udp_update_time=
+account.1.nat.udp_update_enable = {if isset($account.1.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
+account.1.nat.udp_update_time = 30
 account.1.nat.rport= {$yealink_rport}
 
 account.1.dtmf.type= {$yealink_dtmf_type}
@@ -746,8 +746,8 @@ account.2.auto_answer=
 ################################################################
 #                      Account Advanced                       ##
 ################################################################
-account.2.nat.udp_update_enable=
-account.2.nat.udp_update_time=
+account.2.nat.udp_update_enable = {if isset($account.2.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
+account.2.nat.udp_update_time = 30
 account.2.nat.rport=  {$yealink_rport}
 
 account.2.dtmf.type= {$yealink_dtmf_type}
@@ -1309,8 +1309,8 @@ account.3.auto_answer=
 ################################################################
 #                      Account Advanced                       ##
 ################################################################
-account.3.nat.udp_update_enable=
-account.3.nat.udp_update_time=
+account.3.nat.udp_update_enable = {if isset($account.3.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
+account.3.nat.udp_update_time = 30
 account.3.nat.rport= {$yealink_rport}
 
 account.3.dtmf.type= {$yealink_dtmf_type}
@@ -1872,8 +1872,8 @@ account.4.auto_answer=
 ################################################################
 #                      Account Advanced                       ##
 ################################################################
-account.4.nat.udp_update_enable=
-account.4.nat.udp_update_time=
+account.4.nat.udp_update_enable = {if isset($account.4.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
+account.4.nat.udp_update_time = 30
 account.4.nat.rport= {$yealink_rport}
 
 account.4.dtmf.type= {$yealink_dtmf_type}
@@ -2435,8 +2435,8 @@ account.5.auto_answer=
 ################################################################
 #                      Account Advanced                       ##
 ################################################################
-account.5.nat.udp_update_enable=
-account.5.nat.udp_update_time=
+account.5.nat.udp_update_enable = {if isset($account.5.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
+account.5.nat.udp_update_time = 30
 account.5.nat.rport= {$yealink_rport}
 
 account.5.dtmf.type= {$yealink_dtmf_type}
@@ -2998,8 +2998,8 @@ account.6.auto_answer=
 ################################################################
 #                      Account Advanced                       ##
 ################################################################
-account.6.nat.udp_update_enable=
-account.6.nat.udp_update_time=
+account.6.nat.udp_update_enable = {if isset($account.6.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
+account.6.nat.udp_update_time = 30
 account.6.nat.rport= {$yealink_rport}
 
 account.6.dtmf.type= {$yealink_dtmf_type}

--- a/resources/templates/provision/yealink/t48g/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t48g/{$mac}.cfg
@@ -156,7 +156,7 @@ account.1.nat.stun_server = {$stun_server}
 account.1.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.1.nat.udp_update_enable = 3
+account.1.nat.udp_update_enable = {if isset($account.1.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
 account.1.nat.udp_update_time = 30
@@ -661,7 +661,7 @@ account.2.nat.stun_server = {$stun_server}
 account.2.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.2.nat.udp_update_enable = 1
+account.2.nat.udp_update_enable = {if isset($account.2.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
 account.2.nat.udp_update_time = 30
@@ -1147,7 +1147,7 @@ account.3.nat.stun_server = {$stun_server}
 account.3.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.3.nat.udp_update_enable = 1
+account.3.nat.udp_update_enable = {if isset($account.3.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
 account.3.nat.udp_update_time = 30
@@ -1623,7 +1623,7 @@ account.4.nat.stun_server = {$stun_server}
 account.4.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.4.nat.udp_update_enable = 1
+account.4.nat.udp_update_enable = {if isset($account.4.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
 account.4.nat.udp_update_time = 30
@@ -2099,7 +2099,7 @@ account.5.nat.stun_server = {$stun_server}
 account.5.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.5.nat.udp_update_enable = 1
+account.5.nat.udp_update_enable = {if isset($account.5.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
 account.5.nat.udp_update_time = 30
@@ -2574,7 +2574,7 @@ account.6.nat.stun_server =
 account.6.nat.stun_port = 3478
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.6.nat.udp_update_enable = 1
+account.6.nat.udp_update_enable = {if isset($account.6.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
 account.6.nat.udp_update_time = 30

--- a/resources/templates/provision/yealink/t48s/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t48s/{$mac}.cfg
@@ -156,7 +156,7 @@ account.1.nat.stun_server = {$stun_server}
 account.1.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.1.nat.udp_update_enable = 3
+account.1.nat.udp_update_enable = {if isset($account.1.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
 account.1.nat.udp_update_time = 30
@@ -660,7 +660,7 @@ account.2.nat.stun_server = {$stun_server}
 account.2.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.2.nat.udp_update_enable = 1
+account.2.nat.udp_update_enable = {if isset($account.2.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
 account.2.nat.udp_update_time = 30
@@ -1146,7 +1146,7 @@ account.3.nat.stun_server = {$stun_server}
 account.3.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.3.nat.udp_update_enable = 1
+account.3.nat.udp_update_enable = {if isset($account.3.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
 account.3.nat.udp_update_time = 30
@@ -1623,7 +1623,7 @@ account.4.nat.stun_server = {$stun_server}
 account.4.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.4.nat.udp_update_enable = 1
+account.4.nat.udp_update_enable = {if isset($account.4.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
 account.4.nat.udp_update_time = 30
@@ -2095,7 +2095,7 @@ account.5.nat.stun_server = {$stun_server}
 account.5.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.5.nat.udp_update_enable = 1
+account.5.nat.udp_update_enable = {if isset($account.5.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
 account.5.nat.udp_update_time = 30
@@ -2566,7 +2566,7 @@ account.6.nat.stun_server =
 account.6.nat.stun_port = 3478
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.6.nat.udp_update_enable = 1
+account.6.nat.udp_update_enable = {if isset($account.6.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
 account.6.nat.udp_update_time = 30

--- a/resources/templates/provision/yealink/t48u/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t48u/{$mac}.cfg
@@ -183,8 +183,8 @@ account.1.auto_answer=
 ################################################################
 #                      Account Advanced                       ##
 ################################################################
-account.1.nat.udp_update_enable=
-account.1.nat.udp_update_time=
+account.1.nat.udp_update_enable = {if isset($account.1.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
+account.1.nat.udp_update_time = 30
 account.1.nat.rport= {$yealink_rport}
 
 account.1.dtmf.type= {$yealink_dtmf_type}
@@ -746,8 +746,8 @@ account.2.auto_answer=
 ################################################################
 #                      Account Advanced                       ##
 ################################################################
-account.2.nat.udp_update_enable=
-account.2.nat.udp_update_time=
+account.2.nat.udp_update_enable = {if isset($account.2.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
+account.2.nat.udp_update_time = 30
 account.2.nat.rport=  {$yealink_rport}
 
 account.2.dtmf.type= {$yealink_dtmf_type}
@@ -1309,8 +1309,8 @@ account.3.auto_answer=
 ################################################################
 #                      Account Advanced                       ##
 ################################################################
-account.3.nat.udp_update_enable=
-account.3.nat.udp_update_time=
+account.3.nat.udp_update_enable = {if isset($account.3.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
+account.3.nat.udp_update_time = 30
 account.3.nat.rport= {$yealink_rport}
 
 account.3.dtmf.type= {$yealink_dtmf_type}
@@ -1872,8 +1872,8 @@ account.4.auto_answer=
 ################################################################
 #                      Account Advanced                       ##
 ################################################################
-account.4.nat.udp_update_enable=
-account.4.nat.udp_update_time=
+account.4.nat.udp_update_enable = {if isset($account.4.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
+account.4.nat.udp_update_time = 30
 account.4.nat.rport= {$yealink_rport}
 
 account.4.dtmf.type= {$yealink_dtmf_type}
@@ -2435,8 +2435,8 @@ account.5.auto_answer=
 ################################################################
 #                      Account Advanced                       ##
 ################################################################
-account.5.nat.udp_update_enable=
-account.5.nat.udp_update_time=
+account.5.nat.udp_update_enable = {if isset($account.5.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
+account.5.nat.udp_update_time = 30
 account.5.nat.rport= {$yealink_rport}
 
 account.5.dtmf.type= {$yealink_dtmf_type}
@@ -2998,8 +2998,8 @@ account.6.auto_answer=
 ################################################################
 #                      Account Advanced                       ##
 ################################################################
-account.6.nat.udp_update_enable=
-account.6.nat.udp_update_time=
+account.6.nat.udp_update_enable = {if isset($account.6.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
+account.6.nat.udp_update_time = 30
 account.6.nat.rport= {$yealink_rport}
 
 account.6.dtmf.type= {$yealink_dtmf_type}

--- a/resources/templates/provision/yealink/t49g/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t49g/{$mac}.cfg
@@ -156,7 +156,7 @@ account.1.nat.stun_server = {$stun_server}
 account.1.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.1.nat.udp_update_enable = 3
+account.1.nat.udp_update_enable = {if isset($account.1.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
 account.1.nat.udp_update_time = 30
@@ -661,7 +661,7 @@ account.2.nat.stun_server = {$stun_server}
 account.2.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.2.nat.udp_update_enable = 1
+account.2.nat.udp_update_enable = {if isset($account.2.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
 account.2.nat.udp_update_time = 30
@@ -1186,7 +1186,7 @@ account.3.nat.stun_server = {$stun_server}
 account.3.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.3.nat.udp_update_enable = 1
+account.3.nat.udp_update_enable = {if isset($account.3.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
 account.3.nat.udp_update_time = 30
@@ -1685,7 +1685,7 @@ account.4.nat.stun_server = {$stun_server}
 account.4.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.4.nat.udp_update_enable = 1
+account.4.nat.udp_update_enable = {if isset($account.4.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
 account.4.nat.udp_update_time = 30
@@ -2184,7 +2184,7 @@ account.5.nat.stun_server = {$stun_server}
 account.5.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.5.nat.udp_update_enable = 1
+account.5.nat.udp_update_enable = {if isset($account.5.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
 account.5.nat.udp_update_time = 30
@@ -2682,7 +2682,7 @@ account.6.nat.stun_server =
 account.6.nat.stun_port = 3478
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.6.nat.udp_update_enable = 1
+account.6.nat.udp_update_enable = {if isset($account.6.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
 account.6.nat.udp_update_time = 30

--- a/resources/templates/provision/yealink/t52s/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t52s/{$mac}.cfg
@@ -338,8 +338,8 @@ account.2.auto_answer=
 ################################################################
 #                      Account Advanced                       ##
 ################################################################
-account.1.nat.udp_update_enable= 3
-account.1.nat.udp_update_time= 30
+account.1.nat.udp_update_enable = {if isset($account.1.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
+account.1.nat.udp_update_time = 30
 account.1.nat.rport= {$yealink_rport}
 
 account.1.dtmf.type= {$yealink_dtmf_type}
@@ -364,8 +364,8 @@ account.1.session_timer.enable= {$yealink_session_timer}
 account.1.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 account.1.sip_server_type=
 
-account.2.nat.udp_update_enable= 3
-account.2.nat.udp_update_time= 30
+account.2.nat.udp_update_enable = {if isset($account.2.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
+account.2.nat.udp_update_time = 30
 account.2.nat.rport= {$yealink_rport}
 
 account.2.dtmf.type= {$yealink_dtmf_type}

--- a/resources/templates/provision/yealink/t53/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t53/{$mac}.cfg
@@ -182,8 +182,8 @@ account.1.auto_answer=
 ################################################################
 #                      Account Advanced                       ##
 ################################################################
-account.1.nat.udp_update_enable= 3
-account.1.nat.udp_update_time= 30
+account.1.nat.udp_update_enable = {if isset($account.1.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
+account.1.nat.udp_update_time = 30
 account.1.nat.rport= {$yealink_rport}
 
 account.1.dtmf.type= {$yealink_dtmf_type}
@@ -721,8 +721,8 @@ account.2.auto_answer=
 ################################################################
 #                      Account Advanced                       ##
 ################################################################
-account.2.nat.udp_update_enable= 3
-account.2.nat.udp_update_time= 30
+account.2.nat.udp_update_enable = {if isset($account.2.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
+account.2.nat.udp_update_time = 30
 account.2.nat.rport= {$yealink_rport}
 
 account.2.dtmf.type= {$yealink_dtmf_type}
@@ -1248,8 +1248,8 @@ account.3.auto_answer=
 ################################################################
 #                      Account Advanced                       ##
 ################################################################
-account.3.nat.udp_update_enable= 3
-account.3.nat.udp_update_time= 30
+account.3.nat.udp_update_enable = {if isset($account.3.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
+account.3.nat.udp_update_time = 30
 account.3.nat.rport= {$yealink_rport}
 
 account.3.dtmf.type= {$yealink_dtmf_type}
@@ -1775,8 +1775,8 @@ account.4.auto_answer=
 ################################################################
 #                      Account Advanced                       ##
 ################################################################
-account.4.nat.udp_update_enable= 3
-account.4.nat.udp_update_time= 30
+account.4.nat.udp_update_enable = {if isset($account.4.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
+account.4.nat.udp_update_time = 30
 account.4.nat.rport= {$yealink_rport}
 
 account.4.dtmf.type= {$yealink_dtmf_type}
@@ -2301,8 +2301,8 @@ account.5.auto_answer=
 ################################################################
 #                      Account Advanced                       ##
 ################################################################
-account.5.nat.udp_update_enable= 3
-account.5.nat.udp_update_time= 30
+account.5.nat.udp_update_enable = {if isset($account.5.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
+account.5.nat.udp_update_time = 30
 account.5.nat.rport= {$yealink_rport}
 
 account.5.dtmf.type= {$yealink_dtmf_type}
@@ -2841,8 +2841,8 @@ account.6.auto_answer=
 ################################################################
 #                      Account Advanced                       ##
 ################################################################
-account.6.nat.udp_update_enable= 3
-account.6.nat.udp_update_time= 30
+account.6.nat.udp_update_enable = {if isset($account.6.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
+account.6.nat.udp_update_time = 30
 account.6.nat.rport= {$yealink_rport}
 
 account.6.dtmf.type= {$yealink_dtmf_type}
@@ -3368,8 +3368,8 @@ account.7.auto_answer=
 ################################################################
 #                      Account Advanced                       ##
 ################################################################
-account.7.nat.udp_update_enable= 3
-account.7.nat.udp_update_time= 30
+account.7.nat.udp_update_enable = {if isset($account.7.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
+account.7.nat.udp_update_time = 30
 account.7.nat.rport= {$yealink_rport}
 
 account.7.dtmf.type= {$yealink_dtmf_type}
@@ -3895,8 +3895,8 @@ account.8.auto_answer=
 ################################################################
 #                      Account Advanced                       ##
 ################################################################
-account.8.nat.udp_update_enable= 3
-account.8.nat.udp_update_time= 30
+account.8.nat.udp_update_enable = {if isset($account.8.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
+account.8.nat.udp_update_time = 30
 account.8.nat.rport= {$yealink_rport}
 
 account.8.dtmf.type= {$yealink_dtmf_type}
@@ -4422,8 +4422,8 @@ account.9.auto_answer=
 ################################################################
 #                      Account Advanced                       ##
 ################################################################
-account.9.nat.udp_update_enable= 3
-account.9.nat.udp_update_time= 30
+account.9.nat.udp_update_enable = {if isset($account.9.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
+account.9.nat.udp_update_time = 30
 account.9.nat.rport= {$yealink_rport}
 
 account.9.dtmf.type= {$yealink_dtmf_type}
@@ -4949,8 +4949,8 @@ account.10.auto_answer=
 ################################################################
 #                      Account Advanced                       ##
 ################################################################
-account.10.nat.udp_update_enable= 3
-account.10.nat.udp_update_time= 30
+account.10.nat.udp_update_enable = {if isset($account.10.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
+account.10.nat.udp_update_time = 30
 account.10.nat.rport= {$yealink_rport}
 
 account.10.dtmf.type= {$yealink_dtmf_type}

--- a/resources/templates/provision/yealink/t53w/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t53w/{$mac}.cfg
@@ -183,8 +183,8 @@ account.1.auto_answer=
 ################################################################
 #                      Account Advanced                       ##
 ################################################################
-account.1.nat.udp_update_enable= 3
-account.1.nat.udp_update_time= 30
+account.1.nat.udp_update_enable = {if isset($account.1.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
+account.1.nat.udp_update_time = 30
 account.1.nat.rport= {$yealink_rport}
 
 account.1.dtmf.type= {$yealink_dtmf_type}
@@ -723,8 +723,8 @@ account.2.auto_answer=
 ################################################################
 #                      Account Advanced                       ##
 ################################################################
-account.2.nat.udp_update_enable= 3
-account.2.nat.udp_update_time= 30
+account.2.nat.udp_update_enable = {if isset($account.2.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
+account.2.nat.udp_update_time = 30
 account.2.nat.rport= {$yealink_rport}
 
 account.2.dtmf.type= {$yealink_dtmf_type}
@@ -1251,8 +1251,8 @@ account.3.auto_answer=
 ################################################################
 #                      Account Advanced                       ##
 ################################################################
-account.3.nat.udp_update_enable= 3
-account.3.nat.udp_update_time= 30
+account.3.nat.udp_update_enable = {if isset($account.3.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
+account.3.nat.udp_update_time = 30
 account.3.nat.rport= {$yealink_rport}
 
 account.3.dtmf.type= {$yealink_dtmf_type}
@@ -1779,8 +1779,8 @@ account.4.auto_answer=
 ################################################################
 #                      Account Advanced                       ##
 ################################################################
-account.4.nat.udp_update_enable= 3
-account.4.nat.udp_update_time= 30
+account.4.nat.udp_update_enable = {if isset($account.4.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
+account.4.nat.udp_update_time = 30
 account.4.nat.rport= {$yealink_rport}
 
 account.4.dtmf.type= {$yealink_dtmf_type}
@@ -2306,8 +2306,8 @@ account.5.auto_answer=
 ################################################################
 #                      Account Advanced                       ##
 ################################################################
-account.5.nat.udp_update_enable= 3
-account.5.nat.udp_update_time= 30
+account.5.nat.udp_update_enable = {if isset($account.5.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
+account.5.nat.udp_update_time = 30
 account.5.nat.rport= {$yealink_rport}
 
 account.5.dtmf.type= {$yealink_dtmf_type}
@@ -2847,8 +2847,8 @@ account.6.auto_answer=
 ################################################################
 #                      Account Advanced                       ##
 ################################################################
-account.6.nat.udp_update_enable= 3
-account.6.nat.udp_update_time= 30
+account.6.nat.udp_update_enable = {if isset($account.6.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
+account.6.nat.udp_update_time = 30
 account.6.nat.rport= {$yealink_rport}
 
 account.6.dtmf.type= {$yealink_dtmf_type}
@@ -3375,8 +3375,8 @@ account.7.auto_answer=
 ################################################################
 #                      Account Advanced                       ##
 ################################################################
-account.7.nat.udp_update_enable= 3
-account.7.nat.udp_update_time= 30
+account.7.nat.udp_update_enable = {if isset($account.7.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
+account.7.nat.udp_update_time = 30
 account.7.nat.rport= {$yealink_rport}
 
 account.7.dtmf.type= {$yealink_dtmf_type}
@@ -3903,8 +3903,8 @@ account.8.auto_answer=
 ################################################################
 #                      Account Advanced                       ##
 ################################################################
-account.8.nat.udp_update_enable= 3
-account.8.nat.udp_update_time= 30
+account.8.nat.udp_update_enable = {if isset($account.8.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
+account.8.nat.udp_update_time = 30
 account.8.nat.rport= {$yealink_rport}
 
 account.8.dtmf.type= {$yealink_dtmf_type}
@@ -4431,8 +4431,8 @@ account.9.auto_answer=
 ################################################################
 #                      Account Advanced                       ##
 ################################################################
-account.9.nat.udp_update_enable= 3
-account.9.nat.udp_update_time= 30
+account.9.nat.udp_update_enable = {if isset($account.9.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
+account.9.nat.udp_update_time = 30
 account.9.nat.rport= {$yealink_rport}
 
 account.9.dtmf.type= {$yealink_dtmf_type}
@@ -4959,8 +4959,8 @@ account.10.auto_answer=
 ################################################################
 #                      Account Advanced                       ##
 ################################################################
-account.10.nat.udp_update_enable= 3
-account.10.nat.udp_update_time= 30
+account.10.nat.udp_update_enable = {if isset($account.10.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
+account.10.nat.udp_update_time = 30
 account.10.nat.rport= {$yealink_rport}
 
 account.10.dtmf.type= {$yealink_dtmf_type}

--- a/resources/templates/provision/yealink/t54s/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t54s/{$mac}.cfg
@@ -339,8 +339,8 @@ account.2.auto_answer=
 ################################################################
 #                      Account Advanced                       ##
 ################################################################
-account.1.nat.udp_update_enable= 3
-account.1.nat.udp_update_time= 30
+account.1.nat.udp_update_enable = {if isset($account.1.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
+account.1.nat.udp_update_time = 30
 account.1.nat.rport= {$yealink_rport}
 
 account.1.dtmf.type= {$yealink_dtmf_type}
@@ -365,8 +365,8 @@ account.1.session_timer.enable= {$yealink_session_timer}
 account.1.conf_type = {if $nway_conference == 'true'}2{elseif $nway_conference == 'false'}0{/if}
 account.1.sip_server_type=
 
-account.2.nat.udp_update_enable= 3
-account.2.nat.udp_update_time= 30
+account.2.nat.udp_update_enable = {if isset($account.2.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
+account.2.nat.udp_update_time = 30
 account.2.nat.rport= {$yealink_rport}
 
 account.2.dtmf.type= {$yealink_dtmf_type}

--- a/resources/templates/provision/yealink/t56a/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t56a/{$mac}.cfg
@@ -111,9 +111,9 @@ account.1.reg_fail_retry_interval =
 account.1.nat.nat_traversal = {if isset($stun_server)}1{else}0{/if}
 
 ##It configures the type of keep-alive packets sent by the phone to the NAT static to keep the communication port open so that NAT can continue to function for account X.
-##0-Dsiabled,1-Default: the phone sends UDP packets to the server,2-Option: the phone sends SIP OPTION packets to the server,3-Notify: the phone sends SIP NOTIFY packets to the server.
+##0-Disabled,1-Default: the phone sends UDP packets to the server,2-Option: the phone sends SIP OPTION packets to the server,3-Notify: the phone sends SIP NOTIFY packets to the server.
 ##The default value is 1.
-account.1.nat.udp_update_enable = 3
+account.1.nat.udp_update_enable = {if isset($account.1.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 ##It configures the keep-alive interval (in seconds) for account X.
 ##The default value is 30.Integer from 15 to 2147483647
@@ -576,13 +576,13 @@ account.2.reg_fail_retry_interval =
 ##The default value is 0.
 account.2.nat.nat_traversal = 
 ##It configures the type of keep-alive packets sent by the phone to the NAT static to keep the communication port open so that NAT can continue to function for account X.
-##0-Dsiabled,1-Default: the phone sends UDP packets to the server,2-Option: the phone sends SIP OPTION packets to the server,3-Notify: the phone sends SIP NOTIFY packets to the server.
+##0-Disabled,1-Default: the phone sends UDP packets to the server,2-Option: the phone sends SIP OPTION packets to the server,3-Notify: the phone sends SIP NOTIFY packets to the server.
 ##The default value is 1.
-account.2.nat.udp_update_enable = 
+account.2.nat.udp_update_enable = {if isset($account.2.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 ##It configures the keep-alive interval (in seconds) for account X.
 ##The default value is 30.Integer from 15 to 2147483647
-account.2.nat.udp_update_time = 
+account.2.nat.udp_update_time = 30
 
 ##It enables or disables NAT Rport feature for account X.0-Disabled,1-Enabled
 ##The default value is 0.
@@ -1040,13 +1040,13 @@ account.3.reg_fail_retry_interval =
 account.3.nat.nat_traversal = 
 
 ##It configures the type of keep-alive packets sent by the phone to the NAT static to keep the communication port open so that NAT can continue to function for account X.
-##0-Dsiabled,1-Default: the phone sends UDP packets to the server,2-Option: the phone sends SIP OPTION packets to the server,3-Notify: the phone sends SIP NOTIFY packets to the server.
+##0-Disabled,1-Default: the phone sends UDP packets to the server,2-Option: the phone sends SIP OPTION packets to the server,3-Notify: the phone sends SIP NOTIFY packets to the server.
 ##The default value is 1.
-account.3.nat.udp_update_enable = 
+account.3.nat.udp_update_enable = {if isset($account.3.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 ##It configures the keep-alive interval (in seconds) for account X.
 ##The default value is 30.Integer from 15 to 2147483647
-account.3.nat.udp_update_time = 
+account.3.nat.udp_update_time = 30
 
 ##It enables or disables NAT Rport feature for account X.0-Disabled,1-Enabled
 ##The default value is 0.
@@ -1499,13 +1499,13 @@ account.4.reg_fail_retry_interval =
 ##The default value is 0.
 account.4.nat.nat_traversal = 
 ##It configures the type of keep-alive packets sent by the phone to the NAT static to keep the communication port open so that NAT can continue to function for account X.
-##0-Dsiabled,1-Default: the phone sends UDP packets to the server,2-Option: the phone sends SIP OPTION packets to the server,3-Notify: the phone sends SIP NOTIFY packets to the server.
+##0-Disabled,1-Default: the phone sends UDP packets to the server,2-Option: the phone sends SIP OPTION packets to the server,3-Notify: the phone sends SIP NOTIFY packets to the server.
 ##The default value is 1.
-account.4.nat.udp_update_enable = 
+account.4.nat.udp_update_enable = {if isset($account.4.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 ##It configures the keep-alive interval (in seconds) for account X.
 ##The default value is 30.Integer from 15 to 2147483647
-account.4.nat.udp_update_time = 
+account.4.nat.udp_update_time = 30
 
 ##It enables or disables NAT Rport feature for account X.0-Disabled,1-Enabled
 ##The default value is 0.
@@ -1966,13 +1966,13 @@ account.5.reg_fail_retry_interval =
 account.5.nat.nat_traversal = 
 
 ##It configures the type of keep-alive packets sent by the phone to the NAT static to keep the communication port open so that NAT can continue to function for account X.
-##0-Dsiabled,1-Default: the phone sends UDP packets to the server,2-Option: the phone sends SIP OPTION packets to the server,3-Notify: the phone sends SIP NOTIFY packets to the server.
+##0-Disabled,1-Default: the phone sends UDP packets to the server,2-Option: the phone sends SIP OPTION packets to the server,3-Notify: the phone sends SIP NOTIFY packets to the server.
 ##The default value is 1.
-account.5.nat.udp_update_enable = 
+account.5.nat.udp_update_enable = {if isset($account.5.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 ##It configures the keep-alive interval (in seconds) for account X.
 ##The default value is 30.Integer from 15 to 2147483647
-account.5.nat.udp_update_time = 
+account.5.nat.udp_update_time = 30
 
 ##It enables or disables NAT Rport feature for account X.0-Disabled,1-Enabled
 ##The default value is 0.
@@ -2437,13 +2437,13 @@ account.6.nat.nat_traversal =
 
 
 ##It configures the type of keep-alive packets sent by the phone to the NAT static to keep the communication port open so that NAT can continue to function for account X.
-##0-Dsiabled,1-Default: the phone sends UDP packets to the server,2-Option: the phone sends SIP OPTION packets to the server,3-Notify: the phone sends SIP NOTIFY packets to the server.
+##0-Disabled,1-Default: the phone sends UDP packets to the server,2-Option: the phone sends SIP OPTION packets to the server,3-Notify: the phone sends SIP NOTIFY packets to the server.
 ##The default value is 1.
-account.6.nat.udp_update_enable = 
+account.6.nat.udp_update_enable = {if isset($account.6.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 ##It configures the keep-alive interval (in seconds) for account X.
 ##The default value is 30.Integer from 15 to 2147483647
-account.6.nat.udp_update_time = 
+account.6.nat.udp_update_time = 30
 
 ##It enables or disables NAT Rport feature for account X.0-Disabled,1-Enabled
 ##The default value is 0.

--- a/resources/templates/provision/yealink/t57w/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t57w/{$mac}.cfg
@@ -183,8 +183,8 @@ account.1.auto_answer=
 ################################################################
 #                      Account Advanced                       ##
 ################################################################
-account.1.nat.udp_update_enable= 3
-account.1.nat.udp_update_time= 30
+account.1.nat.udp_update_enable = {if isset($account.1.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
+account.1.nat.udp_update_time = 30
 account.1.nat.rport= {$yealink_rport}
 
 account.1.dtmf.type= {$yealink_dtmf_type}
@@ -722,8 +722,8 @@ account.2.auto_answer=
 ################################################################
 #                      Account Advanced                       ##
 ################################################################
-account.2.nat.udp_update_enable= 3
-account.2.nat.udp_update_time= 30
+account.2.nat.udp_update_enable = {if isset($account.2.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
+account.2.nat.udp_update_time = 30
 account.2.nat.rport= {$yealink_rport}
 
 account.2.dtmf.type= {$yealink_dtmf_type}
@@ -1249,8 +1249,8 @@ account.3.auto_answer=
 ################################################################
 #                      Account Advanced                       ##
 ################################################################
-account.3.nat.udp_update_enable= 3
-account.3.nat.udp_update_time= 30
+account.3.nat.udp_update_enable = {if isset($account.3.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
+account.3.nat.udp_update_time = 30
 account.3.nat.rport= {$yealink_rport}
 
 account.3.dtmf.type= {$yealink_dtmf_type}
@@ -1776,8 +1776,8 @@ account.4.auto_answer=
 ################################################################
 #                      Account Advanced                       ##
 ################################################################
-account.4.nat.udp_update_enable= 3
-account.4.nat.udp_update_time= 30
+account.4.nat.udp_update_enable = {if isset($account.4.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
+account.4.nat.udp_update_time = 30
 account.4.nat.rport= {$yealink_rport}
 
 account.4.dtmf.type= {$yealink_dtmf_type}
@@ -2302,8 +2302,8 @@ account.5.auto_answer=
 ################################################################
 #                      Account Advanced                       ##
 ################################################################
-account.5.nat.udp_update_enable= 3
-account.5.nat.udp_update_time= 30
+account.5.nat.udp_update_enable = {if isset($account.5.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
+account.5.nat.udp_update_time = 30
 account.5.nat.rport= {$yealink_rport}
 
 account.5.dtmf.type= {$yealink_dtmf_type}
@@ -2842,8 +2842,8 @@ account.6.auto_answer=
 ################################################################
 #                      Account Advanced                       ##
 ################################################################
-account.6.nat.udp_update_enable= 3
-account.6.nat.udp_update_time= 30
+account.6.nat.udp_update_enable = {if isset($account.6.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
+account.6.nat.udp_update_time = 30
 account.6.nat.rport= {$yealink_rport}
 
 account.6.dtmf.type= {$yealink_dtmf_type}
@@ -3369,8 +3369,8 @@ account.7.auto_answer=
 ################################################################
 #                      Account Advanced                       ##
 ################################################################
-account.7.nat.udp_update_enable= 3
-account.7.nat.udp_update_time= 30
+account.7.nat.udp_update_enable = {if isset($account.7.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
+account.7.nat.udp_update_time = 30
 account.7.nat.rport= {$yealink_rport}
 
 account.7.dtmf.type= {$yealink_dtmf_type}
@@ -3896,8 +3896,8 @@ account.8.auto_answer=
 ################################################################
 #                      Account Advanced                       ##
 ################################################################
-account.8.nat.udp_update_enable= 3
-account.8.nat.udp_update_time= 30
+account.8.nat.udp_update_enable = {if isset($account.8.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
+account.8.nat.udp_update_time = 30
 account.8.nat.rport= {$yealink_rport}
 
 account.8.dtmf.type= {$yealink_dtmf_type}
@@ -4423,8 +4423,8 @@ account.9.auto_answer=
 ################################################################
 #                      Account Advanced                       ##
 ################################################################
-account.9.nat.udp_update_enable= 3
-account.9.nat.udp_update_time= 30
+account.9.nat.udp_update_enable = {if isset($account.9.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
+account.9.nat.udp_update_time = 30
 account.9.nat.rport= {$yealink_rport}
 
 account.9.dtmf.type= {$yealink_dtmf_type}
@@ -4950,8 +4950,8 @@ account.10.auto_answer=
 ################################################################
 #                      Account Advanced                       ##
 ################################################################
-account.10.nat.udp_update_enable= 3
-account.10.nat.udp_update_time= 30
+account.10.nat.udp_update_enable = {if isset($account.10.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
+account.10.nat.udp_update_time = 30
 account.10.nat.rport= {$yealink_rport}
 
 account.10.dtmf.type= {$yealink_dtmf_type}

--- a/resources/templates/provision/yealink/t58a/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t58a/{$mac}.cfg
@@ -111,9 +111,9 @@ account.1.reg_fail_retry_interval =
 account.1.nat.nat_traversal = {if isset($stun_server)}1{else}0{/if}
 
 ##It configures the type of keep-alive packets sent by the phone to the NAT static to keep the communication port open so that NAT can continue to function for account X.
-##0-Dsiabled,1-Default: the phone sends UDP packets to the server,2-Option: the phone sends SIP OPTION packets to the server,3-Notify: the phone sends SIP NOTIFY packets to the server.
+##0-Disabled,1-Default: the phone sends UDP packets to the server,2-Option: the phone sends SIP OPTION packets to the server,3-Notify: the phone sends SIP NOTIFY packets to the server.
 ##The default value is 1.
-account.1.nat.udp_update_enable = 3
+account.1.nat.udp_update_enable = {if isset($account.1.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 ##It configures the keep-alive interval (in seconds) for account X.
 ##The default value is 30.Integer from 15 to 2147483647
@@ -576,13 +576,13 @@ account.2.reg_fail_retry_interval =
 ##The default value is 0.
 account.2.nat.nat_traversal = 
 ##It configures the type of keep-alive packets sent by the phone to the NAT static to keep the communication port open so that NAT can continue to function for account X.
-##0-Dsiabled,1-Default: the phone sends UDP packets to the server,2-Option: the phone sends SIP OPTION packets to the server,3-Notify: the phone sends SIP NOTIFY packets to the server.
+##0-Disabled,1-Default: the phone sends UDP packets to the server,2-Option: the phone sends SIP OPTION packets to the server,3-Notify: the phone sends SIP NOTIFY packets to the server.
 ##The default value is 1.
-account.2.nat.udp_update_enable = 
+account.2.nat.udp_update_enable = {if isset($account.2.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 ##It configures the keep-alive interval (in seconds) for account X.
 ##The default value is 30.Integer from 15 to 2147483647
-account.2.nat.udp_update_time = 
+account.2.nat.udp_update_time = 30
 
 ##It enables or disables NAT Rport feature for account X.0-Disabled,1-Enabled
 ##The default value is 0.
@@ -1040,13 +1040,13 @@ account.3.reg_fail_retry_interval =
 account.3.nat.nat_traversal = 
 
 ##It configures the type of keep-alive packets sent by the phone to the NAT static to keep the communication port open so that NAT can continue to function for account X.
-##0-Dsiabled,1-Default: the phone sends UDP packets to the server,2-Option: the phone sends SIP OPTION packets to the server,3-Notify: the phone sends SIP NOTIFY packets to the server.
+##0-Disabled,1-Default: the phone sends UDP packets to the server,2-Option: the phone sends SIP OPTION packets to the server,3-Notify: the phone sends SIP NOTIFY packets to the server.
 ##The default value is 1.
-account.3.nat.udp_update_enable = 
+account.3.nat.udp_update_enable = {if isset($account.3.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 ##It configures the keep-alive interval (in seconds) for account X.
 ##The default value is 30.Integer from 15 to 2147483647
-account.3.nat.udp_update_time = 
+account.3.nat.udp_update_time = 30
 
 ##It enables or disables NAT Rport feature for account X.0-Disabled,1-Enabled
 ##The default value is 0.
@@ -1499,13 +1499,13 @@ account.4.reg_fail_retry_interval =
 ##The default value is 0.
 account.4.nat.nat_traversal = 
 ##It configures the type of keep-alive packets sent by the phone to the NAT static to keep the communication port open so that NAT can continue to function for account X.
-##0-Dsiabled,1-Default: the phone sends UDP packets to the server,2-Option: the phone sends SIP OPTION packets to the server,3-Notify: the phone sends SIP NOTIFY packets to the server.
+##0-Disabled,1-Default: the phone sends UDP packets to the server,2-Option: the phone sends SIP OPTION packets to the server,3-Notify: the phone sends SIP NOTIFY packets to the server.
 ##The default value is 1.
-account.4.nat.udp_update_enable = 
+account.4.nat.udp_update_enable = {if isset($account.4.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 ##It configures the keep-alive interval (in seconds) for account X.
 ##The default value is 30.Integer from 15 to 2147483647
-account.4.nat.udp_update_time = 
+account.4.nat.udp_update_time = 30
 
 ##It enables or disables NAT Rport feature for account X.0-Disabled,1-Enabled
 ##The default value is 0.
@@ -1966,13 +1966,13 @@ account.5.reg_fail_retry_interval =
 account.5.nat.nat_traversal = 
 
 ##It configures the type of keep-alive packets sent by the phone to the NAT static to keep the communication port open so that NAT can continue to function for account X.
-##0-Dsiabled,1-Default: the phone sends UDP packets to the server,2-Option: the phone sends SIP OPTION packets to the server,3-Notify: the phone sends SIP NOTIFY packets to the server.
+##0-Disabled,1-Default: the phone sends UDP packets to the server,2-Option: the phone sends SIP OPTION packets to the server,3-Notify: the phone sends SIP NOTIFY packets to the server.
 ##The default value is 1.
-account.5.nat.udp_update_enable = 
+account.5.nat.udp_update_enable = {if isset($account.5.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 ##It configures the keep-alive interval (in seconds) for account X.
 ##The default value is 30.Integer from 15 to 2147483647
-account.5.nat.udp_update_time = 
+account.5.nat.udp_update_time = 30
 
 ##It enables or disables NAT Rport feature for account X.0-Disabled,1-Enabled
 ##The default value is 0.
@@ -2437,13 +2437,13 @@ account.6.nat.nat_traversal =
 
 
 ##It configures the type of keep-alive packets sent by the phone to the NAT static to keep the communication port open so that NAT can continue to function for account X.
-##0-Dsiabled,1-Default: the phone sends UDP packets to the server,2-Option: the phone sends SIP OPTION packets to the server,3-Notify: the phone sends SIP NOTIFY packets to the server.
+##0-Disabled,1-Default: the phone sends UDP packets to the server,2-Option: the phone sends SIP OPTION packets to the server,3-Notify: the phone sends SIP NOTIFY packets to the server.
 ##The default value is 1.
-account.6.nat.udp_update_enable = 
+account.6.nat.udp_update_enable = {if isset($account.6.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 ##It configures the keep-alive interval (in seconds) for account X.
 ##The default value is 30.Integer from 15 to 2147483647
-account.6.nat.udp_update_time = 
+account.6.nat.udp_update_time = 30
 
 ##It enables or disables NAT Rport feature for account X.0-Disabled,1-Enabled
 ##The default value is 0.

--- a/resources/templates/provision/yealink/t58v/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t58v/{$mac}.cfg
@@ -117,7 +117,7 @@ account.{$row.line_number}.reg_fail_retry_interval =
 account.{$row.line_number}.nat.nat_traversal = {if isset($stun_server)}1{else}0{/if}
 
 ##It configures the type of keep-alive packets sent by the phone to the NAT static to keep the communication port open so that NAT can continue to function for account X.
-##0-Dsiabled,1-Default: the phone sends UDP packets to the server,2-Option: the phone sends SIP OPTION packets to the server,3-Notify: the phone sends SIP NOTIFY packets to the server.
+##0-Disabled,1-Default: the phone sends UDP packets to the server,2-Option: the phone sends SIP OPTION packets to the server,3-Notify: the phone sends SIP NOTIFY packets to the server.
 ##The default value is 1.
 account.{$row.line_number}.nat.udp_update_enable = 3
 

--- a/resources/templates/provision/yealink/vp530/{$mac}.cfg
+++ b/resources/templates/provision/yealink/vp530/{$mac}.cfg
@@ -137,7 +137,7 @@ account.1.nat.stun_server = {$stun_server}
 account.1.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.1.nat.udp_update_enable = 3
+account.1.nat.udp_update_enable = {if isset($account.1.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
 account.1.nat.udp_update_time = 30
@@ -635,7 +635,7 @@ account.2.nat.stun_server = {$stun_server}
 account.2.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.2.nat.udp_update_enable = 1
+account.2.nat.udp_update_enable = {if isset($account.2.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
 account.2.nat.udp_update_time = 30
@@ -1144,7 +1144,7 @@ account.3.nat.stun_server = {$stun_server}
 account.3.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.3.nat.udp_update_enable = 1
+account.3.nat.udp_update_enable = {if isset($account.3.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
 account.3.nat.udp_update_time = 30
@@ -1636,7 +1636,7 @@ account.4.nat.stun_server = {$stun_server}
 account.4.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.4.nat.udp_update_enable = 1
+account.4.nat.udp_update_enable = {if isset($account.4.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
 account.4.nat.udp_update_time = 30
@@ -2128,7 +2128,7 @@ account.5.nat.stun_server = {$stun_server}
 account.5.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.5.nat.udp_update_enable = 1
+account.5.nat.udp_update_enable = {if isset($account.5.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
 account.5.nat.udp_update_time = 30
@@ -2619,7 +2619,7 @@ account.6.nat.stun_server =
 account.6.nat.stun_port = 3478
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.6.nat.udp_update_enable = 1
+account.6.nat.udp_update_enable = {if isset($account.6.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
 account.6.nat.udp_update_time = 30

--- a/resources/templates/provision/yealink/vp59/{$mac}.cfg
+++ b/resources/templates/provision/yealink/vp59/{$mac}.cfg
@@ -108,7 +108,7 @@ account.{$row.line_number}.srtp_encryption =
 account.{$row.line_number}.nat.nat_traversal = {if isset($stun_server)}1{else}0{/if}
 
 ##It configures the type of keep-alive packets sent by the phone to the NAT static to keep the communication port open so that NAT can continue to function for account X.
-##0-Dsiabled,1-Default: the phone sends UDP packets to the server,2-Option: the phone sends SIP OPTION packets to the server,3-Notify: the phone sends SIP NOTIFY packets to the server.
+##0-Disabled,1-Default: the phone sends UDP packets to the server,2-Option: the phone sends SIP OPTION packets to the server,3-Notify: the phone sends SIP NOTIFY packets to the server.
 ##The default value is 1.
 account.{$row.line_number}.nat.udp_update_enable = 3
 

--- a/resources/templates/provision/yealink/w52p/{$mac}.cfg
+++ b/resources/templates/provision/yealink/w52p/{$mac}.cfg
@@ -176,10 +176,10 @@ account.1.nat.stun_server = {$stun_server}
 account.1.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.1.nat.udp_update_enable = 3
+account.1.nat.udp_update_enable = {if isset($account.1.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
-account.1.nat.udp_update_time =
+account.1.nat.udp_update_time = 30
 
 #Enable or disable the NAT Rport; 0-Disabled (default), 1-Enabled;
 account.1.nat.rport = {$yealink_rport}
@@ -496,11 +496,11 @@ account.2.nat.stun_server = {$stun_server}
 #Configure the STUN server port, the default value is 3478.
 account.2.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
-#Enable or disable the NAT keep-alive; 0-Disabled, 1-Enabled (default);
-account.2.nat.udp_update_enable =
+#Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
+account.2.nat.udp_update_enable = {if isset($account.2.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
-account.2.nat.udp_update_time =
+account.2.nat.udp_update_time = 30
 
 #Enable or disable the NAT Rport; 0-Disabled (default), 1-Enabled;
 account.2.nat.rport = {$yealink_rport}
@@ -769,11 +769,11 @@ account.3.nat.stun_server = {$stun_server}
 #Configure the STUN server port, the default value is 3478.
 account.3.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
-#Enable or disable the NAT keep-alive; 0-Disabled, 1-Enabled (default);
-account.3.nat.udp_update_enable =
+#Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
+account.3.nat.udp_update_enable = {if isset($account.3.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
-account.3.nat.udp_update_time =
+account.3.nat.udp_update_time = 30
 
 #Enable or disable the NAT Rport; 0-Disabled (default), 1-Enabled;
 account.3.nat.rport = {$yealink_rport}
@@ -1043,11 +1043,11 @@ account.4.nat.stun_server = {$stun_server}
 #Configure the STUN server port, the default value is 3478.
 account.4.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
-#Enable or disable the NAT keep-alive; 0-Disabled, 1-Enabled (default);
-account.4.nat.udp_update_enable =
+#Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
+account.4.nat.udp_update_enable = {if isset($account.4.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
-account.4.nat.udp_update_time =
+account.4.nat.udp_update_time = 30
 
 #Enable or disable the NAT Rport; 0-Disabled (default), 1-Enabled;
 account.4.nat.rport = {$yealink_rport}
@@ -1317,11 +1317,11 @@ account.5.nat.stun_server = {$stun_server}
 #Configure the STUN server port, the default value is 3478.
 account.5.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
-#Enable or disable the NAT keep-alive; 0-Disabled, 1-Enabled (default);
-account.5.nat.udp_update_enable =
+#Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
+account.5.nat.udp_update_enable = {if isset($account.5.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
-account.5.nat.udp_update_time =
+account.5.nat.udp_update_time = 30
 
 #Enable or disable the NAT Rport; 0-Disabled (default), 1-Enabled;
 account.5.nat.rport = {$yealink_rport}

--- a/resources/templates/provision/yealink/w56p/{$mac}.cfg
+++ b/resources/templates/provision/yealink/w56p/{$mac}.cfg
@@ -176,10 +176,10 @@ account.1.nat.stun_server = {$stun_server}
 account.1.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.1.nat.udp_update_enable = 3
+account.1.nat.udp_update_enable = {if isset($account.1.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
-account.1.nat.udp_update_time =
+account.1.nat.udp_update_time = 30
 
 #Enable or disable the NAT Rport; 0-Disabled (default), 1-Enabled;
 account.1.nat.rport = {$yealink_rport}
@@ -481,11 +481,11 @@ account.2.nat.stun_server = {$stun_server}
 #Configure the STUN server port, the default value is 3478.
 account.2.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
-#Enable or disable the NAT keep-alive; 0-Disabled, 1-Enabled (default);
-account.2.nat.udp_update_enable =
+#Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
+account.2.nat.udp_update_enable = {if isset($account.2.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
-account.2.nat.udp_update_time =
+account.2.nat.udp_update_time = 30
 
 #Enable or disable the NAT Rport; 0-Disabled (default), 1-Enabled;
 account.2.nat.rport = {$yealink_rport}
@@ -739,11 +739,11 @@ account.3.nat.stun_server = {$stun_server}
 #Configure the STUN server port, the default value is 3478.
 account.3.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
-#Enable or disable the NAT keep-alive; 0-Disabled, 1-Enabled (default);
-account.3.nat.udp_update_enable =
+#Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
+account.3.nat.udp_update_enable = {if isset($account.3.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
-account.3.nat.udp_update_time =
+account.3.nat.udp_update_time = 30
 
 #Enable or disable the NAT Rport; 0-Disabled (default), 1-Enabled;
 account.3.nat.rport = {$yealink_rport}
@@ -998,11 +998,11 @@ account.4.nat.stun_server = {$stun_server}
 #Configure the STUN server port, the default value is 3478.
 account.4.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
-#Enable or disable the NAT keep-alive; 0-Disabled, 1-Enabled (default);
-account.4.nat.udp_update_enable =
+#Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
+account.4.nat.udp_update_enable = {if isset($account.4.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
-account.4.nat.udp_update_time =
+account.4.nat.udp_update_time = 30
 
 #Enable or disable the NAT Rport; 0-Disabled (default), 1-Enabled;
 account.4.nat.rport = {$yealink_rport}
@@ -1257,11 +1257,11 @@ account.5.nat.stun_server = {$stun_server}
 #Configure the STUN server port, the default value is 3478.
 account.5.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}
 
-#Enable or disable the NAT keep-alive; 0-Disabled, 1-Enabled (default);
-account.5.nat.udp_update_enable =
+#Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
+account.5.nat.udp_update_enable = {if isset($account.5.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
-account.5.nat.udp_update_time =
+account.5.nat.udp_update_time = 30
 
 #Enable or disable the NAT Rport; 0-Disabled (default), 1-Enabled;
 account.5.nat.rport = {$yealink_rport}

--- a/resources/templates/provision/yealink/w60b/{$mac}.cfg
+++ b/resources/templates/provision/yealink/w60b/{$mac}.cfg
@@ -147,7 +147,7 @@ account.1.nat.stun_server = {$stun_server}
 account.1.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}{""}
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.1.nat.udp_update_enable = 3
+account.1.nat.udp_update_enable = {if isset($account.1.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
 account.1.nat.udp_update_time = 30
@@ -440,11 +440,11 @@ account.2.nat.stun_server = {$stun_server}
 #Configure the STUN server port, the default value is 3478.
 account.2.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}{""}
 
-#Enable or disable the NAT keep-alive; 0-Disabled, 1-Enabled (default);
-account.2.nat.udp_update_enable =
+#Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
+account.2.nat.udp_update_enable = {if isset($account.2.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
-account.2.nat.udp_update_time =
+account.2.nat.udp_update_time = 30
 
 #Enable or disable the NAT Rport; 0-Disabled (default), 1-Enabled;
 account.2.nat.rport = {$yealink_rport}
@@ -686,11 +686,11 @@ account.3.nat.stun_server = {$stun_server}
 #Configure the STUN server port, the default value is 3478.
 account.3.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}{""}
 
-#Enable or disable the NAT keep-alive; 0-Disabled, 1-Enabled (default);
-account.3.nat.udp_update_enable =
+#Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
+account.3.nat.udp_update_enable = {if isset($account.3.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
-account.3.nat.udp_update_time =
+account.3.nat.udp_update_time = 30
 
 #Enable or disable the NAT Rport; 0-Disabled (default), 1-Enabled;
 account.3.nat.rport = {$yealink_rport}
@@ -931,11 +931,11 @@ account.4.nat.stun_server = {$stun_server}
 #Configure the STUN server port, the default value is 3478.
 account.4.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}{""}
 
-#Enable or disable the NAT keep-alive; 0-Disabled, 1-Enabled (default);
-account.4.nat.udp_update_enable =
+#Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
+account.4.nat.udp_update_enable = {if isset($account.4.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
-account.4.nat.udp_update_time =
+account.4.nat.udp_update_time = 30
 
 #Enable or disable the NAT Rport; 0-Disabled (default), 1-Enabled;
 account.4.nat.rport = {$yealink_rport}
@@ -1178,11 +1178,11 @@ account.5.nat.stun_server = {$stun_server}
 #Configure the STUN server port, the default value is 3478.
 account.5.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}{""}
 
-#Enable or disable the NAT keep-alive; 0-Disabled, 1-Enabled (default);
-account.5.nat.udp_update_enable =
+#Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
+account.5.nat.udp_update_enable = {if isset($account.5.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
-account.5.nat.udp_update_time =
+account.5.nat.udp_update_time = 30
 
 #Enable or disable the NAT Rport; 0-Disabled (default), 1-Enabled;
 account.5.nat.rport = {$yealink_rport}
@@ -1443,11 +1443,11 @@ account.6.nat.stun_server = {$stun_server}
 #Configure the STUN server port, the default value is 3478.
 account.6.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}{""}
 
-#Enable or disable the NAT keep-alive; 0-Disabled, 1-Enabled (default);
-account.6.nat.udp_update_enable =
+#Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
+account.6.nat.udp_update_enable = {if isset($account.6.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
-account.6.nat.udp_update_time =
+account.6.nat.udp_update_time = 30
 
 #Enable or disable the NAT Rport; 0-Disabled (default), 1-Enabled;
 account.6.nat.rport = {$yealink_rport}
@@ -1708,11 +1708,11 @@ account.7.nat.stun_server = {$stun_server}
 #Configure the STUN server port, the default value is 3478.
 account.7.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}{""}
 
-#Enable or disable the NAT keep-alive; 0-Disabled, 1-Enabled (default);
-account.7.nat.udp_update_enable =
+#Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
+account.7.nat.udp_update_enable = {if isset($account.7.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
-account.7.nat.udp_update_time =
+account.7.nat.udp_update_time = 30
 
 #Enable or disable the NAT Rport; 0-Disabled (default), 1-Enabled;
 account.7.nat.rport = {$yealink_rport}
@@ -1973,11 +1973,11 @@ account.8.nat.stun_server = {$stun_server}
 #Configure the STUN server port, the default value is 3478.
 account.8.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}{""}
 
-#Enable or disable the NAT keep-alive; 0-Disabled, 1-Enabled (default);
-account.8.nat.udp_update_enable =
+#Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
+account.8.nat.udp_update_enable = {if isset($account.8.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
-account.8.nat.udp_update_time =
+account.8.nat.udp_update_time = 30
 
 #Enable or disable the NAT Rport; 0-Disabled (default), 1-Enabled;
 account.8.nat.rport = {$yealink_rport}

--- a/resources/templates/provision/yealink/w7xp/{$mac}.cfg
+++ b/resources/templates/provision/yealink/w7xp/{$mac}.cfg
@@ -147,7 +147,7 @@ account.1.nat.stun_server = {$stun_server}
 account.1.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}{""}
 
 #Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
-account.1.nat.udp_update_enable = 3
+account.1.nat.udp_update_enable = {if isset($account.1.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
 account.1.nat.udp_update_time = 30
@@ -440,11 +440,11 @@ account.2.nat.stun_server = {$stun_server}
 #Configure the STUN server port, the default value is 3478.
 account.2.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}{""}
 
-#Enable or disable the NAT keep-alive; 0-Disabled, 1-Enabled (default);
-account.2.nat.udp_update_enable =
+#Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
+account.2.nat.udp_update_enable = {if isset($account.2.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
-account.2.nat.udp_update_time =
+account.2.nat.udp_update_time = 30
 
 #Enable or disable the NAT Rport; 0-Disabled (default), 1-Enabled;
 account.2.nat.rport = {$yealink_rport}
@@ -686,11 +686,11 @@ account.3.nat.stun_server = {$stun_server}
 #Configure the STUN server port, the default value is 3478.
 account.3.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}{""}
 
-#Enable or disable the NAT keep-alive; 0-Disabled, 1-Enabled (default);
-account.3.nat.udp_update_enable =
+#Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
+account.3.nat.udp_update_enable = {if isset($account.3.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
-account.3.nat.udp_update_time =
+account.3.nat.udp_update_time = 30
 
 #Enable or disable the NAT Rport; 0-Disabled (default), 1-Enabled;
 account.3.nat.rport = {$yealink_rport}
@@ -931,11 +931,11 @@ account.4.nat.stun_server = {$stun_server}
 #Configure the STUN server port, the default value is 3478.
 account.4.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}{""}
 
-#Enable or disable the NAT keep-alive; 0-Disabled, 1-Enabled (default);
-account.4.nat.udp_update_enable =
+#Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
+account.4.nat.udp_update_enable = {if isset($account.4.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
-account.4.nat.udp_update_time =
+account.4.nat.udp_update_time = 30
 
 #Enable or disable the NAT Rport; 0-Disabled (default), 1-Enabled;
 account.4.nat.rport = {$yealink_rport}
@@ -1178,11 +1178,11 @@ account.5.nat.stun_server = {$stun_server}
 #Configure the STUN server port, the default value is 3478.
 account.5.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}{""}
 
-#Enable or disable the NAT keep-alive; 0-Disabled, 1-Enabled (default);
-account.5.nat.udp_update_enable =
+#Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
+account.5.nat.udp_update_enable = {if isset($account.5.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
-account.5.nat.udp_update_time =
+account.5.nat.udp_update_time = 30
 
 #Enable or disable the NAT Rport; 0-Disabled (default), 1-Enabled;
 account.5.nat.rport = {$yealink_rport}
@@ -1443,11 +1443,11 @@ account.6.nat.stun_server = {$stun_server}
 #Configure the STUN server port, the default value is 3478.
 account.6.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}{""}
 
-#Enable or disable the NAT keep-alive; 0-Disabled, 1-Enabled (default);
-account.6.nat.udp_update_enable =
+#Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
+account.6.nat.udp_update_enable = {if isset($account.6.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
-account.6.nat.udp_update_time =
+account.6.nat.udp_update_time = 30
 
 #Enable or disable the NAT Rport; 0-Disabled (default), 1-Enabled;
 account.6.nat.rport = {$yealink_rport}
@@ -1708,11 +1708,11 @@ account.7.nat.stun_server = {$stun_server}
 #Configure the STUN server port, the default value is 3478.
 account.7.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}{""}
 
-#Enable or disable the NAT keep-alive; 0-Disabled, 1-Enabled (default);
-account.7.nat.udp_update_enable =
+#Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
+account.7.nat.udp_update_enable = {if isset($account.7.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
-account.7.nat.udp_update_time =
+account.7.nat.udp_update_time = 30
 
 #Enable or disable the NAT Rport; 0-Disabled (default), 1-Enabled;
 account.7.nat.rport = {$yealink_rport}
@@ -1973,11 +1973,11 @@ account.8.nat.stun_server = {$stun_server}
 #Configure the STUN server port, the default value is 3478.
 account.8.nat.stun_port = {if isset($stun_port)}{$stun_port}{else}3478{/if}{""}
 
-#Enable or disable the NAT keep-alive; 0-Disabled, 1-Enabled (default);
-account.8.nat.udp_update_enable =
+#Enable or disable the NAT keep-alive; 0-Disabled, 1-Default (default), 2-Option, 3-Notify;
+account.8.nat.udp_update_enable = {if isset($account.8.password)}{if isset($yealink_udp_update_enable)}{$yealink_udp_update_enable}{else}3{/if}{else}1{/if}{""}
 
 #Specify the keep-alive interval (in seconds), the default value is 30.
-account.8.nat.udp_update_time =
+account.8.nat.udp_update_time = 30
 
 #Enable or disable the NAT Rport; 0-Disabled (default), 1-Enabled;
 account.8.nat.rport = {$yealink_rport}


### PR DESCRIPTION
Changes to make the templates a bit more consistent while also fixing some typos and creating a new variable for the NAT Update setting.

By default, the account.1.nat.udp_update_enable is set to "3" on most templates which means to have the phone periodically send NOTIFY messages. This is not the case though on additional accounts (e.g. account 2). This makes for inconsistent configs that sometimes cause issues with phones ringing.

This fixes the issue while also giving the ability to use a variable to set it.