### PR TITLE
Wallpaper setting added to provisioning template

### DIFF
--- a/resources/templates/provision/snom/D375/{$mac}.xml
+++ b/resources/templates/provision/snom/D375/{$mac}.xml
@@ -24,6 +24,9 @@
     <alert_external_ring_sound perm="">{if isset($snom_alert_external)}{$snom_alert_external}{else}Ringer1{/if}</alert_external_ring_sound>
     <alert_group_ring_text perm="">alert-group</alert_group_ring_text>
     <alert_group_ring_sound perm="">{if isset($snom_alert_group)}{$snom_alert_group}{else}Ringer1{/if}</alert_group_ring_sound>
+    <!-- Wallpaper (480x272px PNG)-->
+    <custom_bg_image_url perm="">{$snom_wallpaper_url}</custom_bg_image_url>
+    <expansion_module_background_image perm="">{$snom_exp_wallpaper_url}</expansion_module_background_image>
     <!-- SIP Settings -->
     <mwi_notification perm="">silent</mwi_notification>
     <mwi_dialtone perm="">stutter</mwi_dialtone>

--- a/resources/templates/provision/snom/D375/{$mac}.xml
+++ b/resources/templates/provision/snom/D375/{$mac}.xml
@@ -26,6 +26,7 @@
     <alert_group_ring_sound perm="">{if isset($snom_alert_group)}{$snom_alert_group}{else}Ringer1{/if}</alert_group_ring_sound>
     <!-- Wallpaper (480x272px PNG)-->
     <custom_bg_image_url perm="">{$snom_wallpaper_url}</custom_bg_image_url>
+    <!-- Expansion Mod (480x1280px PNG <2MB) -->
     <expansion_module_background_image perm="">{$snom_exp_wallpaper_url}</expansion_module_background_image>
     <!-- SIP Settings -->
     <mwi_notification perm="">silent</mwi_notification>

--- a/resources/templates/provision/snom/D385/{$mac}.xml
+++ b/resources/templates/provision/snom/D385/{$mac}.xml
@@ -24,6 +24,9 @@
     <alert_external_ring_sound perm="">{if isset($snom_alert_external)}{$snom_alert_external}{else}Ringer1{/if}</alert_external_ring_sound>
     <alert_group_ring_text perm="">alert-group</alert_group_ring_text>
     <alert_group_ring_sound perm="">{if isset($snom_alert_group)}{$snom_alert_group}{else}Ringer1{/if}</alert_group_ring_sound>
+    <!-- Wallpaper (480x272px PNG)-->
+    <custom_bg_image_url perm="">{$snom_wallpaper_url}</custom_bg_image_url>
+    <expansion_module_background_image perm="">{$snom_exp_wallpaper_url}</expansion_module_background_image>
     <!-- SIP Settings -->
     <mwi_notification perm="">silent</mwi_notification>
     <mwi_dialtone perm="">stutter</mwi_dialtone>

--- a/resources/templates/provision/snom/D385/{$mac}.xml
+++ b/resources/templates/provision/snom/D385/{$mac}.xml
@@ -26,6 +26,7 @@
     <alert_group_ring_sound perm="">{if isset($snom_alert_group)}{$snom_alert_group}{else}Ringer1{/if}</alert_group_ring_sound>
     <!-- Wallpaper (480x272px PNG)-->
     <custom_bg_image_url perm="">{$snom_wallpaper_url}</custom_bg_image_url>
+    <!-- Expansion Mod (480x1280px PNG <2MB) -->
     <expansion_module_background_image perm="">{$snom_exp_wallpaper_url}</expansion_module_background_image>
     <!-- SIP Settings -->
     <mwi_notification perm="">silent</mwi_notification>

--- a/resources/templates/provision/snom/D717/{$mac}.xml
+++ b/resources/templates/provision/snom/D717/{$mac}.xml
@@ -26,6 +26,7 @@
     <alert_group_ring_sound perm="">{if isset($snom_alert_group)}{$snom_alert_group}{else}Ringer1{/if}</alert_group_ring_sound>
     <!-- Wallpaper (426x240px PNG) (Firmware: 10.1.41.1+) -->
     <custom_bg_image_url perm="">{$snom_wallpaper_url}</custom_bg_image_url>
+    <!-- Expansion Mod (480x1280px PNG <2MB) -->
     <expansion_module_background_image perm="">{$snom_exp_wallpaper_url}</expansion_module_background_image>
     <!-- SIP Settings -->
     <mwi_notification perm="">silent</mwi_notification>

--- a/resources/templates/provision/snom/D717/{$mac}.xml
+++ b/resources/templates/provision/snom/D717/{$mac}.xml
@@ -24,6 +24,9 @@
     <alert_external_ring_sound perm="">{if isset($snom_alert_external)}{$snom_alert_external}{else}Ringer1{/if}</alert_external_ring_sound>
     <alert_group_ring_text perm="">alert-group</alert_group_ring_text>
     <alert_group_ring_sound perm="">{if isset($snom_alert_group)}{$snom_alert_group}{else}Ringer1{/if}</alert_group_ring_sound>
+    <!-- Wallpaper (426x240px PNG) (Firmware: 10.1.41.1+) -->
+    <custom_bg_image_url perm="">{$snom_wallpaper_url}</custom_bg_image_url>
+    <expansion_module_background_image perm="">{$snom_exp_wallpaper_url}</expansion_module_background_image>
     <!-- SIP Settings -->
     <mwi_notification perm="">silent</mwi_notification>
     <mwi_dialtone perm="">stutter</mwi_dialtone>

--- a/resources/templates/provision/snom/D735/{$mac}.xml
+++ b/resources/templates/provision/snom/D735/{$mac}.xml
@@ -26,6 +26,7 @@
     <alert_group_ring_sound perm="">{if isset($snom_alert_group)}{$snom_alert_group}{else}Ringer1{/if}</alert_group_ring_sound>
     <!-- Wallpaper (320x240px PNG)-->
     <custom_bg_image_url perm="">{$snom_wallpaper_url}</custom_bg_image_url>
+    <!-- Expansion Mod (480x1280px PNG <2MB) -->
     <expansion_module_background_image perm="">{$snom_exp_wallpaper_url}</expansion_module_background_image>
     <!-- SIP Settings -->
     <mwi_notification perm="">silent</mwi_notification>

--- a/resources/templates/provision/snom/D735/{$mac}.xml
+++ b/resources/templates/provision/snom/D735/{$mac}.xml
@@ -24,6 +24,9 @@
     <alert_external_ring_sound perm="">{if isset($snom_alert_external)}{$snom_alert_external}{else}Ringer1{/if}</alert_external_ring_sound>
     <alert_group_ring_text perm="">alert-group</alert_group_ring_text>
     <alert_group_ring_sound perm="">{if isset($snom_alert_group)}{$snom_alert_group}{else}Ringer1{/if}</alert_group_ring_sound>
+    <!-- Wallpaper (320x240px PNG)-->
+    <custom_bg_image_url perm="">{$snom_wallpaper_url}</custom_bg_image_url>
+    <expansion_module_background_image perm="">{$snom_exp_wallpaper_url}</expansion_module_background_image>
     <!-- SIP Settings -->
     <mwi_notification perm="">silent</mwi_notification>
     <mwi_dialtone perm="">stutter</mwi_dialtone>

--- a/resources/templates/provision/snom/D765/{$mac}.xml
+++ b/resources/templates/provision/snom/D765/{$mac}.xml
@@ -26,6 +26,7 @@
     <alert_group_ring_sound perm="">{if isset($snom_alert_group)}{$snom_alert_group}{else}Ringer1{/if}</alert_group_ring_sound>
     <!-- Wallpaper (320x240px PNG)-->
     <custom_bg_image_url perm="">{$snom_wallpaper_url}</custom_bg_image_url>
+    <!-- Expansion Mod (480x1280px PNG <2MB) -->
     <expansion_module_background_image perm="">{$snom_exp_wallpaper_url}</expansion_module_background_image>
     <!-- SIP Settings -->
     <mwi_notification perm="">silent</mwi_notification>

--- a/resources/templates/provision/snom/D765/{$mac}.xml
+++ b/resources/templates/provision/snom/D765/{$mac}.xml
@@ -24,6 +24,9 @@
     <alert_external_ring_sound perm="">{if isset($snom_alert_external)}{$snom_alert_external}{else}Ringer1{/if}</alert_external_ring_sound>
     <alert_group_ring_text perm="">alert-group</alert_group_ring_text>
     <alert_group_ring_sound perm="">{if isset($snom_alert_group)}{$snom_alert_group}{else}Ringer1{/if}</alert_group_ring_sound>
+    <!-- Wallpaper (320x240px PNG)-->
+    <custom_bg_image_url perm="">{$snom_wallpaper_url}</custom_bg_image_url>
+    <expansion_module_background_image perm="">{$snom_exp_wallpaper_url}</expansion_module_background_image>
     <!-- SIP Settings -->
     <mwi_notification perm="">silent</mwi_notification>
     <mwi_dialtone perm="">stutter</mwi_dialtone>

--- a/resources/templates/provision/snom/D785/{$mac}.xml
+++ b/resources/templates/provision/snom/D785/{$mac}.xml
@@ -24,6 +24,9 @@
     <alert_external_ring_sound perm="">{if isset($snom_alert_external)}{$snom_alert_external}{else}Ringer1{/if}</alert_external_ring_sound>
     <alert_group_ring_text perm="">alert-group</alert_group_ring_text>
     <alert_group_ring_sound perm="">{if isset($snom_alert_group)}{$snom_alert_group}{else}Ringer1{/if}</alert_group_ring_sound>
+    <!-- Wallpaper (480x272px PNG)-->
+    <custom_bg_image_url perm="">{$snom_wallpaper_url}</custom_bg_image_url>
+    <expansion_module_background_image perm="">{$snom_exp_wallpaper_url}</expansion_module_background_image>
     <!-- SIP Settings -->
     <mwi_notification perm="">silent</mwi_notification>
     <mwi_dialtone perm="">stutter</mwi_dialtone>

--- a/resources/templates/provision/snom/D785/{$mac}.xml
+++ b/resources/templates/provision/snom/D785/{$mac}.xml
@@ -26,6 +26,7 @@
     <alert_group_ring_sound perm="">{if isset($snom_alert_group)}{$snom_alert_group}{else}Ringer1{/if}</alert_group_ring_sound>
     <!-- Wallpaper (480x272px PNG)-->
     <custom_bg_image_url perm="">{$snom_wallpaper_url}</custom_bg_image_url>
+    <!-- Expansion Mod (480x1280px PNG <2MB) -->
     <expansion_module_background_image perm="">{$snom_exp_wallpaper_url}</expansion_module_background_image>
     <!-- SIP Settings -->
     <mwi_notification perm="">silent</mwi_notification>


### PR DESCRIPTION
This PR includes new settings for both the snom wallpaper on the main screen as well as the expansion module. Snom documentation states that if the option is left blank then the default will be used. I tested this on my lab system and when the variable exists it shows up in the template like this:

> `<custom_bg_image_url perm="">https://imgur.com/fakeimage.png</custom_bg_image_url>`

When the variable is blank or not set it looks like this:
> `<custom_bg_image_url perm=""/>`