### PR TITLE
Hide Extension Summary Show all by default.

### DIFF
--- a/app/xml_cdr/app_config.php
+++ b/app/xml_cdr/app_config.php
@@ -221,6 +221,8 @@
 		$apps[$x]['permissions'][$y]['name'] = "xml_cdr_export_pdf";
 		$apps[$x]['permissions'][$y]['groups'][] = "superadmin";
 		$apps[$x]['permissions'][$y]['groups'][] = "admin";
+		$y++;
+		$apps[$x]['permissions'][$y]['name'] = "xml_cdr_extension_summary_all";
 
 	//default settings
 		$y=0;

--- a/app/xml_cdr/resources/classes/xml_cdr.php
+++ b/app/xml_cdr/resources/classes/xml_cdr.php
@@ -1149,7 +1149,7 @@ if (!class_exists('xml_cdr')) {
 				$sql .= " originating_leg_uuid, \n";
 				$sql .= " billsec \n";
 				$sql .= " from v_xml_cdr \n";
-				if (!($_GET['show'] === 'all' && permission_exists('xml_cdr_all'))) {
+				if (!($_GET['show'] === 'all' && permission_exists('xml_cdr_extension_summary_all'))) {
 					$sql .= " where domain_uuid = :domain_uuid \n";
 				}
 				else {
@@ -1160,12 +1160,12 @@ if (!class_exists('xml_cdr')) {
 
 				$sql .= "where \n";
 				$sql .= "d.domain_uuid = e.domain_uuid \n";
-				if (!($_GET['show'] === 'all' && permission_exists('xml_cdr_all'))) {
+				if (!($_GET['show'] === 'all' && permission_exists('xml_cdr_extension_summary_all'))) {
 					$sql .= "and e.domain_uuid = :domain_uuid \n";
 				}
 				$sql .= "group by e.extension, e.domain_uuid, d.domain_uuid, e.number_alias, e.description \n";
 				$sql .= "order by extension asc \n";
-				if (!($_GET['show'] === 'all' && permission_exists('xml_cdr_all'))) {
+				if (!($_GET['show'] === 'all' && permission_exists('xml_cdr_extension_summary_all'))) {
 					$parameters['domain_uuid'] = $this->domain_uuid;
 				}
 				$database = new database;

--- a/app/xml_cdr/xml_cdr_extension_summary.php
+++ b/app/xml_cdr/xml_cdr_extension_summary.php
@@ -178,7 +178,7 @@
 
 		echo "</div>\n";
 
-		if (permission_exists('xml_cdr_all') && $_GET['show'] == 'all') {
+		if (permission_exists('xml_cdr_extension_summary_all') && $_GET['show'] == 'all') {
 			echo "<input type='hidden' name='show' value='all'>";
 		}
 
@@ -188,7 +188,7 @@
 //show the results
 	echo "<table class='list'>\n";
 	echo "	<tr class='list-header'>\n";
-	if ($_GET['show'] === "all" && permission_exists('xml_cdr_all')) {
+	if ($_GET['show'] === "all" && permission_exists('xml_cdr_extension_summary_all')) {
 		echo "		<th>".$text['label-domain']."</th>\n";
 	}
 	echo "		<th>".$text['label-extension']."</th>\n";
@@ -208,7 +208,7 @@
 	if (is_array($summary)) {
 		foreach ($summary as $key => $row) {
 			echo "<tr class='list-row'>\n";
-			if ($_GET['show'] === "all" && permission_exists('xml_cdr_all')) {
+			if ($_GET['show'] === "all" && permission_exists('xml_cdr_extension_summary_all')) {
 				echo "	<td>".escape($row['domain_name'])."</td>\n";
 			}
 			echo "	<td>".escape($row['extension'])."</td>\n";

--- a/app/xml_cdr/xml_cdr_extension_summary.php
+++ b/app/xml_cdr/xml_cdr_extension_summary.php
@@ -113,7 +113,7 @@
 	echo "<div class='action_bar' id='action_bar'>\n";
 	echo "	<div class='heading'><b>".$text['title-extension_summary']."</b></div>\n";
 	echo "	<div class='actions'>\n";
-	if (permission_exists('xml_cdr_all') && $_GET['show'] != 'all') {
+	if (permission_exists('xml_cdr_extension_summary_all') && $_GET['show'] != 'all') {
 		echo button::create(['type'=>'button','label'=>$text['button-show_all'],'icon'=>$_SESSION['theme']['button_icon_all'],'collapse'=>'hide-sm-dn','link'=>'xml_cdr_extension_summary.php?show=all']);
 	}
 	echo button::create(['type'=>'button','label'=>$text['button-download_csv'],'icon'=>$_SESSION['theme']['button_icon_download'],'collapse'=>'hide-sm-dn','link'=>'xml_cdr_extension_summary.php?'.(strlen($_SERVER["QUERY_STRING"]) > 0 ? $_SERVER["QUERY_STRING"].'&' : null).'type=csv']);


### PR DESCRIPTION
 Add new permission xml_cdr_extension_summary_all. Reason is many extensions and CDR records make this a  very resource intensive query use with caution and only on smaller system.  Disabled by default for all groups.