### PR TITLE
Removing invalid lines in Yealink t31g template, appears to be a dodgy concatenation

### DIFF
--- a/resources/templates/provision/yealink/t31g/y000000000123.cfg
+++ b/resources/templates/provision/yealink/t31g/y000000000123.cfg
@@ -1,12 +1,4 @@
 #!version:1.0.0.1
-## The header above must appear as-is in the first line
-
-include:config "y000000000123.cfg"
-include:config "{$mac}.cfg"
-
-overwrite_mode = {$yealink_overwrite_mode}
-root@hvox3:/var/www/fusionpbx/resources/templates/provision/yealink/t31g# cat y000000000123.cfg 
-#!version:1.0.0.1
 
 ##File header "#!version:1.0.0.1" can not be edited or deleted.##
 


### PR DESCRIPTION
Looks like a combined boot file and a config, minor template issue. Stops the Yealink t31g from provisioning.