### PR TITLE
[4.5] Fixes the blank password issue

### DIFF
--- a/resources/functions.php
+++ b/resources/functions.php
@@ -2181,8 +2181,8 @@ function number_pad($number,$n) {
 
 //convert bytes to readable human format
 	if (!function_exists('random_int')) {
-		function random_int() {
-			return rand ();
+		function random_int($min, $max) {
+			return rand ($min, $max);
 		}
 	}
 


### PR DESCRIPTION
When an old server has been upgrading fusion, it gets to the combination of having PHP5 + Fusion 4.5  And yes, there are a lot of these combos out there.

random_int function is not properly implemented.

I have been reported that creating an extension gets a blank extension, after researching I found the root cause.

PR #4460 tried to fix it properly, but you rejected it. This is an ugly patch following your style.