### PR TITLE
remove space before tag

### DIFF
--- a/app/dialplans/resources/classes/dialplan.php
+++ b/app/dialplans/resources/classes/dialplan.php
@@ -1,4 +1,3 @@
- 
 <?php
 /*
 	FusionPBX


### PR DESCRIPTION
Having a space before the opening of the PHP tag causes headers to be sent prematurely.