### PR TITLE
Resolve bug when saving CFWD settings

### DIFF
--- a/app/call_forward/call_forward_edit.php
+++ b/app/call_forward/call_forward_edit.php
@@ -147,7 +147,7 @@
 			$token = new token;
 			if (!$token->validate($_SERVER['PHP_SELF'])) {
 				message::add($text['message-invalid_token'],'negative');
-				header('Location: calls.php');
+				header('Location: call_forward.php');
 				exit;
 			}
 


### PR DESCRIPTION
calls.php no longer exists as of recent updates. We are now redirecting to call_forward.php instead of calls.php file.