### PR TITLE
Fix voicemail transcriptions not being pushed

### DIFF
--- a/app/extensions/extension_edit.php
+++ b/app/extensions/extension_edit.php
@@ -679,11 +679,10 @@
 											if (permission_exists('voicemail_local_after_email')) {
 												$array["voicemails"][$i]["voicemail_local_after_email"] = $voicemail_local_after_email;
 											}
-											$array["voicemails"][$i]["voicemail_enabled"] = $voicemail_enabled;
-											$array["voicemails"][$i]["voicemail_enabled"] = $voicemail_transcription_enabled;
-
-											$array["voicemails"][$i]["voicemail_description"] = $description;
+											$array["voicemails"][$i]["voicemail_transcription_enabled"] = $voicemail_transcription_enabled;
 											$array["voicemails"][$i]["voicemail_tutorial"] = $voicemail_tutorial;
+											$array["voicemails"][$i]["voicemail_enabled"] = $voicemail_enabled;
+											$array["voicemails"][$i]["voicemail_description"] = $description;
 
 										//make sure the voicemail directory exists
 											if (is_numeric($voicemail_id)) {
@@ -888,7 +887,6 @@
 				$voicemail_file = $row["voicemail_file"];
 				$voicemail_local_after_email = $row["voicemail_local_after_email"];
 				$voicemail_enabled = $row["voicemail_enabled"];
-				$voicemail_transcription_enabled = $row["voicemail_enabled"];
 				$voicemail_transcription_enabled = $row["voicemail_transcription_enabled"];
 				$voicemail_tutorial = $row["voicemail_tutorial"];
 			}

--- a/app/extensions/extension_edit.php
+++ b/app/extensions/extension_edit.php
@@ -680,6 +680,8 @@
 												$array["voicemails"][$i]["voicemail_local_after_email"] = $voicemail_local_after_email;
 											}
 											$array["voicemails"][$i]["voicemail_enabled"] = $voicemail_enabled;
+											$array["voicemails"][$i]["voicemail_enabled"] = $voicemail_transcription_enabled;
+
 											$array["voicemails"][$i]["voicemail_description"] = $description;
 											$array["voicemails"][$i]["voicemail_tutorial"] = $voicemail_tutorial;
 
@@ -886,6 +888,8 @@
 				$voicemail_file = $row["voicemail_file"];
 				$voicemail_local_after_email = $row["voicemail_local_after_email"];
 				$voicemail_enabled = $row["voicemail_enabled"];
+				$voicemail_transcription_enabled = $row["voicemail_enabled"];
+				$voicemail_transcription_enabled = $row["voicemail_transcription_enabled"];
 				$voicemail_tutorial = $row["voicemail_tutorial"];
 			}
 			unset($sql, $parameters, $row);
@@ -1707,6 +1711,30 @@
 		echo "    </select>\n";
 		echo "<br />\n";
 		echo $text['description-voicemail_enabled']."\n";
+		echo "</td>\n";
+		echo "</tr>\n";
+		
+		echo "<tr>\n";
+		echo "<td class='vncell' valign='top' align='left' nowrap='nowrap'>\n";
+		echo "    ".$text['label-voicemail_transcription_enabled']."\n";
+		echo "</td>\n";
+		echo "<td class='vtable' align='left'>\n";
+		echo "    <select class='formfld' name='voicemail_transcription_enabled'>\n";
+		if ($voicemail_transcription_enabled == "true") {
+			echo "    <option value='true' selected='selected'>".$text['label-true']."</option>\n";
+		}
+		else {
+			echo "    <option value='true'>".$text['label-true']."</option>\n";
+		}
+		if ($voicemail_transcription_enabled == "false") {
+			echo "    <option value='false' selected='selected'>".$text['label-false']."</option>\n";
+		}
+		else {
+			echo "    <option value='false'>".$text['label-false']."</option>\n";
+		}
+		echo "    </select>\n";
+		echo "<br />\n";
+		echo $text['description-voicemail_transcription_enabled']."\n";
 		echo "</td>\n";
 		echo "</tr>\n";
 


### PR DESCRIPTION
When creating a new extension, under the Voicemail tab, Transcribe is empty. This was causing users to not receive VM transcriptions. Adding the above code will push transcribe = true or false (depending on the value in default settings) after creating a new extension.