### PR TITLE
fix issue with device vendors

### DIFF
--- a/app/devices/device_edit.php
+++ b/app/devices/device_edit.php
@@ -523,7 +523,7 @@
 //use the mac address to get the vendor
 	if (strlen($device_vendor) == 0) {
 		$template_array = explode("/", $device_template);
-		$device_vendor = $template_array[0];
+		$device_vendor = device::get_vendor($device_mac_address);
 	}
 
 //set the sub array index


### PR DESCRIPTION
If mac address and template already exists in Devices page and you attempt to associate the mac address with the extension from the extensions page, the "vendor" is removed from the device, thus causing provisioning not to look at the device profiles settings of the mac address