### PR TITLE
Add DND Variable to Yealink T54W Template

### DIFF
--- a/resources/templates/provision/yealink/t54w/y000000000096.cfg
+++ b/resources/templates/provision/yealink/t54w/y000000000096.cfg
@@ -1146,8 +1146,8 @@ features.dnd.allow= {$yealink_dnd_allow}
 features.dnd_mode=
 features.dnd.enable=
 
-features.dnd.off_code= {$yealink_forward_always_off_code}
-features.dnd.on_code= {$yealink_forward_always_on_code}
+features.dnd.off_code= {$yealink_dnd_off_code}
+features.dnd.on_code= {$yealink_dnd_on_code}
 
 features.dnd.emergency_authorized_number=
 features.dnd.emergency_enable= 1


### PR DESCRIPTION
Resolve current issue with T54W template DND using the call forward all feature code. My other pull request adding the DND variable option will need to be accepted prior to this one.