### PR TITLE
[dialplans] don't set hold music if from user exists

### DIFF
--- a/app/dialplans/resources/switch/conf/dialplan/080_user_hold_music.xml
+++ b/app/dialplans/resources/switch/conf/dialplan/080_user_hold_music.xml
@@ -1,7 +1,8 @@
 <context name="{v_context}">
 	<extension name="user_hold_music" number="" continue="true" app_uuid="3ace0990-ef23-45b2-a81d-a5857a671e74" order="80">
 		<condition field="${hold_music}" expression="^$" break="never"/>
-		<condition field="${user_exists}" expression="true">
+		<condition field="${user_exists}" expression="true"/>
+		<condition field="${from_user_exists}" expression="false">
 			<action application="set" data="hold_music=${user_data ${destination_number}@${domain_name} var hold_music}" inline="true"/>
 		</condition>
 	</extension>


### PR DESCRIPTION
If the aleg is an existing user, setting the hold_music on his leg causes the wrong hold_music to be used when he puts the other leg on hold.