### PR TITLE
Fixes NULL in _SESSION[context]

### DIFF
--- a/core/domains/domains.php
+++ b/core/domains/domains.php
@@ -65,6 +65,7 @@
 				$_SESSION['domain_uuid'] = $domain_uuid;
 				$_SESSION["domain_name"] = $_SESSION['domains'][$domain_uuid]['domain_name'];
 				$_SESSION['domain']['template']['name'] = $_SESSION['domains'][$domain_uuid]['template_name'];
+				$_SESSION["context"] = $_SESSION["domain_name"];
 
 			//clear the extension array so that it is regenerated for the selected domain
 				unset($_SESSION['extension_array']);

--- a/resources/check_auth.php
+++ b/resources/check_auth.php
@@ -122,6 +122,7 @@
 					$_SESSION["domain_uuid"] = $result["domain_uuid"];
 					//$_SESSION["domain_name"] = $result["domain_name"];
 					$_SESSION["user_uuid"] = $result["user_uuid"];
+					$_SESSION["context"] = $result['domain_name'];
 
 				//user session array
 					$_SESSION["user"]["domain_uuid"] = $result["domain_uuid"];


### PR DESCRIPTION
This was a tricky one to find, but it was reported that IVRs were broken. After digging into why this was happening,  I found the v_dialplan.dialplan_context field was null.

dialplan_context Is fed from $_SESSION[[context] variable, which is not set in all use cases. 

This bug especially happens when you log into fusion using a URL that do not matches the username, for example, HTTP://1.1.1.1/ and using a username admin@mydomain

This could be the root cause of the well-known bug of ghost-dial plans that were very common in Fusion 4.2 and the bug from 4.4 where you clone a global dialplan and it was missing (but exists in the DB).

Fusion 5.0 and 4.4 are affected as well, I will send the PR soon.