### PR TITLE
Added variables to grandstream configs for idle mute fuction

### DIFF
--- a/resources/templates/provision/grandstream/grp2612/{$mac}.xml
+++ b/resources/templates/provision/grandstream/grp2612/{$mac}.xml
@@ -3573,7 +3573,11 @@
     <!-- # Mute Key Functions While Idle. 0 - DND, 1 - Idle Mute, 2 - Disabled. Default is 0 -->
     <!-- # Number: 0,1,2 -->
     <!-- # Mandatory -->
-    <P1565>2</P1565>
+{if isset($grandstream_idle_mute_function)}
+    <P1565>$grandstream_idle_mute_function</P1565>
+{else}
+    <P1565>0</P1565>
+{/if}
 
     <!-- # # Enable Auto Unmute. 0 - No, 1 - Yes. Default is 1 -->
     <P8488>0</P8488>

--- a/resources/templates/provision/grandstream/grp2612w/{$mac}.xml
+++ b/resources/templates/provision/grandstream/grp2612w/{$mac}.xml
@@ -3668,7 +3668,11 @@
     <!-- # Mute Key Functions While Idle. 0 - DND, 1 - Idle Mute, 2 - Disabled. Default is 0 -->
     <!-- # Number: 0,1,2 -->
     <!-- # Mandatory -->
-    <P1565>2</P1565>
+{if isset($grandstream_idle_mute_function)}
+    <P1565>$grandstream_idle_mute_function</P1565>
+{else}
+    <P1565>0</P1565>
+{/if}
 
     <!-- # # Enable Auto Unmute. 0 - No, 1 - Yes. Default is 1 -->
     <P8488>0</P8488>

--- a/resources/templates/provision/grandstream/grp2613/{$mac}.xml
+++ b/resources/templates/provision/grandstream/grp2613/{$mac}.xml
@@ -4412,7 +4412,11 @@
     <!-- # Mute Key Functions While Idle. 0 - DND, 1 - Idle Mute, 2 - Disabled. Default is 0 -->
     <!-- # Number: 0,1,2 -->
     <!-- # Mandatory -->
-    <P1565>2</P1565>
+{if isset($grandstream_idle_mute_function)}
+    <P1565>$grandstream_idle_mute_function</P1565>
+{else}
+    <P1565>0</P1565>
+{/if}
 
     <!-- # DND Override. 0 - Off, 1 - Allow All, 2 - Allow Only Contacts, 3 - Allow Only Favourites. Default is 0 -->
     <!-- # Number: 0,1,2,3 -->

--- a/resources/templates/provision/grandstream/grp2614/{$mac}.xml
+++ b/resources/templates/provision/grandstream/grp2614/{$mac}.xml
@@ -5683,7 +5683,11 @@
     <!-- # Mute Key Functions While Idle. 0 - DND, 1 - Idle Mute, 2 - Disabled. Default is 0 -->
     <!-- # Number: 0,1,2 -->
     <!-- # Mandatory -->
-    <P1565>2</P1565>
+{if isset($grandstream_idle_mute_function)}
+    <P1565>$grandstream_idle_mute_function</P1565>
+{else}
+    <P1565>0</P1565>
+{/if}
 
     <!-- # DND Override. 0 - Off, 1 - Allow All, 2 - Allow Only Contacts, 3 - Allow Only Favourites. Default is 0 -->
     <!-- # Number: 0,1,2,3 -->

--- a/resources/templates/provision/grandstream/grp2615/{$mac}.xml
+++ b/resources/templates/provision/grandstream/grp2615/{$mac}.xml
@@ -6714,7 +6714,11 @@
     <!-- # Mute Key Functions While Idle. 0 - DND, 1 - Idle Mute, 2 - Disabled. Default is 0 -->
     <!-- # Number: 0,1,2 -->
     <!-- # Mandatory -->
-    <P1565>2</P1565>
+{if isset($grandstream_idle_mute_function)}
+    <P1565>$grandstream_idle_mute_function</P1565>
+{else}
+    <P1565>0</P1565>
+{/if}
 
     <!-- # DND Override. 0 - Off, 1 - Allow All, 2 - Allow Only Contacts, 3 - Allow Only Favourites. Default is 0 -->
     <!-- # Number: 0,1,2,3 -->

--- a/resources/templates/provision/grandstream/grp2616/{$mac}.xml
+++ b/resources/templates/provision/grandstream/grp2616/{$mac}.xml
@@ -7606,7 +7606,11 @@
     <!-- # Mute Key Functions While Idle. 0 - DND, 1 - Idle Mute, 2 - Disabled. Default is 0 -->
     <!-- # Number: 0,1,2 -->
     <!-- # Mandatory -->
-    <P1565>2</P1565>
+{if isset($grandstream_idle_mute_function)}
+    <P1565>$grandstream_idle_mute_function</P1565>
+{else}
+    <P1565>0</P1565>
+{/if}
 
     <!-- # DND Override. 0 - Off, 1 - Allow All, 2 - Allow Only Contacts, 3 - Allow Only Favourites. Default is 0 -->
     <!-- # Number: 0,1,2,3 -->

--- a/resources/templates/provision/grandstream/grp26xx/{$mac}.xml
+++ b/resources/templates/provision/grandstream/grp26xx/{$mac}.xml
@@ -6927,7 +6927,11 @@
     <!-- # Mute Key Functions While Idle. 0 - DND, 1 - Idle Mute, 2 - Disabled. Default is 0 -->
     <!-- # Number: 0,1,2 -->
     <!-- # Mandatory -->
+{if isset($grandstream_idle_mute_function)}
+    <P1565>$grandstream_idle_mute_function</P1565>
+{else}
     <P1565>0</P1565>
+{/if}
 
     <!-- # Enable Auto Unmute. 0 - No, 1 - Yes. Default is 1 -->
     <P8488>1</P8488>

--- a/resources/templates/provision/grandstream/gxp110x/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp110x/{$mac}.xml
@@ -1170,7 +1170,11 @@
 <!-- Enable Idle Mute. 0 - No, 1 - Yes. Default is 0 -->
 <!-- Number: 0, 1 -->
 <!-- Mandatory -->
-<P1565>0</P1565>
+{if isset($grandstream_idle_mute_function_old)}
+    <P1565>$grandstream_idle_mute_function_old</P1565>
+{else}
+    <P1565>0</P1565>
+{/if}
 
 <!-- Disable Transfer. 0 - No, 1 - Yes. Defauls is 0 -->
 <!-- Number: 0, 1 -->

--- a/resources/templates/provision/grandstream/gxp116x/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp116x/{$mac}.xml
@@ -1188,7 +1188,11 @@
 <!--  Enable Idle Mute. 0 - No, 1 - Yes. Default is 0 -->
 <!--  Number: 0, 1 -->
 <!--  Mandatory -->
-<P1565>0</P1565>
+{if isset($grandstream_idle_mute_function_old)}
+    <P1565>$grandstream_idle_mute_function_old</P1565>
+{else}
+    <P1565>0</P1565>
+{/if}
 
 <!--  Disable Transfer. 0 - No, 1 - Yes. Defauls is 0 -->
 <!--  Number: 0, 1 -->

--- a/resources/templates/provision/grandstream/gxp140x/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp140x/{$mac}.xml
@@ -1481,7 +1481,11 @@
     <!--  Enable Idle Mute. 0 - No, 1 - Yes. Default is 0 -->
     <!--  Number: 0, 1 -->
     <!--  Mandatory -->
+{if isset($grandstream_idle_mute_function_old)}
+    <P1565>$grandstream_idle_mute_function_old</P1565>
+{else}
     <P1565>0</P1565>
+{/if}
     <!--  Disable Transfer. 0 - No, 1 - Yes. Defauls is 0 -->
     <!--  Number: 0, 1 -->
     <!--  Mandatory -->

--- a/resources/templates/provision/grandstream/gxp140xbk/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp140xbk/{$mac}.xml
@@ -1481,7 +1481,11 @@
     <!--  Enable Idle Mute. 0 - No, 1 - Yes. Default is 0 -->
     <!--  Number: 0, 1 -->
     <!--  Mandatory -->
+{if isset($grandstream_idle_mute_function_old)}
+    <P1565>$grandstream_idle_mute_function_old</P1565>
+{else}
     <P1565>0</P1565>
+{/if}
     <!--  Disable Transfer. 0 - No, 1 - Yes. Defauls is 0 -->
     <!--  Number: 0, 1 -->
     <!--  Mandatory -->

--- a/resources/templates/provision/grandstream/gxp1450/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp1450/{$mac}.xml
@@ -1962,7 +1962,11 @@
 <!-- Enable Idle Mute. 0 - No, 1 - Yes. Default is 0 -->
 <!-- Number: 0, 1 -->
 <!-- Mandatory -->
-<P1565>0</P1565>
+{if isset($grandstream_idle_mute_function_old)}
+    <P1565>$grandstream_idle_mute_function_old</P1565>
+{else}
+    <P1565>0</P1565>
+{/if}
 
 <!-- Disable Transfer. 0 - No, 1 - Yes. Defauls is 0 -->
 <!-- Number: 0, 1 -->

--- a/resources/templates/provision/grandstream/gxp1450bk/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp1450bk/{$mac}.xml
@@ -1769,7 +1769,11 @@
 <!-- Enable Idle Mute. 0 - No, 1 - Yes. Default is 0 -->
 <!-- Number: 0, 1 -->
 <!-- Mandatory -->
-<P1565>0</P1565>
+{if isset($grandstream_idle_mute_function_old)}
+    <P1565>$grandstream_idle_mute_function_old</P1565>
+{else}
+    <P1565>0</P1565>
+{/if}
 
 <!-- Disable Transfer. 0 - No, 1 - Yes. Defauls is 0 -->
 <!-- Number: 0, 1 -->

--- a/resources/templates/provision/grandstream/gxp16xx/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp16xx/{$mac}.xml
@@ -2523,7 +2523,11 @@
 <!--  Mute Key Functions While Idle. 0 - DND, 1 - Idle Mute, 2 - Disabled. Default is 0 -->
 <!--  Number: 0, 1, 2 -->
 <!--  Mandatory -->
-<P1565>0</P1565>
+{if isset($grandstream_idle_mute_function)}
+    <P1565>$grandstream_idle_mute_function</P1565>
+{else}
+    <P1565>0</P1565>
+{/if}
 <!--  Disable Transfer. 0 - No, 1 - Yes. Defauls is 0 -->
 <!--  Number: 0, 1 -->
 <!--  Mandatory -->

--- a/resources/templates/provision/grandstream/gxp17xx/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp17xx/{$mac}.xml
@@ -3630,7 +3630,11 @@
 <!-- # Mute Key Functions While Idle. 0 - DND, 1 - Idle Mute, 2 - Disabled. Default is 0 -->
 <!-- # Number: 0,1,2 -->
 <!-- # Mandatory -->
-<P1565>0</P1565>
+{if isset($grandstream_idle_mute_function)}
+    <P1565>$grandstream_idle_mute_function</P1565>
+{else}
+    <P1565>0</P1565>
+{/if}
 
 <!-- # Disable Transfer. 0 - No, 1 - Yes. Defauls is 0 -->
 <!-- # Number: 0, 1 -->

--- a/resources/templates/provision/grandstream/gxp2100/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp2100/{$mac}.xml
@@ -3265,7 +3265,11 @@
 <!--# Enable Idle Mute. 0 - No, 1 - Yes. Default is 0-->
 <!--# Number: 0, 1-->
 <!--# Mandatory-->
+{if isset($grandstream_idle_mute_function_old)}
+    <P1565>$grandstream_idle_mute_function_old</P1565>
+{else}
     <P1565>0</P1565>
+{/if}
 
 <!--# Disable Transfer. 0 - No, 1 - Yes. Defauls is 0-->
 <!--# Number: 0, 1-->

--- a/resources/templates/provision/grandstream/gxp2124/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp2124/{$mac}.xml
@@ -2216,7 +2216,11 @@
     <!-- Enable Idle Mute. 0 - No, 1 - Yes. Default is 0 -->
     <!-- Number: 0, 1 -->
     <!-- Mandatory -->
+{if isset($grandstream_idle_mute_function_old)}
+    <P1565>$grandstream_idle_mute_function_old</P1565>
+{else}
     <P1565>0</P1565>
+{/if}
     <!-- Disable Transfer. 0 - No, 1 - Yes. Defauls is 0 -->
     <!-- Number: 0, 1 -->
     <!-- Mandatory -->

--- a/resources/templates/provision/grandstream/gxp2130/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp2130/{$mac}.xml
@@ -7573,7 +7573,11 @@
     <!-- # Mute Key Functions While Idle. 0 - DND, 1 - Idle Mute, 2 - Disabled. Default is 0 -->
     <!-- # Number: 0,1,2 -->
     <!-- # Mandatory -->
+{if isset($grandstream_idle_mute_function)}
+    <P1565>$grandstream_idle_mute_function</P1565>
+{else}
     <P1565>0</P1565>
+{/if}
 
     <!-- # DND Override. 0 - Off, 1 - Allow All, 2 - Allow Only Contacts, 3 - Allow Only Favourites. Default is 0 -->
     <!-- # Number: 0,1,2,3 -->

--- a/resources/templates/provision/grandstream/gxp2135/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp2135/{$mac}.xml
@@ -7573,7 +7573,11 @@
     <!-- # Mute Key Functions While Idle. 0 - DND, 1 - Idle Mute, 2 - Disabled. Default is 0 -->
     <!-- # Number: 0,1,2 -->
     <!-- # Mandatory -->
+{if isset($grandstream_idle_mute_function)}
+    <P1565>$grandstream_idle_mute_function</P1565>
+{else}
     <P1565>0</P1565>
+{/if}
 
     <!-- # DND Override. 0 - Off, 1 - Allow All, 2 - Allow Only Contacts, 3 - Allow Only Favourites. Default is 0 -->
     <!-- # Number: 0,1,2,3 -->

--- a/resources/templates/provision/grandstream/gxp2140/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp2140/{$mac}.xml
@@ -7573,7 +7573,11 @@
     <!-- # Mute Key Functions While Idle. 0 - DND, 1 - Idle Mute, 2 - Disabled. Default is 0 -->
     <!-- # Number: 0,1,2 -->
     <!-- # Mandatory -->
+{if isset($grandstream_idle_mute_function)}
+    <P1565>$grandstream_idle_mute_function</P1565>
+{else}
     <P1565>0</P1565>
+{/if}
 
     <!-- # DND Override. 0 - Off, 1 - Allow All, 2 - Allow Only Contacts, 3 - Allow Only Favourites. Default is 0 -->
     <!-- # Number: 0,1,2,3 -->

--- a/resources/templates/provision/grandstream/gxp2160/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp2160/{$mac}.xml
@@ -7573,7 +7573,11 @@
     <!-- # Mute Key Functions While Idle. 0 - DND, 1 - Idle Mute, 2 - Disabled. Default is 0 -->
     <!-- # Number: 0,1,2 -->
     <!-- # Mandatory -->
+{if isset($grandstream_idle_mute_function)}
+    <P1565>$grandstream_idle_mute_function</P1565>
+{else}
     <P1565>0</P1565>
+{/if}
 
     <!-- # DND Override. 0 - Off, 1 - Allow All, 2 - Allow Only Contacts, 3 - Allow Only Favourites. Default is 0 -->
     <!-- # Number: 0,1,2,3 -->

--- a/resources/templates/provision/grandstream/gxp2170/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp2170/{$mac}.xml
@@ -7573,7 +7573,11 @@
     <!-- # Mute Key Functions While Idle. 0 - DND, 1 - Idle Mute, 2 - Disabled. Default is 0 -->
     <!-- # Number: 0,1,2 -->
     <!-- # Mandatory -->
+{if isset($grandstream_idle_mute_function)}
+    <P1565>$grandstream_idle_mute_function</P1565>
+{else}
     <P1565>0</P1565>
+{/if}
 
     <!-- # DND Override. 0 - Off, 1 - Allow All, 2 - Allow Only Contacts, 3 - Allow Only Favourites. Default is 0 -->
     <!-- # Number: 0,1,2,3 -->

--- a/resources/templates/provision/grandstream/gxp21xx/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp21xx/{$mac}.xml
@@ -3029,7 +3029,11 @@ Outgoing calls. 0 - No, 1 - Yes. Default is 0 -->
     <!-- Enable Idle Mute. 0 - No, 1 - Yes. Default is 0 -->
     <!-- Number: 0, 1 -->
     <!-- Mandatory -->
+{if isset($grandstream_idle_mute_function)}
+    <P1565>$grandstream_idle_mute_function</P1565>
+{else}
     <P1565>0</P1565>
+{/if}
     <!-- Disable Transfer. 0 - No, 1 - Yes. Defauls is 0 -->
     <!-- Number: 0, 1 -->
     <!-- Mandatory -->

--- a/resources/templates/provision/grandstream/gxp21xxbk/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp21xxbk/{$mac}.xml
@@ -3730,7 +3730,11 @@ Outgoing calls. 0 - No, 1 - Yes. Default is 0 -->
 <!-- Enable Idle Mute. 0 - No, 1 - Yes. Default is 0 -->
 <!-- Number: 0, 1 -->
 <!-- Mandatory -->
-<P1565>0</P1565>
+{if isset($grandstream_idle_mute_function_old)}
+    <P1565>$grandstream_idle_mute_function_old</P1565>
+{else}
+    <P1565>0</P1565>
+{/if}
 
 <!-- Disable Transfer. 0 - No, 1 - Yes. Defauls is 0 -->
 <!-- Number: 0, 1 -->

--- a/resources/templates/provision/grandstream/gxv3240/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxv3240/{$mac}.xml
@@ -4109,7 +4109,11 @@
 
 <!-- Mute Key Function While Idle. 0 - DND, 1 - Idle Mute, 2 -  Permanent Mute. Default value is 0 -->
 <!-- Number: 0,1,2 -->
-<P1565>0  </P1565>
+{if isset($grandstream_idle_mute_function)}
+    <P1565>$grandstream_idle_mute_function</P1565>
+{else}
+    <P1565>0</P1565>
+{/if}
 
 <!-- Auto Unhold When Press the Line Key. 0 - No, 1 - Yes. Default value is 0. -->
 <!-- Number: 0, 1 -->


### PR DESCRIPTION
I have changed them all to the default of "0" and then added a
variable called "grandstream_idle_mute_function" that overwrites
the default option of 0

There seems to be older configs where 0 = no instead of dnd
so I've added grandstream_idle_mute_function_old for these configs