### PR TITLE
Snom templates - added per model wallpaper settings

### DIFF
--- a/resources/templates/provision/snom/D717/{$mac}.xml
+++ b/resources/templates/provision/snom/D717/{$mac}.xml
@@ -25,9 +25,9 @@
     <alert_group_ring_text perm="">alert-group</alert_group_ring_text>
     <alert_group_ring_sound perm="">{if isset($snom_alert_group)}{$snom_alert_group}{else}Ringer1{/if}</alert_group_ring_sound>
     <!-- Wallpaper (426x240px PNG) (Firmware: 10.1.41.1+) -->
-    <custom_bg_image_url perm="">{$snom_wallpaper_url}</custom_bg_image_url>
+    <custom_bg_image_url perm="">{if isset($snom_wallpaper_url_d717)}{$snom_wallpaper_url_d717}{else}{$snom_wallpaper_url}{/if}</custom_bg_image_url>
     <!-- Expansion Mod (480x1280px PNG <2MB) -->
-    <expansion_module_background_image perm="">{$snom_exp_wallpaper_url}</expansion_module_background_image>
+    <expansion_module_background_image perm="">{if isset($snom_exp_wallpaper_url_d717)}{$snom_exp_wallpaper_url_d717}{else}{$snom_exp_wallpaper_url}{/if}</expansion_module_background_image>
     <!-- SIP Settings -->
     <mwi_notification perm="">silent</mwi_notification>
     <mwi_dialtone perm="">stutter</mwi_dialtone>

--- a/resources/templates/provision/snom/D735/{$mac}.xml
+++ b/resources/templates/provision/snom/D735/{$mac}.xml
@@ -25,9 +25,9 @@
     <alert_group_ring_text perm="">alert-group</alert_group_ring_text>
     <alert_group_ring_sound perm="">{if isset($snom_alert_group)}{$snom_alert_group}{else}Ringer1{/if}</alert_group_ring_sound>
     <!-- Wallpaper (320x240px PNG)-->
-    <custom_bg_image_url perm="">{$snom_wallpaper_url}</custom_bg_image_url>
+    <custom_bg_image_url perm="">{if isset($snom_wallpaper_url_d735)}{$snom_wallpaper_url_d735}{else}{$snom_wallpaper_url}{/if}</custom_bg_image_url>
     <!-- Expansion Mod (480x1280px PNG <2MB) -->
-    <expansion_module_background_image perm="">{$snom_exp_wallpaper_url}</expansion_module_background_image>
+    <expansion_module_background_image perm="">{if isset($snom_exp_wallpaper_url_d735)}{$snom_exp_wallpaper_url_d735}{else}{$snom_exp_wallpaper_url}{/if}</expansion_module_background_image>
     <!-- SIP Settings -->
     <mwi_notification perm="">silent</mwi_notification>
     <mwi_dialtone perm="">stutter</mwi_dialtone>

--- a/resources/templates/provision/snom/D765/{$mac}.xml
+++ b/resources/templates/provision/snom/D765/{$mac}.xml
@@ -25,9 +25,9 @@
     <alert_group_ring_text perm="">alert-group</alert_group_ring_text>
     <alert_group_ring_sound perm="">{if isset($snom_alert_group)}{$snom_alert_group}{else}Ringer1{/if}</alert_group_ring_sound>
     <!-- Wallpaper (320x240px PNG)-->
-    <custom_bg_image_url perm="">{$snom_wallpaper_url}</custom_bg_image_url>
+    <custom_bg_image_url perm="">{if isset($snom_wallpaper_url_d765)}{$snom_wallpaper_url_d765}{else}{$snom_wallpaper_url}{/if}</custom_bg_image_url>
     <!-- Expansion Mod (480x1280px PNG <2MB) -->
-    <expansion_module_background_image perm="">{$snom_exp_wallpaper_url}</expansion_module_background_image>
+    <expansion_module_background_image perm="">{if isset($snom_exp_wallpaper_url_d765)}{$snom_exp_wallpaper_url_d765}{else}{$snom_exp_wallpaper_url}{/if}</expansion_module_background_image>
     <!-- SIP Settings -->
     <mwi_notification perm="">silent</mwi_notification>
     <mwi_dialtone perm="">stutter</mwi_dialtone>

--- a/resources/templates/provision/snom/D785/{$mac}.xml
+++ b/resources/templates/provision/snom/D785/{$mac}.xml
@@ -25,9 +25,9 @@
     <alert_group_ring_text perm="">alert-group</alert_group_ring_text>
     <alert_group_ring_sound perm="">{if isset($snom_alert_group)}{$snom_alert_group}{else}Ringer1{/if}</alert_group_ring_sound>
     <!-- Wallpaper (480x272px PNG)-->
-    <custom_bg_image_url perm="">{$snom_wallpaper_url}</custom_bg_image_url>
+    <custom_bg_image_url perm="">{if isset($snom_wallpaper_url_d785)}{$snom_wallpaper_url_d785}{else}{$snom_wallpaper_url}{/if}</custom_bg_image_url>
     <!-- Expansion Mod (480x1280px PNG <2MB) -->
-    <expansion_module_background_image perm="">{$snom_exp_wallpaper_url}</expansion_module_background_image>
+    <expansion_module_background_image perm="">{if isset($snom_exp_wallpaper_url_d785)}{$snom_exp_wallpaper_url_d785}{else}{$snom_exp_wallpaper_url}{/if}</expansion_module_background_image>
     <!-- SIP Settings -->
     <mwi_notification perm="">silent</mwi_notification>
     <mwi_dialtone perm="">stutter</mwi_dialtone>


### PR DESCRIPTION
Currently there is only one wallpaper variable used for all Snom phones. That works fine if you set a wallpaper on a per device level.

It doesn't work if you want to set the same wallpaper across the domain since some users may have different models of phone which might use a different resolution.

This PR hopes to fix that by maintaining the existing variable that users might be using as well as adding a few new ones for model specific wallpapers.

If a domain has just one model of phone they can keep using the old variable.