### PR TITLE
Update y000000000035.cfg

### DIFF
--- a/resources/templates/provision/yealink/t48g/y000000000035.cfg
+++ b/resources/templates/provision/yealink/t48g/y000000000035.cfg
@@ -790,7 +790,7 @@ features.dtmf.replace_tran =
 ##                                   Features Audio Settings                         ##
 #######################################################################################
 #Enable or disable the headset prior feature; 0-Disabled (default), 1-Enabled;
-features.headset_prior =
+features.headset_prior= {$yealink_headset_prior}
 
 #Enable or disable the dual headset feature; 0-Disabled (default), 1-Enabled;
 features.headset_training =


### PR DESCRIPTION
This should be paired with a default setting to match. it controls the behavior of the headset if you make a call while it is connected. by default (0), yealink phones will not connect the call via the headset. if you set it to 1, the phone will immediately start using the headset for the call, instead of requiring you to press the headset button after dialing.