### PR TITLE
Update y000000000058.cfg

### DIFF
--- a/resources/templates/provision/yealink/t58a/y000000000058.cfg
+++ b/resources/templates/provision/yealink/t58a/y000000000058.cfg
@@ -815,7 +815,7 @@ features.play_local_dtmf_tone_enable =
 #######################################################################################
 ##                                   Features Audio Settings                         ##
 #######################################################################################
-features.headset_prior = 
+features.headset_prior= {$yealink_headset_prior}
 features.headset_training = 
 features.alert_info_tone =
 features.busy_tone_delay = 


### PR DESCRIPTION
This should be paired with a default setting to match. it controls the behavior of the headset if you make a call while it is connected. by default (0), yealink phones will not connect the call via the headset. if you set it to 1, the phone will immediately start using the headset for the call, instead of requiring you to press the headset button after dialing.