### PR TITLE
Update y000000000150.cfg

### DIFF
--- a/resources/templates/provision/yealink/t58w/y000000000150.cfg
+++ b/resources/templates/provision/yealink/t58w/y000000000150.cfg
@@ -897,7 +897,7 @@ features.dtmf.min_interval=
 #######################################################################################
 ##                                   Features Audio Settings                         ##
 #######################################################################################
-features.headset_prior= {$yealink_headset_prior}
+features.headset_prior = {$yealink_headset_prior}
 features.headset_training = 
 features.alert_info_tone =
 features.busy_tone_delay = 

--- a/resources/templates/provision/yealink/t58w/y000000000150.cfg
+++ b/resources/templates/provision/yealink/t58w/y000000000150.cfg
@@ -897,7 +897,7 @@ features.dtmf.min_interval=
 #######################################################################################
 ##                                   Features Audio Settings                         ##
 #######################################################################################
-features.headset_prior = 
+features.headset_prior= {$yealink_headset_prior}
 features.headset_training = 
 features.alert_info_tone =
 features.busy_tone_delay = 


### PR DESCRIPTION
This should be paired with a default setting to match. it controls the behavior of the headset if you make a call while it is connected. by default (0), yealink phones will not connect the call via the headset. if you set it to 1, the phone will immediately start using the headset for the call, instead of requiring you to press the headset button after dialing.