### PR TITLE
Added grandstream_show_key_labels and other default values.

### DIFF
--- a/app/grandstream/app_config.php
+++ b/app/grandstream/app_config.php
@@ -822,5 +822,28 @@
 		$apps[$x]['default_settings'][$y]['default_setting_enabled'] = "true";
 		$apps[$x]['default_settings'][$y]['default_setting_description'] = "Allow DHCP server to set Time Zone. 0 - No, 1 - Yes";
 		$y++;
-
+		$apps[$x]['default_settings'][$y]['default_setting_uuid'] = "db6bf37d-b240-4cd9-91d3-bf326a4d8462";
+		$apps[$x]['default_settings'][$y]['default_setting_category'] = "provision";
+		$apps[$x]['default_settings'][$y]['default_setting_subcategory'] = "grandstream_idle_mute_function";
+		$apps[$x]['default_settings'][$y]['default_setting_name'] = "numeric";
+		$apps[$x]['default_settings'][$y]['default_setting_value'] = "0";
+		$apps[$x]['default_settings'][$y]['default_setting_enabled'] = "true";
+		$apps[$x]['default_settings'][$y]['default_setting_description'] = "Mute Key Functions While Idle. 0 - DND, 1 - Idle Mute, 2 - Disabled. Default is 0";
+		$y++;
+		$apps[$x]['default_settings'][$y]['default_setting_uuid'] = "bba15ab9-fb7b-4551-b83c-101b968bef02";
+		$apps[$x]['default_settings'][$y]['default_setting_category'] = "provision";
+		$apps[$x]['default_settings'][$y]['default_setting_subcategory'] = "grandstream_idle_mute_function_old";
+		$apps[$x]['default_settings'][$y]['default_setting_name'] = "numeric";
+		$apps[$x]['default_settings'][$y]['default_setting_value'] = "0";
+		$apps[$x]['default_settings'][$y]['default_setting_enabled'] = "true";
+		$apps[$x]['default_settings'][$y]['default_setting_description'] = "Enable Idle Mute. 0 - No, 1 - Yes. Default is 0";
+		$y++;
+		$apps[$x]['default_settings'][$y]['default_setting_uuid'] = "e08a9c4e-fd4b-485a-bb60-c47fa03d525f";
+		$apps[$x]['default_settings'][$y]['default_setting_category'] = "provision";
+		$apps[$x]['default_settings'][$y]['default_setting_subcategory'] = "grandstream_show_key_labels";
+		$apps[$x]['default_settings'][$y]['default_setting_name'] = "numeric";
+		$apps[$x]['default_settings'][$y]['default_setting_value'] = "0";
+		$apps[$x]['default_settings'][$y]['default_setting_enabled'] = "true";
+		$apps[$x]['default_settings'][$y]['default_setting_description'] = "Show Keys Label. 1 - Show, 2 - Hide, 0 - Toggle. Default is 0";
+		$y++;
 ?>

--- a/resources/templates/provision/grandstream/grp2612/{$mac}.xml
+++ b/resources/templates/provision/grandstream/grp2612/{$mac}.xml
@@ -4404,7 +4404,11 @@
     <!-- # Show Keys Label. 1 - Show, 2 - Hide, 0 - Toggle. Default is 0 -->
     <!-- # Number: 0, 1, 2 -->
     <!-- # Mandatory -->
-    <P8386>1</P8386>
+    {if isset($grandstream_show_key_labels)}
+        <P8386>{$grandstream_show_key_labels}</P8386>
+    {else}
+        <P8386>1</P8386>
+    {/if}
 
 
     <!-- ############################################################################## -->

--- a/resources/templates/provision/grandstream/grp2612w/{$mac}.xml
+++ b/resources/templates/provision/grandstream/grp2612w/{$mac}.xml
@@ -4499,7 +4499,11 @@
     <!-- # Show Keys Label. 1 - Show, 2 - Hide, 0 - Toggle. Default is 0 -->
     <!-- # Number: 0, 1, 2 -->
     <!-- # Mandatory -->
-    <P8386>1</P8386>
+    {if isset($grandstream_show_key_labels)}
+        <P8386>{$grandstream_show_key_labels}</P8386>
+    {else}
+        <P8386>1</P8386>
+    {/if}
 
 
     <!-- ############################################################################## -->

--- a/resources/templates/provision/grandstream/grp2613/{$mac}.xml
+++ b/resources/templates/provision/grandstream/grp2613/{$mac}.xml
@@ -5231,7 +5231,11 @@
     <!-- # Show Keys Label. 1 - Show, 2 - Hide, 0 - Toggle. Default is 0 -->
     <!-- # Number: 0, 1, 2 -->
     <!-- # Mandatory -->
-    <P8386>0</P8386>
+    {if isset($grandstream_show_key_labels)}
+        <P8386>{$grandstream_show_key_labels}</P8386>
+    {else}
+        <P8386>1</P8386>
+    {/if}
 
     <!-- # Show VPK shared line display description (This only can be done with provisioning) -->
     <!-- # Number: 0, 1. 0 - No, 1 - Yes. Default is 1 -->

--- a/resources/templates/provision/grandstream/grp2614/{$mac}.xml
+++ b/resources/templates/provision/grandstream/grp2614/{$mac}.xml
@@ -6582,7 +6582,11 @@
     <!-- # Show Keys Label. 1 - Show, 2 - Hide, 0 - Toggle. Default is 0 -->
     <!-- # Number: 0, 1, 2 -->
     <!-- # Mandatory -->
-    <P8386>0</P8386>
+    {if isset($grandstream_show_key_labels)}
+        <P8386>{$grandstream_show_key_labels}</P8386>
+    {else}
+        <P8386>1</P8386>
+    {/if}
 
     <!-- # Show VPK shared line display description (This only can be done with provisioning) -->
     <!-- # Number: 0, 1. 0 - No, 1 - Yes. Default is 1 -->

--- a/resources/templates/provision/grandstream/grp2615/{$mac}.xml
+++ b/resources/templates/provision/grandstream/grp2615/{$mac}.xml
@@ -7594,7 +7594,11 @@
     <!-- # Show Keys Label. 1 - Show, 2 - Hide, 0 - Toggle. Default is 0 -->
     <!-- # Number: 0, 1, 2 -->
     <!-- # Mandatory -->
-    <P8386>0</P8386>
+    {if isset($grandstream_show_key_labels)}
+        <P8386>{$grandstream_show_key_labels}</P8386>
+    {else}
+        <P8386>1</P8386>
+    {/if}
 
     <!-- # Show VPK shared line display description (This only can be done with provisioning) -->
     <!-- # Number: 0, 1. 0 - No, 1 - Yes. Default is 1 -->

--- a/resources/templates/provision/grandstream/grp2616/{$mac}.xml
+++ b/resources/templates/provision/grandstream/grp2616/{$mac}.xml
@@ -8505,7 +8505,11 @@
     <!-- # Show Keys Label. 1 - Show, 2 - Hide, 0 - Toggle. Default is 0 -->
     <!-- # Number: 0, 1, 2 -->
     <!-- # Mandatory -->
-    <P8386>0</P8386>
+    {if isset($grandstream_show_key_labels)}
+        <P8386>{$grandstream_show_key_labels}</P8386>
+    {else}
+        <P8386>1</P8386>
+    {/if}
 
     <!-- # Show VPK shared line display description (This only can be done with provisioning) -->
     <!-- # Number: 0, 1. 0 - No, 1 - Yes. Default is 1 -->

--- a/resources/templates/provision/grandstream/grp26xx/{$mac}.xml
+++ b/resources/templates/provision/grandstream/grp26xx/{$mac}.xml
@@ -7816,7 +7816,11 @@
     <!-- # Show Keys Label. 1 - Show, 2 - Hide, 0 - Toggle. Default is 0 -->
     <!-- # Number: 0, 1, 2 -->
     <!-- # Mandatory -->
-    <P8386>1</P8386>
+    {if isset($grandstream_show_key_labels)}
+        <P8386>{$grandstream_show_key_labels}</P8386>
+    {else}
+        <P8386>1</P8386>
+    {/if}
 
     <!-- ############################################################################## -->
     <!-- ##  Settings/Programmable Keys/Virtual Multi-Purpose Keys -->

--- a/resources/templates/provision/grandstream/gxp2130/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp2130/{$mac}.xml
@@ -8503,7 +8503,11 @@
     <!-- # Show Keys Label. 1 - Show, 2 - Hide, 0 - Toggle. Default is 0 -->
     <!-- # Number: 0, 1, 2 -->
     <!-- # Mandatory -->
-    <P8386>0</P8386>
+    {if isset($grandstream_show_key_labels)}
+        <P8386>{$grandstream_show_key_labels}</P8386>
+    {else}
+        <P8386>1</P8386>
+    {/if}
 
     <!-- # Show VPK shared line display description (This only can be done with provisioning) -->
     <!-- # Number: 0, 1. 0 - No, 1 - Yes. Default is 1 -->

--- a/resources/templates/provision/grandstream/gxp2135/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp2135/{$mac}.xml
@@ -8503,7 +8503,11 @@
     <!-- # Show Keys Label. 1 - Show, 2 - Hide, 0 - Toggle. Default is 0 -->
     <!-- # Number: 0, 1, 2 -->
     <!-- # Mandatory -->
-    <P8386>0</P8386>
+    {if isset($grandstream_show_key_labels)}
+        <P8386>{$grandstream_show_key_labels}</P8386>
+    {else}
+        <P8386>1</P8386>
+    {/if}
 
     <!-- # Show VPK shared line display description (This only can be done with provisioning) -->
     <!-- # Number: 0, 1. 0 - No, 1 - Yes. Default is 1 -->

--- a/resources/templates/provision/grandstream/gxp2140/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp2140/{$mac}.xml
@@ -8503,7 +8503,11 @@
     <!-- # Show Keys Label. 1 - Show, 2 - Hide, 0 - Toggle. Default is 0 -->
     <!-- # Number: 0, 1, 2 -->
     <!-- # Mandatory -->
-    <P8386>0</P8386>
+    {if isset($grandstream_show_key_labels)}
+        <P8386>{$grandstream_show_key_labels}</P8386>
+    {else}
+        <P8386>1</P8386>
+    {/if}
 
     <!-- # Show VPK shared line display description (This only can be done with provisioning) -->
     <!-- # Number: 0, 1. 0 - No, 1 - Yes. Default is 1 -->

--- a/resources/templates/provision/grandstream/gxp2160/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp2160/{$mac}.xml
@@ -8503,7 +8503,11 @@
     <!-- # Show Keys Label. 1 - Show, 2 - Hide, 0 - Toggle. Default is 0 -->
     <!-- # Number: 0, 1, 2 -->
     <!-- # Mandatory -->
-    <P8386>0</P8386>
+    {if isset($grandstream_show_key_labels)}
+        <P8386>{$grandstream_show_key_labels}</P8386>
+    {else}
+        <P8386>1</P8386>
+    {/if}
 
     <!-- # Show VPK shared line display description (This only can be done with provisioning) -->
     <!-- # Number: 0, 1. 0 - No, 1 - Yes. Default is 1 -->

--- a/resources/templates/provision/grandstream/gxp2170/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp2170/{$mac}.xml
@@ -8507,7 +8507,11 @@
     <!-- # Show Keys Label. 1 - Show, 2 - Hide, 0 - Toggle. Default is 0 -->
     <!-- # Number: 0, 1, 2 -->
     <!-- # Mandatory -->
-    <P8386>0</P8386>
+    {if isset($grandstream_show_key_labels)}
+        <P8386>{$grandstream_show_key_labels}</P8386>
+    {else}
+        <P8386>1</P8386>
+    {/if}
 
     <!-- # Show VPK shared line display description (This only can be done with provisioning) -->
     <!-- # Number: 0, 1. 0 - No, 1 - Yes. Default is 1 -->


### PR DESCRIPTION
@danry25 requested `grandstream_show_key_labels` to be configurable for P code `P8386`, I've also added it as a option through the UI along with the settings from a previous commit
- `grandstream_idle_mute_function`
- `grandstream_idle_mute_function_old`
