### PR TITLE
Check to make sure accountcode has some value

### DIFF
--- a/app/scripts/resources/scripts/app/follow_me/index.lua
+++ b/app/scripts/resources/scripts/app/follow_me/index.lua
@@ -285,7 +285,11 @@
 				--set the values
 					external = "true";
 					row['user_exists'] = "false";
-					row['accountcode'] = accountcode;
+					if (accountcode ~= nil) then
+						row['accountcode'] = accountcode;
+					else
+						row['accountcode'] = domain_name;
+					end
 				--add the row to the destinations array
 					destinations[x] = row;
 			end


### PR DESCRIPTION
The accountcode variable is used in a dialstring later on and if it comes back nil for any reason, then the following error is thrown:

```
2022-07-22 16:19:11.524674 [ERR] mod_lua.cpp:202 /usr/share/freeswitch/scripts/app/follow_me/index.lua:396: attempt to concatenate global 'accountcode' (a nil value)
stack traceback:
        /usr/share/freeswitch/scripts/app/follow_me/index.lua:396: in main chunk
        /usr/share/freeswitch/scripts/app.lua:48: in main chunk
```

This completely breaks follow-me.

This code sets the accountcode variable to the domain name if it comes back nil during script execution, thus protecting the script from failing with an empty accountcode value in the db or query.