### PR TITLE
adding template support for call waiting tone

### DIFF
--- a/resources/templates/provision/snom/D120/{$mac}.xml
+++ b/resources/templates/provision/snom/D120/{$mac}.xml
@@ -17,6 +17,7 @@
     <global_missed_counter perm="">on</global_missed_counter>
     <dialnumber_us_format perm="">on</dialnumber_us_format>
     <show_ivr_digits perm="">off</show_ivr_digits>
+    <cw_dialtone perm="">{if isset($snom_dialtone_on_hold)}{$snom_dialtone_on_hold}{else}true{/if}</cw_dialtone>
     <!-- Ringtones -->
     <alert_internal_ring_text perm="">alert-internal</alert_internal_ring_text>
     <alert_internal_ring_sound perm="">{if isset($snom_alert_internal)}{$snom_alert_internal}{else}Ringer1{/if}</alert_internal_ring_sound>

--- a/resources/templates/provision/snom/D315/{$mac}.xml
+++ b/resources/templates/provision/snom/D315/{$mac}.xml
@@ -17,6 +17,7 @@
     <global_missed_counter perm="">on</global_missed_counter>
     <dialnumber_us_format perm="">on</dialnumber_us_format>
     <show_ivr_digits perm="">off</show_ivr_digits>
+    <cw_dialtone perm="">{if isset($snom_dialtone_on_hold)}{$snom_dialtone_on_hold}{else}true{/if}</cw_dialtone>
     <!-- Ringtones -->
     <alert_internal_ring_text perm="">alert-internal</alert_internal_ring_text>
     <alert_internal_ring_sound perm="">{if isset($snom_alert_internal)}{$snom_alert_internal}{else}Ringer1{/if}</alert_internal_ring_sound>

--- a/resources/templates/provision/snom/D345/{$mac}.xml
+++ b/resources/templates/provision/snom/D345/{$mac}.xml
@@ -17,6 +17,7 @@
     <global_missed_counter perm="">on</global_missed_counter>
     <dialnumber_us_format perm="">on</dialnumber_us_format>
     <show_ivr_digits perm="">off</show_ivr_digits>
+    <cw_dialtone perm="">{if isset($snom_dialtone_on_hold)}{$snom_dialtone_on_hold}{else}true{/if}</cw_dialtone>
     <!-- Ringtones -->
     <alert_internal_ring_text perm="">alert-internal</alert_internal_ring_text>
     <alert_internal_ring_sound perm="">{if isset($snom_alert_internal)}{$snom_alert_internal}{else}Ringer1{/if}</alert_internal_ring_sound>

--- a/resources/templates/provision/snom/D375/{$mac}.xml
+++ b/resources/templates/provision/snom/D375/{$mac}.xml
@@ -17,6 +17,7 @@
     <global_missed_counter perm="">on</global_missed_counter>
     <dialnumber_us_format perm="">on</dialnumber_us_format>
     <show_ivr_digits perm="">off</show_ivr_digits>
+    <cw_dialtone perm="">{if isset($snom_dialtone_on_hold)}{$snom_dialtone_on_hold}{else}true{/if}</cw_dialtone>
     <!-- Ringtones -->
     <alert_internal_ring_text perm="">alert-internal</alert_internal_ring_text>
     <alert_internal_ring_sound perm="">{if isset($snom_alert_internal)}{$snom_alert_internal}{else}Ringer1{/if}</alert_internal_ring_sound>

--- a/resources/templates/provision/snom/D385/{$mac}.xml
+++ b/resources/templates/provision/snom/D385/{$mac}.xml
@@ -17,6 +17,7 @@
     <global_missed_counter perm="">on</global_missed_counter>
     <dialnumber_us_format perm="">on</dialnumber_us_format>
     <show_ivr_digits perm="">off</show_ivr_digits>
+    <cw_dialtone perm="">{if isset($snom_dialtone_on_hold)}{$snom_dialtone_on_hold}{else}true{/if}</cw_dialtone>
     <!-- Ringtones -->
     <alert_internal_ring_text perm="">alert-internal</alert_internal_ring_text>
     <alert_internal_ring_sound perm="">{if isset($snom_alert_internal)}{$snom_alert_internal}{else}Ringer1{/if}</alert_internal_ring_sound>

--- a/resources/templates/provision/snom/D712/{$mac}.xml
+++ b/resources/templates/provision/snom/D712/{$mac}.xml
@@ -17,6 +17,7 @@
     <global_missed_counter perm="">on</global_missed_counter>
     <dialnumber_us_format perm="">on</dialnumber_us_format>
     <show_ivr_digits perm="">off</show_ivr_digits>
+    <cw_dialtone perm="">{if isset($snom_dialtone_on_hold)}{$snom_dialtone_on_hold}{else}true{/if}</cw_dialtone>
     <!-- Ringtones -->
     <alert_internal_ring_text perm="">alert-internal</alert_internal_ring_text>
     <alert_internal_ring_sound perm="">{if isset($snom_alert_internal)}{$snom_alert_internal}{else}Ringer1{/if}</alert_internal_ring_sound>

--- a/resources/templates/provision/snom/D715/{$mac}.xml
+++ b/resources/templates/provision/snom/D715/{$mac}.xml
@@ -17,6 +17,7 @@
     <global_missed_counter perm="">on</global_missed_counter>
     <dialnumber_us_format perm="">on</dialnumber_us_format>
     <show_ivr_digits perm="">off</show_ivr_digits>
+    <cw_dialtone perm="">{if isset($snom_dialtone_on_hold)}{$snom_dialtone_on_hold}{else}true{/if}</cw_dialtone>
     <!-- Ringtones -->
     <alert_internal_ring_text perm="">alert-internal</alert_internal_ring_text>
     <alert_internal_ring_sound perm="">{if isset($snom_alert_internal)}{$snom_alert_internal}{else}Ringer1{/if}</alert_internal_ring_sound>

--- a/resources/templates/provision/snom/D717/{$mac}.xml
+++ b/resources/templates/provision/snom/D717/{$mac}.xml
@@ -17,6 +17,7 @@
     <global_missed_counter perm="">on</global_missed_counter>
     <dialnumber_us_format perm="">on</dialnumber_us_format>
     <show_ivr_digits perm="">off</show_ivr_digits>
+    <cw_dialtone perm="">{if isset($snom_dialtone_on_hold)}{$snom_dialtone_on_hold}{else}true{/if}</cw_dialtone>
     <!-- Ringtones -->
     <alert_internal_ring_text perm="">alert-internal</alert_internal_ring_text>
     <alert_internal_ring_sound perm="">{if isset($snom_alert_internal)}{$snom_alert_internal}{else}Ringer1{/if}</alert_internal_ring_sound>

--- a/resources/templates/provision/snom/D725/{$mac}.xml
+++ b/resources/templates/provision/snom/D725/{$mac}.xml
@@ -17,6 +17,7 @@
     <global_missed_counter perm="">on</global_missed_counter>
     <dialnumber_us_format perm="">on</dialnumber_us_format>
     <show_ivr_digits perm="">off</show_ivr_digits>
+    <cw_dialtone perm="">{if isset($snom_dialtone_on_hold)}{$snom_dialtone_on_hold}{else}true{/if}</cw_dialtone>
     <!-- Ringtones -->
     <alert_internal_ring_text perm="">alert-internal</alert_internal_ring_text>
     <alert_internal_ring_sound perm="">{if isset($snom_alert_internal)}{$snom_alert_internal}{else}Ringer1{/if}</alert_internal_ring_sound>

--- a/resources/templates/provision/snom/D735/{$mac}.xml
+++ b/resources/templates/provision/snom/D735/{$mac}.xml
@@ -17,6 +17,7 @@
     <global_missed_counter perm="">on</global_missed_counter>
     <dialnumber_us_format perm="">on</dialnumber_us_format>
     <show_ivr_digits perm="">off</show_ivr_digits>
+    <cw_dialtone perm="">{if isset($snom_dialtone_on_hold)}{$snom_dialtone_on_hold}{else}true{/if}</cw_dialtone>
     <!-- Ringtones -->
     <alert_internal_ring_text perm="">alert-internal</alert_internal_ring_text>
     <alert_internal_ring_sound perm="">{if isset($snom_alert_internal)}{$snom_alert_internal}{else}Ringer1{/if}</alert_internal_ring_sound>

--- a/resources/templates/provision/snom/D745/{$mac}.xml
+++ b/resources/templates/provision/snom/D745/{$mac}.xml
@@ -17,6 +17,7 @@
     <global_missed_counter perm="">on</global_missed_counter>
     <dialnumber_us_format perm="">on</dialnumber_us_format>
     <show_ivr_digits perm="">off</show_ivr_digits>
+    <cw_dialtone perm="">{if isset($snom_dialtone_on_hold)}{$snom_dialtone_on_hold}{else}true{/if}</cw_dialtone>
     <!-- Ringtones -->
     <alert_internal_ring_text perm="">alert-internal</alert_internal_ring_text>
     <alert_internal_ring_sound perm="">{if isset($snom_alert_internal)}{$snom_alert_internal}{else}Ringer1{/if}</alert_internal_ring_sound>

--- a/resources/templates/provision/snom/D765/{$mac}.xml
+++ b/resources/templates/provision/snom/D765/{$mac}.xml
@@ -17,6 +17,7 @@
     <global_missed_counter perm="">on</global_missed_counter>
     <dialnumber_us_format perm="">on</dialnumber_us_format>
     <show_ivr_digits perm="">off</show_ivr_digits>
+    <cw_dialtone perm="">{if isset($snom_dialtone_on_hold)}{$snom_dialtone_on_hold}{else}true{/if}</cw_dialtone>
     <!-- Ringtones -->
     <alert_internal_ring_text perm="">alert-internal</alert_internal_ring_text>
     <alert_internal_ring_sound perm="">{if isset($snom_alert_internal)}{$snom_alert_internal}{else}Ringer1{/if}</alert_internal_ring_sound>

--- a/resources/templates/provision/snom/D785/{$mac}.xml
+++ b/resources/templates/provision/snom/D785/{$mac}.xml
@@ -17,6 +17,7 @@
     <global_missed_counter perm="">on</global_missed_counter>
     <dialnumber_us_format perm="">on</dialnumber_us_format>
     <show_ivr_digits perm="">off</show_ivr_digits>
+    <cw_dialtone perm="">{if isset($snom_dialtone_on_hold)}{$snom_dialtone_on_hold}{else}true{/if}</cw_dialtone>
     <!-- Ringtones -->
     <alert_internal_ring_text perm="">alert-internal</alert_internal_ring_text>
     <alert_internal_ring_sound perm="">{if isset($snom_alert_internal)}{$snom_alert_internal}{else}Ringer1{/if}</alert_internal_ring_sound>


### PR DESCRIPTION
This template parameter provides the ability to configure whether or not the phone provides a tone while the user is put on hold.

The default is to provide tone so I wrote the change to provide tone so there is no change in user experience.