### PR TITLE
Update deprecated sip profile params

### DIFF
--- a/resources/templates/conf/sip_profiles/external-ipv6.xml.noload
+++ b/resources/templates/conf/sip_profiles/external-ipv6.xml.noload
@@ -67,9 +67,11 @@
 		<param name="sip-ip" value="$${local_ip_v6}"/>
 		<param name="ext-rtp-ip" value="$${external_rtp_ip}" enabled="false"/>
 		<param name="ext-sip-ip" value="$${external_sip_ip}" enabled="false"/>
-		<param name="media_timeout" value="300"/>
-		<param name="media_hold_timeout" value="1800"/>
-		<!--<param name="enable-3pcc" value="true"/>-->
+		<param name="rtp-timeout-sec" value="300" description="deprecated" enabled="false"/>
+		<param name="rtp-hold-timeout-sec" value="1800" description="deprecated" enabled="false"/>
+		<param name="media_timeout" value="300" enabled="true"/>
+		<param name="media_hold_timeout" value="1800" enabled="true"/>
+		<param name="enable-3pcc" value="true" enabled="false"/>
 
 		<!--session timers -->
 		<param name="session-timeout" value="0" enabled="true"/>

--- a/resources/templates/conf/sip_profiles/external-ipv6.xml.noload
+++ b/resources/templates/conf/sip_profiles/external-ipv6.xml.noload
@@ -67,8 +67,8 @@
 		<param name="sip-ip" value="$${local_ip_v6}"/>
 		<param name="ext-rtp-ip" value="$${external_rtp_ip}" enabled="false"/>
 		<param name="ext-sip-ip" value="$${external_sip_ip}" enabled="false"/>
-		<param name="rtp-timeout-sec" value="300"/>
-		<param name="rtp-hold-timeout-sec" value="1800"/>
+		<param name="media_timeout" value="300"/>
+		<param name="media_hold_timeout" value="1800"/>
 		<!--<param name="enable-3pcc" value="true"/>-->
 
 		<!--session timers -->


### PR DESCRIPTION
Parameter names have changed. See here: https://freeswitch.org/confluence/display/FREESWITCH/Sofia+Configuration+Files

When starting a profile, the following warnings would appear:
[WARNING] sofia.c:5332 rtp-hold-timeout-sec deprecated use media_hold_timeout variable.
[WARNING] sofia.c:5325 rtp-timeout-sec deprecated use media_timeout variable.

Updating the parameters fixes the issue.