### PR TITLE
Update deprecated sip profile params

### DIFF
--- a/resources/templates/conf/sip_profiles/internal-ipv6.xml.noload
+++ b/resources/templates/conf/sip_profiles/internal-ipv6.xml.noload
@@ -116,10 +116,12 @@
 		<param name="ext-rtp-ip" value="$${external_rtp_ip}" enabled="false"/>
 		<param name="ext-sip-ip" value="$${external_sip_ip}" enabled="false"/>
 		<!-- rtp inactivity timeout -->
-		<param name="media_timeout" value="300"/>
-		<param name="media_hold_timeout" value="1800"/>
+		<param name="rtp-timeout-sec" value="300" description="deprecated" enabled="false"/>
+		<param name="rtp-hold-timeout-sec" value="1800" description="deprecated" enabled="false"/>
+		<param name="media_timeout" value="300" enabled="true"/>
+		<param name="media_hold_timeout" value="1800" enabled="true"/>
 		<!-- VAD choose one (out is a good choice); -->
-		<!-- <param name="vad" value="in"/> -->
+		<!-- <param name="vad" value="in" enabled="false"/> -->
 		<param name="vad" value="out" enabled="false"/>
 		<!-- <param name="vad" value="both"/> -->
 		<param name="alias" value="sip:10.0.1.251:5555" enabled="false"/>

--- a/resources/templates/conf/sip_profiles/internal-ipv6.xml.noload
+++ b/resources/templates/conf/sip_profiles/internal-ipv6.xml.noload
@@ -116,8 +116,8 @@
 		<param name="ext-rtp-ip" value="$${external_rtp_ip}" enabled="false"/>
 		<param name="ext-sip-ip" value="$${external_sip_ip}" enabled="false"/>
 		<!-- rtp inactivity timeout -->
-		<param name="rtp-timeout-sec" value="300"/>
-		<param name="rtp-hold-timeout-sec" value="1800"/>
+		<param name="media_timeout" value="300"/>
+		<param name="media_hold_timeout" value="1800"/>
 		<!-- VAD choose one (out is a good choice); -->
 		<!-- <param name="vad" value="in"/> -->
 		<param name="vad" value="out" enabled="false"/>


### PR DESCRIPTION
Parameter names have changed. See here: https://freeswitch.org/confluence/display/FREESWITCH/Sofia+Configuration+Files

When starting a profile, the following warnings would appear:
[WARNING] sofia.c:5332 rtp-hold-timeout-sec deprecated use media_hold_timeout variable.
[WARNING] sofia.c:5325 rtp-timeout-sec deprecated use media_timeout variable.

Updating the parameters fixes the issue.