### PR TITLE
Update deprecated sip profile params

### DIFF
--- a/resources/templates/conf/sip_profiles/internal.xml.noload
+++ b/resources/templates/conf/sip_profiles/internal.xml.noload
@@ -258,8 +258,10 @@
 		<param name="ext-sip-ip" value="$${external_sip_ip}"/>
 
 		<!-- rtp inactivity timeout -->
-		<param name="media_timeout" value="300"/>
-		<param name="media_hold_timeout" value="1800"/>
+		<param name="rtp-timeout-sec" value="300" description="deprecated" enabled="false"/>
+		<param name="rtp-hold-timeout-sec" value="1800" description="deprecated" enabled="false"/>
+		<param name="media_timeout" value="300" enabled="true"/>
+		<param name="media_hold_timeout" value="1800" enabled="true"/>
 		<!-- VAD choose one (out is a good choice); -->
 		<!-- <param name="vad" value="in" enabled="false"/> -->
 		<param name="vad" value="out" enabled="false"/>

--- a/resources/templates/conf/sip_profiles/internal.xml.noload
+++ b/resources/templates/conf/sip_profiles/internal.xml.noload
@@ -258,8 +258,8 @@
 		<param name="ext-sip-ip" value="$${external_sip_ip}"/>
 
 		<!-- rtp inactivity timeout -->
-		<param name="rtp-timeout-sec" value="300"/>
-		<param name="rtp-hold-timeout-sec" value="1800"/>
+		<param name="media_timeout" value="300"/>
+		<param name="media_hold_timeout" value="1800"/>
 		<!-- VAD choose one (out is a good choice); -->
 		<!-- <param name="vad" value="in" enabled="false"/> -->
 		<param name="vad" value="out" enabled="false"/>


### PR DESCRIPTION
Parameter names have changed. See here: https://freeswitch.org/confluence/display/FREESWITCH/Sofia+Configuration+Files

When starting a profile, the following warnings would appear:
[WARNING] sofia.c:5332 rtp-hold-timeout-sec deprecated use media_hold_timeout variable.
[WARNING] sofia.c:5325 rtp-timeout-sec deprecated use media_timeout variable.

Updating the parameters fixes the issue.