### PR TITLE
This timer service helps with event_gaurd starting too quickly. Unable to connect to event socket and high CPU utilization up to 90 to 99% have been observed.

### DIFF
--- a/app/event_guard/resources/service/debian.timer
+++ b/app/event_guard/resources/service/debian.timer
@@ -1,0 +1,11 @@
+; cp /var/www/fusionpbx/app/event_guard/resources/service/debian.timer /etc/systemd/system/event_guard.timer
+; systemctl enable event_guard.timer
+; systemctl daemon-reload
+
+[Unit]
+Description=Timer for the event_guard service
+
+[Timer]
+OnBootSec=20sec
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
this commit along with my other one in fusionpbx/fusionpbx-install fixes the issue after a server reboot.