### PR TITLE
[ht814] Grandstream escape html and sip_port

### DIFF
--- a/resources/templates/provision/grandstream/ht814/{$mac}.xml
+++ b/resources/templates/provision/grandstream/ht814/{$mac}.xml
@@ -16,7 +16,7 @@
     <!-- # Admin password for web interface -->
     <!-- # String; between ascii values 33 and 126 -->
     <!-- # Mandatory -->
-    <P2>{$admin_password}</P2>
+    <P2>{$admin_password|escape: 'html'}</P2>
 
 
     <!-- # Layer 2 QoS.  -->
@@ -109,7 +109,7 @@
 
     <!-- # HTTP/HTTPS Password -->
     <!-- # String; between ascii values 33 and 126 -->
-    <P1361>{$http_auth_password}</P1361>
+    <P1361>{$http_auth_password|escape: 'html'}</P1361>
 
     <!-- # Firmware File Prefix -->
     <!-- # String; between ascii values 33 and 126 -->
@@ -503,8 +503,11 @@
 
     <!-- # Primary SIP Server -->
     <!-- # Server address -->
+    {if $account.1.sip_transport != 'dns srv'}
+    <P47>{$account.1.server_address}:{$account.1.sip_port}</P47>
+    {else}
     <P47>{$account.1.server_address}</P47>
-
+    {/if}
 
     <!-- # Failover SIP Server -->
     <!-- # Server address -->
@@ -961,7 +964,7 @@
     <!-- # Dial Plan -->
     <!-- # String -->
     {if isset($grandstream_dial_plan) }
-    <P4200>{$grandstream_dial_plan}</P4200>
+    <P4200>{$grandstream_dial_plan|escape: 'html'}</P4200>
     {else}
     <P4200>{literal}{ x+ | *x+ | *xx*x+ }{/literal}</P4200>
     {/if}
@@ -1744,7 +1747,7 @@
     <P28161>0</P28161>
 
     <!-- # Management Access. 0- Management Interface Only, 1 - Both Services and Management Interfaces -->
-    <!-- # Number： 0， 1 -->
+    <!-- # Number:  0, 1 -->
     <!-- # Mandatory -->
     <P28162>0</P28162>
 


### PR DESCRIPTION
Fixes 2 issues:
1. if any password contains HTML special chars the XML breaks
2. This file doesn't use non-standard SIP port.