### PR TITLE
Add Fax Queue TX Email Variables

### DIFF
--- a/app/fax/app_config.php
+++ b/app/fax/app_config.php
@@ -764,6 +764,10 @@
 		$apps[$x]['db'][$y]['fields'][$z]['type'] = "text";
 		$apps[$x]['db'][$y]['fields'][$z]['description']['en-us'] = "";
 		$z++;
+		$apps[$x]['db'][$y]['fields'][$z]['name'] = "fax_duration";
+		$apps[$x]['db'][$y]['fields'][$z]['type'] = "numeric";
+		$apps[$x]['db'][$y]['fields'][$z]['description']['en-us'] = "";
+		$z++;
 		$apps[$x]['db'][$y]['fields'][$z]['name'] = "fax_date";
 		$apps[$x]['db'][$y]['fields'][$z]['type']['pgsql'] = "timestamptz";
 		$apps[$x]['db'][$y]['fields'][$z]['type']['sqlite'] = "date";

--- a/app/fax_queue/app_config.php
+++ b/app/fax_queue/app_config.php
@@ -114,6 +114,14 @@
 		$apps[$x]['db'][$y]['fields'][$z]['type']['sqlite'] = 'text';
 		$apps[$x]['db'][$y]['fields'][$z]['type']['mysql'] = 'char(36)';
 		$z++;
+		$apps[$x]['db'][$y]['fields'][$z]['name'] = 'fax_log_uuid';
+		$apps[$x]['db'][$y]['fields'][$z]['type']['pgsql'] = 'uuid';
+		$apps[$x]['db'][$y]['fields'][$z]['type']['sqlite'] = 'text';
+		$apps[$x]['db'][$y]['fields'][$z]['type']['mysql'] = 'char(36)';
+		$apps[$x]['db'][$y]['fields'][$z]['key']['type'] = 'foreign';
+		$apps[$x]['db'][$y]['fields'][$z]['key']['reference']['table'] = 'v_fax_logs';
+		$apps[$x]['db'][$y]['fields'][$z]['key']['reference']['field'] = 'fax_log_uuid';
+		$z++;
 		$apps[$x]['db'][$y]['fields'][$z]['name'] = 'fax_date';
 		$apps[$x]['db'][$y]['fields'][$z]['type']['pgsql'] = 'timestamptz';
 		$apps[$x]['db'][$y]['fields'][$z]['type']['sqlite'] = 'date';

--- a/app/fax_queue/resources/job/fax_send.php
+++ b/app/fax_queue/resources/job/fax_send.php
@@ -160,6 +160,7 @@
 		$domain_name = $row['domain_name'];
 		$fax_uuid = $row['fax_uuid'];
 		$origination_uuid = $row['origination_uuid'];
+		$fax_log_uuid = $row['fax_log_uuid'];
 		$hostname = $row["hostname"];
 		$fax_date = $row["fax_date"];
 		$fax_caller_id_name = $row["fax_caller_id_name"];
@@ -498,6 +499,33 @@
 					$fax_file_name = $fax_file_filename . '.' . $fax_file_extension;
 				}
 
+				//get fax log data for email variables
+				if (isset($fax_email_address) && strlen($fax_email_address) > 0 && isset($fax_log_uuid)) {
+					$sql = "select * ";
+					$sql .= "from v_fax_logs ";
+					$sql .= "where fax_log_uuid = :fax_log_uuid ";
+					$parameters['fax_log_uuid'] = $fax_log_uuid;
+					$database = new database;
+					$row = $database->select($sql, $parameters, 'row');
+					if (is_array($row)) {
+						$fax_success = $row['fax_success'];
+						$fax_result_code = $row['fax_result_code'];
+						$fax_result_text = $row['fax_result_text'];
+						$fax_ecm_used = $row['fax_ecm_used'];
+						$fax_local_station_id = $row['fax_local_station_id'];
+						$fax_document_transferred_pages = $row["fax_document_transferred_pages"];
+						$fax_document_total_pages = $row["fax_document_total_pages"];
+						$fax_image_resolution = $row["fax_image_resolution"];
+						$fax_image_size = $row["fax_image_size"];
+						$fax_bad_rows = $row["fax_bad_rows"];
+						$fax_transfer_rate = $row["fax_transfer_rate"];
+						$fax_epoch = $row["fax_epoch"];
+						$fax_duration = $row["fax_duration"];
+						$fax_duration_formatted = sprintf('%02dh %02dm %02ds', ($fax_duration/ 3600),($fax_duration/ 60 % 60), $fax_duration% 60);
+					}
+					unset($parameters);
+				}
+
 				//replace variables in email subject
 				$email_subject = str_replace('${domain_name}', $domain_uuid, $email_subject);
 				$email_subject = str_replace('${number_dialed}', $fax_number, $email_subject);
@@ -506,7 +534,22 @@
 				$email_subject = str_replace('${fax_messages}', $fax_messages, $email_subject);
 				$email_subject = str_replace('${fax_file_warning}', $fax_file_warning, $email_subject);
 				$email_subject = str_replace('${fax_subject_tag}', $fax_email_inbound_subject_tag, $email_subject);
-
+				
+				$email_subject = str_replace('${fax_success}', $fax_success, $email_subject);
+				$email_subject = str_replace('${fax_result_code}', $fax_result_code, $email_subject);
+				$email_subject = str_replace('${fax_result_text}', $fax_result_text, $email_subject);
+				$email_subject = str_replace('${fax_ecm_used}', $fax_ecm_used, $email_subject);
+				$email_subject = str_replace('${fax_local_station_id}', $fax_local_station_id, $email_subject);
+				$email_subject = str_replace('${fax_document_transferred_pages}', $fax_document_transferred_pages, $email_subject);
+				$email_subject = str_replace('${fax_document_total_pages}', $fax_document_total_pages, $email_subject);
+				$email_subject = str_replace('${fax_image_resolution}', $fax_image_resolution, $email_subject);
+				$email_subject = str_replace('${fax_image_size}', $fax_image_size, $email_subject);
+				$email_subject = str_replace('${fax_bad_rows}', $fax_bad_rows, $email_subject);
+				$email_subject = str_replace('${fax_transfer_rate}', $fax_transfer_rate, $email_subject);
+				$email_subject = str_replace('${fax_date}', date('Y-m-d H:i:s', $fax_epoch), $email_subject);
+				$email_subject = str_replace('${fax_duration}', $fax_duration, $email_subject);
+				$email_subject = str_replace('${fax_duration_formatted}', $fax_duration_formatted, $email_subject);
+				
 				//replace variables in email body
 				$email_body = str_replace('${domain_name}', $domain_uuid, $email_body);
 				$email_body = str_replace('${number_dialed}', $fax_number, $email_body);
@@ -515,6 +558,21 @@
 				$email_body = str_replace('${fax_messages}', $fax_messages, $email_body);
 				$email_body = str_replace('${fax_file_warning}', $fax_file_warning, $email_body);
 				$email_body = str_replace('${fax_subject_tag}', $fax_email_inbound_subject_tag, $email_body);
+				
+				$email_body = str_replace('${fax_success}', $fax_success, $email_body);
+				$email_body = str_replace('${fax_result_code}', $fax_result_code, $email_body);
+				$email_body = str_replace('${fax_result_text}', $fax_result_text, $email_body);
+				$email_body = str_replace('${fax_ecm_used}', $fax_ecm_used, $email_body);
+				$email_body = str_replace('${fax_local_station_id}', $fax_local_station_id, $email_body);
+				$email_body = str_replace('${fax_document_transferred_pages}', $fax_document_transferred_pages, $email_body);
+				$email_body = str_replace('${fax_document_total_pages}', $fax_document_total_pages, $email_body);
+				$email_body = str_replace('${fax_image_resolution}', $fax_image_resolution, $email_body);
+				$email_body = str_replace('${fax_image_size}', $fax_image_size, $email_body);
+				$email_body = str_replace('${fax_bad_rows}', $fax_bad_rows, $email_body);
+				$email_body = str_replace('${fax_transfer_rate}', $fax_transfer_rate, $email_body);
+				$email_body = str_replace('${fax_date}', date('Y-m-d H:i:s', $fax_epoch), $email_body);
+				$email_body = str_replace('${fax_duration}', $fax_duration, $email_body);
+				$email_body = str_replace('${fax_duration_formatted}', $fax_duration_formatted, $email_body);
 
 				//send the email
 				if (isset($fax_email_address) && strlen($fax_email_address) > 0) {

--- a/app/scripts/resources/scripts/app/fax/resources/scripts/hangup_tx.lua
+++ b/app/scripts/resources/scripts/app/fax/resources/scripts/hangup_tx.lua
@@ -275,7 +275,6 @@
 	if (fax_uuid ~= nil) then
 		sql = sql .. ":fax_uuid, ";
 	end
-
 	sql = sql .. ":fax_success, ";
 	sql = sql .. ":fax_result_code, ";
 	sql = sql .. ":fax_result_text, ";
@@ -313,7 +312,6 @@
 	end
 	sql = sql .. ":fax_time ";
 	sql = sql .. ")";
-
 	local params = {
 		uuid = uuid;
 		domain_uuid = domain_uuid;

--- a/app/scripts/resources/scripts/app/fax/resources/scripts/hangup_tx.lua
+++ b/app/scripts/resources/scripts/app/fax/resources/scripts/hangup_tx.lua
@@ -122,6 +122,8 @@
 	fax_success = env:getHeader("fax_success");
 	fax_result_text = env:getHeader("fax_result_text");
 	fax_local_station_id = env:getHeader("fax_local_station_id");
+	fax_image_resolution = env:getHeader("fax_image_resolution");
+	fax_image_size = env:getHeader("fax_image_size");
 	fax_ecm_used = env:getHeader("fax_ecm_used");
 	fax_uri = env:getHeader("fax_uri");
 	fax_extension_number = env:getHeader("fax_extension_number");
@@ -133,9 +135,11 @@
 	bridge_hangup_cause = env:getHeader("bridge_hangup_cause");
 	fax_result_code = env:getHeader("fax_result_code");
 	fax_remote_station_id = env:getHeader("fax_remote_station_id");
+	fax_document_transferred_pages = env:getHeader("fax_document_transferred_pages");
 	fax_document_total_pages = env:getHeader("fax_document_total_pages");
 	hangup_cause_q850 = tonumber(env:getHeader("hangup_cause_q850"));
 	fax_file = env:getHeader("fax_file");
+	fax_duration = env:getHeader("billsec");
 
 --prevent nil errors
 	if (fax_file == nil) then
@@ -223,19 +227,10 @@
 		fax_file_name = array[count(array)];
 	end
 
---update the email queue status
-	if (fax_success == '1') then
-		sql = "update v_fax_queue ";
-		sql = sql .. "set fax_status = :fax_status ";
-		sql = sql .. "where fax_queue_uuid = :fax_queue_uuid ";
-		local params = {fax_queue_uuid = fax_queue_uuid, fax_status = fax_status}
-		dbh:query(sql, params);
-	end
-
 --add to fax logs
 	sql = "insert into v_fax_logs ";
 	sql = sql .. "(";
-	sql = sql .. "fax_log_uuid, ";
+	sql = sql .. "fax_log_uuid , ";
 	sql = sql .. "domain_uuid, ";
 	if (fax_uuid ~= nil) then
 		sql = sql .. "fax_uuid, ";
@@ -267,6 +262,9 @@
 	if (fax_uri ~= nil) then
 		sql = sql .. "fax_uri, ";
 	end
+	if (fax_duration ~= nil) then
+		sql = sql .. "fax_duration, ";
+	end
 	sql = sql .. "fax_date, ";
 	sql = sql .. "fax_epoch ";
 	sql = sql .. ") ";
@@ -277,6 +275,7 @@
 	if (fax_uuid ~= nil) then
 		sql = sql .. ":fax_uuid, ";
 	end
+
 	sql = sql .. ":fax_success, ";
 	sql = sql .. ":fax_result_code, ";
 	sql = sql .. ":fax_result_text, ";
@@ -304,6 +303,9 @@
 	if (fax_uri ~= nil) then
 		sql = sql .. ":fax_uri, ";
 	end
+	if (fax_duration ~= nil) then
+		sql = sql .. ":fax_duration, ";
+	end
 	if (database["type"] == "sqlite") then
 		sql = sql .. ":fax_date, ";
 	else
@@ -311,6 +313,7 @@
 	end
 	sql = sql .. ":fax_time ";
 	sql = sql .. ")";
+
 	local params = {
 		uuid = uuid;
 		domain_uuid = domain_uuid;
@@ -328,13 +331,24 @@
 		fax_bad_rows = fax_bad_rows;
 		fax_transfer_rate = fax_transfer_rate;
 		fax_uri = fax_uri;
+		fax_duration = fax_duration;
 		fax_date = os.date("%Y-%m-%d %X");
 		fax_time = os.time();
 	};
+
 	if (debug["sql"]) then
 		freeswitch.consoleLog("notice", "[fax] SQL: " .. sql .. "; params:" .. json.encode(params) .. "\n");
 	end
 	dbh:query(sql, params);
+
+--update the email queue status
+	if (fax_success == '1') then
+		sql = "update v_fax_queue ";
+		sql = sql .. "set fax_status = :fax_status, fax_log_uuid = :fax_log_uuid ";
+		sql = sql .. "where fax_queue_uuid = :fax_queue_uuid ";
+		local params = {fax_queue_uuid = fax_queue_uuid, fax_status = fax_status, fax_log_uuid = uuid}
+		dbh:query(sql, params);
+	end
 
 --prepare base64
 	if (storage_type == "base64") then

--- a/app/scripts/resources/scripts/app/fax/resources/scripts/hangup_tx.lua
+++ b/app/scripts/resources/scripts/app/fax/resources/scripts/hangup_tx.lua
@@ -230,7 +230,7 @@
 --add to fax logs
 	sql = "insert into v_fax_logs ";
 	sql = sql .. "(";
-	sql = sql .. "fax_log_uuid , ";
+	sql = sql .. "fax_log_uuid, ";
 	sql = sql .. "domain_uuid, ";
 	if (fax_uuid ~= nil) then
 		sql = sql .. "fax_uuid, ";


### PR DESCRIPTION
This PR adds back some of the missing session variables that should be logged to v_fax_logs that were lost when fax_queue was rewritten. Additionally, it allows us to access variables logged in v_fax_logs in the fax email templates.

Here are details of the changes:

**Added two new db fields:**

* v_fax_logs - added fax_duration
* v_fax_queue - added fax_log_uuid

**hangup_tx.lua**

* Added back missing session variables needed to save to fax log that were lost when fax_queue was rewritten
* Added new session variable for fax_duration
* Now update fax_log_uuid to v_fax_queue when send is successful so we can access the log data later

**fax_send.php**

* Get the new fax_log_uuid variable
* We now query the db to get all the fax log data
* Add additional replacements to allow us to use these variables in the fax email templates

**New Email Template Variables**

```
${fax_result_code}
${fax_result_text}
${fax_ecm_used}
${fax_local_station_id}
${fax_document_transferred_pages}
${fax_document_total_pages}
${fax_image_resolution}
${fax_image_size}
${fax_bad_rows}
${fax_transfer_rate}
${fax_date}
${fax_duration}
${fax_duration_formatted}
```