### PR TITLE
Fix fax_queue to Email PDF Instead of TIF

### DIFF
--- a/app/fax_queue/resources/job/fax_send.php
+++ b/app/fax_queue/resources/job/fax_send.php
@@ -490,7 +490,7 @@
 				$fax_file_extension = $path_info['extension'];
 				
 				//set the fax file pdf and tif files
-				$fax_file_tif = path_join($fax_file_dirname, $fax_file_filename . "." . $fax_file_extension);
+				$fax_file_tif = path_join($fax_file_dirname, $fax_file_filename . '.' . $fax_file_extension);
 				$fax_file_pdf = path_join($fax_file_dirname, $fax_file_filename . '.pdf');
 				
 				if (file_exists($fax_file_pdf)) {

--- a/app/fax_queue/resources/job/fax_send.php
+++ b/app/fax_queue/resources/job/fax_send.php
@@ -490,9 +490,10 @@
 				$fax_file_extension = $path_info['extension'];
 				
 				//set the fax file pdf and tif files
-				$fax_file_tif = path_join($fax_file_dirname, $fax_file_filename . $fax_file_extension);
-				$fax_file_pdf = path_join($fax_file_dirname, $fax_file_filename . 'pdf');
-				if (file_exists(path_join($fax_file_dirname, $fax_file_filename . 'pdf'))) {
+				$fax_file_tif = path_join($fax_file_dirname, $fax_file_filename . "." . $fax_file_extension);
+				$fax_file_pdf = path_join($fax_file_dirname, $fax_file_filename . '.pdf');
+				
+				if (file_exists($fax_file_pdf)) {
 					$fax_file_name = $fax_file_filename . '.pdf';
 				}
 				else {


### PR DESCRIPTION
Variables `$fax_file_tif` and `$fax_file_pdf` are missing a period before the extension so file_exists is always evaluating to false. Thus, TIF was always sent. Adds the period back into the path so the check works correctly.

NOTE: `$fax_file_tif` is completely unused and can be removed from this code for cleanup.