### PR TITLE
Split languages in to multiple files

### DIFF
--- a/app/bridges/app_languages.php
+++ b/app/bridges/app_languages.php
@@ -1,5 +1,17 @@
 <?php
-
+// Load by file
+$basename = "$lang_path/resources/languages";
+foreach($GLOBALS['language']->languages as $filename) {
+    if (file_exists("$basename/$filename.ini")) {
+        $sections = parse_ini_file("$basename/$filename.ini", true);
+        foreach($sections as $section_name => $section) {
+            foreach($section as $name => $value) {
+                $text[$section_name.$name][$filename] = $value;
+            }
+        }
+    }
+}
+/*
 	//Bridges
 		$text['title-bridges']['en-us'] = 'Bridges';
 		$text['title-bridges']['en-gb'] = 'Bridges';
@@ -255,3 +267,4 @@
 		$text['label-bridge_description']['tr-tr'] = "Açıklama";
 
 ?>
+*/

--- a/app/bridges/resources/languages/de-at.ini
+++ b/app/bridges/resources/languages/de-at.ini
@@ -1,0 +1,3 @@
+; Bridges de-at
+[label-bridge_]
+description = "Beschreibung"; //copied from de-de

--- a/app/bridges/resources/languages/de-ch.ini
+++ b/app/bridges/resources/languages/de-ch.ini
@@ -1,0 +1,3 @@
+; Bridges de-ch
+[description-bridge_]
+description = "Beschreibung"; //copied from de-de

--- a/app/bridges/resources/languages/de-de.ini
+++ b/app/bridges/resources/languages/de-de.ini
@@ -1,0 +1,3 @@
+; Bridges de-de
+[description-bridge_]
+description = "Beschreibung"

--- a/app/bridges/resources/languages/en-gb.ini
+++ b/app/bridges/resources/languages/en-gb.ini
@@ -1,0 +1,16 @@
+; Bridges English GB
+[title-]
+bridges = 'Bridges'
+bridge = 'Bridge'
+[title_description-]
+bridge = 'Add bridge statements to destination select list.'
+[label-bridge_]
+name = 'Name'
+destination = 'Destination'
+enabled = 'Enabled'
+description = 'Description'
+[description-bridge_]
+name = 'Enter the name.'
+destination = 'Enter the destination.'
+enabled = 'Select to enable or disable.'
+description = 'Enter the description. '

--- a/app/bridges/resources/languages/en-us.ini
+++ b/app/bridges/resources/languages/en-us.ini
@@ -1,0 +1,16 @@
+; Bridges English US
+[title-]
+bridges = 'Bridges'
+bridge = 'Bridge'
+[title_description-]
+bridge = 'Add bridge statements to destination select list.'
+[label-bridge_]
+name = 'Name'
+destination = 'Destination'
+enabled = 'Enabled'
+description = 'Description'
+[description-bridge_]
+name = 'Enter the name.'
+destination = 'Enter the destination.'
+enabled = 'Select to enable or disable.'
+description = 'Enter the description. '

--- a/app/bridges/resources/languages/es-cl.ini
+++ b/app/bridges/resources/languages/es-cl.ini
@@ -1,0 +1,16 @@
+; Bridges es-cl
+[title-]
+bridges = 'Bridges'
+bridge = 'Bridge'
+[title_description-]
+bridge = 'Add bridge statements to destination select list.'
+[label-bridge_]
+name = 'Name'
+destination = 'Destination'
+enabled = 'Enabled'
+description = 'Description'
+[description-bridge_]
+name = 'Enter the name.'
+destination = 'Enter the destination.'
+enabled = 'Select to enable or disable.'
+description = 'Descripción'

--- a/app/bridges/resources/languages/fr-ca.ini
+++ b/app/bridges/resources/languages/fr-ca.ini
@@ -1,0 +1,16 @@
+; Bridges French CA
+[title-]
+bridges = 'Ponts'
+bridge = 'Pont'
+[title_description-]
+bridge = 'Ajouter des déclarations de pont à la liste de sélection'
+[label-bridge_]
+name = 'Nom'
+destination = 'Destination'
+enabled = 'Activé'
+description = 'La description'
+[description-bridge_]
+name = 'Entrez le nom'
+destination = 'Entrer la destination'
+enabled = 'Sélectionnez pour activer ou désactiver'
+description = 'Entrez la description'

--- a/app/bridges/resources/languages/fr-fr.ini
+++ b/app/bridges/resources/languages/fr-fr.ini
@@ -1,0 +1,16 @@
+; Bridges French CA
+[title-]
+bridges = 'Ponts'
+bridge = 'Pont'
+[title_description-]
+bridge = 'Ajouter des déclarations de pont à la liste de sélection'
+[label-bridge_]
+name = 'Nom'
+destination = 'Destination'
+enabled = 'Activé'
+description = 'La description'
+[description-bridge_]
+name = 'Entrez le nom'
+destination = 'Entrer la destination'
+enabled = 'Sélectionnez pour activer ou désactiver'
+description = 'Entrez la description'

--- a/app/bridges/resources/languages/nl-nl.ini
+++ b/app/bridges/resources/languages/nl-nl.ini
@@ -1,0 +1,16 @@
+; Bridges NL-NL
+[title-]
+bridges = 'Bruggen'
+bridge = 'Brug'
+[title_description-]
+bridge = 'Voeg brug opdrachten toe aan bestemmings lijst.'
+[label-bridge_]
+name = 'Naam'
+destination = 'Bestemming'
+enabled = 'Geactiveerd'
+description = 'Omschrijving'
+[description-bridge_]
+name = 'Voer naam in.'
+destination = 'Voer de bestemming in.'
+enabled = 'Kies aktiveer/deactiveer.'
+description = 'Voer omschrijving in.'

--- a/app/bridges/resources/languages/pl-pl.ini
+++ b/app/bridges/resources/languages/pl-pl.ini
@@ -1,0 +1,16 @@
+; Bridges PL-PL
+[title-]
+bridges = 'Mostki'
+bridge = 'Mostek'
+[title_description-]
+bridge = 'Dodaj wyrażenia mostkowania do listy wyboru destynacji.'
+[label-bridge_]
+name = 'Nazwa'
+destination = 'Destynacja'
+enabled = 'Aktywny'
+description = 'Opis'
+[description-bridge_]
+name = 'Wprowadź nazwę.'
+destination = 'Wprowadź destynację.'
+enabled = 'Wybierz czy aktywować lub dezaktywować.'
+description = 'Wprowadź opis.'


### PR DESCRIPTION
Split languages in to files named with their language code while still maintaining compatibility.