### PR TITLE
Frytimo patch fix send custom cache event

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ secure/*.sqlite
 *.php~
 
 app/yealink/resources/firmware/*
+nbproject/*

--- a/resources/classes/cache.php
+++ b/resources/classes/cache.php
@@ -187,6 +187,10 @@ class cache {
 
 		//cache method file 
 			if ($_SESSION['cache']['method']['text'] == "file") {
+				$fp = event_socket_create($_SESSION['event_socket_ip_address'], $_SESSION['event_socket_port'], $_SESSION['event_socket_password']);
+					if ($fp === false) {
+						return false;
+					}
 				//send a custom event
 					$event = "sendevent CUSTOM\n";
 					$event .= "Event-Name: CUSTOM\n";
@@ -200,6 +204,10 @@ class cache {
 
 				//set message
 					$result = '+OK cache flushed';
+
+				//close event socket
+					fclose($fp);
+
 			}
 
 		//return result


### PR DESCRIPTION
cache method file does not initialize the variable $fp before requesting the custom event to be sent. This initializes the $fp event socket stream to send the command.