### PR TITLE
Update blf_subscribe.lua

### DIFF
--- a/app/scripts/resources/scripts/blf_subscribe.lua
+++ b/app/scripts/resources/scripts/blf_subscribe.lua
@@ -7,6 +7,9 @@ else
 	service_name = proto
 end
 
+--make sure the scripts/run dir exists
+mkdir(scripts_dir .. "/run");
+
 require "resources.functions.config"
 require "resources.functions.split"
 require "resources.functions.trim";
@@ -22,7 +25,9 @@ local find_voicemail do
 	from v_voicemail_messages t1
 	inner join v_domains t2 on t1.domain_uuid = t2.domain_uuid
 	inner join v_voicemails t3 on t1.voicemail_uuid = t3.voicemail_uuid
-	where t2.domain_name = :domain_name and t3.voicemail_id = :extension and t1.message_status != 'saved']]
+	where t2.domain_name = :domain_name 
+	and t3.voicemail_id = :extension 
+	and (t1.message_status is null or message_status = '')]]
 	
 	function find_voicemail(user)
 		local ext, domain_name = split_first(user, '@', true)


### PR DESCRIPTION
This PR fixes the WHERE clause of the SQL query used to determine if there are new voicemails that should count towards the mailbox BLF being 'true'. This SQL was mimicked from the voicemail app's main_menu script: voicemail/resources/functions/main_menu.lua

In addition, in case the {scripts_dir}/run subfolder doesn't exist, the command to create it was added.