### PR TITLE
[5.1] Fix Timeconditions (and other apps) with custom values

### DIFF
--- a/app/destinations/resources/classes/destinations.php
+++ b/app/destinations/resources/classes/destinations.php
@@ -989,7 +989,7 @@ if (!class_exists('destinations')) {
 		/**
 		* valid destination
 		*/
-		public function valid($destination, $type = 'dialplan') {
+		public function valid($destination, $type = 'dialplan', $strict = false) {
 			//allow an empty destination
 			if ($destination == ':') {
 				return true;
@@ -1008,6 +1008,14 @@ if (!class_exists('destinations')) {
 					}
 				}
 			}
+			
+			// Custom values
+                        if (!$strict){
+                                if (preg_match('/\w+:.*/', $destination)){
+                                        return true;
+                                }
+                        }
+			
 			return false;
 		}
 


### PR DESCRIPTION
I found this in the time condition app (but it will apply to any that uses the class destinations).

When the destinations::valid() function is called, it only checks against the static values preventing any valid custom value from being added, as a consequence, it is nulled.

This patch allows you to be more flexible (you may or may not want custom values)