### PR TITLE
Update local_extension fail_on_single_reject

### DIFF
--- a/app/dialplans/resources/switch/conf/dialplan/890_local_extension.xml
+++ b/app/dialplans/resources/switch/conf/dialplan/890_local_extension.xml
@@ -16,7 +16,7 @@
 			<action application="set" data="called_party_call_group=${user_data(${dialed_extension}@${domain_name} var call_group)}"/>
 			<!--<action application="export" data="nolocal:sip_secure_media=${user_data(${dialed_extension}@${domain_name} var sip_secure_media)}"/>-->
 			<action application="hash" data="insert/${domain_name}-last_dial/${called_party_call_group}/${uuid}"/>
-			<action application="set" data="fail_on_single_reject=true"/>
+			<action application="set" data="fail_on_single_reject=^^:CALL_REJECTED:NORMAL_CLEARING:USER_BUSY"/>
 			<action application="set" data="api_hangup_hook=lua app.lua hangup"/>
 			<action application="export" data="domain_name=${domain_name}"/>
 			<!-- standard method -->


### PR DESCRIPTION
Update local_extension fail_on_single_reject to handle stale registrations and other failures. Previously any failure mode would cause the call to drop to all.
So if a mobile app has a stale registration that times out when called, that leg fails with RECOVERY_ON_TIMER_EXPIRE and all other legs are cancelled and sent to voicemail.

This change handles 3 situations. All others should not fail the entire call to voicemail/forwarding.

1.  CALL_REJECTED - End User Rejects call - this means they hit cancel/end on their mobile app or desk phone. This reason should handle almost all phones. There may be edge cases that a phone doesn't conform and we can add those if discovered
2.  USER_BUSY - endpoint decides user is already on the phone - since we assume that an extension is a single person in most use cases, if an endpoint is configured with no call waiting and responds with a user_busy response, we should stop ringing and send the call to voicemail.
3.  NORMAL_CLEARING - Might not be necessary, but won't hurt anything. Should handle any "Confirm" options if they end up going through the local_extension dialplan, which I'm not sure they do.


This change might also be required in the call_screen dialplan. 