### PR TITLE
Update t41p {$mac}.cfg to correct IPv4 / IPv6 bug

### DIFF
--- a/resources/templates/provision/yealink/t41p/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t41p/{$mac}.cfg
@@ -1000,7 +1000,7 @@ local_time.time_zone_name = {$yealink_time_zone_name}
 ##                                   NETWORK                                         ##
 #######################################################################################
 ##0-ipv4, 1-ipv6, 2-ipv4&ipv6
-network.ip_address_mode = 2
+network.ip_address_mode = {$yealink_ip_address_mode}
 
 network.ipv6_prefix = 64
 network.ipv6_internet_port.type =
@@ -1503,7 +1503,7 @@ account.3.xsi.port =
 ##                                   NETWORK                                         ##
 #######################################################################################
 ##0-ipv4, 1-ipv6, 2-ipv4&ipv6
-network.ip_address_mode = 2
+network.ip_address_mode = {$yealink_ip_address_mode}
 
 network.ipv6_prefix = 64
 network.ipv6_internet_port.type =
@@ -1999,7 +1999,7 @@ account.4.xsi.port =
 ##                                   NETWORK                                         ##
 #######################################################################################
 ##0-ipv4, 1-ipv6, 2-ipv4&ipv6
-network.ip_address_mode = 2
+network.ip_address_mode = {$yealink_ip_address_mode}
 
 network.ipv6_prefix = 64
 network.ipv6_internet_port.type =
@@ -2495,7 +2495,7 @@ account.5.xsi.port =
 ##                                   NETWORK                                         ##
 #######################################################################################
 ##0-ipv4, 1-ipv6, 2-ipv4&ipv6
-network.ip_address_mode = 2
+network.ip_address_mode = {$yealink_ip_address_mode}
 
 network.ipv6_prefix = 64
 network.ipv6_internet_port.type =
@@ -2990,7 +2990,7 @@ account.6.xsi.port =
 ##                                   NETWORK                                         ##
 #######################################################################################
 ##0-ipv4, 1-ipv6, 2-ipv4&ipv6
-network.ip_address_mode = 2
+network.ip_address_mode = {$yealink_ip_address_mode}
 
 network.ipv6_prefix = 64
 network.ipv6_internet_port.type =


### PR DESCRIPTION
I was having an issue where my T41P phones were getting provisioned with IPv4 & IPv6 - even though I specified in default settings yealink_ip_address_mode=0 for IPv4 only. Checked the y000000000036.cfg, which was setting it correctly. The issue was that {$mac}.cfg was overriding the correct setting. There were several instances of "network.ip_address_mode = 2" in this file, which specifies ipv4&ipv6. I changed all 5 of those entries in this file to pull from the default setting {$yealink_ip_address_mode} rather than just setting a static value of 2. I don't know why it has this listed in this file 5 times. But, this change resolved my issue and will force the T41P provisioning to follow FusionPBX default settings.