### PR TITLE
[call_center] Add uuid to lamp turn

### DIFF
--- a/app/scripts/resources/scripts/app/agent_status/index.lua
+++ b/app/scripts/resources/scripts/app/agent_status/index.lua
@@ -199,7 +199,8 @@
 			end
 			if string.find(agent_name, 'agent+', nil, true) ~= 1 then
 				presence_in.turn_lamp( blf_status,
-					'agent+'..agent_name.."@"..domain_name
+					'agent+'..agent_name.."@"..domain_name,
+					uuid
 				);
 			end			
 	end


### PR DESCRIPTION
Agent log out from queue would have delayed lamp turn off. Solution credit:
https://www.pbxforums.com/threads/agent-status-blf.549/page-2#post-11458