### PR TITLE
separating status and hangup permissions

### DIFF
--- a/app/xml_cdr/app_config.php
+++ b/app/xml_cdr/app_config.php
@@ -97,7 +97,7 @@
 		$apps[$x]['permissions'][$y]['groups'][] = "admin";
 		$y++;
 		$apps[$x]['permissions'][$y]['name'] = "xml_cdr_search_hangup_cause";
-		$apps[$x]['permissions'][$y]['groups'][] = "admin";
+		//$apps[$x]['permissions'][$y]['groups'][] = "admin";
 		$apps[$x]['permissions'][$y]['groups'][] = "superadmin";
 		$y++;
 		$apps[$x]['permissions'][$y]['name'] = "xml_cdr_search_recording";
@@ -184,8 +184,12 @@
 		$apps[$x]['permissions'][$y]['name'] = "xml_cdr_mos";
 		$apps[$x]['permissions'][$y]['groups'][] = "superadmin";
 		$y++;
-		$apps[$x]['permissions'][$y]['name'] = "xml_cdr_hangup_cause";
+		$apps[$x]['permissions'][$y]['name'] = "xml_cdr_status";
 		$apps[$x]['permissions'][$y]['groups'][] = "admin";
+		$apps[$x]['permissions'][$y]['groups'][] = "superadmin";
+		$y++;
+		$apps[$x]['permissions'][$y]['name'] = "xml_cdr_hangup_cause";
+		//$apps[$x]['permissions'][$y]['groups'][] = "admin";
 		$apps[$x]['permissions'][$y]['groups'][] = "superadmin";
 		$y++;
 		$apps[$x]['permissions'][$y]['name'] = "xml_cdr_details";

--- a/app/xml_cdr/app_config.php
+++ b/app/xml_cdr/app_config.php
@@ -188,7 +188,6 @@
 		$apps[$x]['permissions'][$y]['groups'][] = "superadmin";
 		$y++;
 		$apps[$x]['permissions'][$y]['name'] = "xml_cdr_hangup_cause";
-		//$apps[$x]['permissions'][$y]['groups'][] = "admin";
 		$apps[$x]['permissions'][$y]['groups'][] = "superadmin";
 		$y++;
 		$apps[$x]['permissions'][$y]['name'] = "xml_cdr_details";

--- a/app/xml_cdr/app_config.php
+++ b/app/xml_cdr/app_config.php
@@ -97,7 +97,6 @@
 		$apps[$x]['permissions'][$y]['groups'][] = "admin";
 		$y++;
 		$apps[$x]['permissions'][$y]['name'] = "xml_cdr_search_hangup_cause";
-		//$apps[$x]['permissions'][$y]['groups'][] = "admin";
 		$apps[$x]['permissions'][$y]['groups'][] = "superadmin";
 		$y++;
 		$apps[$x]['permissions'][$y]['name'] = "xml_cdr_search_recording";

--- a/app/xml_cdr/xml_cdr.php
+++ b/app/xml_cdr/xml_cdr.php
@@ -597,12 +597,12 @@
 		echo "<th class='center hide-md-dn' title=\"".$text['description-mos']."\">".$text['label-mos']."</th>\n";
 		$col_count++;
 	}
-	if (permission_exists('xml_cdr_hangup_cause')) {
-		echo "<th class='hide-sm-dn shrink'>".$text['label-hangup_cause']."</th>\n";
+	if (permission_exists('xml_cdr_status')) {
+		echo "<th class='hide-sm-dn shrink'>".$text['label-status']."</th>\n";
 		$col_count++;
 	}
-	else {
-		echo "<th>".$text['label-status']."</th>\n";
+	if (permission_exists('xml_cdr_hangup_cause')) {
+		echo "<th class='hide-sm-dn shrink'>".$text['label-hangup_cause']."</th>\n";
 		$col_count++;
 	}
 	if (permission_exists('xml_cdr_details')) {
@@ -806,14 +806,14 @@
 						}
 						$content .= "	<td class='middle center hide-md-dn' ".$title.">".$value."</td>\n";
 					}
-				//hangup cause/call result
+				//call result/status
+					if (permission_exists("xml_cdr_status")) {
+						$content .= "	<td class='middle no-wrap hide-sm-dn'>".ucwords(escape($call_result))."</td>\n";
+					}	
+				//hangup cause
 					if (permission_exists('xml_cdr_hangup_cause')) {
 						$content .= "	<td class='middle no-wrap hide-sm-dn'><a href='".$list_row_url."'>".escape($hangup_cause)."</a></td>\n";
 					}
-					else {
-						$content .= "	<td class='middle no-wrap hide-sm-dn'>".ucwords(escape($call_result))."</td>\n";
-					}
-
 					$content .= "</tr>\n";
 				//show the leg b only to those with the permission
 					if ($row['leg'] == 'a') {


### PR DESCRIPTION
Creating a status permission so status can be displayed independently from hangup cause. The combination of status within the hangup permissions has confused some conversations with admins and superadmins.