### PR TITLE
Updated device_edit.php 'Save' to be a submit function for the form. 

### DIFF
--- a/app/devices/device_edit.php
+++ b/app/devices/device_edit.php
@@ -883,7 +883,7 @@
 			echo button::create(['type'=>'button','label'=>$text['button-delete'],'icon'=>$_SESSION['theme']['button_icon_delete'],'name'=>'btn_delete','onclick'=>"modal_open('modal-delete','btn_delete');"]);
 		}
 	}
-	echo button::create(['type'=>'button','label'=>$text['button-save'],'icon'=>$_SESSION['theme']['button_icon_save'],'id'=>'btn_save','style'=>'margin-left: 15px;','onclick'=>'submit_form();']);
+	echo button::create(['type'=>'submit','label'=>$text['button-save'],'icon'=>$_SESSION['theme']['button_icon_save'],'id'=>'btn_save','style'=>'margin-left: 15px;','onclick'=>'submit_form();']);
 	echo "	</div>\n";
 	echo "	<div style='clear: both;'></div>\n";
 	echo "</div>\n";


### PR DESCRIPTION
The reason for this is the default behaviour for 'return' or 'enter' is to delete the device entirely. This makes using a barcode scanner impossible, or user error resulting in a lot of lost time. 