### PR TITLE
Remove Ring Ready from Lua and support disabling it in dialplan

### DIFF
--- a/app/ring_groups/app_config.php
+++ b/app/ring_groups/app_config.php
@@ -177,6 +177,14 @@
 		$apps[$x]['default_settings'][$y]['default_setting_value'] = "3";
 		$apps[$x]['default_settings'][$y]['default_setting_enabled'] = "false";
 		$apps[$x]['default_settings'][$y]['default_setting_description'] = "";
+		$y++;
+		$apps[$x]['default_settings'][$y]['default_setting_uuid'] = "50cbb1bb-3d67-4320-9f7e-0b09aa09676d";
+		$apps[$x]['default_settings'][$y]['default_setting_category'] = "ring_group";
+		$apps[$x]['default_settings'][$y]['default_setting_subcategory'] = "ring_ready";
+		$apps[$x]['default_settings'][$y]['default_setting_name'] = "boolean";
+		$apps[$x]['default_settings'][$y]['default_setting_value'] = "true";
+		$apps[$x]['default_settings'][$y]['default_setting_enabled'] = "true";
+		$apps[$x]['default_settings'][$y]['default_setting_description'] = "execute ring_ready to send 180 ringing to calling party";
 
 	//schema details
 		$y=0;

--- a/app/ring_groups/ring_group_edit.php
+++ b/app/ring_groups/ring_group_edit.php
@@ -383,10 +383,14 @@
 				$y++;
 			}
 
+			$ring_ready = $_SESSION['ring_group']['ring_ready']['boolean'];
+
 		//build the xml dialplan
 			$dialplan_xml = "<extension name=\"".$ring_group_name."\" continue=\"\" uuid=\"".$dialplan_uuid."\">\n";
 			$dialplan_xml .= "	<condition field=\"destination_number\" expression=\"^".$ring_group_extension."$\">\n";
-			$dialplan_xml .= "		<action application=\"ring_ready\" data=\"\"/>\n";
+			if ($ring_ready == "true") {
+				$dialplan_xml .= "		<action application=\"ring_ready\" data=\"\"/>\n";
+			}
 			$dialplan_xml .= "		<action application=\"set\" data=\"ring_group_uuid=".$ring_group_uuid."\"/>\n";
 			$dialplan_xml .= "		<action application=\"lua\" data=\"app.lua ring_groups\"/>\n";
 			$dialplan_xml .= "	</condition>\n";

--- a/app/scripts/resources/scripts/app/ring_groups/index.lua
+++ b/app/scripts/resources/scripts/app/ring_groups/index.lua
@@ -179,9 +179,9 @@
 	end
 
 --set ring ready
-	if (session:ready()) then
-		session:execute("ring_ready", "");
-	end
+--	if (session:ready()) then
+--		session:execute("ring_ready", "");
+--	end
 
 --define additional variables
 	external = "false";


### PR DESCRIPTION
ring_ready is already being used in the dialplan right before the lua script is being called. I couldn't find a reason for it to be in both locations.

This change enables you to disable sending "180 ringing" whenever a ring group is called. Freeswitch will usually send a 183 session progress with early media while processing our ring group calls and we found an endpoint that breaks if you send both 180 and 183, so we had to disable sending 180. This just makes it a setting.

If we want to control ring_ready in the lua file, we have to read the database another time to get the default setting value so I opted to remove it from the lua so we aren't reading the database more than we have to.