### PR TITLE
BLF Not Showing Correct Status When Using DNS-SRV

### DIFF
--- a/resources/templates/provision/yealink/t58w/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t58w/{$mac}.cfg
@@ -21,6 +21,10 @@ account.{$row.line_number}.password = {$row.password}
 
 {if isset($row.server.1.address)}
 account.{$row.line_number}.user_name = {$row.user_id}@{$row.server_address}
+account.{$row.line_number}.fallback.redundancy_type=1
+account.{$row.line_number}.fallback.timeout={$row.register_expires}
+account.{$row.line_number}.sip_server.1.address={$row.server.1.address}
+account.{$row.line_number}.sip_server.2.address={$row.server.2.address}
 {else}
 account.{$row.line_number}.user_name = {$row.user_id}
 {/if}


### PR DESCRIPTION
Hi!
I was having trouble with the BLF as I am testing on two servers. Fixed with:

[BLF Not Showing Correct Status When Using DNS-SRV](https://support.yealink.com/en/portal/knowledge/show?id=12344b47acf9b6b78e431508)


Is it possible to add in the file {$mac}.cfg

```
account.{$row.line_number}.fallback.redundancy_type=1
account.{$row.line_number}.fallback.timeout={$row.register_expires}
account.{$row.line_number}.sip_server.1.address={$row.server.1.address}
account.{$row.line_number}.sip_server.2.address={$row.server.2.address}
```

```
{if isset($row.server.1.address)}
account.{$row.line_number}.user_name = {$row.user_id}@{$row.server_address}
account.{$row.line_number}.fallback.redundancy_type=1
account.{$row.line_number}.fallback.timeout={$row.register_expires}
account.{$row.line_number}.sip_server.1.address={$row.server.1.address}
account.{$row.line_number}.sip_server.2.address={$row.server.2.address}
{else}
account.{$row.line_number}.user_name = {$row.user_id}
{/if}
```

