### PR TITLE
Make the XML CDR Importer more resilient

### DIFF
--- a/app/xml_cdr/resources/classes/xml_cdr.php
+++ b/app/xml_cdr/resources/classes/xml_cdr.php
@@ -202,6 +202,7 @@ if (!class_exists('xml_cdr')) {
 					$this->fields[] = $field_name;
 				}
 			}
+			$this->fields = array_unique($this->fields);
 		}
 
 		/**
@@ -571,20 +572,22 @@ if (!class_exists('xml_cdr')) {
 								$fields = explode(",", $field);
 								$field_name = end($fields);
 								$this->fields[] = $field_name;
-								if (count($fields) == 1) {
-									$this->array[$key][$field_name] = urldecode($xml->variables->{$fields[0]});
-								}
-								if (count($fields) == 2) {
-									$this->array[$key][$field_name] = urldecode($xml->{$fields[0]}->{$fields[1]});
-								}
-								if (count($fields) == 3) {
-									$this->array[$key][$field_name] = urldecode($xml->{$fields[0]}->{$fields[1]}->{$fields[2]});
-								}
-								if (count($fields) == 4) {
-									$this->array[$key][$field_name] = urldecode($xml->{$fields[0]}->{$fields[1]}->{$fields[2]}->{$fields[3]});
-								}
-								if (count($fields) == 5) {
-									$this->array[$key][$field_name] = urldecode($xml->{$fields[0]}->{$fields[1]}->{$fields[2]}->{$fields[3]}->{$fields[4]});
+								if (!isset($this->array[$key][$field_name])){
+									if (count($fields) == 1) {
+										$this->array[$key][$field_name] = urldecode($xml->variables->{$fields[0]});
+									}
+									if (count($fields) == 2) {
+										$this->array[$key][$field_name] = urldecode($xml->{$fields[0]}->{$fields[1]});
+									}
+									if (count($fields) == 3) {
+										$this->array[$key][$field_name] = urldecode($xml->{$fields[0]}->{$fields[1]}->{$fields[2]});
+									}
+									if (count($fields) == 4) {
+										$this->array[$key][$field_name] = urldecode($xml->{$fields[0]}->{$fields[1]}->{$fields[2]}->{$fields[3]});
+									}
+									if (count($fields) == 5) {
+										$this->array[$key][$field_name] = urldecode($xml->{$fields[0]}->{$fields[1]}->{$fields[2]}->{$fields[3]}->{$fields[4]});
+									}
 								}
 							}
 						}


### PR DESCRIPTION
So I discovered 2 things,

1. If a user adds the default config cdr-field-array with the content of a database field Let's pretend they want to show the xml_cdr_uuid column (for support purposes) - it could be any column (please don't argue with the column name, it is an example only), the SQL construction will fail as not Postgresql, Not MariaDB/MySQL allow having a column repeated twice. Adding array_unique() fixes this issue.

2. This one is for developers: If a developer wants to create more columns in the v_xml_cdr table and make them visible in the CDR app, common sense tells to add the default setting cdr-field-array to show it. As the code is now, this will look into the freeswitch variables and overwrite it with NULL. I am adding a condition that verifies if the value has been already assigned, if it is, it won't overwrite it. This allows any developer who may be interested in extending the CDR to simply extend the class without touching it; very handy to keep the original code untouched.