### PR TITLE
Fix page issue of hold music heard

### DIFF
--- a/app/scripts/resources/scripts/page.lua
+++ b/app/scripts/resources/scripts/page.lua
@@ -250,7 +250,7 @@
 				else
 					moderator_flag = "";
 				end
-				session:execute("conference", conference_bridge.."+flags{endconf"..moderator_flag.."}");
+				session:execute("conference", conference_bridge.."+flags{endconf,mintwo"..moderator_flag.."}");
 			else
 				session:execute("playback", "tone_stream://%(500,500,480,620);loops=3");
 			end


### PR DESCRIPTION
Adding "mintwo" flag will tell the system that there has to be a minimum of two people in the conference to keep it open. This fixes the problem of when a user initiates a *8[ext] to someone and the far end hangs up and the initiator does not hang up the line they will hear hold music till they hang up.  Adding this will disconnect the intercom page if either party hangs up the call.