### PR TITLE
Proposal: Include originated internal calls in extension filter

### DIFF
--- a/app/xml_cdr/xml_cdr_inc.php
+++ b/app/xml_cdr/xml_cdr_inc.php
@@ -341,7 +341,11 @@
 	}
 
 	if (strlen($extension_uuid) > 0 && is_uuid($extension_uuid)) {
-		$sql .= "and e.extension_uuid = :extension_uuid \n";
+		$sql .= "and (e.extension_uuid = :extension_uuid \n";
+		$sql .= "or caller_id_number = \n";
+		$sql .= " (SELECT COALESCE(effective_caller_id_number,number_alias,extension) \n";
+		$sql .= "  FROM v_extensions WHERE extension_uuid = :extension_uuid) \n";
+		$sql .= ") \n";
 		$parameters['extension_uuid'] = $extension_uuid;
 	}
 	if (strlen($caller_destination) > 0) {


### PR DESCRIPTION
Include calls that the extension most likely placed based on the effective_caller_id_number, number_alias, extension of the extension that is being used in the filter. 

The v_xml_cdr only includes a single extension's uuid, which means that filtering by uuid will not include all calls of an extension. Notably, the previous behavior excludes extension-to-extension calls that were placed by an extension, you would only see extension-to-extension calls that the extension received.

This is one proposed solution that will only work for users with the xml_cdr_domain permission.

Line number 300 `$sql .= "and (c.extension_uuid = '".implode("' or c.extension_uuid = '", $extension_uuids)."') \n";` would need modification with this same subquery logic if we wanted to make the same filtering change for users who can only see their own CDRs.