### PR TITLE
Remove redundant SQL condition

### DIFF
--- a/app/dialplans/resources/classes/dialplan.php
+++ b/app/dialplans/resources/classes/dialplan.php
@@ -662,7 +662,6 @@
 							}
 							if (is_uuid($this->uuid)) {
 								$sql .= "and p.dialplan_uuid = :dialplan_uuid \n";
-//								$sql .= "and s.dialplan_uuid = :dialplan_uuid \n";
 								$parameters['dialplan_uuid'] = $this->uuid;
 							}
 							$sql .= "and (s.dialplan_detail_enabled = 'true' or s.dialplan_detail_enabled is null) \n";

--- a/app/dialplans/resources/classes/dialplan.php
+++ b/app/dialplans/resources/classes/dialplan.php
@@ -662,7 +662,7 @@
 							}
 							if (is_uuid($this->uuid)) {
 								$sql .= "and p.dialplan_uuid = :dialplan_uuid \n";
-								$sql .= "and s.dialplan_uuid = :dialplan_uuid \n";
+//								$sql .= "and s.dialplan_uuid = :dialplan_uuid \n";
 								$parameters['dialplan_uuid'] = $this->uuid;
 							}
 							$sql .= "and (s.dialplan_detail_enabled = 'true' or s.dialplan_detail_enabled is null) \n";


### PR DESCRIPTION
In this condition you already have  p.dialplay_uuid = s.dialplay_uuid  and you have p.dialplay_uuid = CONST, no need tor s.dialplay_uuid=CONST,

if a = b, and a = c, then b = c

In small databases, this could be trivial; but in significant databases, this saves a lot of processing.