### PR TITLE
update custom transcription provider for async transcriptions and retry logic

### DIFF
--- a/app/email_queue/resources/functions/transcribe.php
+++ b/app/email_queue/resources/functions/transcribe.php
@@ -223,9 +223,8 @@ if (!function_exists('transcribe')) {
 
 			}
 
-			//transcribe - custom
-			//Works with Mozilla DeepSpeech or Coqui with https://github.com/AccelerateNetworks/DeepSpeech_Frontend
-			//or Vosk with https://git.callpipe.com/fusionpbx/vosk_frontend
+			// transcribe - custom
+			// Works with self-hostable transcription service at https://github.com/AccelerateNetworks/an-transcriptions
 			if ($transcribe_provider == 'custom') {
 				$api_key = $_SESSION['voicemail']['api_key']['text'];
 				$api_url = $_SESSION['voicemail']['transcription_server']['text'];
@@ -241,21 +240,63 @@ if (!function_exists('transcribe')) {
 					$content_type = 'audio/wav';
 				}
 
-				$file_path = $file_path.'/'.$file_name;
-				$command = "curl -X POST ".$api_url." -H 'Authorization: Bearer ".$api_key."' -F file=@".$file_path;
-				echo $command."\n";
-				$http_response = shell_exec($command);
-				$array = json_decode($http_response, true);
-				if ($array === null) {
+				$message = null;
+				for($retries = 5; $retries > 0; $retries--) {
+					echo "sending voicemail recording to ".$api_url." for transcription";
+
+					// submit the file for transcribing
+					$file_path = $file_path.'/'.$file_name;
+					$command = "curl -sX POST ".$api_url."/enqueue -H 'Authorization: Bearer ".$api_key."' -F file=@".$file_path;
+					$stdout = shell_exec($command);
+					$resp = json_decode($stdout, true);
+					if ($resp === null) {
+						echo "unexpected error: ".$stdout;
+						// json not parsable, try again
+						continue;
+					}
+
+					$transcription_id = $resp['id'];
+
+					// wait for transcription to complete
+					sleep(1);
+
+					while(true) {
+						echo "checking ".$api_url." for completion of job ".$transcription_id;
+						$command = "curl -s ".$api_url."/j/".$transcription_id." -H 'Authorization: Bearer ".$api_key."'";
+						$resp = json_decode(shell_exec($command), true);
+						if ($resp === null) {
+							// json not parsable, try again
+							continue;
+						}
+
+						if($resp['status'] == "failed") {
+							echo "transcription failed, retrying";
+							break;
+						}
+
+						if($resp['status'] == "finished") {
+							echo "transcription succeeded";
+							$message = $resp['result'];
+							break;
+						}
+
+						// transcription is queued or in progress, check again in 1 second
+						sleep(1);
+					}
+
+					if($message !== null) {
+						break;
+					}
+				}
+
+				if($message == null) {
 					return false;
 				}
-				else {
-					$message = $array['message'];
-				}
+
 				$array['provider'] = $transcribe_provider;
 				$array['language'] = $transcribe_language;
 				$array['api_key'] = $api_key;
-				$array['command'] = $command;
+				// $array['command'] = $command
 				$array['message'] = $message;
 				return $array;
 			}


### PR DESCRIPTION
This updates the custom transcription endpoint to support async transcriptions. We've been running into issues with the old method were the connection would sometimes drop before the  transcribing is completed, which lead to users getting emails with no transcription. These changes allow for retrying on failure, and not depending on the initial request remaining open during transcription.