### PR TITLE
contacts app_defaults breaks PDO db

### DIFF
--- a/app/contacts/app_defaults.php
+++ b/app/contacts/app_defaults.php
@@ -4,7 +4,6 @@ if ($domains_processed == 1) {
 
 	//populate new phone_label values, phone_type_* values
 		$obj = new schema;
-		$obj->db = $db;
 		$obj->db_type = $db_type;
 		$obj->schema();
 		$field_exists = $obj->column_exists($db_name, 'v_contact_phones', 'phone_type');	//check if field exists
@@ -62,7 +61,6 @@ if ($domains_processed == 1) {
 
 	//populate primary email from deprecated field in v_contact table
 		$obj = new schema;
-		$obj->db = $db;
 		$obj->db_type = $db_type;
 		$obj->schema();
 		$field_exists = $obj->column_exists($db_name, 'v_contacts', 'contact_email');	//check if field exists
@@ -123,7 +121,6 @@ if ($domains_processed == 1) {
 
 	//populate primary url from deprecated field in v_contact table
 		$obj = new schema;
-		$obj->db = $db;
 		$obj->db_type = $db_type;
 		$obj->schema();
 		$field_exists = $obj->column_exists($db_name, 'v_contacts', 'contact_url');	//check if field exists

--- a/resources/classes/schema.php
+++ b/resources/classes/schema.php
@@ -29,7 +29,7 @@ if (!class_exists('schema')) {
 	class schema {
 
 		//define variables
-			public $db;
+			private $db;
 			public $apps;
 			public $db_type;
 			public $result;
@@ -37,13 +37,10 @@ if (!class_exists('schema')) {
 
 		//class constructor
 			public function __construct() {
-				//connect to the database if not connected
-				if (!$this->db) {
-					require_once "resources/classes/database.php";
-					$database = new database;
-					$database->connect();
-					$this->db = $database->db;
-				}
+				require_once "resources/classes/database.php";
+				$database = new database;
+				$database->connect();
+				$this->db = $database->db;
 
 				//set the include path
 				$conf = glob("{/usr/local/etc,/etc}/fusionpbx/config.conf", GLOB_BRACE);


### PR DESCRIPTION
removed setting `$obj->db` in contacts app_defaults as it will break the expected behaviour within the schema class (specifically the call to `$this->db->prepare()`. This will prevent app defaults from completing successfully and will die silently. Also, set the schema object $db to be private because the object property is assigned immediately in the constructor when the object is created. Removed the condition to check for the db property being set as it will always be unset when it is constructing. Also, sorry for the commit message I couldn't figure out how to change it.