### PR TITLE
Keep device vendor when using alternate device

### DIFF
--- a/app/provision/resources/classes/provision.php
+++ b/app/provision/resources/classes/provision.php
@@ -600,10 +600,9 @@
 										$device_firmware_version = $row["device_firmware_version"];
 										$device_user_uuid = $row["device_user_uuid"];
 										$device_location = strtolower($row["device_location"]);
-										//Do not override vendor when hotdesking (alternate uuid)
-										//$device_vendor = strtolower($row["device_vendor"]);
+										//keep the original device_vendor
 										$device_enabled = $row["device_enabled"];
-										//keep the original template
+										//keep the original device_template
 										$device_description = $row["device_description"];
 									}
 								}

--- a/app/provision/resources/classes/provision.php
+++ b/app/provision/resources/classes/provision.php
@@ -600,7 +600,8 @@
 										$device_firmware_version = $row["device_firmware_version"];
 										$device_user_uuid = $row["device_user_uuid"];
 										$device_location = strtolower($row["device_location"]);
-										$device_vendor = strtolower($row["device_vendor"]);
+										//Do not override vendor when hotdesking (alternate uuid)
+										//$device_vendor = strtolower($row["device_vendor"]);
 										$device_enabled = $row["device_enabled"];
 										//keep the original template
 										$device_description = $row["device_description"];


### PR DESCRIPTION
When alternate device, the vendor should not be overwritten as this will break device profiles.