### PR TITLE
Add fax_download_view permission

### DIFF
--- a/app/fax/app_config.php
+++ b/app/fax/app_config.php
@@ -197,7 +197,11 @@
 		$apps[$x]['permissions'][$y]['groups'][] = "superadmin";
 		$apps[$x]['permissions'][$y]['groups'][] = "admin";
 		$apps[$x]['permissions'][$y]['groups'][] = "user";
-
+		$y++;
+		$apps[$x]['permissions'][$y]['name'] = "fax_download_view";
+		$apps[$x]['permissions'][$y]['groups'][] = "superadmin";
+		$apps[$x]['permissions'][$y]['groups'][] = "admin";
+		$apps[$x]['permissions'][$y]['groups'][] = "user";
 	//default settings
 		$y=0;
 		$apps[$x]['default_settings'][$y]['default_setting_uuid'] = "6840bdb0-eb9d-45bd-a79a-ccb64d08fd97";

--- a/app/fax/fax_files.php
+++ b/app/fax/fax_files.php
@@ -322,7 +322,9 @@
 	if ($_REQUEST['box'] == 'sent') {
 		echo th_order_by('fax_destination', $text['label-fax_destination'], $order_by, $order, "&id=".$fax_uuid."&box=".$_GET['box']."&page=".$_GET['page']);
 	}
-	echo "<th>".$text['table-file']."</th>\n";
+	if (permission_exists('fax_download_view')) {
+		echo "<th>".$text['table-file']."</th>\n";
+	}
 	echo "<th width='10%'>".$text['table-view']."</th>\n";
 	echo th_order_by('fax_date', $text['label-fax_date'], $order_by, $order, "&id=".$fax_uuid."&box=".$_GET['box']."&page=".$_GET['page']);
 	echo "</tr>\n";
@@ -423,7 +425,9 @@
 			if ($_REQUEST['box'] == 'sent') {
 				echo "	<td>".escape(format_phone($row['fax_destination']))."&nbsp;</td>\n";
 			}
-			echo "  <td><a href='".$list_row_url."'>".$file_name."</a></td>\n";
+			if (permission_exists('fax_download_view')) {
+				echo "  <td><a href='".$list_row_url."'>".$file_name."</a></td>\n";
+			}
 			echo "  <td class='no-link'>\n";
 			if ($_REQUEST['box'] == 'inbox') {
 				$dir_fax = $dir_fax_inbox;


### PR DESCRIPTION
Add fax_download_view permission to allow hiding the "File Name (Download)" column on Fax Inbox and Fax Sent pages. Some users prefer hiding this field as they also have the "View" column that they can click on to view and download PDFs of the faxes.