### PR TITLE
Disable fax sending when domain is disabled

### DIFF
--- a/app/fax/app_languages.php
+++ b/app/fax/app_languages.php
@@ -3571,6 +3571,27 @@ $text['description-2']['ru-ru'] = "Чтобы послать факс, загр�
 $text['description-2']['sv-se'] = "Om du vill skicka ett fax, ladda upp en PDF eller TIF -fil. För att generera ett försättsblad, ange ett Ämne och / eller meddelande nedan.";
 $text['description-2']['uk-ua'] = "";
 
+$text['notice-sending-disabled']['en-us'] = "<strong>Notice</strong>: Sending Disabled";
+$text['notice-sending-disabled']['en-gb'] = "<strong>Notice</strong>: Sending Disabled";
+$text['notice-sending-disabled']['ar-eg'] = "إشعار: إرسال معطل";
+$text['notice-sending-disabled']['de-at'] = "<strong>Hinweis</strong>: Senden deaktiviert";
+$text['notice-sending-disabled']['de-ch'] = "<strong>Hinweis</strong>: Senden deaktiviert";
+$text['notice-sending-disabled']['de-de'] = "<strong>Hinweis</strong>: Senden deaktiviert";
+$text['notice-sending-disabled']['es-cl'] = "<strong>Aviso</strong>: Envío deshabilitado";
+$text['notice-sending-disabled']['es-mx'] = "<strong>Aviso</strong>: Envío deshabilitado";
+$text['notice-sending-disabled']['fr-ca'] = "<strong>Avis</strong> : Envoi désactivé";
+$text['notice-sending-disabled']['fr-fr'] = "<strong>Avis</strong> : Envoi désactivé";
+$text['notice-sending-disabled']['he-il'] = "שים לב: השליחה מושבתת";
+$text['notice-sending-disabled']['it-it'] = "<strong>Avviso</strong>: invio disabilitato";
+$text['notice-sending-disabled']['nl-nl'] = "<strong>Let op</strong>: Verzenden uitgeschakeld";
+$text['notice-sending-disabled']['pl-pl'] = "<strong>Uwaga</strong>: Wysyłanie wyłączone";
+$text['notice-sending-disabled']['pt-br'] = "<strong>Aviso</strong>: Envio desativado";
+$text['notice-sending-disabled']['pt-pt'] = "<strong>Aviso</strong>: Envio desativado";
+$text['notice-sending-disabled']['ro-ro'] = "<strong>Notă</strong>: Trimiterea este dezactivată";
+$text['notice-sending-disabled']['ru-ru'] = "<strong>Уведомление</strong>: отправка отключена";
+$text['notice-sending-disabled']['sv-se'] = "<strong>Observera</strong>: Sändning avaktiverad";
+$text['notice-sending-disabled']['uk-ua'] = "<strong>Примітка</strong>: надсилання вимкнено";
+
 $text['description']['en-us'] = "To receive a FAX setup a fax extension and then direct the incoming to it.";
 $text['description']['en-gb'] = "To receive a FAX setup a fax extension and then direct the incoming to it.";
 $text['description']['ar-eg'] = "";

--- a/app/fax/fax_send.php
+++ b/app/fax/fax_send.php
@@ -184,13 +184,21 @@ if (!function_exists('fax_split_dtmf')) {
 			}
 	}
 
+//check if the domain is enabled
+if($_SESSION['domains'][$_SESSION['domain_uuid']]['domain_enabled'] == "1" || $_SESSION['domains'][$_SESSION['domain_uuid']]['domain_enabled'] == "true") {
+	$domain_enabled = true;
+}
+else {
+	$domain_enabled = false;
+}
+
 //clear file status cache
 	clearstatcache();
 
 //send the fax
 	$continue = false;
 	if (!$included) {
-		if (($_POST['action'] == "send")) {
+		if (($_POST['action'] == "send") && $domain_enabled == true) {
 			//get the values from the HTTP POST
 				$fax_numbers = $_POST['fax_numbers'];
 				$fax_uuid = $_POST["id"];
@@ -940,14 +948,20 @@ if (!$included) {
 		echo "	<div class='heading'><b>".$text['header-new_fax']."</b></div>\n";
 		echo "	<div class='actions'>\n";
 		echo button::create(['type'=>'button','label'=>$text['button-back'],'icon'=>$_SESSION['theme']['button_icon_back'],'id'=>'btn_back','style'=>'margin-right: 15px;','link'=>'fax.php']);
+		if ($domain_enabled == true) {
 		echo button::create(['type'=>'submit','label'=>$text['button-preview'],'icon'=>'eye','name'=>'submit','value'=>'preview']);
 		echo button::create(['type'=>'submit','label'=>$text['button-send'],'icon'=>'paper-plane','id'=>'btn_save','name'=>'submit','value'=>'send','style'=>'margin-left: 15px;']);
+		}
 		echo "	</div>\n";
 		echo "	<div style='clear: both;'></div>\n";
 		echo "</div>\n";
 		echo $text['description-2']." ".(permission_exists('fax_extension_view_domain') ? $text['description-3'] : null)."\n";
 		echo "<br /><br />\n";
-
+		
+		if ($domain_enabled == false) {
+		echo "<div class='warning_bar'>".$text['notice-sending-disabled']."</div>\n";
+		}
+		
 		echo "<table width='100%' border='0' cellspacing='0' cellpadding='0'>\n";
 
 		echo "<tr>\n";

--- a/themes/default/css.php
+++ b/themes/default/css.php
@@ -2759,6 +2759,17 @@ header('Expires: '.gmdate('D, d M Y H:i:s',time()+3600).' GMT');
 		font-size: 100%;
 		}
 
+	.warning_bar {
+		width: 100%;
+		text-align: center;
+		border: 2px dashed #c00;
+		padding: 10px 20px;
+		margin-bottom: 16px;
+		color: #e00;
+		background: #fafafa;
+		font-size: 1.4em;
+	}
+
 /* LIST ************************************************************************/
 
 	.list {


### PR DESCRIPTION
Similarly to disabling extension registration and other functions, fax server sending should also be disabled for disabled domains. This prevents users from being able to send a fax and adds a warning message saying that sending is disabled.

Disabling of sending on disabled domains is accomplished in 2 ways:

- Preview and Send buttons are not rendered on the fax_send.php page
- POST data is not captured to prevent users from injecting the button back and completing the send that way

We have done regression testing to ensure that this does not break sending for users, admins or superadmins on domains which are still active.

### Example of sending disabled
![sending-disabled-example](https://user-images.githubusercontent.com/20842146/230493690-e5434764-6e46-414e-9aab-dfcd3dce297b.png)