### PR TITLE
add a missing import to some of the xml_handling lua scripts.

### DIFF
--- a/app/scripts/resources/scripts/app/xml_handler/resources/scripts/directory/action/acl.lua
+++ b/app/scripts/resources/scripts/app/xml_handler/resources/scripts/directory/action/acl.lua
@@ -1,3 +1,5 @@
+	local Xml = require "resources.functions.xml";
+
 --connect to the database
 	local Database = require "resources.functions.database"
 	local log      = require "resources.functions.log"["directory_acl"]

--- a/app/scripts/resources/scripts/app/xml_handler/resources/scripts/directory/action/group_call.lua
+++ b/app/scripts/resources/scripts/app/xml_handler/resources/scripts/directory/action/group_call.lua
@@ -24,6 +24,8 @@
 --	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 --	POSSIBILITY OF SUCH DAMAGE.
 
+	local Xml = require "resources.functions.xml";
+
 --get the cache
 	if (trim(api:execute("module_exists", "mod_memcache")) == "true") then
 		XML_STRING = trim(api:execute("memcache", "get directory:groups:"..domain_name));

--- a/app/scripts/resources/scripts/app/xml_handler/resources/scripts/directory/action/reverse-auth-lookup.lua
+++ b/app/scripts/resources/scripts/app/xml_handler/resources/scripts/directory/action/reverse-auth-lookup.lua
@@ -24,6 +24,8 @@
 --	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 --	POSSIBILITY OF SUCH DAMAGE.
 
+	local Xml = require "resources.functions.xml";
+
 --get the action
 	action = params:getHeader("action");
 	purpose = params:getHeader("purpose");


### PR DESCRIPTION
`acl.lua` and `reverse-auth-lookup.lua` were was breaking our "provision" button. never actually ran into it with `group_call.lua` but i can see that the Xml library is used there and not required, so I added that too.