### PR TITLE
Hide field for key subtype when $show_key_subtype is false

### DIFF
--- a/app/devices/device_edit.php
+++ b/app/devices/device_edit.php
@@ -1608,9 +1608,11 @@
 				echo "</select>\n";
 				echo "</td>\n";
 
-				echo "<td align='left'>\n";
-				echo "	<input class='formfld' type='text' name='device_keys[".$x."][device_key_subtype]' style='width: 120px;' maxlength='255' value=\"".escape($row['device_key_subtype'])."\"/>\n";
-				echo "</td>\n";
+				if($show_key_subtype) {
+					echo "<td align='left'>\n";
+					echo "	<input class='formfld' type='text' name='device_keys[".$x."][device_key_subtype]' style='width: 120px;' maxlength='255' value=\"".escape($row['device_key_subtype'])."\"/>\n";
+					echo "</td>\n";
+				}
 
 				if (permission_exists('device_key_line')) {
 					echo "<td valign='top' align='left' nowrap='nowrap'>\n";


### PR DESCRIPTION
We are currently seeing some UI weirdness that seems to stem from the changes in #6409. The key subtype field is displayed and labeled "line", and all following field labels are shifted one to the left of what they should be, with the last field being unlabeled:

![image](https://user-images.githubusercontent.com/692970/230675378-1b220e3c-a83e-4271-8bff-2517d8ae1cff.png)

This PR fixes