### PR TITLE
Fixing Yealink T46s codecs in template

### DIFF
--- a/resources/templates/provision/yealink/t46s/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t46s/{$mac}.cfg
@@ -249,96 +249,96 @@ account.1.bla_subscribe_period = 300
 #The payload of the specified codec.
 #account.1.codec.Y.rtpmap =
 
-account.1.codec.1.enable = {if isset($yealink_codec_pcmu_enable)}1{else}0{/if}
+account.1.codec.pcmu.enable = {if isset($yealink_codec_pcmu_enable)}1{else}0{/if}
 
-account.1.codec.1.payload_type = PCMU
-account.1.codec.1.priority = {if isset($yealink_codec_pcmu_priority)}{$yealink_codec_pcmu_priority}{else}0{/if}
+account.1.codec.pcmu.payload_type = PCMU
+account.1.codec.pcmu.priority = {if isset($yealink_codec_pcmu_priority)}{$yealink_codec_pcmu_priority}{else}0{/if}
 
-account.1.codec.1.rtpmap = 0
+account.1.codec.pcmu.rtpmap = 0
 
-account.1.codec.2.enable = {if isset($yealink_codec_pcma_enable)}1{else}0{/if}
+account.1.codec.pcma.enable = {if isset($yealink_codec_pcma_enable)}1{else}0{/if}
 
-account.1.codec.2.payload_type = PCMA
-account.1.codec.2.priority = {if isset($yealink_codec_pcma_priority)}{$yealink_codec_pcma_priority}{else}0{/if}
+account.1.codec.pcma.payload_type = PCMA
+account.1.codec.pcma.priority = {if isset($yealink_codec_pcma_priority)}{$yealink_codec_pcma_priority}{else}0{/if}
 
-account.1.codec.2.rtpmap = 8
+account.1.codec.pcma.rtpmap = 8
 
-account.1.codec.3.enable = {if isset($yealink_codec_g723_53_enable)}1{else}0{/if}
+account.1.codec.g723_53.enable = {if isset($yealink_codec_g723_53_enable)}1{else}0{/if}
 
-account.1.codec.3.payload_type = G723_53
-account.1.codec.3.priority ={if isset($yealink_codec_g723_53_priority)}{$yealink_codec_g723_53_priority}{else}0{/if}
+account.1.codec.g723_53.payload_type = G723_53
+account.1.codec.g723_53.priority ={if isset($yealink_codec_g723_53_priority)}{$yealink_codec_g723_53_priority}{else}0{/if}
 
-account.1.codec.3.rtpmap = 4
+account.1.codec.g723_53.rtpmap = 4
 
-account.1.codec.4.enable = {if isset($yealink_codec_g723_63_enable)}1{else}0{/if}
+account.1.codec.g723_63.enable = {if isset($yealink_codec_g723_63_enable)}1{else}0{/if}
 
-account.1.codec.4.payload_type = G723_63
-account.1.codec.4.priority = {if isset($yealink_codec_g723_63_priority)}{$yealink_codec_g723_63_priority}{else}0{/if}
+account.1.codec.g723_63.payload_type = G723_63
+account.1.codec.g723_63.priority = {if isset($yealink_codec_g723_63_priority)}{$yealink_codec_g723_63_priority}{else}0{/if}
 
-account.1.codec.4.rtpmap = 4
+account.1.codec.g723_63.rtpmap = 4
 
-account.1.codec.5.enable = {if isset($yealink_codec_g729_enable)}1{else}0{/if}
+account.1.codec.g729.enable = {if isset($yealink_codec_g729_enable)}1{else}0{/if}
 
-account.1.codec.5.payload_type = G729
-account.1.codec.5.priority = {if isset($yealink_codec_g729_priority)}{$yealink_codec_g729_priority}{else}0{/if}
+account.1.codec.g729.payload_type = G729
+account.1.codec.g729.priority = {if isset($yealink_codec_g729_priority)}{$yealink_codec_g729_priority}{else}0{/if}
 
-account.1.codec.5.rtpmap = 18
+account.1.codec.g729.rtpmap = 18
 
-account.1.codec.6.enable = {if isset($yealink_codec_g722_enable)}1{else}0{/if}
+account.1.codec.g722.enable = {if isset($yealink_codec_g722_enable)}1{else}0{/if}
 
-account.1.codec.6.payload_type = G722
-account.1.codec.6.priority = {if isset($yealink_codec_g722_priority)}{$yealink_codec_g722_priority}{else}0{/if}
+account.1.codec.g722.payload_type = G722
+account.1.codec.g722.priority = {if isset($yealink_codec_g722_priority)}{$yealink_codec_g722_priority}{else}0{/if}
 
-account.1.codec.6.rtpmap = 9
+account.1.codec.g722.rtpmap = 9
 
-account.1.codec.7.enable = {if isset($yealink_codec_iLBC_enable)}1{else}0{/if}
+account.1.codec.ilbc_13_33kbps.enable = {if isset($yealink_codec_iLBC_enable)}1{else}0{/if}
 
-account.1.codec.7.payload_type = iLBC
-account.1.codec.7.priority =  {if isset($yealink_codec_iLBC_priority)}{$yealink_codec_iLBC_priority}{else}0{/if}
+account.1.codec.ilbc_13_33kbps.payload_type = iLBC
+account.1.codec.ilbc_13_33kbps.priority =  {if isset($yealink_codec_iLBC_priority)}{$yealink_codec_iLBC_priority}{else}0{/if}
 
-account.1.codec.7.rtpmap = 106
+account.1.codec.ilbc_13_33kbps.rtpmap = 106
 
-account.1.codec.8.enable = {if isset($yealink_codec_g726_16_enable)}1{else}0{/if}
+account.1.codec.g726_16.enable = {if isset($yealink_codec_g726_16_enable)}1{else}0{/if}
 
-account.1.codec.8.payload_type = G726-16
-account.1.codec.8.priority = {if isset($yealink_codec_g726_16_priority)}{$yealink_codec_g726_16_priority}{else}0{/if}
+account.1.codec.g726_16.payload_type = G726-16
+account.1.codec.g726_16.priority = {if isset($yealink_codec_g726_16_priority)}{$yealink_codec_g726_16_priority}{else}0{/if}
 
-account.1.codec.8.rtpmap = 103
+account.1.codec.g726_16.rtpmap = 103
 
-account.1.codec.9.enable = {if isset($yealink_codec_g726_24_enable)}1{else}0{/if}
+account.1.codec.g726_24.enable = {if isset($yealink_codec_g726_24_enable)}1{else}0{/if}
 
-account.1.codec.9.payload_type = G726-24
-account.1.codec.9.priority = {if isset($yealink_codec_g726_24_priority)}{$yealink_codec_g726_24_priority}{else}0{/if}
+account.1.codec.g726_24.payload_type = G726-24
+account.1.codec.g726_24.priority = {if isset($yealink_codec_g726_24_priority)}{$yealink_codec_g726_24_priority}{else}0{/if}
 
-account.1.codec.9.rtpmap = 104
+account.1.codec.g726_24.rtpmap = 104
 
-account.1.codec.10.enable = {if isset($yealink_codec_g726_32_enable)}1{else}0{/if}
+account.1.codec.g726_32.enable = {if isset($yealink_codec_g726_32_enable)}1{else}0{/if}
 
-account.1.codec.10.payload_type = G726-32
-account.1.codec.10.priority = {if isset($yealink_codec_g726_32_priority)}{$yealink_codec_g726_32_priority}{else}0{/if}
+account.1.codec.g726_32.payload_type = G726-32
+account.1.codec.g726_32.priority = {if isset($yealink_codec_g726_32_priority)}{$yealink_codec_g726_32_priority}{else}0{/if}
 
-account.1.codec.10.rtpmap = 102
+account.1.codec.g726_32.rtpmap = 102
 
-account.1.codec.11.enable = {if isset($yealink_codec_g726_40_enable)}1{else}0{/if}
+account.1.codec.g726_40.enable = {if isset($yealink_codec_g726_40_enable)}1{else}0{/if}
 
-account.1.codec.11.payload_type = G726-40
-account.1.codec.11.priority = {if isset($yealink_codec_g726_40_priority)}{$yealink_codec_g726_40_priority}{else}0{/if}
+account.1.codec.g726_40.payload_type = G726-40
+account.1.codec.g726_40.priority = {if isset($yealink_codec_g726_40_priority)}{$yealink_codec_g726_40_priority}{else}0{/if}
 
-account.1.codec.11.rtpmap = 105
+account.1.codec.g726_40.rtpmap = 105
 
-account.1.codec.12.enable = {if isset($yealink_codec_gsm_enable)}1{else}0{/if}
+account.1.codec.gsm.enable = {if isset($yealink_codec_gsm_enable)}1{else}0{/if}
 
-account.1.codec.12.payload_type = GSM
-account.1.codec.12.priority = {if isset($yealink_codec_gsm_priority)}{$yealink_codec_gsm_priority}{else}0{/if}
+account.1.codec.gsm.payload_type = GSM
+account.1.codec.gsm.priority = {if isset($yealink_codec_gsm_priority)}{$yealink_codec_gsm_priority}{else}0{/if}
 
-account.1.codec.12.rtpmap = 3
+account.1.codec.gsm.rtpmap = 3
 
-account.1.codec.13.enable = {if isset($yealink_codec_opus_enable)}1{else}0{/if}
+account.1.codec.opus.enable = {if isset($yealink_codec_opus_enable)}1{else}0{/if}
 
-account.1.codec.13.payload_type = opus
-account.1.codec.13.priority = {if isset($yealink_codec_opus_priority)}{$yealink_codec_opus_priority}{else}0{/if}
+account.1.codec.opus.payload_type = opus
+account.1.codec.opus.priority = {if isset($yealink_codec_opus_priority)}{$yealink_codec_opus_priority}{else}0{/if}
 
-account.1.codec.13.rtpmap = 106
+account.1.codec.opus.rtpmap = 106
 
 
 


### PR DESCRIPTION
This change is required to get OPUS working. It seem that Yealink may have changed their template structure a few years ago and the T46s was not updated. These changes are tested working with the latest T46s firmware which was released a while back.