### PR TITLE
Add support for XMLApp to grp2615 provisioning template

### DIFF
--- a/app/grandstream/app_config.php
+++ b/app/grandstream/app_config.php
@@ -1061,5 +1061,20 @@
 		$apps[$x]['default_settings'][$y]['default_setting_value'] = "1";
 		$apps[$x]['default_settings'][$y]['default_setting_enabled'] = "false";
 		$apps[$x]['default_settings'][$y]['default_setting_description'] = "Enable weather update. 0 - No, 1 - Yes. Default is 1";
-
+		$y++;
+		$apps[$x]['default_settings'][$y]['default_setting_uuid'] = "f2ad92e0-669c-4553-9c99-5386f93e75df";
+		$apps[$x]['default_settings'][$y]['default_setting_category'] = "provision";
+		$apps[$x]['default_settings'][$y]['default_setting_subcategory'] = "grandstreaml_xmlapp_url";
+		$apps[$x]['default_settings'][$y]['default_setting_name'] = "text";
+		$apps[$x]['default_settings'][$y]['default_setting_value'] = "";
+		$apps[$x]['default_settings'][$y]['default_setting_enabled'] = "false";
+		$apps[$x]['default_settings'][$y]['default_setting_description'] = "URL for the XML application. XML Application disabled if blank";
+		$y++;
+		$apps[$x]['default_settings'][$y]['default_setting_uuid'] = "dfd1e86a-d864-4947-89af-6ba51380e47c";
+		$apps[$x]['default_settings'][$y]['default_setting_category'] = "provision";
+		$apps[$x]['default_settings'][$y]['default_setting_subcategory'] = "grandstream_xmlapp_label";
+		$apps[$x]['default_settings'][$y]['default_setting_name'] = "text";
+		$apps[$x]['default_settings'][$y]['default_setting_value'] = "XMLApp";
+		$apps[$x]['default_settings'][$y]['default_setting_enabled'] = "false";
+		$apps[$x]['default_settings'][$y]['default_setting_description'] = "label to display for XML application softkey";
 ?>

--- a/resources/templates/provision/grandstream/grp2615/{$mac}.xml
+++ b/resources/templates/provision/grandstream/grp2615/{$mac}.xml
@@ -7591,11 +7591,11 @@
     <!-- ############################################################################## -->
     <!-- # Server Path -->
     <!-- # String -->
-    <P337></P337>
+    <P337>{$grandstreaml_xmlapp_url}</P337>
 
     <!-- # Softkey Label -->
     <!-- # String -->
-    <P352>XMLApp</P352>
+    <P352>{$grandstream_xmlapp_label}</P352>
 
     <!-- # Default Background Color -->
     <!-- # String -->


### PR DESCRIPTION
This adds two variables to the Grandstream GRP2615 provisioning template that we would like to set.