### PR TITLE
T46U: enable/disable codec settings for all accounts

### DIFF
--- a/core/install/resources/classes/install.php
+++ b/core/install/resources/classes/install.php
@@ -131,7 +131,7 @@ if (!class_exists('install')) {
 			$conf .= "xml_handler.number_as_presence_id = true\n";
 			$conf .= "\n";
 			$conf .= "#error reporting options: user,dev,all\n";
-			$conf .= "error.reporting = 'user'\n";
+			$conf .= "error.reporting = user\n";
 
 			//write the config file
 			$file_handle = fopen($config_file,"w");


### PR DESCRIPTION
The template for codec enable settings was taking a value as 1 if it was set in the settings. It was not taking the actual value inside it. So I have edited the templates to check the value if it's set to true.