### PR TITLE
remove unneeded destruct methods as GC has higher performance

### DIFF
--- a/app/access_controls/resources/classes/access_controls.php
+++ b/app/access_controls/resources/classes/access_controls.php
@@ -31,16 +31,6 @@ if (!class_exists('access_controls')) {
 		}
 
 		/**
-		 * called when there are no references to a particular object
-		 * unset the variables used in the class
-		 */
-		public function __destruct() {
-			foreach ($this as $key => $value) {
-				unset($this->$key);
-			}
-		}
-
-		/**
 		 * delete records
 		 */
 		public function delete($records) {

--- a/app/basic_operator_panel/resources/classes/basic_operator_panel.php
+++ b/app/basic_operator_panel/resources/classes/basic_operator_panel.php
@@ -45,16 +45,6 @@ if (!class_exists('basic_operator_panel')) {
 		}
 
 		/**
-		 * Called when there are no references to a particular object
-		 * unset the variables used in the class
-		 */
-		public function __destruct() {
-			foreach ($this as $key => $value) {
-				unset($this->$key);
-			}
-		}
-
-		/**
 		 * Get the call activity
 		 */
 		public function call_activity() {

--- a/app/bridges/resources/classes/bridges.php
+++ b/app/bridges/resources/classes/bridges.php
@@ -58,16 +58,6 @@ if (!class_exists('bridges')) {
 		}
 
 		/**
-		 * called when there are no references to a particular object
-		 * unset the variables used in the class
-		 */
-		public function __destruct() {
-			foreach ($this as $key => $value) {
-				unset($this->$key);
-			}
-		}
-
-		/**
 		 * delete records
 		 */
 		public function delete($records) {

--- a/app/call_block/resources/classes/call_block.php
+++ b/app/call_block/resources/classes/call_block.php
@@ -46,16 +46,6 @@ if (!class_exists('call_block')) {
 		}
 
 		/**
-		 * called when there are no references to a particular object
-		 * unset the variables used in the class
-		 */
-		public function __destruct() {
-			foreach ($this as $key => $value) {
-				unset($this->$key);
-			}
-		}
-
-		/**
 		 * delete records
 		 */
 		public function delete($records) {

--- a/app/call_broadcast/resources/classes/call_broadcast.php
+++ b/app/call_broadcast/resources/classes/call_broadcast.php
@@ -34,16 +34,6 @@ if (!class_exists('call_broadcast')) {
 		}
 
 		/**
-		 * called when there are no references to a particular object
-		 * unset the variables used in the class
-		 */
-		public function __destruct() {
-			foreach ($this as $key => $value) {
-				unset($this->$key);
-			}
-		}
-
-		/**
 		 * delete records
 		 */
 		public function delete($records) {

--- a/app/call_centers/resources/classes/call_center.php
+++ b/app/call_centers/resources/classes/call_center.php
@@ -63,16 +63,6 @@
 			}
 
 			/**
-			 * Called when there are no references to a particular object
-			 * unset the variables used in the class
-			 */
-			public function __destruct() {
-				foreach ($this as $key => $value) {
-					unset($this->$key);
-				}
-			}
-
-			/**
 			 * Add a dialplan for call center
 			 * @var string $domain_uuid		the multi-tenant id
 			 * @var string $value	string to be cached

--- a/app/call_flows/resources/classes/call_flows.php
+++ b/app/call_flows/resources/classes/call_flows.php
@@ -61,16 +61,6 @@ if (!class_exists('call_flows')) {
 		}
 
 		/**
-		 * called when there are no references to a particular object
-		 * unset the variables used in the class
-		 */
-		public function __destruct() {
-			foreach ($this as $key => $value) {
-				unset($this->$key);
-			}
-		}
-
-		/**
 		 * delete records
 		 */
 		public function delete($records) {

--- a/app/call_recordings/resources/classes/call_recordings.php
+++ b/app/call_recordings/resources/classes/call_recordings.php
@@ -34,16 +34,6 @@ if (!class_exists('call_recordings')) {
 		}
 
 		/**
-		 * called when there are no references to a particular object
-		 * unset the variables used in the class
-		 */
-		public function __destruct() {
-			foreach ($this as $key => $value) {
-				unset($this->$key);
-			}
-		}
-
-		/**
 		 * delete rows from the database
 		 */
 		public function delete($records) {

--- a/app/conference_centers/resources/classes/conference_centers.php
+++ b/app/conference_centers/resources/classes/conference_centers.php
@@ -69,16 +69,6 @@ if (!class_exists('conference_centers')) {
 		}
 
 		/**
-		 * Called when there are no references to a particular object
-		 * unset the variables used in the class
-		 */
-		public function __destruct() {
-			foreach ($this as $key => $value) {
-				unset($this->$key);
-			}
-		}
-
-		/**
 		 * count the conference rooms
 		 */
 		public function room_count() {

--- a/app/conference_controls/resources/classes/conference_controls.php
+++ b/app/conference_controls/resources/classes/conference_controls.php
@@ -61,16 +61,6 @@ if (!class_exists('conference_controls')) {
 		}
 
 		/**
-		 * called when there are no references to a particular object
-		 * unset the variables used in the class
-		 */
-		public function __destruct() {
-			foreach ($this as $key => $value) {
-				unset($this->$key);
-			}
-		}
-
-		/**
 		 * delete rows from the database
 		 */
 		public function delete($records) {

--- a/app/conference_profiles/resources/classes/conference_profiles.php
+++ b/app/conference_profiles/resources/classes/conference_profiles.php
@@ -61,16 +61,6 @@ if (!class_exists('conference_profiles')) {
 		}
 
 		/**
-		 * called when there are no references to a particular object
-		 * unset the variables used in the class
-		 */
-		public function __destruct() {
-			foreach ($this as $key => $value) {
-				unset($this->$key);
-			}
-		}
-
-		/**
 		 * delete rows from the database
 		 */
 		public function delete($records) {

--- a/app/conferences/resources/classes/conferences.php
+++ b/app/conferences/resources/classes/conferences.php
@@ -56,17 +56,6 @@ if (!class_exists('conferences')) {
 				$this->toggle_values = ['true','false'];
 
 		}
-
-		/**
-		 * called when there are no references to a particular object
-		 * unset the variables used in the class
-		 */
-		public function __destruct() {
-			foreach ($this as $key => $value) {
-				unset($this->$key);
-			}
-		}
-
 		/**
 		 * delete records
 		 */

--- a/app/contacts/resources/classes/contacts.php
+++ b/app/contacts/resources/classes/contacts.php
@@ -70,16 +70,6 @@ if (!class_exists('contacts')) {
 		}
 
 		/**
-		 * called when there are no references to a particular object
-		 * unset the variables used in the class
-		 */
-		public function __destruct() {
-			foreach ($this as $key => $value) {
-				unset($this->$key);
-			}
-		}
-
-		/**
 		 * delete records
 		 */
 		public function delete($records) {

--- a/app/destinations/resources/classes/destinations.php
+++ b/app/destinations/resources/classes/destinations.php
@@ -69,16 +69,6 @@ if (!class_exists('destinations')) {
 		}
 
 		/**
-		* Called when there are no references to a particular object
-		* unset the variables used in the class
-		*/
-		public function __destruct() {
-			foreach ($this as $key => $value) {
-				unset($this->$key);
-			}
-		}
-
-		/**
 		* Convert destination number to a regular expression
 		* @var string $array destination_prefix, destination_trunk_prefix, destination_area_code, destination_number
 		*/

--- a/app/devices/resources/classes/device.php
+++ b/app/devices/resources/classes/device.php
@@ -53,12 +53,6 @@
 
 		}
 
-		public function __destruct() {
-			foreach ($this as $key => $value) {
-				unset($this->$key);
-			}
-		}
-
 		public function get_domain_uuid() {
 			return $this->domain_uuid;
 		}

--- a/app/email_logs/resources/classes/email_logs.php
+++ b/app/email_logs/resources/classes/email_logs.php
@@ -54,16 +54,6 @@ if (!class_exists('email_logs')) {
 		}
 
 		/**
-		 * called when there are no references to a particular object
-		 * unset the variables used in the class
-		 */
-		public function __destruct() {
-			foreach ($this as $key => $value) {
-				unset($this->$key);
-			}
-		}
-
-		/**
 		 * delete records
 		 */
 		public function delete($records) {

--- a/app/email_queue/resources/classes/email_queue.php
+++ b/app/email_queue/resources/classes/email_queue.php
@@ -36,16 +36,6 @@ if (!class_exists('email_queue')) {
 		}
 
 		/**
-		 * called when there are no references to a particular object
-		 * unset the variables used in the class
-		 */
-		public function __destruct() {
-			foreach ($this as $key => $value) {
-				unset($this->$key);
-			}
-		}
-
-		/**
 		 * delete rows from the database
 		 */
 		public function delete($records) {

--- a/app/email_templates/resources/classes/email_templates.php
+++ b/app/email_templates/resources/classes/email_templates.php
@@ -58,16 +58,6 @@ if (!class_exists('email_templates')) {
 		}
 
 		/**
-		 * called when there are no references to a particular object
-		 * unset the variables used in the class
-		 */
-		public function __destruct() {
-			foreach ($this as $key => $value) {
-				unset($this->$key);
-			}
-		}
-
-		/**
 		 * delete records
 		 */
 		public function delete($records) {

--- a/app/event_guard/resources/classes/event_guard.php
+++ b/app/event_guard/resources/classes/event_guard.php
@@ -60,16 +60,6 @@ if (!class_exists('event_guard')) {
 		}
 
 		/**
-		 * called when there are no references to a particular object
-		 * unset the variables used in the class
-		 */
-		public function __destruct() {
-			foreach ($this as $key => $value) {
-				unset($this->$key);
-			}
-		}
-
-		/**
 		 * delete rows from the database
 		 */
 		public function delete($records) {

--- a/app/extension_settings/resources/classes/extension_settings.php
+++ b/app/extension_settings/resources/classes/extension_settings.php
@@ -62,16 +62,6 @@ if (!class_exists('extension_settings')) {
 		}
 
 		/**
-		 * called when there are no references to a particular object
-		 * unset the variables used in the class
-		 */
-		public function __destruct() {
-			foreach ($this as $key => $value) {
-				unset($this->$key);
-			}
-		}
-
-		/**
 		 * delete rows from the database
 		 */
 		public function delete($records) {

--- a/app/extensions/resources/classes/extension.php
+++ b/app/extensions/resources/classes/extension.php
@@ -103,16 +103,6 @@ if (!class_exists('extension')) {
 
 		}
 
-		/**
-		 * called when there are no references to a particular object
-		 * unset the variables used in the class
-		 */
-		public function __destruct() {
-			foreach ($this as $key => $value) {
-				unset($this->$key);
-			}
-		}
-
 		public function exists($domain_uuid, $extension) {
 			$sql = "select count(*) from v_extensions ";
 			$sql .= "where domain_uuid = :domain_uuid ";

--- a/app/fax/resources/classes/fax.php
+++ b/app/fax/resources/classes/fax.php
@@ -66,16 +66,6 @@ if (!class_exists('fax')) {
 		}
 
 		/**
-		* Called when there are no references to a particular object
-		* unset the variables used in the class
-		*/
-		public function __destruct() {
-			foreach ($this as $key => $value) {
-				unset($this->$key);
-			}
-		}
-
-		/**
 		* Add a dialplan for call center
 		* @var string $domain_uuid		the multi-tenant id
 		* @var string $value	string to be cached

--- a/app/fax_queue/resources/classes/fax_queue.php
+++ b/app/fax_queue/resources/classes/fax_queue.php
@@ -60,16 +60,6 @@ if (!class_exists('fax_queue')) {
 		}
 
 		/**
-		 * called when there are no references to a particular object
-		 * unset the variables used in the class
-		 */
-		public function __destruct() {
-			foreach ($this as $key => $value) {
-				unset($this->$key);
-			}
-		}
-
-		/**
 		 * delete rows from the database
 		 */
 		public function delete($records) {

--- a/app/gateways/resources/classes/gateways.php
+++ b/app/gateways/resources/classes/gateways.php
@@ -58,16 +58,6 @@ if (!class_exists('gateways')) {
 		}
 
 		/**
-		 * called when there are no references to a particular object
-		 * unset the variables used in the class
-		 */
-		public function __destruct() {
-			foreach ($this as $key => $value) {
-				unset($this->$key);
-			}
-		}
-
-		/**
 		 * start gateways
 		 */
 		public function start($records) {

--- a/app/ivr_menus/resources/classes/ivr_menu.php
+++ b/app/ivr_menus/resources/classes/ivr_menu.php
@@ -58,16 +58,6 @@ if (!class_exists('ivr_menu')) {
 
 		}
 
-		/**
-		 * called when there are no references to a particular object
-		 * unset the variables used in the class
-		 */
-		public function __destruct() {
-			foreach ($this as $key => $value) {
-				unset($this->$key);
-			}
-		}
-
 		public function find() {
 			$sql = "select * from v_ivr_menus ";
 			$sql .= "where domain_uuid = :domain_uuid ";

--- a/app/modules/resources/classes/modules.php
+++ b/app/modules/resources/classes/modules.php
@@ -65,16 +65,6 @@ if (!class_exists('modules')) {
 
 		}
 
-		/**
-		 * called when there are no references to a particular object
-		 * unset the variables used in the class
-		 */
-		public function __destruct() {
-			foreach ($this as $key => $value) {
-				unset($this->$key);
-			}
-		}
-
 		//get the additional information about a specific module
 			public function info($name) {
 				$module_label = substr($name, 4);

--- a/app/music_on_hold/resources/classes/switch_music_on_hold.php
+++ b/app/music_on_hold/resources/classes/switch_music_on_hold.php
@@ -56,16 +56,6 @@ if (!class_exists('switch_music_on_hold')) {
 
 		}
 
-		/**
-		 * called when there are no references to a particular object
-		 * unset the variables used in the class
-		 */
-		public function __destruct() {
-			foreach ($this as $key => $value) {
-				unset($this->$key);
-			}
-		}
-
 		public function select($name, $selected, $options) {
 			//add multi-lingual support
 				$language = new text;

--- a/app/number_translations/resources/classes/number_translations.php
+++ b/app/number_translations/resources/classes/number_translations.php
@@ -63,16 +63,6 @@ if (!class_exists('number_translations')) {
 		}
 
 		/**
-		 * called when there are no references to a particular object
-		 * unset the variables used in the class
-		 */
-		public function __destruct() {
-			foreach ($this as $key => $value) {
-				unset($this->$key);
-			}
-		}
-
-		/**
 		 * Check to see if the number translation already exists
 		 */
 		public function number_translation_exists($name) {

--- a/app/phrases/resources/classes/phrases.php
+++ b/app/phrases/resources/classes/phrases.php
@@ -63,16 +63,6 @@ if (!class_exists('phrases')) {
 		}
 
 		/**
-		 * called when there are no references to a particular object
-		 * unset the variables used in the class
-		 */
-		public function __destruct() {
-			foreach ($this as $key => $value) {
-				unset($this->$key);
-			}
-		}
-
-		/**
 		 * delete records
 		 */
 		public function delete($records) {

--- a/app/pin_numbers/resources/classes/pin_numbers.php
+++ b/app/pin_numbers/resources/classes/pin_numbers.php
@@ -58,16 +58,6 @@ if (!class_exists('pin_numbers')) {
 		}
 
 		/**
-		 * called when there are no references to a particular object
-		 * unset the variables used in the class
-		 */
-		public function __destruct() {
-			foreach ($this as $key => $value) {
-				unset($this->$key);
-			}
-		}
-
-		/**
 		 * delete records
 		 */
 		public function delete($records) {

--- a/app/provision/resources/classes/provision.php
+++ b/app/provision/resources/classes/provision.php
@@ -88,12 +88,6 @@
 				}
 		}
 
-		public function __destruct() {
-			foreach ($this as $key => $value) {
-				unset($this->$key);
-			}
-		}
-
 		public function get_domain_uuid() {
 			return $this->domain_uuid;
 		}

--- a/app/recordings/resources/classes/switch_recordings.php
+++ b/app/recordings/resources/classes/switch_recordings.php
@@ -63,16 +63,6 @@ if (!class_exists('switch_recordings')) {
 		}
 
 		/**
-		 * called when there are no references to a particular object
-		 * unset the variables used in the class
-		 */
-		public function __destruct() {
-			foreach ($this as $key => $value) {
-				unset($this->$key);
-			}
-		}
-
-		/**
 		 * list recordings
 		 */
 		public function list_recordings() {

--- a/app/registrations/resources/classes/registrations.php
+++ b/app/registrations/resources/classes/registrations.php
@@ -52,16 +52,6 @@ if (!class_exists('registrations')) {
 		}
 
 		/**
-		 * called when there are no references to a particular object
-		 * unset the variables used in the class
-		 */
-		public function __destruct() {
-			foreach ($this as $key => $value) {
-				unset($this->$key);
-			}
-		}
-
-		/**
 		 * get the registrations
 		 */
 		public function get($profile = 'all') {

--- a/app/ring_groups/resources/classes/ring_groups.php
+++ b/app/ring_groups/resources/classes/ring_groups.php
@@ -63,16 +63,6 @@ if (!class_exists('ring_groups')) {
 		}
 
 		/**
-		 * called when there are no references to a particular object
-		 * unset the variables used in the class
-		 */
-		public function __destruct() {
-			foreach ($this as $key => $value) {
-				unset($this->$key);
-			}
-		}
-
-		/**
 		 * delete records
 		 */
 		public function delete($records) {

--- a/app/scripts/resources/classes/scripts.php
+++ b/app/scripts/resources/classes/scripts.php
@@ -68,16 +68,6 @@ if (!class_exists('scripts')) {
 		}
 
 		/**
-		 * Called when there are no references to a particular object
-		 * unset the variables used in the class
-		 */
-		public function __destruct() {
-			foreach ($this as $key => $value) {
-				unset($this->$key);
-			}
-		}
-
-		/**
 		 * Corrects the path for specifically for windows
 		 */
 		private function correct_path($path) {

--- a/app/sip_profiles/resources/classes/sip_profiles.php
+++ b/app/sip_profiles/resources/classes/sip_profiles.php
@@ -63,16 +63,6 @@ if (!class_exists('sip_profiles')) {
 		}
 
 		/**
-		 * called when there are no references to a particular object
-		 * unset the variables used in the class
-		 */
-		public function __destruct() {
-			foreach ($this as $key => $value) {
-				unset($this->$key);
-			}
-		}
-
-		/**
 		 * delete records
 		 */
 		public function delete($records) {

--- a/app/sofia_global_settings/resources/classes/sofia_global_settings.php
+++ b/app/sofia_global_settings/resources/classes/sofia_global_settings.php
@@ -62,16 +62,6 @@ if (!class_exists('sofia_global_settings')) {
 		}
 
 		/**
-		 * called when there are no references to a particular object
-		 * unset the variables used in the class
-		 */
-		public function __destruct() {
-			foreach ($this as $key => $value) {
-				unset($this->$key);
-			}
-		}
-
-		/**
 		 * delete rows from the database
 		 */
 		public function delete($records) {

--- a/app/streams/resources/classes/streams.php
+++ b/app/streams/resources/classes/streams.php
@@ -58,16 +58,6 @@ if (!class_exists('streams')) {
 		}
 
 		/**
-		 * called when there are no references to a particular object
-		 * unset the variables used in the class
-		 */
-		public function __destruct() {
-			foreach ($this as $key => $value) {
-				unset($this->$key);
-			}
-		}
-
-		/**
 		 * delete records
 		 */
 		public function delete($records) {

--- a/app/vars/resources/classes/vars.php
+++ b/app/vars/resources/classes/vars.php
@@ -58,16 +58,6 @@ if (!class_exists('vars')) {
 		}
 
 		/**
-		 * called when there are no references to a particular object
-		 * unset the variables used in the class
-		 */
-		public function __destruct() {
-			foreach ($this as $key => $value) {
-				unset($this->$key);
-			}
-		}
-
-		/**
 		 * delete records
 		 */
 		public function delete($records) {

--- a/app/voicemail_greetings/resources/classes/voicemail_greetings.php
+++ b/app/voicemail_greetings/resources/classes/voicemail_greetings.php
@@ -64,16 +64,6 @@ if (!class_exists('voicemail_greetings')) {
 		}
 
 		/**
-		 * called when there are no references to a particular object
-		 * unset the variables used in the class
-		 */
-		public function __destruct() {
-			foreach ($this as $key => $value) {
-				unset($this->$key);
-			}
-		}
-
-		/**
 		 * delete records
 		 */
 		public function delete($records) {

--- a/app/voicemails/resources/classes/voicemail.php
+++ b/app/voicemails/resources/classes/voicemail.php
@@ -70,12 +70,6 @@
 
 		}
 
-		public function __destruct() {
-			foreach ($this as $key => $value) {
-				unset($this->$key);
-			}
-		}
-		
 		public function get_voicemail_id() {
 
 			//check if for valid input

--- a/app/xml_cdr/resources/classes/xml_cdr.php
+++ b/app/xml_cdr/resources/classes/xml_cdr.php
@@ -81,16 +81,6 @@ if (!class_exists('xml_cdr')) {
 		}
 
 		/**
-		 * Called when there are no references to a particular object
-		 * unset the variables used in the class
-		 */
-		public function __destruct() {
-			if (isset($this)) foreach ($this as $key => $value) {
-				unset($this->$key);
-			}
-		}
-
-		/**
 		 * cdr process logging
 		 */
 		public function log($message) {

--- a/core/authentication/resources/classes/authentication.php
+++ b/core/authentication/resources/classes/authentication.php
@@ -24,16 +24,6 @@ class authentication {
 	}
 
 	/**
-	 * Called when there are no references to a particular object
-	 * unset the variables used in the class
-	 */
-	public function __destruct() {
-		foreach ($this as $key => $value) {
-			unset($this->$key);
-		}
-	}
-
-	/**
 	 * validate uses authentication plugins to check if a user is authorized to login
 	 * @return array [plugin] => last plugin used to authenticate the user [authorized] => true or false
 	 */

--- a/core/dashboard/resources/classes/dashboard.php
+++ b/core/dashboard/resources/classes/dashboard.php
@@ -62,16 +62,6 @@ if (!class_exists('dashboard')) {
 		}
 
 		/**
-		 * called when there are no references to a particular object
-		 * unset the variables used in the class
-		 */
-		public function __destruct() {
-			foreach ($this as $key => $value) {
-				unset($this->$key);
-			}
-		}
-
-		/**
 		 * delete rows from the database
 		 */
 		public function delete($records) {

--- a/core/databases/resources/classes/databases.php
+++ b/core/databases/resources/classes/databases.php
@@ -54,16 +54,6 @@ if (!class_exists('databases')) {
 		}
 
 		/**
-		 * called when there are no references to a particular object
-		 * unset the variables used in the class
-		 */
-		public function __destruct() {
-			foreach ($this as $key => $value) {
-				unset($this->$key);
-			}
-		}
-
-		/**
 		 * delete records
 		 */
 		public function delete($records) {

--- a/core/default_settings/resources/classes/default_settings.php
+++ b/core/default_settings/resources/classes/default_settings.php
@@ -61,16 +61,6 @@ if (!class_exists('default_settings')) {
 		}
 
 		/**
-		 * called when there are no references to a particular object
-		 * unset the variables used in the class
-		 */
-		public function __destruct() {
-			foreach ($this as $key => $value) {
-				unset($this->$key);
-			}
-		}
-
-		/**
 		 * delete rows from the database
 		 */
 		public function delete($records) {

--- a/core/domain_settings/resources/classes/domain_settings.php
+++ b/core/domain_settings/resources/classes/domain_settings.php
@@ -64,16 +64,6 @@ if (!class_exists('domain_settings')) {
 		}
 
 		/**
-		 * called when there are no references to a particular object
-		 * unset the variables used in the class
-		 */
-		public function __destruct() {
-			foreach ($this as $key => $value) {
-				unset($this->$key);
-			}
-		}
-
-		/**
 		 * delete records
 		 */
 		public function delete($records) {

--- a/core/events/resources/classes/events.php
+++ b/core/events/resources/classes/events.php
@@ -55,16 +55,6 @@ class events {
 	}
 
 	/**
-	 * Called when there are no references to a particular object
-	 * unset the variables used in the class
-	 */
-	public function __destruct() {
-		foreach ($this as $key => $value) {
-			unset($this->$key);
-		}
-	}
-
-	/**
 	 * This function will load all available plugins into the memory
 	 * Rules:
 	 * 		plugins are stored in ./plugins

--- a/core/install/resources/classes/install.php
+++ b/core/install/resources/classes/install.php
@@ -25,16 +25,6 @@ if (!class_exists('install')) {
 		}
 
 		/**
-		 * called when there are no references to a particular object
-		 * unset the variables used in the class
-		 */
-		public function __destruct() {
-			foreach ($this as $key => $value) {
-				unset($this->$key);
-			}
-		}
-
-		/**
 		 * <p>Used to create the config.conf file.</p>
 		 * <p>BSD /usr/local/etc/fusionpbx</p>
 		 * <p>Linux /etc/fusionpbx</p>

--- a/core/user_logs/resources/classes/user_logs.php
+++ b/core/user_logs/resources/classes/user_logs.php
@@ -60,16 +60,6 @@ if (!class_exists('user_logs')) {
 		}
 
 		/**
-		 * called when there are no references to a particular object
-		 * unset the variables used in the class
-		 */
-		public function __destruct() {
-			foreach ($this as $key => $value) {
-				unset($this->$key);
-			}
-		}
-
-		/**
 		 * add user_logs
 		 */
 		public static function add($result) {

--- a/core/user_settings/resources/classes/user_settings.php
+++ b/core/user_settings/resources/classes/user_settings.php
@@ -63,16 +63,6 @@ if (!class_exists('user_settings')) {
 		}
 
 		/**
-		 * called when there are no references to a particular object
-		 * unset the variables used in the class
-		 */
-		public function __destruct() {
-			foreach ($this as $key => $value) {
-				unset($this->$key);
-			}
-		}
-
-		/**
 		 * delete records
 		 */
 		public function delete($records) {

--- a/core/users/resources/classes/users.php
+++ b/core/users/resources/classes/users.php
@@ -60,16 +60,6 @@ if (!class_exists('users')) {
 		}
 
 		/**
-		 * called when there are no references to a particular object
-		 * unset the variables used in the class
-		 */
-		public function __destruct() {
-			foreach ($this as $key => $value) {
-				unset($this->$key);
-			}
-		}
-
-		/**
 		 * delete rows from the database
 		 */
 		public function delete($records) {

--- a/resources/classes/cache.php
+++ b/resources/classes/cache.php
@@ -18,16 +18,6 @@ class cache {
 	}
 
 	/**
-	 * Called when there are no references to a particular object
-	 * unset the variables used in the class
-	 */
-	public function __destruct() {
-		foreach ($this as $key => $value) {
-			unset($this->$key);
-		}
-	}
-
-	/**
 	 * Add a specific item in the cache
 	 * @var string $key		the cache id
 	 * @var string $value	string to be cached

--- a/resources/classes/captcha.php
+++ b/resources/classes/captcha.php
@@ -44,16 +44,6 @@ class captcha {
 	}
 
 	/**
-	 * Called when there are no references to a particular object
-	 * unset the variables used in the class
-	 */
-	public function __destruct() {
-		foreach ($this as $key => $value) {
-			unset($this->$key);
-		}
-	}
-
-	/**
 	 * Create the captcha image
 	 * @var string $code
 	 */

--- a/resources/classes/config.php
+++ b/resources/classes/config.php
@@ -31,16 +31,6 @@ class config {
 	}
 
 	/**
-	 * Called when there are no references to a particular object
-	 * unset the variables used in the class
-	 */
-	public function __destruct() {
-		foreach ($this as $key => $value) {
-			unset($this->$key);
-		}
-	}
-
-	/**
 	 * Determine whether the config.php exists
 	 * @var string $db_type - type of database
 	 * @var string $db_name - name of the database

--- a/resources/classes/database.php
+++ b/resources/classes/database.php
@@ -384,16 +384,6 @@
 			}
 
 			/**
-			 * Called when there are no references to a particular object
-			 * unset the variables used in the class
-			 */
-			public function __destruct() {
-				foreach ($this as $key => $value) {
-					unset($this->$key);
-				}
-			}
-
-			/**
 			 * <p>Connect to the database.</p>
 			 * <p>Database driver must be set before calling connect.</p>
 			 * <p>For types other than sqlite. Execution will stop on failure.</p>

--- a/resources/classes/domains.php
+++ b/resources/classes/domains.php
@@ -62,16 +62,6 @@ if (!class_exists('domains')) {
 		}
 
 		/**
-		 * called when there are no references to a particular object
-		 * unset the variables used in the class
-		 */
-		public function __destruct() {
-			foreach ($this as $key => $value) {
-				unset($this->$key);
-			}
-		}
-
-		/**
 		 * delete rows from the database
 		 */
 		public function delete($records) {

--- a/resources/classes/email.php
+++ b/resources/classes/email.php
@@ -67,16 +67,6 @@ if (!class_exists('email')) {
 		}
 
 		/**
-		 * called when there are no references to a particular object
-		 * unset the variables used in the class
-		 */
-		public function __destruct() {
-			foreach ($this as $key => $value) {
-				unset($this->$key);
-			}
-		}
-
-		/**
 		 * parse raw emails
 		 */
 		public function parse($message) {

--- a/resources/classes/file.php
+++ b/resources/classes/file.php
@@ -21,16 +21,6 @@ class file {
 	}
 
 	/**
-	 * Called when there are no references to a particular object
-	 * unset the variables used in the class
-	 */
-	public function __destruct() {
-		foreach ($this as $key => $value) {
-			unset($this->$key);
-		}
-	}
-
-	/**
 	 * Glob search for a list of files
 	 * @var string $dir			this is the directory to scan
 	 * @var boolean $recursive	get the sub directories

--- a/resources/classes/groups.php
+++ b/resources/classes/groups.php
@@ -56,16 +56,6 @@ if (!class_exists('groups')) {
 		}
 
 		/**
-		 * called when there are no references to a particular object
-		 * unset the variables used in the class
-		 */
-		public function __destruct() {
-			foreach ($this as $key => $value) {
-				unset($this->$key);
-			}
-		}
-
-		/**
 		 * delete rows from the database
 		 */
 		public function delete($records) {

--- a/resources/classes/menu.php
+++ b/resources/classes/menu.php
@@ -60,16 +60,6 @@ if (!class_exists('menu')) {
 		}
 
 		/**
-		 * called when there are no references to a particular object
-		 * unset the variables used in the class
-		 */
-		public function __destruct() {
-			foreach ($this as $key => $value) {
-				unset($this->$key);
-			}
-		}
-
-		/**
 		 * delete rows from the database
 		 */
 		public function delete($records) {

--- a/resources/classes/sounds.php
+++ b/resources/classes/sounds.php
@@ -20,16 +20,6 @@ class sounds {
 	}
 
 	/**
-	 * Called when there are no references to a particular object
-	 * unset the variables used in the class
-	 */
-	public function __destruct() {
-		foreach ($this as $key => $value) {
-			unset($this->$key);
-		}
-	}
-
-	/**
 	 * Add a specific item in the cache
 	 * @var array $array
 	 * @var string $value	string to be cached

--- a/resources/classes/switch_settings.php
+++ b/resources/classes/switch_settings.php
@@ -20,16 +20,6 @@ if (!class_exists('switch_settings')) {
 		}
 
 		/**
-		 * Called when there are no references to a particular object
-		 * unset the variables used in the class
-		 */
-		public function __destruct() {
-			foreach ($this as $key => $value) {
-				unset($this->$key);
-			}
-		}
-
-		/**
 		 * settings Set switch directories in default settings
 		 */
 		public function settings() {

--- a/resources/classes/template.php
+++ b/resources/classes/template.php
@@ -65,12 +65,6 @@
 				}
 			}
 
-			public function __destruct() {
-				foreach ($this as $key => $value) {
-					unset($this->$key);
-				}
-			}
-
 			public function assign($key, $value) {
 				if ($this->engine === 'smarty') {
 					$this->object->assign($key, $value);

--- a/resources/classes/text.php
+++ b/resources/classes/text.php
@@ -51,16 +51,6 @@ class text {
 	}
 
 	/**
-	 * Called when there are no references to a particular object
-	 * unset the variables used in the class
-	 */
-	public function __destruct() {
-		if (is_array($this)) foreach ($this as $key => $value) {
-			unset($this->$key);
-		}
-	}
-
-	/**
 	 * Get a specific item from the cache
 	 * @var string $language_code	examples: en-us, es-cl, fr-fr, pt-pt
 	 * @var string $app_path		examples: app/exec or core/domains

--- a/resources/classes/token.php
+++ b/resources/classes/token.php
@@ -44,16 +44,6 @@ class token {
 	}
 
 	/**
-	 * Called when there are no references to a particular object
-	 * unset the variables used in the class
-	 */
-	public function __destruct() {
-		foreach ($this as $key => $value) {
-			unset($this->$key);
-		}
-	}
-
-	/**
 	 * Create the token
 	 * @var string $key
 	 */

--- a/resources/classes/vcard.php
+++ b/resources/classes/vcard.php
@@ -62,16 +62,6 @@ class vcard {
 		return true;
 	}
 
-	/**
-	 * Called when there are no references to a particular object
-	 * unset the variables used in the class
-	 */
-	public function __destruct() {
-		foreach ($this as $key => $value) {
-			unset($this->$key);
-		}
-	}
-
 	/*
 	build() method checks all the values, builds appropriate defaults for
 	missing values, generates the vcard data string.


### PR DESCRIPTION
destruct methods are not needed as the garbage collector will destroy and unset the object but will do it at a much faster performance as it is highly optimized for it. Any destruct methods needed for closing handles or other tasks are left in place.