### PR TITLE
Honor the settings for password complexity when copying extensions

### DIFF
--- a/app/extensions/extension_copy.php
+++ b/app/extensions/extension_copy.php
@@ -112,7 +112,7 @@
 	$array['extensions'][0]['extension_uuid'] = uuid();
 	$array['extensions'][0]['extension'] = $extension_new;
 	$array['extensions'][0]['number_alias'] = $number_alias_new;
-	$array['extensions'][0]['password'] = generate_password();
+	$array['extensions'][0]['password'] = generate_password($_SESSION["extension"]["password_length"]["numeric"], $_SESSION["extension"]["password_strength"]["numeric"]);
 	$array['extensions'][0]['accountcode'] = $password;
 	$array['extensions'][0]['effective_caller_id_name'] = $effective_caller_id_name;
 	$array['extensions'][0]['effective_caller_id_number'] = $effective_caller_id_number;


### PR DESCRIPTION
When you copy an extension, it just uses the default algorithm for generate_password(). This includes the session variables for complexity and length to keep the extensions consistent.