### PR TITLE
[device] Add emergency caller ID to device

### DIFF
--- a/app/devices/app_config.php
+++ b/app/devices/app_config.php
@@ -227,6 +227,10 @@
 		$apps[$x]['permissions'][$y]['name'] = "device_serial_number";
 		$apps[$x]['permissions'][$y]['groups'][] = "superadmin";
 		$y++;
+		$apps[$x]['permissions'][$y]['name'] = "device_emergency_cid";
+		$apps[$x]['permissions'][$y]['groups'][] = "superadmin";
+		$apps[$x]['permissions'][$y]['groups'][] = "admin";
+		$y++;
 		$apps[$x]['permissions'][$y]['name'] = "device_model";
 		//$apps[$x]['permissions'][$y]['groups'][] = "superadmin";
 		$y++;
@@ -468,6 +472,10 @@
 		$apps[$x]['db'][$y]['fields'][$z]['name'] = "device_serial_number";
 		$apps[$x]['db'][$y]['fields'][$z]['type'] = "text";
 		$apps[$x]['db'][$y]['fields'][$z]['search'] = 'true';
+		$apps[$x]['db'][$y]['fields'][$z]['description']['en-us'] = "";
+		$z++;
+		$apps[$x]['db'][$y]['fields'][$z]['name'] = "device_emergency_cid";
+		$apps[$x]['db'][$y]['fields'][$z]['type'] = "text";
 		$apps[$x]['db'][$y]['fields'][$z]['description']['en-us'] = "";
 		$z++;
 		$apps[$x]['db'][$y]['fields'][$z]['name']['text'] = "device_model";

--- a/app/devices/app_languages.php
+++ b/app/devices/app_languages.php
@@ -3224,6 +3224,10 @@ $text['label-device_serial_number']['zh-cn'] = "序列号";
 $text['label-device_serial_number']['ja-jp'] = "シリアル番号";
 $text['label-device_serial_number']['ko-kr'] = "시리얼 번호";
 
+$text['label-device_emergency_cid']['en-us'] = 'Emergency Caller ID';
+
+$text['description-device_emergency_cid']['en-us'] = 'The Emergency Caller ID to send when calling from a hotdesk device';
+
 $text['label-device_key_vendor']['en-us'] = "Vendor";
 $text['label-device_key_vendor']['en-gb'] = "Vendor";
 $text['label-device_key_vendor']['ar-eg'] = "البائع";

--- a/app/devices/device_edit.php
+++ b/app/devices/device_edit.php
@@ -120,6 +120,7 @@
 			$device_vendor = $_POST["device_vendor"];
 			$device_location = $_POST["device_location"];
 			$device_serial_number = $_POST["device_serial_number"];
+			$device_emergency_cid = $_POST["device_emergency_cid"];
 			$device_uuid_alternate = $_POST["device_uuid_alternate"] ?? null;
 			$device_model = $_POST["device_model"] ?? null;
 			$device_firmware_version = $_POST["device_firmware_version"] ?? null;
@@ -267,6 +268,9 @@
 					}
 					if (permission_exists('device_serial_number')) {
 						$array['devices'][0]['device_serial_number'] = $device_serial_number;
+					}
+					if (permission_exists('device_emergency_cid')) {
+						$array['devices'][0]['device_emergency_cid'] = $device_emergency_cid;
 					}
 					if (permission_exists('device_alternate')) {
 						$array['devices'][0]['device_uuid_alternate'] = is_uuid($device_uuid_alternate) ? $device_uuid_alternate : null;
@@ -519,6 +523,7 @@
 			$device_vendor = $row["device_vendor"];
 			$device_location = $row["device_location"];
 			$device_serial_number = $row["device_serial_number"];
+			$device_emergency_cid = $row["device_emergency_cid"];
 			$device_uuid_alternate = $row["device_uuid_alternate"];
 			$device_model = $row["device_model"];
 			$device_firmware_version = $row["device_firmware_version"];
@@ -1942,6 +1947,19 @@
 		echo "	<input class='formfld' type='text' name='device_serial_number' maxlength='255' value=\"".escape($device_serial_number ?? '')."\"/>\n";
 		echo "<br />\n";
 		echo $text['description-device_serial_number']."\n";
+		echo "</td>\n";
+		echo "</tr>\n";
+	}
+		
+	if (permission_exists('device_emergency_cid')) {
+		echo "<tr>\n";
+		echo "<td class='vncell' valign='top' align='left' nowrap='nowrap'>\n";
+		echo "	".$text['label-device_emergency_cid']."\n";
+		echo "</td>\n";
+		echo "<td class='vtable' align='left'>\n";
+		echo "	<input class='formfld' type='text' name='device_emergency_cid' maxlength='255' value=\"".escape($device_emergency_cid)."\"/>\n";
+		echo "<br />\n";
+		echo $text['description-device_emergency_cid']."\n";
 		echo "</td>\n";
 		echo "</tr>\n";
 	}

--- a/app/dialplan_outbound/dialplan_outbound_add.php
+++ b/app/dialplan_outbound/dialplan_outbound_add.php
@@ -651,6 +651,18 @@
 								$array['dialplans'][$x]['dialplan_details'][$y]['dialplan_detail_order'] = $y * 10;
 								$array['dialplans'][$x]['dialplan_details'][$y]['dialplan_detail_group'] = '0';
 								$array['dialplans'][$x]['dialplan_details'][$y]['dialplan_detail_enabled'] = false;
+								
+								$y++;
+								$array['dialplans'][$x]['dialplan_details'][$y]['dialplan_detail_uuid'] = uuid();
+								$array['dialplans'][$x]['dialplan_details'][$y]['domain_uuid'] = $_SESSION['domain_uuid'];
+								$array['dialplans'][$x]['dialplan_details'][$y]['dialplan_uuid'] = $dialplan_uuid;
+								$array['dialplans'][$x]['dialplan_details'][$y]['dialplan_detail_tag'] = 'action';
+								$array['dialplans'][$x]['dialplan_details'][$y]['dialplan_detail_type'] = 'lua';
+								$array['dialplans'][$x]['dialplan_details'][$y]['dialplan_detail_data'] = "emergency_cid.lua'";
+								$array['dialplans'][$x]['dialplan_details'][$y]['dialplan_detail_order'] = $y * 10;
+								$array['dialplans'][$x]['dialplan_details'][$y]['dialplan_detail_group'] = '0';
+								$array['dialplans'][$x]['dialplan_details'][$y]['dialplan_detail_enabled'] = true;
+
 								$y++;
 								$array['dialplans'][$x]['dialplan_details'][$y]['dialplan_detail_uuid'] = uuid();
 								$array['dialplans'][$x]['dialplan_details'][$y]['domain_uuid'] = $_SESSION['domain_uuid'];

--- a/app/switch/resources/scripts/emergency_cid.lua
+++ b/app/switch/resources/scripts/emergency_cid.lua
@@ -1,0 +1,105 @@
+--	Part of FusionPBX
+--	Copyright (C) 2015-2023 Mark J Crane <markjcrane@fusionpbx.com>
+--	All rights reserved.
+--
+--	Redistribution and use in source and binary forms, with or without
+--	modification, are permitted provided that the following conditions are met:
+--
+--	1. Redistributions of source code must retain the above copyright notice,
+--	  this list of conditions and the following disclaimer.
+--
+--	2. Redistributions in binary form must reproduce the above copyright
+--	  notice, this list of conditions and the following disclaimer in the
+--	  documentation and/or other materials provided with the distribution.
+--
+--	THIS SOFTWARE IS PROVIDED ''AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+--	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+--	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+--	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+--	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+--	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+--	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+--	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+--	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+--	POSSIBILITY OF SUCH DAMAGE.
+
+-- Contributor: Joseph Nadiv <ynadiv@corpit.xyz>
+
+--set the debug options
+debug["sql"] = false;
+
+--define the explode function
+	require "resources.functions.explode";
+	require "resources.functions.trim";
+
+--set the defaults
+	max_tries = 3;
+	digit_timeout = 5000;
+	max_retries = 3;
+	tries = 0;
+
+--connect to the database
+	local Database = require "resources.functions.database";
+	dbh = Database.new('system');
+
+--include json library
+	local json
+	if (debug["sql"]) then
+		json = require "resources.functions.lunajson"
+	end
+
+--get the domain_uuid
+	domain_uuid = session:getVariable("domain_uuid");
+
+--get the user and domain name from the user argv user@domain
+	sip_from_uri = session:getVariable("sip_from_uri");
+	user_table = explode("@",sip_from_uri);
+	domain_table = explode(":",user_table[2]);
+	user = user_table[1];
+	domain = domain_table[1];
+
+--show the phone that we're looking up
+	if (sip_from_uri ~= nil) then
+		freeswitch.consoleLog("NOTICE", "[e911] sip_from_uri: ".. user .. "@" .. domain .. "\n");
+	end
+
+--get the device uuid for the phone that will have its configuration overridden
+	if (user ~= nil and domain ~= nil and domain_uuid ~= nil) then
+		local sql = [[SELECT device_uuid FROM v_device_lines ]];
+		sql = sql .. [[WHERE user_id = :user ]];
+		sql = sql .. [[AND server_address = :domain ]];
+		sql = sql .. [[AND domain_uuid = :domain_uuid ]];
+		local params = {user = user, domain = domain, domain_uuid = domain_uuid};
+		if (debug["sql"]) then
+			freeswitch.consoleLog("NOTICE", "[e911] SQL: ".. sql .. "; params: " .. json.encode(params) .. "\n");
+		end
+		dbh:query(sql, params, function(row)
+			--get device uuid
+			device_uuid = row.device_uuid;
+			freeswitch.consoleLog("NOTICE", "[e911] device_uuid: ".. device_uuid .. "\n");
+		end);
+	end
+
+-- If this device logged in as a hotdesk, get the real device id
+	if (device_uuid ~= nil and domain_uuid ~= nil) then
+		local sql = [[SELECT * FROM v_devices ]];
+		sql = sql .. [[WHERE device_uuid_alternate = :device_uuid ]];
+		sql = sql .. [[AND domain_uuid = :domain_uuid ]];
+		local params = {device_uuid = device_uuid, domain_uuid = domain_uuid};
+		if (debug["sql"]) then
+			freeswitch.consoleLog("NOTICE", "[e911] SQL: ".. sql .. "; params: " .. json.encode(params) .. "\n");
+		end
+		dbh:query(sql, params, function(row)
+			if (row.device_uuid_alternate ~= nil) then
+				device_mac_address = row.device_mac_address;
+                device_emergency_cid = row.device_emergency_cid;
+                freeswitch.consoleLog("NOTICE", 
+                    "[e911] device_mac_address: ".. device_mac_address .. ", device_emergency_cid " .. device_emergency_cid .. "\n");
+			end
+		end);
+	end
+
+-- If we got a device_emergency_cid then set it
+    if (device_emergency_cid ~= nil and string.len(device_emergency_cid) > 0) then
+        session:setVariable('effective_caller_id_number', device_emergency_cid);
+    end


### PR DESCRIPTION
In a hotdesking environment, it is essential
to keep track of devices to properly
route 911 calls to the proper PSAP.

We create a field to popluate an emergency
caller ID number that will be looked up when an alternate device is set for this station.