### PR TITLE
restore any missing default groups when permissions are restored

### DIFF
--- a/core/upgrade/upgrade.php
+++ b/core/upgrade/upgrade.php
@@ -222,6 +222,9 @@
 
 //restore the default permissions
 	if ($upgrade_type == 'permissions') {
+		//default the groups in case they are missing
+		(new groups())->defaults();
+
 		//default the permissions
 		$included = true;
 		require_once("core/groups/permissions_default.php");


### PR DESCRIPTION
allow default groups to be restored just before calling the permissions restore