### PR TITLE
Fix Call Broadcast file upload

### DIFF
--- a/app/call_broadcast/call_broadcast_edit.php
+++ b/app/call_broadcast/call_broadcast_edit.php
@@ -72,7 +72,7 @@
 					$separator = $getData[0];
 					$separator .= (isset($getData[1]) && $getData[1] != '')? '|'.$getData[1] : '';
 					$separator .= (isset($getData[2]) && $getData[2] != '')? ','.$getData[2] : '';
-					$separator .= '\n';
+					$separator .= PHP_EOL;
 					$upload_csv .= $separator;
 				}
 				 fclose($file);


### PR DESCRIPTION
Fixed file import. Previously would import with \n separator instead of \r\n (in PHP 7.1), which breaks dialing.