### PR TITLE
allow object with __toString method to be validated in is_uuid

### DIFF
--- a/resources/functions.php
+++ b/resources/functions.php
@@ -151,7 +151,7 @@
 
 	if (!function_exists('is_uuid')) {
 		function is_uuid($uuid) {
-			if (gettype($uuid) == 'string') {
+			if (is_string($uuid) || (is_object($uuid) && method_exists($uuid, '__toString'))) {
 				$regex = '/^[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}$/i';
 				return preg_match($regex, $uuid);
 			}


### PR DESCRIPTION
if the object passed to is_uuid has a __toString method that is a uuid it would previously not be detected as the gettype and is_string methods would always return false as an object is not a string.