### PR TITLE
Fix missing php tags

### DIFF
--- a/resources/classes/event/handler/syslog.php
+++ b/resources/classes/event/handler/syslog.php
@@ -1,4 +1,6 @@
-include_once('virtual.php');
+<?php
+
+	include_once('virtual.php');
 
 class Syslog extends Event_Handler{
 

--- a/resources/classes/event/handler/virtual.php
+++ b/resources/classes/event/handler/virtual.php
@@ -1,3 +1,5 @@
+<?php
+	
 abstract class Event_Handler{
 	// Force Extending class to define this method
 	abstract public function log_event($event_type, $params);


### PR DESCRIPTION
php tags are missing from the beginning of the file. These do not seem like they are used but thought it important to have the tags there anyway.