### PR TITLE
DB and protection

### DIFF
--- a/app/xml_cdr/xml_cdr_inc.php
+++ b/app/xml_cdr/xml_cdr_inc.php
@@ -591,8 +591,8 @@
 		}
 		else {
 			$sql .= " limit :limit offset :offset \n";
-			$parameters['limit'] = $rows_per_page;
-			$parameters['offset'] = $offset;
+			$parameters['limit'] = intval($rows_per_page);
+			$parameters['offset'] = intval($offset);
 		}
 	}
 	$sql = str_replace("  ", " ", $sql);


### PR DESCRIPTION
so this small change has 2 purposes.
first, I found the hard way, that PHP PDO is not always coded with the same criteria between versions and databases.  While PDO PGSQL on PHP 8.x may work, PDO SQLITE on PHP 7.4 may not and so on.. This will make sure that the value there is an integer.

Second, since these two values are taken from the _GET, which is in the URL string, it will protect against "imaginative" users.