### PR TITLE
Update xml_cdr_statistics_inc.php

### DIFF
--- a/app/xml_cdr/xml_cdr_statistics_inc.php
+++ b/app/xml_cdr/xml_cdr_statistics_inc.php
@@ -149,7 +149,9 @@
 	}
 	else {
 		$show_all = permission_exists('xml_cdr_all') && ($_GET['showall'] === 'true');
-		//$direction = 'inbound';
+		if (isset($_SESSION['cdr']['stats_default_direction']['text'])){
+			$direction = $_SESSION['cdr']['stats_default_direction']['text'];
+		}
 	}
 
 //if we do not see b-leg then use only a-leg to generate statistics


### PR DESCRIPTION
On some special use cases (especially when acting as class 4), the call_direction is not set. Using a default from a default setting is better than having a // = incoming value.