### PR TITLE
add template variables to override DTMF method on certain grandstream devices

### DIFF
--- a/resources/templates/provision/grandstream/gxw42xx/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxw42xx/{$mac}.xml
@@ -796,17 +796,29 @@
 <!-- Priority 1 -->
 <!-- Number: 100 to 102 -->
 <!-- Mandatory -->
+{if isset($grandstream_dtmf_method_1)}
+<P850>{$grandstream_dtmf_method_1}</P850>
+{else}
 <P850>100</P850>
+{endif}
 
 <!-- Preferred DTMF Method 2 -->
 <!-- Number: 100 to 102 -->
 <!-- Mandatory -->
+{if isset($grandstream_dtmf_method_2)}
+<P851>{$grandstream_dtmf_method_2}</P851>
+{else}
 <P851>101</P851>
+{endif}
 
 <!-- Preferred DTMF Method 3 -->
 <!-- Number: 100 to 102 -->
 <!-- Mandatory -->
+{if isset($grandstream_dtmf_method_3)}
+<P852>{$grandstream_dtmf_method_3}</P852>
+{else}
 <P852>102</P852>
+{endif}
 
 <!-- Disable DTMF Negotiation. 0 - no, 1 - yes -->
 <!-- Number: 0,1 -->

--- a/resources/templates/provision/grandstream/ht701/{$mac}.xml
+++ b/resources/templates/provision/grandstream/ht701/{$mac}.xml
@@ -478,17 +478,30 @@
 <!-- Priority 1 -->
 <!-- Number: 100, 101, 102 -->
 <!-- Mandatory -->
+{if isset($grandstream_dtmf_method_1) }
+<P850>{$grandstream_dtmf_method_1}</P850>
+{else}
 <P850>101</P850>
+{/if}
+
 
 <!-- Priority 2 -->
 <!-- Number: 100, 101, 102 -->
 <!-- Mandatory -->
+{if isset($grandstream_dtmf_method_2) }
+<P851>{$grandstream_dtmf_method_1}</P851>
+{else}
 <P851>102</P851>
+{/if}
 
 <!-- Priority 3 -->
 <!-- Number: 100, 101, 102 -->
 <!-- Mandatory -->
+{if isset($grandstream_dtmf_method_3) }
+<P852>{$grandstream_dtmf_method_1}</P852>
+{else}
 <P852>100</P852>
+{/if}
 
 <!-- Disable DTMF Negotiation. 0 - No, 1 - Yes -->
 <!-- Number: 0, 1 -->
@@ -1154,22 +1167,39 @@
 <!-- Priority 1 -->
 <!-- Number: 100, 101, 102 -->
 <!-- Mandatory -->
+{if isset($grandstream_dtmf_method_1) }
+<P860>{$grandstream_dtmf_method_1}</P860>
+{else}
 <P860>101</P860>
+{/if}
+
 
 <!-- Priority 2 -->
 <!-- Number: 100, 101, 102 -->
 <!-- Mandatory -->
+{if isset($grandstream_dtmf_method_2) }
+<P861>{$grandstream_dtmf_method_1}</P861>
+{else}
 <P861>102</P861>
+{/if}
 
 <!-- Priority 3 -->
 <!-- Number: 100, 101, 102 -->
 <!-- Mandatory -->
+{if isset($grandstream_dtmf_method_3) }
+<P862>{$grandstream_dtmf_method_1}</P862>
+{else}
 <P862>100</P862>
+{/if}
 
 <!-- Disable DTMF Negotiation. 0 - No, 1 - Yes -->
 <!-- Number: 0, 1 -->
 <!-- Mandatory -->
+{if isset($grandstream_disable_dtmf_negotiation) }
+<P4826>{$grandstream_disable_dtmf_negotiation}</P4826>
+{else}
 <P4826>0</P4826>
+{/if}
 
 <!-- Send Flash Event. 0 - No, 1 - Yes -->
 <!-- Number: 0, 1 -->

--- a/resources/templates/provision/grandstream/ht702/{$mac}.xml
+++ b/resources/templates/provision/grandstream/ht702/{$mac}.xml
@@ -468,17 +468,30 @@
 <!-- Priority 1 -->
 <!-- Number: 100, 101, 102 -->
 <!-- Mandatory -->
+{if isset($grandstream_dtmf_method_1) }
+<P850>{$grandstream_dtmf_method_1}</P850>
+{else}
 <P850>101</P850>
+{/if}
+
 
 <!-- Priority 2 -->
 <!-- Number: 100, 101, 102 -->
 <!-- Mandatory -->
+{if isset($grandstream_dtmf_method_2) }
+<P851>{$grandstream_dtmf_method_1}</P851>
+{else}
 <P851>102</P851>
+{/if}
 
 <!-- Priority 3 -->
 <!-- Number: 100, 101, 102 -->
 <!-- Mandatory -->
+{if isset($grandstream_dtmf_method_3) }
+<P852>{$grandstream_dtmf_method_1}</P852>
+{else}
 <P852>100</P852>
+{/if}
 
 <!-- Disable DTMF Negotiation. 0 - No, 1 - Yes -->
 <!-- Number: 0, 1 -->
@@ -1147,17 +1160,30 @@
 <!-- Priority 1 -->
 <!-- Number: 100, 101, 102 -->
 <!-- Mandatory -->
+{if isset($grandstream_dtmf_method_1) }
+<P860>{$grandstream_dtmf_method_1}</P860>
+{else}
 <P860>101</P860>
+{/if}
+
 
 <!-- Priority 2 -->
 <!-- Number: 100, 101, 102 -->
 <!-- Mandatory -->
+{if isset($grandstream_dtmf_method_2) }
+<P861>{$grandstream_dtmf_method_1}</P861>
+{else}
 <P861>102</P861>
+{/if}
 
 <!-- Priority 3 -->
 <!-- Number: 100, 101, 102 -->
 <!-- Mandatory -->
+{if isset($grandstream_dtmf_method_3) }
+<P862>{$grandstream_dtmf_method_1}</P862>
+{else}
 <P862>100</P862>
+{/if}
 
 <!-- Disable DTMF Negotiation. 0 - No, 1 - Yes -->
 <!-- Number: 0, 1 -->

--- a/resources/templates/provision/grandstream/ht704/{$mac}.xml
+++ b/resources/templates/provision/grandstream/ht704/{$mac}.xml
@@ -520,17 +520,30 @@
 <!-- Priority 1-->
 <!-- Number: 100, 101, 102-->
 <!-- Mandatory-->
+{if isset($grandstream_dtmf_method_1) }
+<P850>{$grandstream_dtmf_method_1}</P850>
+{else}
 <P850>101</P850>
+{/if}
+
 
 <!-- Priority 2-->
 <!-- Number: 100, 101, 102-->
 <!-- Mandatory-->
+{if isset($grandstream_dtmf_method_2) }
+<P851>{$grandstream_dtmf_method_1}</P851>
+{else}
 <P851>102</P851>
+{/if}
 
 <!-- Priority 3-->
 <!-- Number: 100, 101, 102-->
 <!-- Mandatory-->
+{if isset($grandstream_dtmf_method_3) }
+<P852>{$grandstream_dtmf_method_1}</P852>
+{else}
 <P852>100</P852>
+{/if}
 
 <!-- Disable DTMF Negotiation. 0 - No, 1 - Yes-->
 <!-- Number: 0, 1-->
@@ -1180,17 +1193,30 @@
 <!-- Priority 1 -->
 <!-- Number: 100, 101, 102 -->
 <!-- Mandatory -->
+{if isset($grandstream_dtmf_method_1) }
+<P860>{$grandstream_dtmf_method_1}</P860>
+{else}
 <P860>101</P860>
+{/if}
+
 
 <!-- Priority 2 -->
 <!-- Number: 100, 101, 102 -->
 <!-- Mandatory -->
+{if isset($grandstream_dtmf_method_2) }
+<P861>{$grandstream_dtmf_method_1}</P861>
+{else}
 <P861>102</P861>
+{/if}
 
 <!-- Priority 3 -->
 <!-- Number: 100, 101, 102 -->
 <!-- Mandatory -->
+{if isset($grandstream_dtmf_method_3) }
+<P862>{$grandstream_dtmf_method_1}</P862>
+{else}
 <P862>100</P862>
+{/if}
 
 <!-- Disable DTMF Negotiation. 0 - No, 1 - Yes  -->
 <!-- Number: 0, 1 -->

--- a/resources/templates/provision/grandstream/ht801/{$mac}.xml
+++ b/resources/templates/provision/grandstream/ht801/{$mac}.xml
@@ -836,17 +836,29 @@
     <!-- # Priority 1 -->
     <!-- # Number: 100, 101, 102 -->
     <!-- # Mandatory -->
+    {if isset($grandstream_dtmf_method_1) }
+    <P850>{$grandstream_dtmf_method_1}</P850>
+    {else}
     <P850>101</P850>
+    {/if}
 
     <!-- # Priority 2 -->
     <!-- # Number: 100, 101, 102 -->
     <!-- # Mandatory -->
+    {if isset($grandstream_dtmf_method_2) }
+    <P851>{$grandstream_dtmf_method_1}</P851>
+    {else}
     <P851>102</P851>
+    {/if}
 
     <!-- # Priority 3 -->
     <!-- # Number: 100, 101, 102 -->
     <!-- # Mandatory -->
+    {if isset($grandstream_dtmf_method_3) }
+    <P852>{$grandstream_dtmf_method_1}</P852>
+    {else}
     <P852>100</P852>
+    {/if}
 
     <!-- # Inband DTMF Duration. duration and inter-duration -->
     <!-- # Number: 40 - 200 milliseconds -->

--- a/resources/templates/provision/grandstream/ht802/{$mac}.xml
+++ b/resources/templates/provision/grandstream/ht802/{$mac}.xml
@@ -836,17 +836,30 @@
     <!-- # Priority 1 -->
     <!-- # Number: 100, 101, 102 -->
     <!-- # Mandatory -->
+    {if isset($grandstream_dtmf_method_1) }
+    <P850>{$grandstream_dtmf_method_1}</P850>
+    {else}
     <P850>101</P850>
+    {/if}
+
 
     <!-- # Priority 2 -->
     <!-- # Number: 100, 101, 102 -->
     <!-- # Mandatory -->
+    {if isset($grandstream_dtmf_method_2) }
+    <P851>{$grandstream_dtmf_method_1}</P851>
+    {else}
     <P851>102</P851>
+    {/if}
 
     <!-- # Priority 3 -->
     <!-- # Number: 100, 101, 102 -->
     <!-- # Mandatory -->
+    {if isset($grandstream_dtmf_method_3) }
+    <P852>{$grandstream_dtmf_method_1}</P852>
+    {else}
     <P852>100</P852>
+    {/if}
 
     <!-- # Inband DTMF Duration. duration and inter-duration -->
     <!-- # Number: 40 - 200 milliseconds -->
@@ -1748,17 +1761,30 @@
     <!-- # Priority 1 -->
     <!-- # Number: 100, 101, 102 -->
     <!-- # Mandatory -->
+    {if isset($grandstream_dtmf_method_1) }
+    <P860>{$grandstream_dtmf_method_1}</P860>
+    {else}
     <P860>101</P860>
+    {/if}
+
 
     <!-- # Priority 2 -->
     <!-- # Number: 100, 101, 102 -->
     <!-- # Mandatory -->
+    {if isset($grandstream_dtmf_method_2) }
+    <P861>{$grandstream_dtmf_method_1}</P861>
+    {else}
     <P861>102</P861>
+    {/if}
 
     <!-- # Priority 3 -->
     <!-- # Number: 100, 101, 102 -->
     <!-- # Mandatory -->
+    {if isset($grandstream_dtmf_method_3) }
+    <P862>{$grandstream_dtmf_method_1}</P862>
+    {else}
     <P862>100</P862>
+    {/if}
 
     <!-- # Inband DTMF Duration. duration and inter-duration -->
     <!-- # Number: 40 - 200 milliseconds -->

--- a/resources/templates/provision/grandstream/ht814/{$mac}.xml
+++ b/resources/templates/provision/grandstream/ht814/{$mac}.xml
@@ -798,17 +798,30 @@
     <!-- # Priority 1 -->
     <!-- # Number: 100, 101, 102 -->
     <!-- # Mandatory -->
+    {if isset($grandstream_dtmf_method_1) }
+    <P850>{$grandstream_dtmf_method_1}</P850>
+    {else}
     <P850>101</P850>
+    {/if}
+
 
     <!-- # Priority 2 -->
     <!-- # Number: 100, 101, 102 -->
     <!-- # Mandatory -->
+    {if isset($grandstream_dtmf_method_2) }
+    <P851>{$grandstream_dtmf_method_1}</P851>
+    {else}
     <P851>102</P851>
+    {/if}
 
     <!-- # Priority 3 -->
     <!-- # Number: 100, 101, 102 -->
     <!-- # Mandatory -->
+    {if isset($grandstream_dtmf_method_3) }
+    <P852>{$grandstream_dtmf_method_1}</P852>
+    {else}
     <P852>100</P852>
+    {/if}
 
     <!-- # Disable DTMF Negotiation. 0 - No(negotiate with peer), 1 - Yes(use above DTMF order without negotiation)  -->
     <!-- # Number: 0, 1 -->

--- a/resources/templates/provision/grandstream/ht818/{$mac}.xml
+++ b/resources/templates/provision/grandstream/ht818/{$mac}.xml
@@ -796,17 +796,30 @@
     <!-- # Priority 1 -->
     <!-- # Number: 100, 101, 102 -->
     <!-- # Mandatory -->
+    {if isset($grandstream_dtmf_method_1) }
+    <P850>{$grandstream_dtmf_method_1}</P850>
+    {else}
     <P850>101</P850>
+    {/if}
+
 
     <!-- # Priority 2 -->
     <!-- # Number: 100, 101, 102 -->
     <!-- # Mandatory -->
+    {if isset($grandstream_dtmf_method_2) }
+    <P851>{$grandstream_dtmf_method_1}</P851>
+    {else}
     <P851>102</P851>
+    {/if}
 
     <!-- # Priority 3 -->
     <!-- # Number: 100, 101, 102 -->
     <!-- # Mandatory -->
+    {if isset($grandstream_dtmf_method_3) }
+    <P852>{$grandstream_dtmf_method_1}</P852>
+    {else}
     <P852>100</P852>
+    {/if}
 
     <!-- # Disable DTMF Negotiation. 0 - No(negotiate with peer), 1 - Yes(use above DTMF order without negotiation)  -->
     <!-- # Number: 0, 1 -->


### PR DESCRIPTION
This change allows us to override some grandstream provisioning options, specifically around in-call DTMF methods.