### PR TITLE
Update {$mac}.cfg

### DIFF
--- a/resources/templates/provision/yealink/t48s/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t48s/{$mac}.cfg
@@ -249,91 +249,103 @@ account.1.bla_subscribe_period = 300
 #The payload of the specified codec.
 #account.1.codec.Y.rtpmap =
 
-account.1.codec.1.enable = {if isset($yealink_codec_pcmu_enable)}1{else}0{/if}
+#by default lets leave PCMU enabled, and stick it at the top of priority, since it is the oldest and most common codec. but if the user has specified the variables, use tht instead!em
+account.1.codec.1.enable = {if isset($yealink_codec_pcmu_enable)}{$yealink_codec_pcmu_enable}{else}1{/if}
 
 account.1.codec.1.payload_type = PCMU
 account.1.codec.1.priority = {if isset($yealink_codec_pcmu_priority)}{$yealink_codec_pcmu_priority}{else}0{/if}
 
 account.1.codec.1.rtpmap = 0
 
-account.1.codec.2.enable = {if isset($yealink_codec_pcma_enable)}1{else}0{/if}
+#same deal, default enabled, stick it high in prio, trying to have safe defaults that wont break anything...
+account.1.codec.2.enable = {if isset($yealink_codec_pcma_enable)}{$yealink_codec_pcma_enable}{else}0{/if}
 
 account.1.codec.2.payload_type = PCMA
-account.1.codec.2.priority = {if isset($yealink_codec_pcma_priority)}{$yealink_codec_pcma_priority}{else}0{/if}
+account.1.codec.2.priority = {if isset($yealink_codec_pcma_priority)}{$yealink_codec_pcma_priority}{else}1{/if}
 
 account.1.codec.2.rtpmap = 8
 
-account.1.codec.3.enable = {if isset($yealink_codec_g723_53_enable)}1{else}0{/if}
+#for all the less common codecs we'll default disable if the user hasn't set the default setting
+account.1.codec.3.enable = {if isset($yealink_codec_g723_53_enable)}{$yealink_codec_g723_53_enable}{else}0{/if}
 
 account.1.codec.3.payload_type = G723_53
 account.1.codec.3.priority ={if isset($yealink_codec_g723_53_priority)}{$yealink_codec_g723_53_priority}{else}0{/if}
 
 account.1.codec.3.rtpmap = 4
 
-account.1.codec.4.enable = {if isset($yealink_codec_g723_63_enable)}1{else}0{/if}
+account.1.codec.4.enable = {if isset($yealink_codec_g723_63_enable)}{$yealink_codec_g723_63_enable}{else}0{/if}
 
 account.1.codec.4.payload_type = G723_63
 account.1.codec.4.priority = {if isset($yealink_codec_g723_63_priority)}{$yealink_codec_g723_63_priority}{else}0{/if}
 
 account.1.codec.4.rtpmap = 4
 
-account.1.codec.5.enable = {if isset($yealink_codec_g729_enable)}1{else}0{/if}
+#G729 sounds bad, please consider using another low bandwidth codec.
+account.1.codec.5.enable= {if isset($yealink_codec_g729_enable)}{$yealink_codec_g729_enable}{else}0{/if}
 
 account.1.codec.5.payload_type = G729
-account.1.codec.5.priority = {if isset($yealink_codec_g729_priority)}{$yealink_codec_g729_priority}{else}0{/if}
+account.1.codec.5.729.priority= {if isset($yealink_codec_g729_priority)}{$yealink_codec_g729_priority}{else}0{/if}
 
 account.1.codec.5.rtpmap = 18
 
-account.1.codec.6.enable = {if isset($yealink_codec_g722_enable)}1{else}0{/if}
+#what a lovely sounding codec
+account.1.codec.6.enable = {if isset($yealink_codec_g722_enable)}{$yealink_codec_g722_enable}{else}0{/if}
 
 account.1.codec.6.payload_type = G722
 account.1.codec.6.priority = {if isset($yealink_codec_g722_priority)}{$yealink_codec_g722_priority}{else}0{/if}
 
 account.1.codec.6.rtpmap = 9
 
-account.1.codec.7.enable = {if isset($yealink_codec_iLBC_enable)}1{else}0{/if}
+
+account.1.codec.7.enable = {if isset($yealink_codec_iLBC_enable)}{$yealink_codec_iLBC_enable}{else}0{/if}
 
 account.1.codec.7.payload_type = iLBC
 account.1.codec.7.priority =  {if isset($yealink_codec_iLBC_priority)}{$yealink_codec_iLBC_priority}{else}0{/if}
 
 account.1.codec.7.rtpmap = 106
 
-account.1.codec.8.enable = {if isset($yealink_codec_g726_16_enable)}1{else}0{/if}
+
+account.1.codec.8.enable = {if isset($yealink_codec_g726_16_enable)}{$yealink_codec_g726_16_enable}{else}0{/if}
 
 account.1.codec.8.payload_type = G726-16
 account.1.codec.8.priority = {if isset($yealink_codec_g726_16_priority)}{$yealink_codec_g726_16_priority}{else}0{/if}
 
 account.1.codec.8.rtpmap = 103
 
-account.1.codec.9.enable = {if isset($yealink_codec_g726_24_enable)}1{else}0{/if}
+
+account.1.codec.9.enable = {if isset($yealink_codec_g726_24_enable)}{$yealink_codec_g726_24_enable}{else}0{/if}
 
 account.1.codec.9.payload_type = G726-24
 account.1.codec.9.priority = {if isset($yealink_codec_g726_24_priority)}{$yealink_codec_g726_24_priority}{else}0{/if}
 
 account.1.codec.9.rtpmap = 104
 
-account.1.codec.10.enable = {if isset($yealink_codec_g726_32_enable)}1{else}0{/if}
+
+account.1.codec.10.enable = {if isset($yealink_codec_g726_32_enable)}{$yealink_codec_g726_32_enable}{else}0{/if}
 
 account.1.codec.10.payload_type = G726-32
 account.1.codec.10.priority = {if isset($yealink_codec_g726_32_priority)}{$yealink_codec_g726_32_priority}{else}0{/if}
 
 account.1.codec.10.rtpmap = 102
 
-account.1.codec.11.enable = {if isset($yealink_codec_g726_40_enable)}1{else}0{/if}
+
+account.1.codec.11.enable = {if isset($yealink_codec_g726_40_enable)}{$yealink_codec_g726_40_enable}{else}0{/if}
 
 account.1.codec.11.payload_type = G726-40
 account.1.codec.11.priority = {if isset($yealink_codec_g726_40_priority)}{$yealink_codec_g726_40_priority}{else}0{/if}
 
 account.1.codec.11.rtpmap = 105
 
-account.1.codec.12.enable = {if isset($yealink_codec_gsm_enable)}1{else}0{/if}
+
+account.1.codec.12.enable = {if isset($yealink_codec_gsm_enable)}{$yealink_codec_gsm_enable}{else}0{/if}
 
 account.1.codec.12.payload_type = GSM
 account.1.codec.12.priority = {if isset($yealink_codec_gsm_priority)}{$yealink_codec_gsm_priority}{else}0{/if}
 
 account.1.codec.12.rtpmap = 3
 
-account.1.codec.13.enable = {if isset($yealink_codec_opus_enable)}1{else}0{/if}
+
+account.1.codec.13.enable = {if isset($yealink_codec_opus_enable)}{$yealink_codec_opus_enable}{else}0{/if}
 
 account.1.codec.13.payload_type = opus
 account.1.codec.13.priority = {if isset($yealink_codec_opus_priority)}{$yealink_codec_opus_priority}{else}0{/if}


### PR DESCRIPTION
my T48s was ignoring my codec settings in default settings. after digging into the provisioning files I think I found two issues:

First: the old definitions for if a codec is enabled checks if the variable for enabling it is set, and then if it is sets it to 1, or 0 if it's not set at all

the problem here was I have a variable called  	yealink_codec_g729_enable , which takes a value...if I set that value to false, it was still setting the codec to 1. I think it was saying "well, the variable ISSET, so I should set this to 1" even though the variable was set to FALSE.


SECOND: the variable itself:
 	yealink_codec_g729_enable
was a boolean. when fusionpbx fills out the config file for the phone to download, it literally puts "false" in the field for the variable if I fill with it. yealink seems to ignore this, it requires a 1 or a 0 in the firmware my phone is on (latest public  66.86.0.15 release)

I uh...I'm not really sure where to change the default setting in the fusionpbx github, but I've just changed it on my system to be numeric and set it to 0 or 1.


I will add the T48G config file to this request as well, as I've tested on one of them as well with these changes