### PR TITLE
Php 8.1 call forward fixes

### DIFF
--- a/app/call_forward/call_forward.php
+++ b/app/call_forward/call_forward.php
@@ -1,28 +1,32 @@
 <?php
-/*
-	FusionPBX
-	Version: MPL 1.1
 
-	The contents of this file are subject to the Mozilla Public License Version
-	1.1 (the "License"); you may not use this file except in compliance with
-	the License. You may obtain a copy of the License at
-	http://www.mozilla.org/MPL/
+	/*
+	  FusionPBX
+	  Version: MPL 1.1
 
-	Software distributed under the License is distributed on an "AS IS" basis,
-	WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License
-	for the specific language governing rights and limitations under the
-	License.
+	  The contents of this file are subject to the Mozilla Public License Version
+	  1.1 (the "License"); you may not use this file except in compliance with
+	  the License. You may obtain a copy of the License at
+	  http://www.mozilla.org/MPL/
 
-	The Original Code is FusionPBX
+	  Software distributed under the License is distributed on an "AS IS" basis,
+	  WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License
+	  for the specific language governing rights and limitations under the
+	  License.
 
-	The Initial Developer of the Original Code is
-	Mark J Crane <markjcrane@fusionpbx.com>
-	Portions created by the Initial Developer are Copyright (C) 2008-2021
-	the Initial Developer. All Rights Reserved.
+	  The Original Code is FusionPBX
 
-	Contributor(s):
-	Mark J Crane <markjcrane@fusionpbx.com>
-*/
+	  The Initial Developer of the Original Code is
+	  Mark J Crane <markjcrane@fusionpbx.com>
+	  Portions created by the Initial Developer are Copyright (C) 2008-2021
+	  the Initial Developer. All Rights Reserved.
+
+	  Contributor(s):
+	  Mark J Crane <markjcrane@fusionpbx.com>
+	 */
+
+//set default
+	$is_included = false;
 
 //set the include path
 	$conf = glob("{/usr/local/etc,/etc}/fusionpbx/config.conf", GLOB_BRACE);
@@ -36,8 +40,7 @@
 //check permissions
 	if (permission_exists('follow_me') || permission_exists('call_forward') || permission_exists('do_not_disturb')) {
 		//access granted
-	}
-	else {
+	} else {
 		echo "access denied";
 		exit;
 	}
@@ -46,15 +49,13 @@
 	$language = new text;
 	$text = $language->get($_SESSION['domain']['language']['code'], 'app/call_forward');
 
-//get posted data
-	if (is_array($_POST['extensions'])) {
-		$action = $_POST['action'];
-		$search = $_POST['search'];
-		$extensions = $_POST['extensions'];
-	}
+//get posted data and set defaults
+	$action = $_POST['action'] ?? '';
+	$search = $_POST['search'] ?? '';
+	$extensions = $_POST['extensions'] ?? [];
 
 //process the http post data by action
-	if ($action != '' && is_array($extensions) && @sizeof($extensions) != 0) {
+	if (!empty($action) && count($extensions) > 0) {
 		switch ($action) {
 			case 'toggle_call_forward':
 				if (permission_exists('call_forward')) {
@@ -76,23 +77,25 @@
 				break;
 		}
 
-		header('Location: call_forward.php'.($search != '' ? '?search='.urlencode($search) : null));
+		header('Location: call_forward.php' . ($search != '' ? '?search=' . urlencode($search) : null));
 		exit;
 	}
 
 //get order and order by
-	$order_by = $_GET["order_by"];
-	$order = $_GET["order"];
+	$order_by = $_GET["order_by"] ?? '';
+	$order = $_GET["order"] ?? '';
 
 //get the search
-	$search = strtolower($_GET["search"]);
+	$search = strtolower($_GET["search"] ?? '');
+
+//set the show variable
+	$show = $_GET['show'] ?? 'domain';
 
 //define select count query
 	$sql = "select count(*) from v_extensions ";
-	if ($_GET['show'] == "all" && permission_exists('call_forward_all')) {
+	if ($show === "all" && permission_exists('call_forward_all')) {
 		$sql .= "where true ";
-	}
-	else {
+	} else {
 		$sql .= "where domain_uuid = :domain_uuid ";
 		$parameters['domain_uuid'] = $_SESSION['domain_uuid'];
 	}
@@ -101,58 +104,63 @@
 		$sql .= "extension like :search ";
 		$sql .= "or lower(description) like :search ";
 		$sql .= ") ";
-		$parameters['search'] = '%'.$search.'%';
+		$parameters['search'] = '%' . $search . '%';
 	}
 	$sql .= "and enabled = 'true' ";
 	if (!permission_exists('extension_edit')) {
 		if (is_array($_SESSION['user']['extension']) && count($_SESSION['user']['extension']) > 0) {
 			$sql .= "and (";
 			$x = 0;
-			foreach($_SESSION['user']['extension'] as $row) {
-				if ($x > 0) { $sql .= "or "; }
-				$sql .= "extension = '".$row['user']."' ";
+			foreach ($_SESSION['user']['extension'] as $row) {
+				if ($x > 0) {
+					$sql .= "or ";
+				}
+				$sql .= "extension = '" . $row['user'] . "' ";
 				$x++;
 			}
 			$sql .= ")";
-		}
-		else {
+		} else {
 			//used to hide any results when a user has not been assigned an extension
 			$sql .= "and extension = 'disabled' ";
 		}
 	}
-	$sql .= $sql_search;
 	$database = new database;
 	$num_rows = $database->select($sql, $parameters, 'column');
 	unset($parameters);
 
 //prepare the paging
-	if ($is_included) {
-		$rows_per_page = 10;
+	$rows_per_page = !empty($_SESSION['domain']['paging']['numeric']) ? $_SESSION['domain']['paging']['numeric'] : 50;
+
+	$params[] = "app_uuid=" . call_forward::APP_UUID;
+
+	if ($search) {
+		$params[] = "search=" . $search;
 	}
-	else {
-		$rows_per_page = ($_SESSION['domain']['paging']['numeric'] != '') ? $_SESSION['domain']['paging']['numeric'] : 50;
+	if ($order_by) {
+		$params[] = "order_by=" . $order_by;
 	}
-	$params[] = "app_uuid=".$app_uuid;
-	if ($search) { $params[] = "search=".$search; }
-	if ($order_by) { $params[] = "order_by=".$order_by; }
-	if ($order) { $params[] = "order=".$order; }
-	if ($_GET['show'] == "all" && permission_exists('call_forward_all')) {
+	if ($order) {
+		$params[] = "order=" . $order;
+	}
+	if ($show == "all" && permission_exists('call_forward_all')) {
 		$params[] .= "show=all";
 	}
-	$param = $params ? implode('&', $params) : null;
+	$param = !empty($params) ? implode('&', $params) : '';
 	unset($params);
-	$page = $_GET['page'];
-	if (empty($page)) { $page = 0; $_GET['page'] = 0; }
+	$page = $_GET['page'] ?? '';
+	if (empty($page)) {
+		$page = 0;
+		$_GET['page'] = 0;
+	}
 	list($paging_controls, $rows_per_page) = paging($num_rows, $param, $rows_per_page);
 	list($paging_controls_mini, $rows_per_page) = paging($num_rows, $param, $rows_per_page, true);
 	$offset = $rows_per_page * $page;
 
 //get the list
 	$sql = "select * from v_extensions ";
-	if ($_GET['show'] == "all" && permission_exists('call_forward_all')) {
+	if ($show == "all" && permission_exists('call_forward_all')) {
 		$sql .= "where true ";
-	}
-	else {
+	} else {
 		$sql .= "where domain_uuid = :domain_uuid ";
 		$parameters['domain_uuid'] = $_SESSION['domain_uuid'];
 	}
@@ -161,31 +169,36 @@
 		$sql .= "extension like :search ";
 		$sql .= "or lower(description) like :search ";
 		$sql .= ") ";
-		$parameters['search'] = '%'.$search.'%';
+		$parameters['search'] = '%' . $search . '%';
 	}
 	$sql .= "and enabled = 'true' ";
 	if (!permission_exists('extension_edit')) {
 		if (is_array($_SESSION['user']['extension']) && count($_SESSION['user']['extension']) > 0) {
 			$sql .= "and (";
 			$x = 0;
-			foreach($_SESSION['user']['extension'] as $row) {
-				if ($x > 0) { $sql .= "or "; }
-				$sql .= "extension = '".$row['user']."' ";
+			foreach ($_SESSION['user']['extension'] as $row) {
+				if ($x > 0) {
+					$sql .= "or ";
+				}
+				$sql .= "extension = '" . $row['user'] . "' ";
 				$x++;
 			}
 			$sql .= ")";
-		}
-		else {
+		} else {
 			//used to hide any results when a user has not been assigned an extension
 			$sql .= "and extension = 'disabled' ";
 		}
 	}
-	$sql .= $sql_search;
 	$sql .= order_by($order_by, $order, 'extension', 'asc');
 	$sql .= limit_offset($rows_per_page, $offset);
 	$database = new database;
 	$extensions = $database->select($sql, $parameters, 'all');
 	unset($parameters);
+
+	//if there are no extensions then set to empty array
+	if($extensions === false) {
+		$extensions = [];
+	}
 
 //create token
 	$object = new token;
@@ -193,28 +206,27 @@
 
 //include header
 	if (!$is_included) {
-		$document['title'] = $text['title-call_forward'];
+	$document['title'] = $text['title-call_forward'];
 	}
 	require_once "resources/header.php";
 
 //show the content
 	if ($is_included) {
 		echo "<div class='action_bar sub'>\n";
-		echo "	<div class='heading'><b>".$text['header-call_forward']."</b></div>\n";
+		echo "	<div class='heading'><b>" . $text['header-call_forward'] . "</b></div>\n";
 		echo "	<div class='actions'>\n";
 		if ($num_rows > 10) {
-			echo button::create(['type'=>'button','label'=>$text['button-view_all'],'icon'=>'project-diagram','collapse'=>false,'link'=>PROJECT_PATH.'/app/call_forward/call_forward.php']);
+			echo button::create(['type' => 'button', 'label' => $text['button-view_all'], 'icon' => 'project-diagram', 'collapse' => false, 'link' => PROJECT_PATH . '/app/call_forward/call_forward.php']);
 		}
 		echo "	</div>\n";
 		echo "	<div style='clear: both;'></div>\n";
 		echo "</div>\n";
-	}
-	else {
+	} else {
 		echo "<div class='action_bar' id='action_bar'>\n";
-		echo "	<div class='heading'><b>".$text['header-call_forward']." (".$num_rows.")</b></div>\n";
+		echo "	<div class='heading'><b>" . $text['header-call_forward'] . " (" . $num_rows . ")</b></div>\n";
 		echo "	<div class='actions'>\n";
 
-		if ($extensions) {
+		if (count($extensions) > 0) {
 			if (permission_exists('call_forward')) {
 				echo button::create(['type' => 'button', 'label' => $text['label-call_forward'], 'icon' => $_SESSION['theme']['button_icon_toggle'], 'collapse' => false, 'name' => 'btn_toggle_cfwd', 'onclick' => "list_action_set('toggle_call_forward'); modal_open('modal-toggle','btn_toggle');"]);
 			}
@@ -225,87 +237,87 @@
 				echo button::create(['type' => 'button', 'label' => $text['label-dnd'], 'icon' => $_SESSION['theme']['button_icon_toggle'], 'collapse' => false, 'name' => 'btn_toggle_dnd', 'onclick' => "list_action_set('toggle_do_not_disturb'); modal_open('modal-toggle','btn_toggle');"]);
 			}
 		}
-		if ($_GET['show'] !== 'all' && permission_exists('call_forward_all')) {
-			echo button::create(['type'=>'button','label'=>$text['button-show_all'],'icon'=>$_SESSION['theme']['button_icon_all'],'link'=>'?show=all'.($params ? '&'.implode('&', $params) : null)]);
+		if ($show !== 'all' && permission_exists('call_forward_all')) {
+			echo button::create(['type' => 'button', 'label' => $text['button-show_all'], 'icon' => $_SESSION['theme']['button_icon_all'], 'link' => '?show=all' . $param]);
 		}
-		echo 		"<form id='form_search' class='inline' method='get'>\n";
-		if ($_GET['show'] == 'all' && permission_exists('call_forward_all')) {
+		echo "<form id='form_search' class='inline' method='get'>\n";
+		if ($show == 'all' && permission_exists('call_forward_all')) {
 			echo "		<input type='hidden' name='show' value='all'>";
 		}
-		echo 		"<input type='text' class='txt list-search' name='search' id='search' value=\"".escape($search)."\" placeholder=\"".$text['label-search']."\" onkeydown=''>";
-		echo button::create(['label'=>$text['button-search'],'icon'=>$_SESSION['theme']['button_icon_search'],'type'=>'submit','id'=>'btn_search']);
+		echo "<input type='text' class='txt list-search' name='search' id='search' value=\"" . escape($search) . "\" placeholder=\"" . $text['label-search'] . "\" onkeydown=''>";
+		echo button::create(['label' => $text['button-search'], 'icon' => $_SESSION['theme']['button_icon_search'], 'type' => 'submit', 'id' => 'btn_search']);
 		//echo button::create(['label'=>$text['button-reset'],'icon'=>$_SESSION['theme']['button_icon_reset'],'type'=>'button','id'=>'btn_reset','link'=>'call_forward.php','style'=>($search == '' ? 'display: none;' : null)]);
 		if ($paging_controls_mini != '') {
-			echo 	"<span style='margin-left: 15px;'>".$paging_controls_mini."</span>";
+			echo "<span style='margin-left: 15px;'>" . $paging_controls_mini . "</span>";
 		}
 		echo "		</form>\n";
 		echo "	</div>\n";
 		echo "	<div style='clear: both;'></div>\n";
 		echo "</div>\n";
 
-		if ($extensions) {
-			echo modal::create(['id'=>'modal-toggle','type'=>'toggle','actions'=>button::create(['type'=>'button','label'=>$text['button-continue'],'icon'=>'check','id'=>'btn_toggle','style'=>'float: right; margin-left: 15px;','collapse'=>'never','onclick'=>"modal_close(); list_form_submit('form_list');"])]);
+		if (count($extensions) > 0) {
+			echo modal::create(['id' => 'modal-toggle', 'type' => 'toggle', 'actions' => button::create(['type' => 'button', 'label' => $text['button-continue'], 'icon' => 'check', 'id' => 'btn_toggle', 'style' => 'float: right; margin-left: 15px;', 'collapse' => 'never', 'onclick' => "modal_close(); list_form_submit('form_list');"])]);
 		}
 
-		echo $text['description-call_routing']."\n";
+		echo $text['description-call_routing'] . "\n";
 		echo "<br /><br />\n";
 
 		echo "<form id='form_list' method='post'>\n";
-		if ($_GET['show'] == 'all' && permission_exists('call_forward_all')) {
+		if ($show == 'all' && permission_exists('call_forward_all')) {
 			echo "		<input type='hidden' name='show' value='all'>";
 		}
 		echo "<input type='hidden' id='action' name='action' value=''>\n";
-		echo "<input type='hidden' name='search' value=\"".escape($search)."\">\n";
+		echo "<input type='hidden' name='search' value=\"" . escape($search) . "\">\n";
 	}
 
 	echo "<table class='list'>\n";
 	echo "<tr class='list-header'>\n";
 	if (!$is_included) {
 		echo "	<th class='checkbox'>\n";
-		echo "		<input type='checkbox' id='checkbox_all' name='checkbox_all' onclick='list_all_toggle();' ".($extensions ?: "style='visibility: hidden;'").">\n";
+		echo "		<input type='checkbox' id='checkbox_all' name='checkbox_all' onclick='list_all_toggle();' " . (empty($extensions) ?: "style='visibility: hidden;'") . ">\n";
 		echo "	</th>\n";
-		if ($_GET['show'] == "all" && permission_exists('call_forward_all')) {
-			echo "<th>".$text['label-domain']."</th>\n";
+		if ($show == "all" && permission_exists('call_forward_all')) {
+			echo "<th>" . $text['label-domain'] . "</th>\n";
 		}
 	}
-	echo "	<th>".$text['label-extension']."</th>\n";
+	echo "	<th>" . $text['label-extension'] . "</th>\n";
 	if (permission_exists('call_forward')) {
-		echo "	<th>".$text['label-call_forward']."</th>\n";
+		echo "	<th>" . $text['label-call_forward'] . "</th>\n";
 	}
 	if (permission_exists('follow_me')) {
-		echo "	<th>".$text['label-follow_me']."</th>\n";
+		echo "	<th>" . $text['label-follow_me'] . "</th>\n";
 	}
 	if (permission_exists('do_not_disturb')) {
-		echo "	<th>".$text['label-dnd']."</th>\n";
+		echo "	<th>" . $text['label-dnd'] . "</th>\n";
 	}
-	echo "	<th class='".($is_included ? 'hide-md-dn' : 'hide-sm-dn')."'>".$text['label-description']."</th>\n";
-	if ($_SESSION['theme']['list_row_edit_button']['boolean'] == 'true') {
+	echo "	<th class='" . ($is_included ? 'hide-md-dn' : 'hide-sm-dn') . "'>" . $text['label-description'] . "</th>\n";
+	$list_row_edit_button = $_SESSION['theme']['list_row_edit_button']['boolean'] ?? 'false';
+	if ( $list_row_edit_button === 'true') {
 		echo "	<td class='action-button'>&nbsp;</td>\n";
 	}
 	echo "</tr>\n";
 
 	if (is_array($extensions)) {
 		$x = 0;
-		foreach($extensions as $row) {
-			$list_row_url = PROJECT_PATH."/app/call_forward/call_forward_edit.php?id=".$row['extension_uuid']."&return_url=".urlencode($_SERVER['REQUEST_URI']);
-			echo "<tr class='list-row' href='".$list_row_url."'>\n";
+		foreach ($extensions as $row) {
+			$list_row_url = PROJECT_PATH . "/app/call_forward/call_forward_edit.php?id=" . $row['extension_uuid'] . "&return_url=" . urlencode($_SERVER['REQUEST_URI']);
+			echo "<tr class='list-row' href='" . $list_row_url . "'>\n";
 			if (!$is_included && $extensions) {
 				echo "	<td class='checkbox'>\n";
-				echo "		<input type='checkbox' name='extensions[$x][checked]' id='checkbox_".$x."' value='true' onclick=\"if (!this.checked) { document.getElementById('checkbox_all').checked = false; }\">\n";
-				echo "		<input type='hidden' name='extensions[$x][uuid]' value='".escape($row['extension_uuid'])."' />\n";
+				echo "		<input type='checkbox' name='extensions[$x][checked]' id='checkbox_" . $x . "' value='true' onclick=\"if (!this.checked) { document.getElementById('checkbox_all').checked = false; }\">\n";
+				echo "		<input type='hidden' name='extensions[$x][uuid]' value='" . escape($row['extension_uuid']) . "' />\n";
 				echo "	</td>\n";
 
-				if ($_GET['show'] == "all" && permission_exists('call_forward_all')) {
+				if ($show == "all" && permission_exists('call_forward_all')) {
 					if (!empty($_SESSION['domains'][$row['domain_uuid']]['domain_name'])) {
 						$domain = $_SESSION['domains'][$row['domain_uuid']]['domain_name'];
-					}
-					else {
+					} else {
 						$domain = $text['label-global'];
 					}
-					echo "	<td>".escape($domain)."</td>\n";
+					echo "	<td>" . escape($domain) . "</td>\n";
 				}
 			}
-			echo "	<td><a href='".$list_row_url."' title=\"".$text['button-edit']."\">".escape($row['extension'])."</a></td>\n";
+			echo "	<td><a href='" . $list_row_url . "' title=\"" . $text['button-edit'] . "\">" . escape($row['extension']) . "</a></td>\n";
 			if (permission_exists('call_forward')) {
 				//-- inline toggle -----------------
 				//$button_label = $row['forward_all_enabled'] == 'true' ? ($row['forward_all_destination'] != '' ? escape(format_phone($row['forward_all_destination'])) : '('.$text['label-invalid'].')') : null;
@@ -348,7 +360,6 @@
 				//}
 				//unset($button_label);
 				//----------------------------------
-
 				//get destination count
 				$follow_me_destination_count = 0;
 				if ($row['follow_me_enabled'] == 'true' && is_uuid($row['follow_me_uuid'])) {
@@ -362,7 +373,7 @@
 					unset($sql, $parameters);
 				}
 				echo "	<td>\n";
-				echo $follow_me_destination_count ? $text['label-enabled'].' ('.$follow_me_destination_count.')' : '&nbsp;';
+				echo $follow_me_destination_count ? $text['label-enabled'] . ' (' . $follow_me_destination_count . ')' : '&nbsp;';
 				echo "	</td>\n";
 			}
 			if (permission_exists('do_not_disturb')) {
@@ -382,10 +393,10 @@
 				echo $row['do_not_disturb'] == 'true' ? $text['label-enabled'] : '&nbsp;';
 				echo "	</td>\n";
 			}
-			echo "	<td class='description overflow ".($is_included ? 'hide-md-dn' : 'hide-sm-dn')."'>".escape($row['description'])."&nbsp;</td>\n";
-			if ($_SESSION['theme']['list_row_edit_button']['boolean'] == 'true') {
+			echo "	<td class='description overflow " . ($is_included ? 'hide-md-dn' : 'hide-sm-dn') . "'>" . escape($row['description']) . "&nbsp;</td>\n";
+			if ($list_row_edit_button === 'true') {
 				echo "	<td class='action-button'>";
-				echo button::create(['type'=>'button','title'=>$text['button-edit'],'icon'=>$_SESSION['theme']['button_icon_edit'],'link'=>$list_row_url]);
+				echo button::create(['type' => 'button', 'title' => $text['button-edit'], 'icon' => $_SESSION['theme']['button_icon_edit'], 'link' => $list_row_url]);
 				echo "	</td>\n";
 			}
 			echo "</tr>\n";
@@ -398,13 +409,12 @@
 
 	if (!$is_included) {
 		echo "<br />\n";
-		echo "<div align='center'>".$paging_controls."</div>\n";
+		echo "<div align='center'>" . $paging_controls . "</div>\n";
 
-		echo "<input type='hidden' name='".$token['name']."' value='".$token['hash']."'>\n";
+		echo "<input type='hidden' name='" . $token['name'] . "' value='" . $token['hash'] . "'>\n";
 
 		echo "</form>\n";
 
 		require_once "resources/footer.php";
 	}
-
 ?>

--- a/app/call_forward/resources/classes/call_forward.php
+++ b/app/call_forward/resources/classes/call_forward.php
@@ -1,280 +1,277 @@
 <?php
-/*
-	FusionPBX
-	Version: MPL 1.1
 
-	The contents of this file are subject to the Mozilla Public License Version
-	1.1 (the "License"); you may not use this file except in compliance with
-	the License. You may obtain a copy of the License at
-	http://www.mozilla.org/MPL/
+	/*
+	  FusionPBX
+	  Version: MPL 1.1
 
-	Software distributed under the License is distributed on an "AS IS" basis,
-	WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License
-	for the specific language governing rights and limitations under the
-	License.
+	  The contents of this file are subject to the Mozilla Public License Version
+	  1.1 (the "License"); you may not use this file except in compliance with
+	  the License. You may obtain a copy of the License at
+	  http://www.mozilla.org/MPL/
 
-	The Original Code is FusionPBX
+	  Software distributed under the License is distributed on an "AS IS" basis,
+	  WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License
+	  for the specific language governing rights and limitations under the
+	  License.
 
-	The Initial Developer of the Original Code is
-	Mark J Crane <markjcrane@fusionpbx.com>
-	Copyright (C) 2010 - 2022
-	All Rights Reserved.
+	  The Original Code is FusionPBX
 
-	Contributor(s):
-	Mark J Crane <markjcrane@fusionpbx.com>
-	Luis Daniel Lucio Quiroz <dlucio@okay.com.mx>
-	Errol Samuels <voiptology@gmail.com>
+	  The Initial Developer of the Original Code is
+	  Mark J Crane <markjcrane@fusionpbx.com>
+	  Copyright (C) 2010 - 2022
+	  All Rights Reserved.
 
-*/
+	  Contributor(s):
+	  Mark J Crane <markjcrane@fusionpbx.com>
+	  Luis Daniel Lucio Quiroz <dlucio@okay.com.mx>
+	  Errol Samuels <voiptology@gmail.com>
+
+	 */
 
 //define the call_forward class
 	class call_forward {
+
+		// set class constants
+		const APP_NAME = 'calls';
+		const APP_UUID = '19806921-e8ed-dcff-b325-dd3e5da4959d';
+		const PERMISSION = 'call_forward';
+		const LIST_PAGE = 'calls.php';
+		const TABLE = 'extensions';
+		const UUID_PREFIX = 'extension_';
+		const TOGGLE_FIELD = 'forward_all_enabled';
+		const TOGGLE_VALUES = ['true', 'false'];
 
 		public $debug;
 		public $domain_uuid;
 		public $domain_name;
 		public $extension_uuid;
-		private $extension;
-		private $number_alias;
 		public $forward_all_destination;
 		public $forward_all_enabled;
-		private $toll_allow;
 		public $accountcode;
 		public $outbound_caller_id_name;
 		public $outbound_caller_id_number;
 
-		public function set() {
-			//create the database connection
-				$database = new database;
-
-			//determine whether to update the dial string
-				$sql = "select * from v_extensions ";
-				$sql .= "where domain_uuid = :domain_uuid ";
-				$sql .= "and extension_uuid = :extension_uuid ";
-				$parameters['domain_uuid'] = $this->domain_uuid;
-				$parameters['extension_uuid'] = $this->extension_uuid;
-				$row = $database->select($sql, $parameters, 'row');
-				if (is_array($row) && @sizeof($row) != 0) {
-					$this->extension = $row["extension"];
-					$this->number_alias = $row["number_alias"];
-					$this->accountcode = $row["accountcode"];
-					$this->toll_allow = $row["toll_allow"];
-					$this->outbound_caller_id_name = $row["outbound_caller_id_name"];
-					$this->outbound_caller_id_number = $row["outbound_caller_id_number"];
-				}
-				unset($sql, $parameters, $row);
-
-			//build extension update array
-				$array['extensions'][0]['extension_uuid'] = $this->extension_uuid;
-				$array['extensions'][0]['forward_all_destination'] = strlen($this->forward_all_destination) != 0 ? $this->forward_all_destination : null;
-				if (empty($this->forward_all_destination) || $this->forward_all_enabled == "false") {
-					$array['extensions'][0]['forward_all_enabled'] = 'false';
-				}
-				else {
-					$array['extensions'][0]['forward_all_enabled'] = 'true';
-				}
-
-			//grant temporary permissions
-				$p = new permissions;
-				$p->add('extension_add', 'temp');
-
-			//execute update
-				$database->app_name = 'calls';
-				$database->app_uuid = '19806921-e8ed-dcff-b325-dd3e5da4959d';
-				$database->save($array);
-				unset($array);
-
-			//revoke temporary permissions
-				$p->delete('extension_add', 'temp');
-
-			//delete extension from the cache
-				$cache = new cache;
-				$cache->delete("directory:".$this->extension."@".$this->domain_name);
-				if(!empty($this->number_alias)){
-					$cache->delete("directory:".$this->number_alias."@".$this->domain_name);
-				}
-
-		}
-
 		/**
 		 * declare private variables
 		 */
-		private $app_name;
-		private $app_uuid;
-		private $permission;
-		private $list_page;
-		private $table;
-		private $uuid_prefix;
-		private $toggle_field;
-		private $toggle_values;
+		private $extension;
+		private $number_alias;
+		private $toll_allow;
 
-		/**
-		 * toggle records
-		 */
-		public function toggle($records) {
-
+		public function set() {
 			//create the database connection
-				$database = new database;
+			$database = new database;
 
-			//assign private variables
-				$this->app_name = 'calls';
-				$this->app_uuid = '19806921-e8ed-dcff-b325-dd3e5da4959d';
-				$this->permission = 'call_forward';
-				$this->list_page = 'calls.php';
-				$this->table = 'extensions';
-				$this->uuid_prefix = 'extension_';
-				$this->toggle_field = 'forward_all_enabled';
-				$this->toggle_values = ['true','false'];
+			//determine whether to update the dial string
+			$sql = "select * from v_extensions ";
+			$sql .= "where domain_uuid = :domain_uuid ";
+			$sql .= "and extension_uuid = :extension_uuid ";
+			$parameters['domain_uuid'] = $this->domain_uuid;
+			$parameters['extension_uuid'] = $this->extension_uuid;
+			$row = $database->select($sql, $parameters, 'row');
+			if (is_array($row) && @sizeof($row) != 0) {
+				$this->extension = $row["extension"];
+				$this->number_alias = $row["number_alias"];
+				$this->accountcode = $row["accountcode"];
+				$this->toll_allow = $row["toll_allow"];
+				$this->outbound_caller_id_name = $row["outbound_caller_id_name"];
+				$this->outbound_caller_id_number = $row["outbound_caller_id_number"];
+			}
+			unset($sql, $parameters, $row);
 
-			if (permission_exists($this->permission)) {
-
-				//add multi-lingual support
-					$language = new text;
-					$text = $language->get();
-
-				//validate the token
-					$token = new token;
-					if (!$token->validate($_SERVER['PHP_SELF'])) {
-						message::add($text['message-invalid_token'],'negative');
-						header('Location: '.$this->list_page);
-						exit;
-					}
-
-				//toggle the checked records
-					if (is_array($records) && @sizeof($records) != 0) {
-
-						//get current toggle state
-							foreach($records as $x => $record) {
-								if ($record['checked'] == 'true' && is_uuid($record['uuid'])) {
-									$uuids[] = "'".$record['uuid']."'";
-								}
-							}
-							if (is_array($uuids) && @sizeof($uuids) != 0) {
-								$sql = "select ".$this->uuid_prefix."uuid as uuid, extension, number_alias, ";
-								$sql .= "call_timeout, do_not_disturb, ";
-								$sql .= "forward_all_enabled, forward_all_destination, ";
-								$sql .= "forward_busy_enabled, forward_busy_destination, ";
-								$sql .= "forward_no_answer_enabled, forward_no_answer_destination, ";
-								$sql .= $this->toggle_field." as toggle, follow_me_uuid ";
-								$sql .= "from v_".$this->table." ";
-								$sql .= "where (domain_uuid = :domain_uuid or domain_uuid is null) ";
-								$sql .= "and ".$this->uuid_prefix."uuid in (".implode(', ', $uuids).") ";
-								$parameters['domain_uuid'] = $_SESSION['domain_uuid'];
-								$rows = $database->select($sql, $parameters, 'all');
-								if (is_array($rows) && @sizeof($rows) != 0) {
-									foreach ($rows as $row) {
-										$extensions[$row['uuid']]['extension'] = $row['extension'];
-										$extensions[$row['uuid']]['number_alias'] = $row['number_alias'];
-										$extensions[$row['uuid']]['call_timeout'] = $row['call_timeout'];
-										$extensions[$row['uuid']]['do_not_disturb'] = $row['do_not_disturb'];
-										$extensions[$row['uuid']]['forward_all_enabled'] = $row['forward_all_enabled'];
-										$extensions[$row['uuid']]['forward_all_destination'] = $row['forward_all_destination'];
-										$extensions[$row['uuid']]['forward_busy_enabled'] = $row['forward_busy_enabled'];
-										$extensions[$row['uuid']]['forward_busy_destination'] = $row['forward_busy_destination'];
-										$extensions[$row['uuid']]['forward_no_answer_enabled'] = $row['forward_no_answer_enabled'];
-										$extensions[$row['uuid']]['forward_no_answer_destination'] = $row['forward_no_answer_destination'];
-										$extensions[$row['uuid']]['state'] = $row['toggle'];
-										$extensions[$row['uuid']]['follow_me_uuid'] = $row['follow_me_uuid'];
-									}
-								}
-								unset($sql, $parameters, $rows, $row);
-							}
-
-						//build update array
-							$x = 0;
-							foreach ($extensions as $uuid => $extension) {
-
-								//check destination
-									$destination_exists = $extension['forward_all_destination'] != '' ? true : false;
-
-								//determine new state
-									$new_state = $extension['state'] == $this->toggle_values[1] && $destination_exists ? $this->toggle_values[0] : $this->toggle_values[1];
-
-								//toggle feature
-									if ($new_state != $extension['state']) {
-										$array[$this->table][$x][$this->uuid_prefix.'uuid'] = $uuid;
-										$array[$this->table][$x][$this->toggle_field] = $new_state;
-									}
-
-								//disable other features
-									if ($new_state == $this->toggle_values[0]) { //true
-										$array[$this->table][$x]['do_not_disturb'] = $this->toggle_values[1]; //false
-										$array[$this->table][$x]['follow_me_enabled'] = $this->toggle_values[1]; //false
-										if (is_uuid($extension['follow_me_uuid'])) {
-											$array['follow_me'][$x]['follow_me_uuid'] = $extension['follow_me_uuid'];
-											$array['follow_me'][$x]['follow_me_enabled'] = $this->toggle_values[1]; //false
-										}
-									}
-
-								//increment counter
-									$x++;
-
-							}
-
-						//save the changes
-							if (is_array($array) && @sizeof($array) != 0) {
-
-								//grant temporary permissions
-									$p = new permissions;
-									$p->add('extension_edit', 'temp');
-
-								//save the array
-									$database->app_name = $this->app_name;
-									$database->app_uuid = $this->app_uuid;
-									$database->save($array);
-									unset($array);
-
-								//revoke temporary permissions
-									$p->delete('extension_edit', 'temp');
-
-								//send feature event notify to the phone
-									if ($_SESSION['device']['feature_sync']['boolean'] == "true") {
-										foreach ($extensions as $uuid => $extension) {
-											$feature_event_notify = new feature_event_notify;
-											$feature_event_notify->domain_name = $_SESSION['domain_name'];
-											$feature_event_notify->extension = $extension['extension'];
-											$feature_event_notify->do_not_disturb = $extension['do_not_disturb'];
-											$feature_event_notify->ring_count = ceil($extension['call_timeout'] / 6);
-											$feature_event_notify->forward_all_enabled = $extension['forward_all_enabled'];
-											$feature_event_notify->forward_busy_enabled = $extension['forward_busy_enabled'];
-											$feature_event_notify->forward_no_answer_enabled = $extension['forward_no_answer_enabled'];
-											//workarounds: send 0 as freeswitch doesn't send NOTIFY when destination values are nil
-											$feature_event_notify->forward_all_destination = $extension['forward_all_destination'] != '' ? $extension['forward_all_destination'] : '0';
-											$feature_event_notify->forward_busy_destination = $extension['forward_busy_destination'] != '' ? $extension['forward_busy_destination'] : '0';
-											$feature_event_notify->forward_no_answer_destination = $extension['forward_no_answer_destination'] != '' ? $extension['forward_no_answer_destination'] : '0';
-											$feature_event_notify->send_notify();
-											unset($feature_event_notify);
-										}
-									}
-
-								//synchronize configuration
-									if (is_readable($_SESSION['switch']['extensions']['dir'])) {
-										require_once "app/extensions/resources/classes/extension.php";
-										$ext = new extension;
-										$ext->xml();
-										unset($ext);
-									}
-
-								//clear the cache
-									$cache = new cache;
-									foreach ($extensions as $uuid => $extension) {
-										$cache->delete("directory:".$extension['extension']."@".$_SESSION['domain_name']);
-										if ($extension['number_alias'] != '') {
-											$cache->delete("directory:".$extension['number_alias']."@".$_SESSION['domain_name']);
-										}
-									}
-
-								//set message
-									message::add($text['message-toggle']);
-
-							}
-							unset($records, $extensions, $extension);
-					}
-
+			//build extension update array
+			$array['extensions'][0]['extension_uuid'] = $this->extension_uuid;
+			$array['extensions'][0]['forward_all_destination'] = strlen($this->forward_all_destination) != 0 ? $this->forward_all_destination : null;
+			if (empty($this->forward_all_destination) || $this->forward_all_enabled == "false") {
+				$array['extensions'][0]['forward_all_enabled'] = 'false';
+			} else {
+				$array['extensions'][0]['forward_all_enabled'] = 'true';
 			}
 
-		} //function
+			//grant temporary permissions
+			$p = new permissions;
+			$p->add('extension_add', 'temp');
 
-	}// class
+			//execute update
+			$database->app_name = 'calls';
+			$database->app_uuid = '19806921-e8ed-dcff-b325-dd3e5da4959d';
+			$database->save($array);
+			unset($array);
 
+			//revoke temporary permissions
+			$p->delete('extension_add', 'temp');
+
+			//delete extension from the cache
+			$cache = new cache;
+			$cache->delete("directory:" . $this->extension . "@" . $this->domain_name);
+			if (!empty($this->number_alias)) {
+				$cache->delete("directory:" . $this->number_alias . "@" . $this->domain_name);
+			}
+		}
+
+		/**
+		 * Toggle an array of call_forward records
+		 * @param array $records array of records to toggle
+		 */
+		public function toggle(array $records) {
+
+			//validate the token
+			$token = new token;
+			if (!$token->validate($_SERVER['PHP_SELF'])) {
+				message::add($text['message-invalid_token'], 'negative');
+				header('Location: ' . self::LIST_PAGE);
+				exit;
+			}
+
+			//validate there are records to process
+			if (count($records) < 1) return;
+
+			//check we have permission for this action
+			if (permission_exists(self::PERMISSION)) {
+
+				//create the database connection
+				$database = new database;
+
+				//add multi-lingual support
+				$language = new text;
+				$text = $language->get();
+
+				
+				// initialize an empty array
+				$uuids = [];
+				$extensions = [];
+				
+				//get current toggle state
+				foreach ($records as $x => $record) {
+					if ($record['checked'] == 'true' && is_uuid($record['uuid'])) {
+						$uuids[] = "'" . $record['uuid'] . "'";
+					}
+				}
+
+				//toggle the checked records
+				if (count($uuids) > 0) {
+					$sql = "select " . self::UUID_PREFIX . "uuid as uuid, extension, number_alias, ";
+					$sql .= "call_timeout, do_not_disturb, ";
+					$sql .= "forward_all_enabled, forward_all_destination, ";
+					$sql .= "forward_busy_enabled, forward_busy_destination, ";
+					$sql .= "forward_no_answer_enabled, forward_no_answer_destination, ";
+					$sql .= self::TOGGLE_FIELD . " as toggle, follow_me_uuid ";
+					$sql .= "from v_" . self::TABLE . " ";
+					$sql .= "where (domain_uuid = :domain_uuid or domain_uuid is null) ";
+					$sql .= "and " . self::UUID_PREFIX . "uuid in (" . implode(', ', $uuids) . ") ";
+					$parameters['domain_uuid'] = $_SESSION['domain_uuid'];
+					$rows = $database->select($sql, $parameters, 'all');
+					if (is_array($rows) && @sizeof($rows) != 0) {
+						foreach ($rows as $row) {
+							$extensions[$row['uuid']]['extension'] = $row['extension'];
+							$extensions[$row['uuid']]['number_alias'] = $row['number_alias'];
+							$extensions[$row['uuid']]['call_timeout'] = $row['call_timeout'];
+							$extensions[$row['uuid']]['do_not_disturb'] = $row['do_not_disturb'];
+							$extensions[$row['uuid']]['forward_all_enabled'] = $row['forward_all_enabled'];
+							$extensions[$row['uuid']]['forward_all_destination'] = $row['forward_all_destination'];
+							$extensions[$row['uuid']]['forward_busy_enabled'] = $row['forward_busy_enabled'];
+							$extensions[$row['uuid']]['forward_busy_destination'] = $row['forward_busy_destination'];
+							$extensions[$row['uuid']]['forward_no_answer_enabled'] = $row['forward_no_answer_enabled'];
+							$extensions[$row['uuid']]['forward_no_answer_destination'] = $row['forward_no_answer_destination'];
+							$extensions[$row['uuid']]['state'] = $row['toggle'];
+							$extensions[$row['uuid']]['follow_me_uuid'] = $row['follow_me_uuid'];
+						}
+					}
+					unset($sql, $parameters, $rows, $row);
+				}
+
+				//build update array
+				$x = 0;
+				foreach ($extensions as $uuid => $extension) {
+
+					//check destination
+					$destination_exists = $extension['forward_all_destination'] != '' ? true : false;
+
+					//determine new state
+					$new_state = $extension['state'] == self::TOGGLE_VALUES[1] && $destination_exists ? self::TOGGLE_VALUES[0] : self::TOGGLE_VALUES[1];
+
+					//toggle feature
+					if ($new_state != $extension['state']) {
+						$array[self::TABLE][$x][self::UUID_PREFIX . 'uuid'] = $uuid;
+						$array[self::TABLE][$x][self::TOGGLE_FIELD] = $new_state;
+					}
+
+					//disable other features
+					if ($new_state == self::TOGGLE_VALUES[0]) { //true
+						$array[self::TABLE][$x]['do_not_disturb'] = self::TOGGLE_VALUES[1]; //false
+						$array[self::TABLE][$x]['follow_me_enabled'] = self::TOGGLE_VALUES[1]; //false
+						if (is_uuid($extension['follow_me_uuid'])) {
+							$array['follow_me'][$x]['follow_me_uuid'] = $extension['follow_me_uuid'];
+							$array['follow_me'][$x]['follow_me_enabled'] = self::TOGGLE_VALUES[1]; //false
+						}
+					}
+
+					//increment counter
+					$x++;
+				}
+
+				//save the changes
+				if (is_array($array) && @sizeof($array) != 0) {
+
+					//grant temporary permissions
+					$p = new permissions;
+					$p->add('extension_edit', 'temp');
+
+					//save the array
+					$database->app_name = self::APP_NAME;
+					$database->app_uuid = self::APP_UUID;
+					$database->save($array);
+					unset($array);
+
+					//revoke temporary permissions
+					$p->delete('extension_edit', 'temp');
+
+					//send feature event notify to the phone
+					if ($_SESSION['device']['feature_sync']['boolean'] == "true") {
+						foreach ($extensions as $uuid => $extension) {
+							$feature_event_notify = new feature_event_notify;
+							$feature_event_notify->domain_name = $_SESSION['domain_name'];
+							$feature_event_notify->extension = $extension['extension'];
+							$feature_event_notify->do_not_disturb = $extension['do_not_disturb'];
+							$feature_event_notify->ring_count = ceil($extension['call_timeout'] / 6);
+							$feature_event_notify->forward_all_enabled = $extension['forward_all_enabled'];
+							$feature_event_notify->forward_busy_enabled = $extension['forward_busy_enabled'];
+							$feature_event_notify->forward_no_answer_enabled = $extension['forward_no_answer_enabled'];
+							//workarounds: send 0 as freeswitch doesn't send NOTIFY when destination values are nil
+							$feature_event_notify->forward_all_destination = $extension['forward_all_destination'] != '' ? $extension['forward_all_destination'] : '0';
+							$feature_event_notify->forward_busy_destination = $extension['forward_busy_destination'] != '' ? $extension['forward_busy_destination'] : '0';
+							$feature_event_notify->forward_no_answer_destination = $extension['forward_no_answer_destination'] != '' ? $extension['forward_no_answer_destination'] : '0';
+							$feature_event_notify->send_notify();
+							unset($feature_event_notify);
+						}
+					}
+
+					//synchronize configuration
+					if (is_readable($_SESSION['switch']['extensions']['dir'])) {
+						require_once "app/extensions/resources/classes/extension.php";
+						$ext = new extension;
+						$ext->xml();
+						unset($ext);
+					}
+
+					//clear the cache
+					$cache = new cache;
+					foreach ($extensions as $uuid => $extension) {
+						$cache->delete("directory:" . $extension['extension'] . "@" . $_SESSION['domain_name']);
+						if ($extension['number_alias'] != '') {
+							$cache->delete("directory:" . $extension['number_alias'] . "@" . $_SESSION['domain_name']);
+						}
+					}
+
+					//set message
+					message::add($text['message-toggle']);
+				}
+				unset($records, $extensions, $extension);
+			}
+		}
+
+//function
+	}
+
+	// class
 ?>


### PR DESCRIPTION
Fix multiple PHP 8.1 warnings. Change class private vars to class constants so they can be accessed without an object instance. This will make it possible to get the _APP_UUID_ using the form _call_forward::APP_UUID_ and still have them protected from any changes. This could be used for app_defaults and app_config.