### PR TITLE
Add order # to parent menu items dropdown selector

### DIFF
--- a/core/menu/menu_item_edit.php
+++ b/core/menu/menu_item_edit.php
@@ -482,12 +482,12 @@
 	echo "<select name=\"menu_item_parent_uuid\" class='formfld'>\n";
 	echo "<option value=\"\"></option>\n";
 	foreach($menu_items as $field) {
-			if ($menu_item_parent_uuid == $field['menu_item_uuid']) {
-				echo "<option value='".escape($field['menu_item_uuid'])."' selected>".escape($field['menu_item_title'])."</option>\n";
-			}
-			else {
-				echo "<option value='".escape($field['menu_item_uuid'])."'>".escape($field['menu_item_title'])."</option>\n";
-			}
+		if ($menu_item_parent_uuid == $field['menu_item_uuid']) {
+			echo "<option value='".escape($field['menu_item_uuid'])."' selected>".escape($field['menu_item_title'])." (order ".escape($field['menu_item_order']).")</option>\n";
+		}
+		else {
+			echo "<option value='".escape($field['menu_item_uuid'])."'>".escape($field['menu_item_title'])." (order ".escape($field['menu_item_order']).")</option>\n";
+		}
 	}
 	echo "</select>";
 	unset($sql, $result);


### PR DESCRIPTION
This is a way to help fix the issue when you have multiple parent menu and child menu items with the same name. example: should you add a custom Applications parent menu with custom permissions and you install the members' application manager, you will then have 3 "Applications" menu items to choose from when adding/editing menus. Rather than choose one and hope you have selected the correct "Application" menu item, and repeat until you get it correct, this method should reduce the blind selecting.