### PR TITLE
Update call_center_queue_edit.php

### DIFF
--- a/app/call_centers/call_center_queue_edit.php
+++ b/app/call_centers/call_center_queue_edit.php
@@ -592,7 +592,7 @@
 //set default values
 	if (empty($queue_strategy)) { $queue_strategy = "longest-idle-agent"; }
 	if (empty($queue_moh_sound)) { $queue_moh_sound = "\$\${hold_music}"; }
-	if (empty($queue_time_base_score)) { $queue_time_base_score = "system"; }
+	if (empty($queue_time_base_score)) { $queue_time_base_score = "queue"; }
 	if (empty($queue_time_base_score)) { $queue_time_base_score = ""; }
 	if (empty($queue_max_wait_time)) { $queue_max_wait_time = "0"; }
 	if (empty($queue_max_wait_time_with_no_agent)) { $queue_max_wait_time_with_no_agent = "90"; }
@@ -601,7 +601,7 @@
 	if (empty($queue_tier_rule_wait_second)) { $queue_tier_rule_wait_second = "30"; }
 	if (empty($queue_tier_rule_wait_multiply_level)) { $queue_tier_rule_wait_multiply_level = "true"; }
 	if (empty($queue_tier_rule_no_agent_no_wait)) { $queue_tier_rule_no_agent_no_wait = "true"; }
-	if (empty($queue_discard_abandoned_after)) { $queue_discard_abandoned_after = "900"; }
+	if (empty($queue_discard_abandoned_after)) { $queue_discard_abandoned_after = "90"; }
 	if (empty($queue_abandoned_resume_allowed)) { $queue_abandoned_resume_allowed = "false"; }
 
 //create token


### PR DESCRIPTION
1.
changed default value for the time_base_score to match both the default in freeswitch, and what I feel provides a more fair user experience. With it set to system (the old default), you can have situations where a caller is in line, and then gets bumped back further in the queue by someone who technically called in before them to the system, but arrived in the queue later. this can cause customer complaints esp if you have the announce position feature turned on, in which case the customer gets the depressing message that they are 8th in line, having just been 7th in line.

https://developer.signalwire.com/freeswitch/FreeSWITCH-Explained/Modules/mod_callcenter_1049389/#-time-base-score-

a description
"time-base-score
This can be either 'queue' or 'system' (queue is the default). If set to system, it will add the number of seconds since the call was originally answered (or entered the system) to the caller's base score. Raising the caller's score allows them to receive priority over other calls that might have been in the queue longer but not in the system as long. If set to queue, you get the default behavior, i.e., nobody's score gets increased upon entering the queue (regardless of the total length of their call)."


2.
changed default value for discard-abandoned-after to 90 seconds, down from 900 (fifteen minutes!) this is done for similar reasons. there is no default in the fs docs, but I feel that allowing someone to reclaim their queue position 15 minutes after they hung up is excessive, 90 seconds gives a disconnected caller plenty of time to recall and navigate to the queue. the negative effects of 900 seconds are the same as above, they could knock someone else down in queue up to 15 minutes after they hung up.

I think other values could work here, but 900 seems way too long!

https://developer.signalwire.com/freeswitch/FreeSWITCH-Explained/Modules/mod_callcenter_1049389/#discard-abandoned-after

"discard-abandoned-after
The number of seconds before we completely remove an abandoned member from the queue. When used in conjunction with abandoned-resume-allowed, callers can come back into a queue and resume their previous position."