### PR TITLE
Updated Snom D717 template for setting the Smartlabel display mode

### DIFF
--- a/resources/templates/provision/snom/D717/{$mac}.xml
+++ b/resources/templates/provision/snom/D717/{$mac}.xml
@@ -18,6 +18,7 @@
     <dialnumber_us_format perm="">on</dialnumber_us_format>
     <show_ivr_digits perm="">off</show_ivr_digits>
     <cw_dialtone perm="">{if isset($snom_dialtone_on_hold)}{$snom_dialtone_on_hold}{else}true{/if}</cw_dialtone>
+    <smartlabel_idle_default perm="PERMISSIONFLAGS">{if isset($snom_smartlabel_idle)}{$snom_smartlabel_idle}{else}short{/if}</smartlabel_idle_default>
     <!-- Ringtones -->
     <alert_internal_ring_text perm="">alert-internal</alert_internal_ring_text>
     <alert_internal_ring_sound perm="">{if isset($snom_alert_internal)}{$snom_alert_internal}{else}Ringer1{/if}</alert_internal_ring_sound>


### PR DESCRIPTION
By Default, Snom D717 has the smartlabel display mode set to "short". Snom D717 has an issue where for short labels it doesn't take the label that we configure in devices. Instead, it tries to look for the value in the system and if it doesn't find a contact or extension associated, it will just show the number itself.