### PR TITLE
Update translate.conf.lua

### DIFF
--- a/app/switch/resources/scripts/app/xml_handler/resources/scripts/configuration/translate.conf.lua
+++ b/app/switch/resources/scripts/app/xml_handler/resources/scripts/configuration/translate.conf.lua
@@ -93,7 +93,7 @@
 					x = 0;
 					dbh:query(sql, params, function(field)
 						if (string.len(field.number_translation_detail_regex) > 0) then
-							xml:append([[					<rule regex="]] .. xml.sanitize(field.number_translation_detail_regex) .. [[" replace="]] .. xml.sanitize(field.number_translation_detail_replace) .. [[" />]]);
+							xml:append([[					<rule regex="]] .. field.number_translation_detail_regex .. [[" replace="]] .. field.number_translation_detail_replace .. [[" />]]);
 						end
 					end)
 


### PR DESCRIPTION
Remove sanitization of number-translation regexes.
It prevents the number-translations to function properly.
See: https://www.pbxforums.com/threads/mod_translate-issue.7059/