### PR TITLE
[call_center] Optimize for multi-tenancy

### DIFF
--- a/app/call_centers/call_center_agent_edit.php
+++ b/app/call_centers/call_center_agent_edit.php
@@ -204,7 +204,7 @@
 
 		//clear the cache
 			$cache = new cache;
-			$cache->delete('configuration:callcenter.conf');
+			$cache->delete('configuration:callcenter.conf:'.$_SESSION["domain_name"]);
 
 	//get and then set the complete agent_contact with the call_timeout and when necessary confirm
 		//if you change this variable, also change resources/switch.php

--- a/app/call_centers/call_center_queue_edit.php
+++ b/app/call_centers/call_center_queue_edit.php
@@ -446,10 +446,6 @@
 				}
 			}
 
-		//synchronize the configuration
-			save_call_center_xml();
-			remove_config_from_cache('configuration:callcenter.conf');
-
 		//add agent/tier to queue
 			$agent_name = $_POST["agent_name"] ?? null;
 			$tier_level = $_POST["tier_level"] ?? null;
@@ -492,7 +488,7 @@
 
 		//clear the cache
 			$cache = new cache;
-			$cache->delete('configuration:callcenter.conf');
+			$cache->delete('configuration:callcenter.conf:'.$_SESSION["domain_name"]);
 
 		//redirect the user
 			if (is_uuid($call_center_queue_uuid)) {

--- a/app/call_centers/resources/classes/call_center.php
+++ b/app/call_centers/resources/classes/call_center.php
@@ -369,7 +369,7 @@
 									//clear the cache
 										$cache = new cache;
 										$cache->delete("dialplan:".$_SESSION["domain_name"]);
-										remove_config_from_cache('configuration:callcenter.conf');
+										$cache->delete('configuration:callcenter.conf:'.$_SESSION["domain_name"]);
 
 									//clear the destinations session array
 										if (isset($_SESSION['destinations']['array'])) {
@@ -462,7 +462,7 @@
 
 									//synchronize configuration
 										save_call_center_xml();
-										remove_config_from_cache('configuration:callcenter.conf');
+										$cache->delete('configuration:callcenter.conf:'.$_SESSION["domain_name"]);
 
 									//set message
 										message::add($text['message-delete']);


### PR DESCRIPTION
Enhance performance by optimizing the loading and reloading of queues, agents, and tiers in Freeswitch. This improvement eliminates the need for Freeswitch to read through all queues, agents, and tiers of unrelated domains.