### PR TITLE
Fix initial `install.php` failure due to missing `$_SESSION` variable

### DIFF
--- a/resources/switch.php
+++ b/resources/switch.php
@@ -945,7 +945,8 @@ if (!function_exists('xml_cdr_conf_xml')) {
 			unset ($v_pass);
 
 		//write the XML config file
-			$fout = fopen($_SESSION['switch']['conf']['dir']."/autoload_configs/xml_cdr.conf.xml","w");
+			$switch_configuration_dir = !empty($_SESSION['switch']['conf']['dir']) ? $_SESSION['switch']['conf']['dir'] : '/etc/freeswitch';
+			$fout = fopen($switch_configuration_dir . "/autoload_configs/xml_cdr.conf.xml","w");
 			fwrite($fout, $file_contents);
 			fclose($fout);
 


### PR DESCRIPTION
Running `install.php` from a browser when no UI login users exist in the DB causes a failure due to `$_SESSION['switch']['conf']['dir']` not yet existing.  

To reproduce, install FusionPBX via the offical install script and then log into the UI and delete the superadmin user that was created so that no users exist.  Delete `/etc/fusionpbx/config.conf` to cause `install.php` to run and proceed to create a new user via the browser.  You will get a PHP failure on line 948 of `/var/www/fusionpbx/resources/switch.php` because the `$_SESSION` variable on that line does not exist.

Subsequent re-installs (by deleting `/etc/fusionpbx/config.conf`) will work if other login users already exist. It's only when there are no login users configured that it will fail.  There may be better ways to fix this but this is what I came up with that works for me on Debian 11 using PHP 7.4 and 8.1. This used to work in v4.