### PR TITLE
[5.0] Make intercept feature more fault tolerant

### DIFF
--- a/app/scripts/resources/scripts/intercept.lua
+++ b/app/scripts/resources/scripts/intercept.lua
@@ -287,7 +287,7 @@
 			end
 			sql = sql .. ") ";
 			sql = sql .. "AND call_uuid IS NOT NULL ";
-			sql = sql .. "LIMIT 1 ";
+			sql = SQL .. "ORDER BY created_epoch DESC LIMIT 1 ";
 			if (debug["sql"]) then
 				log.noticef("SQL: %s; params: %s", sql, json.encode(params));
 			end


### PR DESCRIPTION
The channel table is not automatically flushed by FreeSWITCH when restarting, this will keep orphan records with time.

The ORDER will make sure that the code *97 will always get an existing UUID.