### PR TITLE
Fixing SRTP Feature on Default Settings Value Dial_String

### DIFF
--- a/app/extensions/app_config.php
+++ b/app/extensions/app_config.php
@@ -244,7 +244,8 @@
 		$apps[$x]['default_settings'][$y]['default_setting_category'] = "domain";
 		$apps[$x]['default_settings'][$y]['default_setting_subcategory'] = "dial_string";
 		$apps[$x]['default_settings'][$y]['default_setting_name'] = "text";
-		$apps[$x]['default_settings'][$y]['default_setting_value'] = "{sip_invite_domain=\${domain_name},leg_timeout=\${call_timeout},presence_id=\${dialed_user}@\${dialed_domain}}\${sofia_contact(*/\${dialed_user}@\${dialed_domain})}";
+		$apps[$x]['default_settings'][$y]['default_setting_value'] = "{sip_invite_domain=\${domain_name},leg_timeout=\${call_timeout},rtp_secure_media=\${regex(\${sofia_contact(\${dialed_user}@\${dialed_domain})}|transport=[Tt][Ll][Ss])},presence_id=\${dialed_user}@\${dialed_domain}}\${sofia_contact(*/\${dialed_user}@\${dialed_domain})}";
+";
 		$apps[$x]['default_settings'][$y]['default_setting_enabled'] = "true";
 		$apps[$x]['default_settings'][$y]['default_setting_description'] = "";
 		$y++;


### PR DESCRIPTION
1 - It properly fixs SRTP feature on TLS enabled environment. It includes new dial_string value on /app/extension/app_config.php and then autogenerated /etc/fusionpbx/config.lua file would be created with properly dial_string values too on installation process (scripts.php).

2 - It also solves issue when Endpoint register with uppercase "TLS" protocol instead lowercase "tls". Regex is case sensitive,rtp_secure_media variable would never turn true with TLS Contact uppercase cases!  

3 - It still accepts transport in lowercase "tls" transport ambient. 

4 - Now, every outbound INVITE to a TLS or tls endpoint Contact would receive crypto options inside SDP messages. Endpoints with compulsory SRTP feature enable should work ok now.