### PR TITLE
Voicemail: Return user to current message options after reviewing mes…

### DIFF
--- a/app/switch/resources/scripts/app/voicemail/resources/functions/listen_to_recording.lua
+++ b/app/switch/resources/scripts/app/voicemail/resources/functions/listen_to_recording.lua
@@ -1,5 +1,5 @@
 --	Part of FusionPBX
---	Copyright (C) 2013-2022 Mark J Crane <markjcrane@fusionpbx.com>
+--	Copyright (C) 2013-2023 Mark J Crane <markjcrane@fusionpbx.com>
 --	All rights reserved.
 --
 --	Redistribution and use in source and binary forms, with or without
@@ -24,11 +24,14 @@
 --	POSSIBILITY OF SUCH DAMAGE.
 
 --define function to listen to the recording
-	function listen_to_recording (message_number, uuid, created_epoch, caller_id_name, caller_id_number, message_status)
+	function listen_to_recording (message_number, uuid, created_epoch, caller_id_name, caller_id_number, message_status, message_play)
 
 		--set default values
 			dtmf_digits = '';
 			max_digits = 1;
+			if (message_play == nil) then
+				message_play = 'true';
+			end
 
 		--flush dtmf digits from the input buffer
 			session:flushDigits();
@@ -44,182 +47,187 @@
 				reply = api:executeString("uuid_display "..session:get_uuid().." "..caller_id_number);
 			end
 
-		--say the message number
-			if (session:ready()) then
-				if (string.len(dtmf_digits) == 0) then
-					session:execute("playback", "phrase:voicemail_say_message_number:" .. message_status .. ":" .. message_number);
-				end
-			end
+		--playback message
+			if (message_play == 'true') then
 
-		--say the caller id number first (default)
-			if (
-				session:ready() and
-				caller_id_number ~= nil and (
-					vm_say_caller_id_number == nil or
-					vm_say_caller_id_number == "true" or
-					vm_say_caller_id_number == "before"
-				)) then
-				session:streamFile(sounds_dir.."/"..default_language.."/"..default_dialect.."/"..default_voice.."/voicemail/vm-from.wav");
-				session:say(caller_id_number, default_language, "name_spelled", "iterated");
-			end
-
-		--say the message date first (default)
-			if (
-				session:ready() and
-				string.len(dtmf_digits) == 0 and (
-					vm_say_date_time == nil or
-					vm_say_date_time == "true" or
-					vm_say_date_time == "before"
-				)) then
-				if (current_time_zone ~= nil) then
-					session:execute("set", "timezone="..current_time_zone.."");
-				end
-				session:say(created_epoch, default_language, "current_date_time", "pronounced");
-			end
-
-		--get the recordings from the database
-			if (storage_type == "base64") then
-				local dbh = Database.new('system', 'base64/read')
-
-				local sql = [[SELECT * FROM v_voicemail_messages
-					WHERE domain_uuid = :domain_uuid
-					AND voicemail_message_uuid = :uuid]];
-				local params = {domain_uuid = domain_uuid, uuid = uuid};
-				if (debug["sql"]) then
-					freeswitch.consoleLog("notice", "[voicemail] SQL: " .. sql .. "; params:" .. json.encode(params) .. "\n");
-				end
-				dbh:query(sql, params, function(row)
-					--set the voicemail message path
-						mkdir(voicemail_dir.."/"..voicemail_id);
-						message_intro_location = voicemail_dir.."/"..voicemail_id.."/intro_"..uuid.."."..vm_message_ext;
-						message_location = voicemail_dir.."/"..voicemail_id.."/msg_"..uuid;
-
-					--save the recording to the file system
-						if (string.len(row["message_intro_base64"]) > 32) then
-							local file = io.open(message_intro_location, "w");
-							file:write(base64.decode(row["message_intro_base64"]));
-							file:close();
+				--say the message number
+					if (session:ready()) then
+						if (string.len(dtmf_digits) == 0) then
+							session:execute("playback", "phrase:voicemail_say_message_number:" .. message_status .. ":" .. message_number);
 						end
-						if (string.len(row["message_base64"]) > 32) then
-							--include the file io
-								local file = require "resources.functions.file"
+					end
 
-							--write decoded string to file
-								assert(file.write_base64(message_location, row["message_base64"]));
+				--say the caller id number first (default)
+					if (
+						session:ready() and
+						caller_id_number ~= nil and (
+							vm_say_caller_id_number == nil or
+							vm_say_caller_id_number == "true" or
+							vm_say_caller_id_number == "before"
+						)) then
+						session:streamFile(sounds_dir.."/"..default_language.."/"..default_dialect.."/"..default_voice.."/voicemail/vm-from.wav");
+						session:say(caller_id_number, default_language, "name_spelled", "iterated");
+					end
+
+				--say the message date first (default)
+					if (
+						session:ready() and
+						string.len(dtmf_digits) == 0 and (
+							vm_say_date_time == nil or
+							vm_say_date_time == "true" or
+							vm_say_date_time == "before"
+						)) then
+						if (current_time_zone ~= nil) then
+							session:execute("set", "timezone="..current_time_zone.."");
 						end
+						session:say(created_epoch, default_language, "current_date_time", "pronounced");
+					end
 
-					--get the file type
-						command = "file -b --mime-type "..message_location;
-						local handle = io.popen(command);
-						local mime_type = trim(handle:read("*a"));
-						handle:close();
-						if (mime_type == 'audio/x-wav') then
-							vm_message_ext = 'wav';
+				--get the recordings from the database
+					if (storage_type == "base64") then
+						local dbh = Database.new('system', 'base64/read')
+
+						local sql = [[SELECT * FROM v_voicemail_messages
+							WHERE domain_uuid = :domain_uuid
+							AND voicemail_message_uuid = :uuid]];
+						local params = {domain_uuid = domain_uuid, uuid = uuid};
+						if (debug["sql"]) then
+							freeswitch.consoleLog("notice", "[voicemail] SQL: " .. sql .. "; params:" .. json.encode(params) .. "\n");
 						end
-						if (mime_type == 'audio/mpeg') then
-							vm_message_ext = 'mp3';
-						end
+						dbh:query(sql, params, function(row)
+							--set the voicemail message path
+								mkdir(voicemail_dir.."/"..voicemail_id);
+								message_intro_location = voicemail_dir.."/"..voicemail_id.."/intro_"..uuid.."."..vm_message_ext;
+								message_location = voicemail_dir.."/"..voicemail_id.."/msg_"..uuid;
 
-					--rename the file
-						os.execute('mv '..message_location..' '..message_location..'.'..vm_message_ext);
-				end);
-				dbh:release()
-			elseif (storage_type == "http_cache") then
-				message_location = storage_path.."/"..voicemail_id.."/msg_"..uuid.."."..vm_message_ext;
-			end
-
-		--play the message intro
-			if (session:ready()) then
-				if (string.len(dtmf_digits) == 0) then
-					if (file_exists(voicemail_dir.."/"..voicemail_id.."/intro_"..uuid.."."..vm_message_ext)) then
-						stream_seek = true;
-						if (storage_type == "http_cache") then
-							message_intro_location = storage_path.."/"..voicemail_id.."/intro_"..uuid.."."..vm_message_ext;
-							session:streamFile(storage_path.."/"..voicemail_id.."/intro_"..uuid.."."..vm_message_ext);
-						else
-							if (vm_message_ext == "mp3") then
-								if (api:executeString("module_exists mod_vlc") == "true") then
-									session:streamFile("vlc://"..voicemail_dir.."/"..voicemail_id.."/intro_"..uuid.."."..vm_message_ext);
-								else
-									session:streamFile(voicemail_dir.."/"..voicemail_id.."/intro_"..uuid.."."..vm_message_ext);
+							--save the recording to the file system
+								if (string.len(row["message_intro_base64"]) > 32) then
+									local file = io.open(message_intro_location, "w");
+									file:write(base64.decode(row["message_intro_base64"]));
+									file:close();
 								end
-							else
-								session:streamFile(voicemail_dir.."/"..voicemail_id.."/intro_"..uuid.."."..vm_message_ext);
+								if (string.len(row["message_base64"]) > 32) then
+									--include the file io
+										local file = require "resources.functions.file"
+
+									--write decoded string to file
+										assert(file.write_base64(message_location, row["message_base64"]));
+								end
+
+							--get the file type
+								command = "file -b --mime-type "..message_location;
+								local handle = io.popen(command);
+								local mime_type = trim(handle:read("*a"));
+								handle:close();
+								if (mime_type == 'audio/x-wav') then
+									vm_message_ext = 'wav';
+								end
+								if (mime_type == 'audio/mpeg') then
+									vm_message_ext = 'mp3';
+								end
+
+							--rename the file
+								os.execute('mv '..message_location..' '..message_location..'.'..vm_message_ext);
+						end);
+						dbh:release()
+					elseif (storage_type == "http_cache") then
+						message_location = storage_path.."/"..voicemail_id.."/msg_"..uuid.."."..vm_message_ext;
+					end
+
+				--play the message intro
+					if (session:ready()) then
+						if (string.len(dtmf_digits) == 0) then
+							if (file_exists(voicemail_dir.."/"..voicemail_id.."/intro_"..uuid.."."..vm_message_ext)) then
+								stream_seek = true;
+								if (storage_type == "http_cache") then
+									message_intro_location = storage_path.."/"..voicemail_id.."/intro_"..uuid.."."..vm_message_ext;
+									session:streamFile(storage_path.."/"..voicemail_id.."/intro_"..uuid.."."..vm_message_ext);
+								else
+									if (vm_message_ext == "mp3") then
+										if (api:executeString("module_exists mod_vlc") == "true") then
+											session:streamFile("vlc://"..voicemail_dir.."/"..voicemail_id.."/intro_"..uuid.."."..vm_message_ext);
+										else
+											session:streamFile(voicemail_dir.."/"..voicemail_id.."/intro_"..uuid.."."..vm_message_ext);
+										end
+									else
+										session:streamFile(voicemail_dir.."/"..voicemail_id.."/intro_"..uuid.."."..vm_message_ext);
+									end
+								end
+								stream_seek = false;
+								--session:streamFile("silence_stream://1000");
 							end
 						end
-						stream_seek = false;
-						--session:streamFile("silence_stream://1000");
-					end
-				end
-			end
-
-		--play the message
-			if (session:ready()) then
-				if (string.len(dtmf_digits) == 0) then
-				    --check if wav file exists then play the file
-				    if (file_exists(voicemail_dir.."/"..voicemail_id.."/msg_"..uuid..".wav")) then
-					   stream_seek = true;
-					   if (storage_type == "http_cache") then
-						  message_location = storage_path.."/"..voicemail_id.."/msg_"..uuid..".wav";
-						  session:streamFile(storage_path.."/"..voicemail_id.."/msg_"..uuid..".wav");
-					   else
-						  session:streamFile(voicemail_dir.."/"..voicemail_id.."/msg_"..uuid..".wav");
-					   end
-					   stream_seek = false;
-					   session:streamFile("silence_stream://1000");
 					end
 
-					--check if mp3 file exists then play the file
-					if (file_exists(voicemail_dir.."/"..voicemail_id.."/msg_"..uuid..".mp3")) then
-					   stream_seek = true;
-					   if (storage_type == "http_cache") then
-						  message_location = storage_path.."/"..voicemail_id.."/msg_"..uuid..".mp3";
-						  session:streamFile(storage_path.."/"..voicemail_id.."/msg_"..uuid..".mp3");
-					   else
-						  if (api:executeString("module_exists mod_vlc") == "true") then
-							 session:streamFile("vlc://"..voicemail_dir.."/"..voicemail_id.."/msg_"..uuid..".mp3");
-						  else
-							 session:streamFile(voicemail_dir.."/"..voicemail_id.."/msg_"..uuid..".mp3");
-						  end
-					   end
-					   stream_seek = false;
-					   session:streamFile("silence_stream://1000");
+				--play the message
+					if (session:ready()) then
+						if (string.len(dtmf_digits) == 0) then
+							--check if wav file exists then play the file
+							if (file_exists(voicemail_dir.."/"..voicemail_id.."/msg_"..uuid..".wav")) then
+							stream_seek = true;
+							if (storage_type == "http_cache") then
+								message_location = storage_path.."/"..voicemail_id.."/msg_"..uuid..".wav";
+								session:streamFile(storage_path.."/"..voicemail_id.."/msg_"..uuid..".wav");
+							else
+								session:streamFile(voicemail_dir.."/"..voicemail_id.."/msg_"..uuid..".wav");
+							end
+							stream_seek = false;
+							session:streamFile("silence_stream://1000");
+							end
+
+							--check if mp3 file exists then play the file
+							if (file_exists(voicemail_dir.."/"..voicemail_id.."/msg_"..uuid..".mp3")) then
+							stream_seek = true;
+							if (storage_type == "http_cache") then
+								message_location = storage_path.."/"..voicemail_id.."/msg_"..uuid..".mp3";
+								session:streamFile(storage_path.."/"..voicemail_id.."/msg_"..uuid..".mp3");
+							else
+								if (api:executeString("module_exists mod_vlc") == "true") then
+									session:streamFile("vlc://"..voicemail_dir.."/"..voicemail_id.."/msg_"..uuid..".mp3");
+								else
+									session:streamFile(voicemail_dir.."/"..voicemail_id.."/msg_"..uuid..".mp3");
+								end
+							end
+							stream_seek = false;
+							session:streamFile("silence_stream://1000");
+							end
+						end
 					end
-				end
-			end
 
-		--remove the voicemail message
-			if (storage_type == "base64") then
-				os.remove(voicemail_dir.."/"..voicemail_id.."/intro_"..uuid.."."..vm_message_ext);
-				os.remove(voicemail_dir.."/"..voicemail_id.."/msg_"..uuid.."."..vm_message_ext);
-			end
+				--remove the voicemail message
+					if (storage_type == "base64") then
+						os.remove(voicemail_dir.."/"..voicemail_id.."/intro_"..uuid.."."..vm_message_ext);
+						os.remove(voicemail_dir.."/"..voicemail_id.."/msg_"..uuid.."."..vm_message_ext);
+					end
 
-		--say the caller id number last (optional)
-			if (
-				session:ready() and
-				caller_id_number ~= nil and
-				vm_say_caller_id_number ~= nil and
-				(
-					vm_say_caller_id_number == "last" or
-					vm_say_caller_id_number == "after"
-				)) then
-				session:streamFile(sounds_dir.."/"..default_language.."/"..default_dialect.."/"..default_voice.."/voicemail/vm-from.wav");
-				session:say(caller_id_number, default_language, "name_spelled", "iterated");
-			end
+				--say the caller id number last (optional)
+					if (
+						session:ready() and
+						caller_id_number ~= nil and
+						vm_say_caller_id_number ~= nil and
+						(
+							vm_say_caller_id_number == "last" or
+							vm_say_caller_id_number == "after"
+						)) then
+						session:streamFile(sounds_dir.."/"..default_language.."/"..default_dialect.."/"..default_voice.."/voicemail/vm-from.wav");
+						session:say(caller_id_number, default_language, "name_spelled", "iterated");
+					end
 
-		--say the message date last (optional)
-			if (
-				session:ready() and
-				string.len(dtmf_digits) == 0 and
-				vm_say_date_time ~= nil and
-				(
-					vm_say_date_time == "last" or
-					vm_say_date_time == "after"
-				)) then
-				if (current_time_zone ~= nil) then
-					session:execute("set", "timezone="..current_time_zone.."");
-				end
-				session:say(created_epoch, default_language, "current_date_time", "pronounced");
+				--say the message date last (optional)
+					if (
+						session:ready() and
+						string.len(dtmf_digits) == 0 and
+						vm_say_date_time ~= nil and
+						(
+							vm_say_date_time == "last" or
+							vm_say_date_time == "after"
+						)) then
+						if (current_time_zone ~= nil) then
+							session:execute("set", "timezone="..current_time_zone.."");
+						end
+						session:say(created_epoch, default_language, "current_date_time", "pronounced");
+					end
+
 			end
 
 		--post listen options
@@ -250,6 +258,8 @@
 						session:execute("set", "timezone="..current_time_zone.."");
 					end
 					session:say(created_epoch, default_language, "current_date_time", "pronounced");
+					session:execute("sleep", "1000");
+					return listen_to_recording (message_number, uuid, created_epoch, caller_id_name, caller_id_number, message_status, 'false');
 				elseif (dtmf_digits == "5") then
 					message_saved(voicemail_id, uuid);
 					return_call(caller_id_number);


### PR DESCRIPTION
…sage envelope.

These changes make it so when a user checks their voicemail messages, and presses the option to listen to the message envelope, the user is then given options again (i.e. "To listen to the recording, press 1.  To save the recording press 2. ..." for the CURRENT message...   INSTEAD of being returned to the root voicemail menu where they must start all over, hearing "To listen to new messages, press 1.", etc.

After reviewing the message envelope (phone number and call time), the user should be offered the same options again for the current message (play the message again, save the message, delete the message, etc)... not returned to the root of the voicemail box menu.