### PR TITLE
Fix Ring Group Delay Timing (Enterprise)

### DIFF
--- a/app/switch/resources/scripts/app/ring_groups/index.lua
+++ b/app/switch/resources/scripts/app/ring_groups/index.lua
@@ -480,7 +480,7 @@
 					d.destination_number, d.destination_timeout, d.destination_prompt,
 					CASE
 						WHEN r.ring_group_strategy = 'enterprise'
-							THEN d.destination_delay * 1000
+							THEN d.destination_delay * 500
 						WHEN r.ring_group_strategy <> 'enterprise'
 							THEN d.destination_delay
 					END as destination_delay,
@@ -592,7 +592,7 @@
 						if (follow_me_uuid ~= nil and row.is_follow_me_destination ~= "true") then
 							sql = "select d.domain_uuid, d.domain_name, f.follow_me_destination as destination_number, ";
 							if (row.ring_group_strategy == 'enterprise') then
-								sql = sql .. "f.follow_me_delay * 1000 as destination_delay, ";
+								sql = sql .. "f.follow_me_delay * 500 as destination_delay, ";
 							else
 								sql = sql .. "f.follow_me_delay as destination_delay, ";
 							end

--- a/app/switch/resources/scripts/app/ring_groups/index.lua
+++ b/app/switch/resources/scripts/app/ring_groups/index.lua
@@ -474,6 +474,7 @@
 			end);
 
 		--get the ring group destinations
+		--we must multiply destination_delay by 500 instead of 1000 because a freeswitch bug doubles the delay set in the dialstring
 			sql = [[
 				SELECT
 					r.ring_group_strategy, r.ring_group_timeout_app, r.ring_group_distinctive_ring,
@@ -592,6 +593,7 @@
 						if (follow_me_uuid ~= nil and row.is_follow_me_destination ~= "true") then
 							sql = "select d.domain_uuid, d.domain_name, f.follow_me_destination as destination_number, ";
 							if (row.ring_group_strategy == 'enterprise') then
+								--we must multiply destination_delay by 500 instead of 1000 because a freeswitch bug doubles the delay set in the dialstring
 								sql = sql .. "f.follow_me_delay * 500 as destination_delay, ";
 							else
 								sql = sql .. "f.follow_me_delay as destination_delay, ";


### PR DESCRIPTION
The delays for enterprise strategy ring groups have recently been broken such that they are double the actual set values. This returns the delays back to what they should be. See the below commits for all details on this bug:

The enterprise ring group  delay timing was broken in the following commit:  https://github.com/fusionpbx/fusionpbx/commit/557284070a353e0b003368773ac151739bdd2d06

The enterprise ring group follow-me delay timing was broken in the following commit: https://github.com/fusionpbx/fusionpbx/commit/c69535413cba9ee2475f22bb7b344814aa3c7cfd

Here is the original commit where it was fixed with full explanation. Please reference this commit from 2019 for full details: https://github.com/fusionpbx/fusionpbx/commit/f44ed4370cd933820ae7c01bb90b749fa541f884