### PR TITLE
Add ability to set custom logout destination

### DIFF
--- a/logout.php
+++ b/logout.php
@@ -26,6 +26,15 @@
 
 //includes files
 	require_once __DIR__ . "/resources/require.php";
+	
+//if custom logout destination is set, redirect to it
+	if (isset($_SESSION["login"]["logout_destination"]["text"])){
+		$logout_destination = $_SESSION["login"]["logout_destination"]["text"]."?SessionID=".session_id();
+	}
+//otherwise, redirect to the index page
+	else {
+		$logout_destination = PROJECT_PATH."/";
+	}
 
 //destroy session
 	session_unset();
@@ -97,7 +106,7 @@
 	}
 
 //redirect the user to the index page
-	header("Location: ".PROJECT_PATH."/");
+	header("Location: ".$logout_destination);
 	exit;
 
 ?>

--- a/logout.php
+++ b/logout.php
@@ -29,7 +29,7 @@
 	
 //if custom logout destination is set, redirect to it
 	if (isset($_SESSION["login"]["logout_destination"]["text"])){
-		$logout_destination = $_SESSION["login"]["logout_destination"]["text"]."?SessionID=".session_id();
+		$logout_destination = $_SESSION["login"]["logout_destination"]["text"];
 	}
 //otherwise, redirect to the index page
 	else {
@@ -105,7 +105,7 @@
 		}
 	}
 
-//redirect the user to the index page
+//redirect the user to the logout page
 	header("Location: ".$logout_destination);
 	exit;
 

--- a/logout.php
+++ b/logout.php
@@ -27,11 +27,10 @@
 //includes files
 	require_once __DIR__ . "/resources/require.php";
 	
-//if custom logout destination is set, redirect to it
+//use custom logout destination if set otherwise redirect to the index page
 	if (isset($_SESSION["login"]["logout_destination"]["text"])){
 		$logout_destination = $_SESSION["login"]["logout_destination"]["text"];
 	}
-//otherwise, redirect to the index page
 	else {
 		$logout_destination = PROJECT_PATH."/";
 	}


### PR DESCRIPTION
Allow administrators to set a custom default setting called `logout_destination` which will redirect the user to a destination of their choosing.

We also pass the PHP session ID after logout was completed to allow custom logic to be executed based on the session ID.