### PR TITLE
illogical condition specified in fax_send

### DIFF
--- a/app/fax/fax_send.php
+++ b/app/fax/fax_send.php
@@ -738,7 +738,7 @@ if (!function_exists('fax_split_dtmf')) {
 				$channel_variables["toll_allow"] = !empty($fax_toll_allow) ? $fax_toll_allow : null;
 				$route_array = outbound_route_to_bridge($domain_uuid, $fax_prefix . $fax_number, $channel_variables);
 
-				if (!empty($route_array) && count($route_array) == 0) {
+				if (empty($route_array)) {
 					//send the internal call to the registered extension
 					$fax_uri = "user/".$fax_number."@".$domain_name;
 					$fax_variables = '';
@@ -1178,5 +1178,3 @@ function showgrid($pdf) {
 	}
 }
 */
-
-?>


### PR DESCRIPTION
It doesn't make logical sense for **!empty($route_array)** to also have **count($route_array) == 0**. In a typical scenario, if an array is not empty, its count should be greater than 0.

The condition **!empty($route_array)** checks if the array is not empty, meaning it has at least one element, and therefore, **count($route_array)** should be greater than 0.