### PR TITLE
Fix vm_disk_quota

### DIFF
--- a/app/switch/resources/scripts/app/voicemail/index.lua
+++ b/app/switch/resources/scripts/app/voicemail/index.lua
@@ -472,7 +472,7 @@
 					dbh:query(sql, params, function(row)
 						message_sum = row["message_sum"];
 					end);
-					if (vm_disk_quota and message_sum and #vm_disk_quota <= #message_sum) then
+					if (vm_disk_quota and message_sum and tonumber(vm_disk_quota) <= tonumber(message_sum)) then
 						--play message mailbox full
 							session:execute("playback", sounds_dir.."/"..default_language.."/"..default_dialect.."/"..default_voice.."/voicemail/vm-mailbox_full.wav")
 						--hangup


### PR DESCRIPTION
The current condition #vm_disk_quota <= #message_sum is checking the lengths of vm_disk_quota and message_sum, not their actual values. So, it won't compare the numeric values for your intended logic.

If they're strings that can be safely converted to numbers, use tonumber():

if (vm_disk_quota and message_sum and tonumber(vm_disk_quota) <= tonumber(message_sum)) then
  -- your code
end

This will compare them as numbers, ensuring that vm_disk_quota is less than or equal to message_sum.