### PR TITLE
[eavesdrop] Fix eavesdropping wrong uuid

### DIFF
--- a/app/switch/resources/scripts/eavesdrop.lua
+++ b/app/switch/resources/scripts/eavesdrop.lua
@@ -109,7 +109,7 @@
 
 --check the database to get the uuid to eavesdrop on
 	if (session:ready()) then
-		local sql = "select uuid from channels where presence_id = :presence_id ";
+		local sql = "select uuid from channels where presence_id = :presence_id and callstate = 'ACTIVE'";
 		local params = {presence_id = extension.."@"..domain_name};
 		if (debug["sql"]) then
 			freeswitch.consoleLog("notice", "[eavesdrop] SQL: " .. sql .. "; params:" .. json.encode(params) .. "\n");


### PR DESCRIPTION
If the extension is in a call and also receives calls at the same time, the query will return more than one uuid causing to eavesdrop the wrong channel.