### PR TITLE
Update logging class

### DIFF
--- a/resources/classes/logging.php
+++ b/resources/classes/logging.php
@@ -8,7 +8,7 @@
 	 * - message is written with the following format: [d/M/Y:H:i:s] (script name) message.
 	 * - log file is closed when the object is destroyed.
 	 */
-	class Logging {
+	class logging {
 
 		// declare log file and file pointer as private properties
 		private $fp;
@@ -118,7 +118,7 @@
 	}
 /*
  * Example:
-	$log = new Logging(sys_get_temp_dir() . '/logging.log');
+	$log = new logging(sys_get_temp_dir() . '/logging.log');
 	$log->writeln("debug", "passed validation");
 	$log->debug("pass");
 	$log->warning("variable should not used");

--- a/resources/classes/logging.php
+++ b/resources/classes/logging.php
@@ -61,11 +61,6 @@
 		// write message to the log file
 		private function _write($msg) {
 			// define current time and suppress E_WARNING if using the system TZ settings
-			// (don't forget to set the INI setting date.timezone)
-			$time = @date('[d/M/Y:H:i:s]');
-			// write current time, script name and message to the log file
-			fwrite($this->fp, "$time ({$this->debug_line}: {$this->debug_file}) $msg");
-			$this->clear_debug();
 		}
 
 		private function clear_debug() {
@@ -77,7 +72,11 @@
 
 		public function write($level, $message) {
 			$this->get_backtrace_details();
-			$this->_write("[" . strtoupper($level) . "] $message");
+			// write current time, script name and message to the log file
+			// (don't forget to set the INI setting date.timezone)
+			$time = @date('Y-m-d H:i:s');
+			fwrite($this->fp, "[$time] [$level] [{$this->debug_file}:{$this->debug_line}] $message");
+			$this->clear_debug();
 		}
 
 		public function writeln($level, $message) {
@@ -87,22 +86,22 @@
 
 		public function debug($message) {
 			$this->get_backtrace_details();
-			$this->writeln("debug", $message);
+			$this->writeln("DEBUG", $message);
 		}
 
 		public function info($message) {
 			$this->get_backtrace_details();
-			$this->writeln("info", $message);
+			$this->writeln("INFO", $message);
 		}
 
 		public function warning($message) {
 			$this->get_backtrace_details();
-			$this->writeln("warning", $message);
+			$this->writeln("WARNING", $message);
 		}
 
 		public function error($message) {
 			$this->get_backtrace_details();
-			$this->writeln("error", $message);
+			$this->writeln("ERROR", $message);
 		}
 
 		private function get_backtrace_details() {
@@ -121,6 +120,6 @@
  * Example:
 	$log = new Logging(sys_get_temp_dir() . '/logging.log');
 	$log->writeln("debug", "passed validation");
-	$log->writeln("debug", "pass");
+	$log->debug("pass");
 	$log->warning("variable should not used");
  */

--- a/resources/classes/logging.php
+++ b/resources/classes/logging.php
@@ -1,91 +1,133 @@
 <?php
-/**
- * Logging class:
- * - contains lfile, lwrite and lclose public methods
- * - lfile sets path and name of log file
- * - lwrite writes message to the log file (and implicitly opens log file)
- * - lclose closes log file
- * - first call of lwrite method will open log file implicitly
- * - message is written with the following format: [d/M/Y:H:i:s] (script name) message
- */
-class Logging
-{
-	// declare log file and file pointer as private properties
-	private $log_file, $fp;
 
-	// set log file (path and name)
+	/**
+	 * Logging class:
+	 * - constructor requires the full file name and path for the log file. if it
+	 * does not exist php will automatically try and create it. The log file will
+	 * remain open for the life cycle of the object to improve performance.
+	 * - message is written with the following format: [d/M/Y:H:i:s] (script name) message.
+	 * - log file is closed when the object is destroyed.
+	 */
+	class Logging {
 
-	public function lfile($path)
-	{
-		$this->log_file = $path;
-	}
+		// declare log file and file pointer as private properties
+		private $fp;
+		private $debug_func;
+		private $debug_line;
+		private $debug_file;
+		private $debug_class;
 
-	// write message to the log file
-
-	public function lwrite($message)
-	{
-		// if file pointer doesn't exist, then open log file
-		if (!$this->fp) {
-			$this->lopen();
-		}
-		// define script name
-		$script_name = pathinfo($_SERVER['PHP_SELF'], PATHINFO_FILENAME);
-		// define current time and suppress E_WARNING if using the system TZ settings
-		// (don't forget to set the INI setting date.timezone)
-		$time = @date('[d/M/Y:H:i:s]');
-		// write current time, script name and message to the log file
-		fwrite($this->fp, "$time ($script_name) $message" . PHP_EOL);
-	}
-
-	// close log file (it's always a good idea to close a file when you're done with it)
-
-	private function lopen()
-	{
-		// in case of Windows set default log file
-		if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
-			$log_file_default = 'c:/php/logfile.txt';
-		} // set default log file for Linux and other systems
-		else {
-			$log_file_default = '/tmp/logfile.txt';
-		}
-		// define log file from lfile method or use previously set default
-		$lfile = $this->log_file ? $this->log_file : $log_file_default;
-		// open log file for writing only and place file pointer at the end of the file
-		// (if the file does not exist, try to create it)
-		$this->fp = fopen($lfile, 'a') or exit("Can't open $lfile!");
-	}
-
-	// open log file (private method)
-
-	public function lclose()
-	{
-		fclose($this->fp);
-	}
-
-	public function log($level, $msg){
-
-		$log_file = $_SESSION['logging']['log']['logfile'];
-		$log_level = $_SESSION['logging']['log']['loglevel'];
-
-		if ($log_level !== $level) {
-			return;
+		public function __construct(string $filename_and_path) {
+			//init values
+			$this->clear_debug();
+			
+			try {
+				//open file in append mode
+				$this->fp = fopen($filename_and_path, 'a');
+			} catch (Exception $ex) {
+				//send the error to the caller
+				throw $ex;
+			}
 		}
 
-		if ($log_file) {
-			$this->lfile($log_file);
+		public function __destruct() {
+			try {
+				$this->flush();
+			} catch (Exception $ex) {
+				//do nothing
+			} finally {
+				//close the file
+				if (is_resource($this->fp)) {
+					fclose($this->fp);
+				}
+			}
 		}
 
-		$this->lopen();
+		/**
+		 * Ensure all data arrives on disk
+		 * @throws Exception
+		 */
+		public function flush() {
+			try {
+				//ensure everything arrives on disk
+				if (is_resource($this->fp)) {
+					fflush($this->fp);
+				}
+			} catch (Exception $ex) {
+				throw $ex;
+			}
+		}
 
-		$this->lwrite("[".strtoupper($level)."] ".$msg);
+		// write message to the log file
+		private function _write($msg) {
+			// define current time and suppress E_WARNING if using the system TZ settings
+			// (don't forget to set the INI setting date.timezone)
+			$time = @date('[d/M/Y:H:i:s]');
+			// write current time, script name and message to the log file
+			fwrite($this->fp, "$time ({$this->debug_line}: {$this->debug_file}) $msg");
+			$this->clear_debug();
+		}
 
-		//close handle
-		$this->lclose();
+		private function clear_debug() {
+			$this->debug_line = null;
+			$this->debug_file = null;
+			$this->debug_func = null;
+			$this->debug_class = null;
+		}
+
+		public function write($level, $message) {
+			$this->get_backtrace_details();
+			$this->_write("[" . strtoupper($level) . "] $message");
+		}
+
+		public function writeln($level, $message) {
+			$this->get_backtrace_details();
+			$this->write($level, $message . "\n");
+		}
+
+		public function debug($message) {
+			$this->get_backtrace_details();
+			$this->writeln("debug", $message);
+		}
+
+		public function info($message) {
+			$this->get_backtrace_details();
+			$this->writeln("info", $message);
+		}
+
+		public function warning($message) {
+			$this->get_backtrace_details();
+			$this->writeln("warning", $message);
+		}
+
+		public function error($message) {
+			$this->get_backtrace_details();
+			$this->writeln("error", $message);
+		}
+
+		private function get_backtrace_details() {
+			if ($this->debug_file === null) {
+				$debug = debug_backtrace();
+				$ndx = count($debug) - 1;
+				$this->debug_file = $debug[$ndx]['file'];
+				$this->debug_line = $debug[$ndx]['line'];
+				$this->debug_func = $debug[$ndx]['function'];
+				$this->debug_class = $debug[$ndx]['class'] ?? '';
+			}
+		}
+
+		/**
+		 * Alias of writeln
+		 * @param type $level
+		 * @param type $message
+		 */
+		public function wln($level, $message) {
+			$this->get_backtrace_details();
+			$this->writeln($level, $message);
+		}
 	}
-}
 
-//$log = new Logging();
-//$log->log("debug", "passed validation, ".__line__);
-//$log->log("debug", check_str($_POST["ivr_menu_uuid"]));
-
-?>
+	$log = new Logging(sys_get_temp_dir() . '/logging.log');
+	$log->writeln("debug", "passed validation");
+	$log->writeln("debug", "pass");
+	$log->warning("variable should not used");

--- a/resources/classes/logging.php
+++ b/resources/classes/logging.php
@@ -20,7 +20,7 @@
 		public function __construct(string $filename_and_path) {
 			//init values
 			$this->clear_debug();
-			
+
 			try {
 				//open file in append mode
 				$this->fp = fopen($filename_and_path, 'a');
@@ -70,13 +70,52 @@
 			$this->debug_class = null;
 		}
 
-		public function write($level, $message) {
+		/**
+		 * Write raw data to the
+		 * @param string $level
+		 * @param string $message
+		 */
+		public function write(string $level, string $message) {
 			$this->get_backtrace_details();
 			// write current time, script name and message to the log file
 			// (don't forget to set the INI setting date.timezone)
 			$time = @date('Y-m-d H:i:s');
-			fwrite($this->fp, "[$time] [$level] [{$this->debug_file}:{$this->debug_line}] $message");
+			$file = $this->debug_file ?? 'file not set';
+			$line = $this->debug_line ?? '0000';
+			fwrite($this->fp, "[$time] [$level] [{$file}:{$line}] $message");
 			$this->clear_debug();
+		}
+
+		public function debug_class(?string $debug_class = null) {
+			if (func_num_args() > 0) {
+				$this->debug_class = $debug_class;
+				return $this;
+			}
+			return $this->debug_class;
+		}
+
+		public function debug_line(?string $debug_line = null) {
+			if (func_num_args() > 0) {
+				$this->debug_line = $debug_line;
+				return $this;
+			}
+			return $this->debug_line;
+		}
+
+		public function debug_func(?string $debug_func = null) {
+			if (func_num_args() > 0) {
+				$this->debug_func = $debug_func;
+				return $this;
+			}
+			return $this->debug_func;
+		}
+
+		public function debug_file(?string $debug_file = null) {
+			if (func_num_args() > 0) {
+				$this->debug_file = $debug_file;
+				return $this;
+			}
+			return $this->debug_file;
 		}
 
 		public function writeln($level, $message) {
@@ -114,12 +153,13 @@
 				$this->debug_class = $debug[$ndx]['class'] ?? '';
 			}
 		}
-
 	}
-/*
+
+	/*
  * Example:
 	$log = new logging(sys_get_temp_dir() . '/logging.log');
 	$log->writeln("debug", "passed validation");
 	$log->debug("pass");
 	$log->warning("variable should not used");
+	$log->debug_file(__FILE__)->debug_line(__LINE__)->write("DEBUG", "Raw message\n");
  */

--- a/resources/classes/logging.php
+++ b/resources/classes/logging.php
@@ -116,18 +116,11 @@
 			}
 		}
 
-		/**
-		 * Alias of writeln
-		 * @param type $level
-		 * @param type $message
-		 */
-		public function wln($level, $message) {
-			$this->get_backtrace_details();
-			$this->writeln($level, $message);
-		}
 	}
-
+/*
+ * Example:
 	$log = new Logging(sys_get_temp_dir() . '/logging.log');
 	$log->writeln("debug", "passed validation");
 	$log->writeln("debug", "pass");
 	$log->warning("variable should not used");
+ */


### PR DESCRIPTION
Updated the logging class to:

- use the construct and destruct magic methods
- logging constructor now requires a path to the file that needs to be created
- automatic file and line detection from caller using the debug_backtrace function
- added methods **debug**, **info**, **warning**, **error** to avoid using toupper function

This will allow for much more flexible method of logging with a very simple syntax.