### PR TITLE
[ENHANCEMENT] Autoassign current user as contact_user

### DIFF
--- a/app/contacts/contact_edit.php
+++ b/app/contacts/contact_edit.php
@@ -89,7 +89,7 @@
 
 		//$contact_users = $_POST["contact_users"];
 		//$contact_groups = $_POST["contact_groups"];
-		$contact_user_uuid = $_POST["contact_user_uuid"] ?? null;
+		$contact_user_uuid = ($_SESSION['contact']['permissions']['boolean'] == "true") ? ($_POST["contact_user_uuid"] ?? $_SESSION["user_uuid"]) : ($contact_user_uuid = $_POST["contact_user_uuid"] ?? null);
 		$contact_group_uuid = $_POST["contact_group_uuid"] ?? null;
 
 		$contact_phones = $_POST["contact_phones"];


### PR DESCRIPTION
If there are contact permissions enabled, autoassign the current user (who is creating the contact via webinterface) as contact_user. Otherwise it could be possible, that the user who creates the contact would not be able to view it afterwards.