### PR TITLE
move explode of $line inside of if block to fix php warning for line 93

### DIFF
--- a/resources/classes/event_socket.php
+++ b/resources/classes/event_socket.php
@@ -87,10 +87,9 @@ class event_socket {
 				if ($line === '') {
 					break;
 				}
+				list($key, $value) = explode(':', $line, 2);
+				$content[trim($key)] = trim($value);
 			}
-
-			list($key, $value) = explode(':', $line, 2);
-			$content[trim($key)] = trim($value);
 
 			if (feof($this->fp)) {
 				break;


### PR DESCRIPTION
$line is already checked for content in the if block above so move it in there to avoid warning messages