### PR TITLE
[dashboard] Fix memory exhaustion on system counts

### DIFF
--- a/app/system/resources/dashboard/system_counts.php
+++ b/app/system/resources/dashboard/system_counts.php
@@ -227,16 +227,27 @@
 		$stats['system']['messages']['new'] = 0;
 		$stats['domain']['messages']['total'] = 0;
 		$stats['domain']['messages']['new'] = 0;
-		$sql = "select domain_uuid, message_status from v_voicemail_messages";
-		$result = $database->select($sql, null, 'all');
+		$sql = "SELECT count(*) total, count(*) FILTER(WHERE message_status IS DISTINCT FROM 'saved') AS new ";
+		$sql .= "FROM v_voicemail_messages WHERE domain_uuid = :domain_uuid ";
+		$parameters["domain_uuid"] = $_SESSION['domain_uuid'];
+		$result = $database->select($sql, $parameters, 'all');
+		
 		if (is_array($result) && sizeof($result) != 0) {
-			$stats['system']['messages']['total'] = sizeof($result);
 			foreach ($result as $row) {
-				$stats['system']['messages']['new'] += ($row['message_status'] != 'saved') ? 1 : 0;
-				if ($row['domain_uuid'] == $_SESSION['domain_uuid']) {
-					$stats['domain']['messages']['total']++;
-					$stats['domain']['messages']['new'] += ($row['message_status'] != 'saved') ? 1 : 0;
-				}
+				$stats['domain']['messages']['total'] = $row['total'];
+				$stats['domain']['messages']['new'] = $row['new'];
+			}
+		}
+		unset($sql, $result, $parameters);
+		
+		$sql = "SELECT count(*) total, count(*) FILTER(WHERE message_status IS DISTINCT FROM 'saved') AS new ";
+		$sql .= "FROM v_voicemail_messages ";
+		$result = $database->select($sql, null, 'all');
+		
+		if (is_array($result) && sizeof($result) != 0) {
+			foreach ($result as $row) {
+				$stats['system']['messages']['total'] = $row['total'];
+				$stats['system']['messages']['new'] = $row['new'];
 			}
 		}
 		unset($sql, $result);


### PR DESCRIPTION
Getting all rows from the database caused PHP to exhaust the memory on systems with a huge amount of VM messages. This was fixed by querying from the database just the total counts.