### PR TITLE
Yealink template updates

### DIFF
--- a/resources/templates/provision/yealink/cp860/y000000000037.cfg
+++ b/resources/templates/provision/yealink/cp860/y000000000037.cfg
@@ -459,7 +459,7 @@ transfer.dsskey_deal_type = {$yealink_dsskey_transfer_mode}
 ##                                   Web Language                                    ##
 #######################################################################################
 #Specify the web language, the valid values are: English, Chinese_S, Turkish, Portuguese, Spanish, Italian, French, Russian, Deutsch and Czech.
-lang.wui =
+lang.wui = {$yealink_language_web}
 
 #Specify the LCD language, the valid values are: English (default), Chinese_S, Chinese_T, German, French, Turkish, Italian, Polish, Spanish and Portuguese.
 lang.gui = {$yealink_language_gui}

--- a/resources/templates/provision/yealink/cp920/y000000000078.cfg
+++ b/resources/templates/provision/yealink/cp920/y000000000078.cfg
@@ -457,7 +457,7 @@ transfer.dsskey_deal_type = {$yealink_dsskey_transfer_mode}
 ##                                   Web Language                                    ##
 #######################################################################################
 #Specify the web language, the valid values are: English, Chinese_S, Turkish, Portuguese, Spanish, Italian, French, Russian, Deutsch and Czech.
-lang.wui =
+lang.wui = {$yealink_language_web}
 
 #Specify the LCD language, the valid values are: English (default), Chinese_S, Chinese_T, German, French, Turkish, Italian, Polish, Spanish and Portuguese.
 lang.gui = {$yealink_language_gui}

--- a/resources/templates/provision/yealink/cp925/y000000000148.cfg
+++ b/resources/templates/provision/yealink/cp925/y000000000148.cfg
@@ -457,7 +457,7 @@ transfer.dsskey_deal_type = {$yealink_dsskey_transfer_mode}
 ##                                   Web Language                                    ##
 #######################################################################################
 #Specify the web language, the valid values are: English, Chinese_S, Turkish, Portuguese, Spanish, Italian, French, Russian, Deutsch and Czech.
-lang.wui =
+lang.wui = {$yealink_language_web}
 
 #Specify the LCD language, the valid values are: English (default), Chinese_S, Chinese_T, German, French, Turkish, Italian, Polish, Spanish and Portuguese.
 lang.gui = {$yealink_language_gui}

--- a/resources/templates/provision/yealink/cp960/y000000000073.cfg
+++ b/resources/templates/provision/yealink/cp960/y000000000073.cfg
@@ -458,7 +458,7 @@ transfer.dsskey_deal_type = {$yealink_dsskey_transfer_mode}
 ##                                   Web Language                                    ##
 #######################################################################################
 #Specify the web language, the valid values are: English, Chinese_S, Turkish, Portuguese, Spanish, Italian, French, Russian, Deutsch and Czech.
-lang.wui =
+lang.wui = {$yealink_language_web}
 
 #Specify the LCD language, the valid values are: English (default), Chinese_S, Chinese_T, German, French, Turkish, Italian, Polish, Spanish and Portuguese.
 lang.gui = {$yealink_language_gui}

--- a/resources/templates/provision/yealink/cp965/y000000000143.cfg
+++ b/resources/templates/provision/yealink/cp965/y000000000143.cfg
@@ -1579,8 +1579,8 @@ wui_lang.delete=
 gui_input_method.delete=
 gui_lang.url=
 gui_lang.delete=
-lang.gui=
-lang.wui=
+lang.gui= {$yealink_language_gui}
+lang.wui= {$yealink_language_web}
 
 
 #######################################################################################

--- a/resources/templates/provision/yealink/t19p/y000000000053.cfg
+++ b/resources/templates/provision/yealink/t19p/y000000000053.cfg
@@ -690,7 +690,7 @@ action_url.transfer_failed =
 #######################################################################################
 
 #Specify the web language, the valid values are: English, Chinese_S, Turkish, Portuguese, Spanish, Italian, French, Russian, Deutsch and Czech.
-lang.wui =
+lang.wui = {$yealink_language_web}
 
 #Specify the LCD language, the valid values are: English (default), Chinese_S, Chinese_T, German, French, Turkish, Italian, Polish, Spanish and Portuguese.
 #lang.gui = English

--- a/resources/templates/provision/yealink/t20p/y000000000007.cfg
+++ b/resources/templates/provision/yealink/t20p/y000000000007.cfg
@@ -690,7 +690,7 @@ action_url.transfer_failed =
 #######################################################################################
 
 #Specify the web language, the valid values are: English, Chinese_S, Turkish, Portuguese, Spanish, Italian, French, Russian, Deutsch and Czech.
-lang.wui =
+lang.wui = {$yealink_language_web}
 
 #Specify the LCD language, the valid values are: English (default), Chinese_S, Chinese_T, German, French, Turkish, Italian, Polish, Spanish and Portuguese.
 #lang.gui = English

--- a/resources/templates/provision/yealink/t21p/y000000000052.cfg
+++ b/resources/templates/provision/yealink/t21p/y000000000052.cfg
@@ -400,7 +400,7 @@ transfer.dsskey_deal_type = {$yealink_dsskey_transfer_mode}
 ##                                   Web Language                                    ##
 #######################################################################################
 #Specify the web language, the valid values are: English, Chinese_S, Turkish, Portuguese, Spanish, Italian, French, Russian, Deutsch and Czech.
-lang.wui =
+lang.wui = {$yealink_language_web}
 
 #Specify the LCD language, the valid values are: English (default), Chinese_S, Chinese_T, German, French, Turkish, Italian, Polish, Spanish and Portuguese.
 lang.gui = {$yealink_language_gui}

--- a/resources/templates/provision/yealink/t22p/y000000000005.cfg
+++ b/resources/templates/provision/yealink/t22p/y000000000005.cfg
@@ -690,7 +690,7 @@ action_url.transfer_failed =
 #######################################################################################
 
 #Specify the web language, the valid values are: English, Chinese_S, Turkish, Portuguese, Spanish, Italian, French, Russian, Deutsch and Czech.
-lang.wui =
+lang.wui = {$yealink_language_web}
 
 #Specify the LCD language, the valid values are: English (default), Chinese_S, Chinese_T, German, French, Turkish, Italian, Polish, Spanish and Portuguese.
 #lang.gui = English

--- a/resources/templates/provision/yealink/t23g/y000000000044.cfg
+++ b/resources/templates/provision/yealink/t23g/y000000000044.cfg
@@ -440,7 +440,7 @@ transfer.dsskey_deal_type = {$yealink_dsskey_transfer_mode}
 ##                                   Web Language                                    ##
 #######################################################################################
 #Specify the web language, the valid values are: English, Chinese_S, Turkish, Portuguese, Spanish, Italian, French, Russian, Deutsch and Czech.
-lang.wui =
+lang.wui = {$yealink_language_web}
 
 #Specify the LCD language, the valid values are: English (default), Chinese_S, Chinese_T, German, French, Turkish, Italian, Polish, Spanish and Portuguese.
 lang.gui = {$yealink_language_gui}

--- a/resources/templates/provision/yealink/t23p/y000000000044.cfg
+++ b/resources/templates/provision/yealink/t23p/y000000000044.cfg
@@ -440,7 +440,7 @@ transfer.dsskey_deal_type = {$yealink_dsskey_transfer_mode}
 ##                                   Web Language                                    ##
 #######################################################################################
 #Specify the web language, the valid values are: English, Chinese_S, Turkish, Portuguese, Spanish, Italian, French, Russian, Deutsch and Czech.
-lang.wui =
+lang.wui = {$yealink_language_web}
 
 #Specify the LCD language, the valid values are: English (default), Chinese_S, Chinese_T, German, French, Turkish, Italian, Polish, Spanish and Portuguese.
 lang.gui = {$yealink_language_gui}

--- a/resources/templates/provision/yealink/t26p/y000000000004.cfg
+++ b/resources/templates/provision/yealink/t26p/y000000000004.cfg
@@ -690,7 +690,7 @@ action_url.transfer_failed =
 #######################################################################################
 
 #Specify the web language, the valid values are: English, Chinese_S, Turkish, Portuguese, Spanish, Italian, French, Russian, Deutsch and Czech.
-lang.wui =
+lang.wui = {$yealink_language_web}
 
 #Specify the LCD language, the valid values are: English (default), Chinese_S, Chinese_T, German, French, Turkish, Italian, Polish, Spanish and Portuguese.
 #lang.gui = English

--- a/resources/templates/provision/yealink/t27g/y000000000069.cfg
+++ b/resources/templates/provision/yealink/t27g/y000000000069.cfg
@@ -439,7 +439,7 @@ transfer.dsskey_deal_type = {$yealink_dsskey_transfer_mode}
 ##                                   Web Language                                    ##
 #######################################################################################
 #Specify the web language, the valid values are: English, Chinese_S, Turkish, Portuguese, Spanish, Italian, French, Russian, Deutsch and Czech.
-lang.wui =
+lang.wui = {$yealink_language_web}
 
 #Specify the LCD language, the valid values are: English (default), Chinese_S, Chinese_T, German, French, Turkish, Italian, Polish, Spanish and Portuguese.
 lang.gui = {$yealink_language_gui}

--- a/resources/templates/provision/yealink/t27p/y000000000045.cfg
+++ b/resources/templates/provision/yealink/t27p/y000000000045.cfg
@@ -440,7 +440,7 @@ transfer.dsskey_deal_type = {$yealink_dsskey_transfer_mode}
 ##                                   Web Language                                    ##
 #######################################################################################
 #Specify the web language, the valid values are: English, Chinese_S, Turkish, Portuguese, Spanish, Italian, French, Russian, Deutsch and Czech.
-lang.wui =
+lang.wui = {$yealink_language_web}
 
 #Specify the LCD language, the valid values are: English (default), Chinese_S, Chinese_T, German, French, Turkish, Italian, Polish, Spanish and Portuguese.
 lang.gui = {$yealink_language_gui}

--- a/resources/templates/provision/yealink/t28p/y000000000000.cfg
+++ b/resources/templates/provision/yealink/t28p/y000000000000.cfg
@@ -690,7 +690,7 @@ action_url.transfer_failed =
 #######################################################################################
 
 #Specify the web language, the valid values are: English, Chinese_S, Turkish, Portuguese, Spanish, Italian, French, Russian, Deutsch and Czech.
-lang.wui =
+lang.wui = {$yealink_language_web}
 
 #Specify the LCD language, the valid values are: English (default), Chinese_S, Chinese_T, German, French, Turkish, Italian, Polish, Spanish and Portuguese.
 #lang.gui = English

--- a/resources/templates/provision/yealink/t29g/y000000000046.cfg
+++ b/resources/templates/provision/yealink/t29g/y000000000046.cfg
@@ -441,7 +441,7 @@ transfer.dsskey_deal_type = {$yealink_dsskey_transfer_mode}
 ##                                   Web Language                                    ##
 #######################################################################################
 #Specify the web language, the valid values are: English, Chinese_S, Turkish, Portuguese, Spanish, Italian, French, Russian, Deutsch and Czech.
-lang.wui =
+lang.wui = {$yealink_language_web}
 
 #Specify the LCD language, the valid values are: English (default), Chinese_S, Chinese_T, German, French, Turkish, Italian, Polish, Spanish and Portuguese.
 lang.gui = {$yealink_language_gui}

--- a/resources/templates/provision/yealink/t2x/y000000000044.cfg
+++ b/resources/templates/provision/yealink/t2x/y000000000044.cfg
@@ -440,7 +440,7 @@ transfer.dsskey_deal_type = {$yealink_dsskey_transfer_mode}
 ##                                   Web Language                                    ##
 #######################################################################################
 #Specify the web language, the valid values are: English, Chinese_S, Turkish, Portuguese, Spanish, Italian, French, Russian, Deutsch and Czech.
-lang.wui =
+lang.wui = {$yealink_language_web}
 
 #Specify the LCD language, the valid values are: English (default), Chinese_S, Chinese_T, German, French, Turkish, Italian, Polish, Spanish and Portuguese.
 lang.gui = {$yealink_language_gui}

--- a/resources/templates/provision/yealink/t2x/y000000000052.cfg
+++ b/resources/templates/provision/yealink/t2x/y000000000052.cfg
@@ -400,7 +400,7 @@ transfer.dsskey_deal_type = {$yealink_dsskey_transfer_mode}
 ##                                   Web Language                                    ##
 #######################################################################################
 #Specify the web language, the valid values are: English, Chinese_S, Turkish, Portuguese, Spanish, Italian, French, Russian, Deutsch and Czech.
-lang.wui =
+lang.wui = {$yealink_language_web}
 
 #Specify the LCD language, the valid values are: English (default), Chinese_S, Chinese_T, German, French, Turkish, Italian, Polish, Spanish and Portuguese.
 lang.gui = {$yealink_language_gui}

--- a/resources/templates/provision/yealink/t2x/y000000000053.cfg
+++ b/resources/templates/provision/yealink/t2x/y000000000053.cfg
@@ -694,7 +694,7 @@ action_url.transfer_failed =
 #######################################################################################
 
 #Specify the web language, the valid values are: English, Chinese_S, Turkish, Portuguese, Spanish, Italian, French, Russian, Deutsch and Czech.
-lang.wui =
+lang.wui = {$yealink_language_web}
 
 #Specify the LCD language, the valid values are: English (default), Chinese_S, Chinese_T, German, French, Turkish, Italian, Polish, Spanish and Portuguese.
 #lang.gui = English

--- a/resources/templates/provision/yealink/t2x/y000000000069.cfg
+++ b/resources/templates/provision/yealink/t2x/y000000000069.cfg
@@ -439,7 +439,7 @@ transfer.dsskey_deal_type = {$yealink_dsskey_transfer_mode}
 ##                                   Web Language                                    ##
 #######################################################################################
 #Specify the web language, the valid values are: English, Chinese_S, Turkish, Portuguese, Spanish, Italian, French, Russian, Deutsch and Czech.
-lang.wui =
+lang.wui = {$yealink_language_web}
 
 #Specify the LCD language, the valid values are: English (default), Chinese_S, Chinese_T, German, French, Turkish, Italian, Polish, Spanish and Portuguese.
 lang.gui = {$yealink_language_gui}

--- a/resources/templates/provision/yealink/t31g/y000000000123.cfg
+++ b/resources/templates/provision/yealink/t31g/y000000000123.cfg
@@ -690,7 +690,7 @@ action_url.transfer_failed =
 #######################################################################################
 
 #Specify the web language, the valid values are: English, Chinese_S, Turkish, Portuguese, Spanish, Italian, French, Russian, Deutsch and Czech.
-lang.wui =
+lang.wui = {$yealink_language_web}
 
 #Specify the LCD language, the valid values are: English (default), Chinese_S, Chinese_T, German, French, Turkish, Italian, Polish, Spanish and Portuguese.
 #lang.gui = English

--- a/resources/templates/provision/yealink/t32g/y000000000032.cfg
+++ b/resources/templates/provision/yealink/t32g/y000000000032.cfg
@@ -690,7 +690,7 @@ action_url.transfer_failed =
 #######################################################################################
 
 #Specify the web language, the valid values are: English, Chinese_S, Turkish, Portuguese, Spanish, Italian, French, Russian, Deutsch and Czech.
-lang.wui =
+lang.wui = {$yealink_language_web}
 
 #Specify the LCD language, the valid values are: English (default), Chinese_S, Chinese_T, German, French, Turkish, Italian, Polish, Spanish and Portuguese.
 #lang.gui = English

--- a/resources/templates/provision/yealink/t33g/y000000000124.cfg
+++ b/resources/templates/provision/yealink/t33g/y000000000124.cfg
@@ -1532,7 +1532,7 @@ gui_input_method.delete=
 gui_lang.url=
 gui_lang.delete=
 lang.gui= {$yealink_language_gui}
-lang.wui=
+lang.wui= {$yealink_language_web}
 
 
 #######################################################################################

--- a/resources/templates/provision/yealink/t38g/y000000000038.cfg
+++ b/resources/templates/provision/yealink/t38g/y000000000038.cfg
@@ -690,7 +690,7 @@ action_url.transfer_failed =
 #######################################################################################
 
 #Specify the web language, the valid values are: English, Chinese_S, Turkish, Portuguese, Spanish, Italian, French, Russian, Deutsch and Czech.
-lang.wui =
+lang.wui = {$yealink_language_web}
 
 #Specify the LCD language, the valid values are: English (default), Chinese_S, Chinese_T, German, French, Turkish, Italian, Polish, Spanish and Portuguese.
 #lang.gui = English

--- a/resources/templates/provision/yealink/t40g/y000000000076.cfg
+++ b/resources/templates/provision/yealink/t40g/y000000000076.cfg
@@ -441,7 +441,7 @@ transfer.dsskey_deal_type = {$yealink_dsskey_transfer_mode}
 ##                                   Web Language                                    ##
 #######################################################################################
 #Specify the web language, the valid values are: English, Chinese_S, Turkish, Portuguese, Spanish, Italian, French, Russian, Deutsch and Czech.
-lang.wui =
+lang.wui = {$yealink_language_web}
 
 #Specify the LCD language, the valid values are: English (default), Chinese_S, Chinese_T, German, French, Turkish, Italian, Polish, Spanish and Portuguese.
 lang.gui = {$yealink_language_gui}

--- a/resources/templates/provision/yealink/t40p/y000000000054.cfg
+++ b/resources/templates/provision/yealink/t40p/y000000000054.cfg
@@ -441,7 +441,7 @@ transfer.dsskey_deal_type = {$yealink_dsskey_transfer_mode}
 ##                                   Web Language                                    ##
 #######################################################################################
 #Specify the web language, the valid values are: English, Chinese_S, Turkish, Portuguese, Spanish, Italian, French, Russian, Deutsch and Czech.
-lang.wui =
+lang.wui = {$yealink_language_web}
 
 #Specify the LCD language, the valid values are: English (default), Chinese_S, Chinese_T, German, French, Turkish, Italian, Polish, Spanish and Portuguese.
 lang.gui = {$yealink_language_gui}

--- a/resources/templates/provision/yealink/t41p/y000000000036.cfg
+++ b/resources/templates/provision/yealink/t41p/y000000000036.cfg
@@ -441,7 +441,7 @@ transfer.dsskey_deal_type = {$yealink_dsskey_transfer_mode}
 ##                                   Web Language                                    ##
 #######################################################################################
 #Specify the web language, the valid values are: English, Chinese_S, Turkish, Portuguese, Spanish, Italian, French, Russian, Deutsch and Czech.
-lang.wui =
+lang.wui = {$yealink_language_web}
 
 #Specify the LCD language, the valid values are: English (default), Chinese_S, Chinese_T, German, French, Turkish, Italian, Polish, Spanish and Portuguese.
 lang.gui = {$yealink_language_gui}

--- a/resources/templates/provision/yealink/t41s/y000000000068.cfg
+++ b/resources/templates/provision/yealink/t41s/y000000000068.cfg
@@ -1393,7 +1393,7 @@ gui_input_method.delete=
 gui_lang.url=
 gui_lang.delete=
 static.lang.gui = {$yealink_language_gui}
-static.lang.wui=
+static.lang.wui= {$yealink_language_web}
 
 
 #######################################################################################

--- a/resources/templates/provision/yealink/t42g/y000000000029.cfg
+++ b/resources/templates/provision/yealink/t42g/y000000000029.cfg
@@ -441,7 +441,7 @@ transfer.dsskey_deal_type = {$yealink_dsskey_transfer_mode}
 ##                                   Web Language                                    ##
 #######################################################################################
 #Specify the web language, the valid values are: English, Chinese_S, Turkish, Portuguese, Spanish, Italian, French, Russian, Deutsch and Czech.
-lang.wui =
+lang.wui = {$yealink_language_web}
 
 #Specify the LCD language, the valid values are: English (default), Chinese_S, Chinese_T, German, French, Turkish, Italian, Polish, Spanish and Portuguese.
 lang.gui = {$yealink_language_gui}

--- a/resources/templates/provision/yealink/t42s/y000000000067.cfg
+++ b/resources/templates/provision/yealink/t42s/y000000000067.cfg
@@ -1419,7 +1419,7 @@ gui_input_method.delete=
 gui_lang.url=
 gui_lang.delete=
 static.lang.gui = {$yealink_language_gui}
-static.lang.wui=
+static.lang.wui= {$yealink_language_web}
 
 
 #######################################################################################

--- a/resources/templates/provision/yealink/t42u/y000000000116.cfg
+++ b/resources/templates/provision/yealink/t42u/y000000000116.cfg
@@ -441,7 +441,7 @@ transfer.dsskey_deal_type = {$yealink_dsskey_transfer_mode}
 ##                                   Web Language                                    ##
 #######################################################################################
 #Specify the web language, the valid values are: English, Chinese_S, Turkish, Portuguese, Spanish, Italian, French, Russian, Deutsch and Czech.
-lang.wui =
+lang.wui = {$yealink_language_web}
 
 #Specify the LCD language, the valid values are: English (default), Chinese_S, Chinese_T, German, French, Turkish, Italian, Polish, Spanish and Portuguese.
 lang.gui = {$yealink_language_gui}

--- a/resources/templates/provision/yealink/t43u/y000000000107.cfg
+++ b/resources/templates/provision/yealink/t43u/y000000000107.cfg
@@ -1581,7 +1581,7 @@ gui_input_method.delete=
 gui_lang.url=
 gui_lang.delete=
 lang.gui= {$yealink_language_gui}
-lang.wui=
+lang.wui= {$yealink_language_web}
 
 
 #######################################################################################

--- a/resources/templates/provision/yealink/t46g/y000000000028.cfg
+++ b/resources/templates/provision/yealink/t46g/y000000000028.cfg
@@ -441,7 +441,7 @@ transfer.dsskey_deal_type = {$yealink_dsskey_transfer_mode}
 ##                                   Web Language                                    ##
 #######################################################################################
 #Specify the web language, the valid values are: English, Chinese_S, Turkish, Portuguese, Spanish, Italian, French, Russian, Deutsch and Czech.
-lang.wui =
+lang.wui = {$yealink_language_web}
 
 #Specify the LCD language, the valid values are: English (default), Chinese_S, Chinese_T, German, French, Turkish, Italian, Polish, Spanish and Portuguese.
 lang.gui = {$yealink_language_gui}

--- a/resources/templates/provision/yealink/t46u/y000000000108.cfg
+++ b/resources/templates/provision/yealink/t46u/y000000000108.cfg
@@ -1552,7 +1552,7 @@ gui_input_method.delete=
 gui_lang.url=
 gui_lang.delete=
 lang.gui= {$yealink_language_gui}
-lang.wui=
+lang.wui= {$yealink_language_web}
 
 
 #######################################################################################

--- a/resources/templates/provision/yealink/t48g/y000000000035.cfg
+++ b/resources/templates/provision/yealink/t48g/y000000000035.cfg
@@ -441,7 +441,7 @@ transfer.dsskey_deal_type = {$yealink_dsskey_transfer_mode}
 ##                                   Web Language                                    ##
 #######################################################################################
 #Specify the web language, the valid values are: English, Chinese_S, Turkish, Portuguese, Spanish, Italian, French, Russian, Deutsch and Czech.
-lang.wui =
+lang.wui = {$yealink_language_web}
 
 #Specify the LCD language, the valid values are: English (default), Chinese_S, Chinese_T, German, French, Turkish, Italian, Polish, Spanish and Portuguese.
 lang.gui = {$yealink_language_gui}

--- a/resources/templates/provision/yealink/t48s/y000000000065.cfg
+++ b/resources/templates/provision/yealink/t48s/y000000000065.cfg
@@ -1462,7 +1462,7 @@ gui_input_method.delete=
 gui_lang.url=
 gui_lang.delete=
 static.lang.gui = {$yealink_language_gui}
-static.lang.wui=
+static.lang.wui= {$yealink_language_web}
 
 
 #######################################################################################

--- a/resources/templates/provision/yealink/t48u/y000000000109.cfg
+++ b/resources/templates/provision/yealink/t48u/y000000000109.cfg
@@ -1557,7 +1557,7 @@ gui_input_method.delete=
 gui_lang.url=
 gui_lang.delete=
 lang.gui= {$yealink_language_gui}
-lang.wui=
+lang.wui= {$yealink_language_web}
 
 
 #######################################################################################

--- a/resources/templates/provision/yealink/t49g/y000000000051.cfg
+++ b/resources/templates/provision/yealink/t49g/y000000000051.cfg
@@ -400,7 +400,7 @@ transfer.dsskey_deal_type = {$yealink_dsskey_transfer_mode}
 ##                                   Web Language                                    ##
 #######################################################################################
 #Specify the web language, the valid values are: English, Chinese_S, Turkish, Portuguese, Spanish, Italian, French, Russian, Deutsch and Czech.
-lang.wui =
+lang.wui = {$yealink_language_web}
 
 #Specify the LCD language, the valid values are: English (default), Chinese_S, Chinese_T, German, French, Turkish, Italian, Polish, Spanish and Portuguese.
 lang.gui = {$yealink_language_gui}

--- a/resources/templates/provision/yealink/t4x/y000000000028.cfg
+++ b/resources/templates/provision/yealink/t4x/y000000000028.cfg
@@ -441,7 +441,7 @@ transfer.dsskey_deal_type = {$yealink_dsskey_transfer_mode}
 ##                                   Web Language                                    ##
 #######################################################################################
 #Specify the web language, the valid values are: English, Chinese_S, Turkish, Portuguese, Spanish, Italian, French, Russian, Deutsch and Czech.
-lang.wui =
+lang.wui = {$yealink_language_web}
 
 #Specify the LCD language, the valid values are: English (default), Chinese_S, Chinese_T, German, French, Turkish, Italian, Polish, Spanish and Portuguese.
 lang.gui = {$yealink_language_gui}

--- a/resources/templates/provision/yealink/t4x/y000000000029.cfg
+++ b/resources/templates/provision/yealink/t4x/y000000000029.cfg
@@ -441,7 +441,7 @@ transfer.dsskey_deal_type = {$yealink_dsskey_transfer_mode}
 ##                                   Web Language                                    ##
 #######################################################################################
 #Specify the web language, the valid values are: English, Chinese_S, Turkish, Portuguese, Spanish, Italian, French, Russian, Deutsch and Czech.
-lang.wui =
+lang.wui = {$yealink_language_web}
 
 #Specify the LCD language, the valid values are: English (default), Chinese_S, Chinese_T, German, French, Turkish, Italian, Polish, Spanish and Portuguese.
 lang.gui = {$yealink_language_gui}

--- a/resources/templates/provision/yealink/t4x/y000000000035.cfg
+++ b/resources/templates/provision/yealink/t4x/y000000000035.cfg
@@ -441,7 +441,7 @@ transfer.dsskey_deal_type = {$yealink_dsskey_transfer_mode}
 ##                                   Web Language                                    ##
 #######################################################################################
 #Specify the web language, the valid values are: English, Chinese_S, Turkish, Portuguese, Spanish, Italian, French, Russian, Deutsch and Czech.
-lang.wui =
+lang.wui = {$yealink_language_web}
 
 #Specify the LCD language, the valid values are: English (default), Chinese_S, Chinese_T, German, French, Turkish, Italian, Polish, Spanish and Portuguese.
 lang.gui = {$yealink_language_gui}

--- a/resources/templates/provision/yealink/t4x/y000000000036.cfg
+++ b/resources/templates/provision/yealink/t4x/y000000000036.cfg
@@ -441,7 +441,7 @@ transfer.dsskey_deal_type = {$yealink_dsskey_transfer_mode}
 ##                                   Web Language                                    ##
 #######################################################################################
 #Specify the web language, the valid values are: English, Chinese_S, Turkish, Portuguese, Spanish, Italian, French, Russian, Deutsch and Czech.
-lang.wui =
+lang.wui = {$yealink_language_web}
 
 #Specify the LCD language, the valid values are: English (default), Chinese_S, Chinese_T, German, French, Turkish, Italian, Polish, Spanish and Portuguese.
 lang.gui = {$yealink_language_gui}

--- a/resources/templates/provision/yealink/t4x/y000000000054.cfg
+++ b/resources/templates/provision/yealink/t4x/y000000000054.cfg
@@ -441,7 +441,7 @@ transfer.dsskey_deal_type = {$yealink_dsskey_transfer_mode}
 ##                                   Web Language                                    ##
 #######################################################################################
 #Specify the web language, the valid values are: English, Chinese_S, Turkish, Portuguese, Spanish, Italian, French, Russian, Deutsch and Czech.
-lang.wui =
+lang.wui = {$yealink_language_web}
 
 #Specify the LCD language, the valid values are: English (default), Chinese_S, Chinese_T, German, French, Turkish, Italian, Polish, Spanish and Portuguese.
 lang.gui = {$yealink_language_gui}

--- a/resources/templates/provision/yealink/t4x/y000000000066.cfg
+++ b/resources/templates/provision/yealink/t4x/y000000000066.cfg
@@ -1389,7 +1389,7 @@ gui_input_method.delete=
 gui_lang.url=
 gui_lang.delete=
 lang.gui = {$yealink_language_gui}
-static.lang.wui=
+static.lang.wui= {$yealink_language_web}
 
 
 #######################################################################################

--- a/resources/templates/provision/yealink/t4x/y000000000067.cfg
+++ b/resources/templates/provision/yealink/t4x/y000000000067.cfg
@@ -1388,7 +1388,7 @@ gui_input_method.delete=
 gui_lang.url=
 gui_lang.delete=
 static.lang.gui = {$yealink_language_gui}
-static.lang.wui=
+static.lang.wui= {$yealink_language_web}
 
 
 #######################################################################################

--- a/resources/templates/provision/yealink/t4x/y000000000068.cfg
+++ b/resources/templates/provision/yealink/t4x/y000000000068.cfg
@@ -1392,7 +1392,7 @@ gui_input_method.delete=
 gui_lang.url=
 gui_lang.delete=
 static.lang.gui = {$yealink_language_gui}
-static.lang.wui=
+static.lang.wui= {$yealink_language_web}
 
 
 #######################################################################################

--- a/resources/templates/provision/yealink/t4x/y000000000076.cfg
+++ b/resources/templates/provision/yealink/t4x/y000000000076.cfg
@@ -441,7 +441,7 @@ transfer.dsskey_deal_type = {$yealink_dsskey_transfer_mode}
 ##                                   Web Language                                    ##
 #######################################################################################
 #Specify the web language, the valid values are: English, Chinese_S, Turkish, Portuguese, Spanish, Italian, French, Russian, Deutsch and Czech.
-lang.wui =
+lang.wui = {$yealink_language_web}
 
 #Specify the LCD language, the valid values are: English (default), Chinese_S, Chinese_T, German, French, Turkish, Italian, Polish, Spanish and Portuguese.
 lang.gui = {$yealink_language_gui}

--- a/resources/templates/provision/yealink/t4x/y000000000107.cfg
+++ b/resources/templates/provision/yealink/t4x/y000000000107.cfg
@@ -1439,7 +1439,7 @@ gui_input_method.delete=
 gui_lang.url=
 gui_lang.delete=
 static.lang.gui = {$yealink_language_gui}
-static.lang.wui=
+static.lang.wui= {$yealink_language_web}
 
 
 #######################################################################################

--- a/resources/templates/provision/yealink/t4x/y000000000108.cfg
+++ b/resources/templates/provision/yealink/t4x/y000000000108.cfg
@@ -1389,7 +1389,7 @@ gui_input_method.delete=
 gui_lang.url=
 gui_lang.delete=
 lang.gui = {$yealink_language_gui}
-static.lang.wui=
+static.lang.wui= {$yealink_language_web}
 
 
 #######################################################################################

--- a/resources/templates/provision/yealink/t4x/y000000000109.cfg
+++ b/resources/templates/provision/yealink/t4x/y000000000109.cfg
@@ -1439,7 +1439,7 @@ gui_input_method.delete=
 gui_lang.url=
 gui_lang.delete=
 static.lang.gui = {$yealink_language_gui}
-static.lang.wui=
+static.lang.wui= {$yealink_language_web}
 
 
 #######################################################################################

--- a/resources/templates/provision/yealink/t4x/y000000000116.cfg
+++ b/resources/templates/provision/yealink/t4x/y000000000116.cfg
@@ -1388,7 +1388,7 @@ gui_input_method.delete=
 gui_lang.url=
 gui_lang.delete=
 static.lang.gui = {$yealink_language_gui}
-static.lang.wui=
+static.lang.wui= {$yealink_language_web}
 
 
 #######################################################################################

--- a/resources/templates/provision/yealink/t53/y000000000095.cfg
+++ b/resources/templates/provision/yealink/t53/y000000000095.cfg
@@ -1538,8 +1538,8 @@ wui_lang.delete=
 gui_input_method.delete=
 gui_lang.url=
 gui_lang.delete=
-lang.gui=
-lang.wui=
+lang.gui= {$yealink_language_gui}
+lang.wui= {$yealink_language_web}
 
 
 #######################################################################################

--- a/resources/templates/provision/yealink/t53w/y000000000095.cfg
+++ b/resources/templates/provision/yealink/t53w/y000000000095.cfg
@@ -1542,8 +1542,8 @@ wui_lang.delete=
 gui_input_method.delete=
 gui_lang.url=
 gui_lang.delete=
-lang.gui=
-lang.wui=
+lang.gui= {$yealink_language_gui}
+lang.wui= {$yealink_language_web}
 
 
 #######################################################################################

--- a/resources/templates/provision/yealink/t54w/y000000000096.cfg
+++ b/resources/templates/provision/yealink/t54w/y000000000096.cfg
@@ -1544,8 +1544,8 @@ wui_lang.delete=
 gui_input_method.delete=
 gui_lang.url=
 gui_lang.delete=
-lang.gui=
-lang.wui=
+lang.gui= {$yealink_language_gui}
+lang.wui= {$yealink_language_web}
 
 
 #######################################################################################

--- a/resources/templates/provision/yealink/t56a/y000000000056.cfg
+++ b/resources/templates/provision/yealink/t56a/y000000000056.cfg
@@ -468,7 +468,7 @@ transfer.multi_call_trans_enable =
 ##                                   Language Settings                               ##
 #######################################################################################
 ##It configures the language of the web user interface.
-static.lang.wui = 
+static.lang.wui = {$yealink_language_web} 
 
 ##It configures the language of the phone user interface.
 ##The default value is English.

--- a/resources/templates/provision/yealink/t57w/y000000000097.cfg
+++ b/resources/templates/provision/yealink/t57w/y000000000097.cfg
@@ -1541,8 +1541,8 @@ wui_lang.delete=
 gui_input_method.delete=
 gui_lang.url=
 gui_lang.delete=
-lang.gui=
-lang.wui=
+lang.gui= {$yealink_language_gui}
+lang.wui= {$yealink_language_web}
 
 
 #######################################################################################

--- a/resources/templates/provision/yealink/t58a/y000000000058.cfg
+++ b/resources/templates/provision/yealink/t58a/y000000000058.cfg
@@ -471,7 +471,7 @@ transfer.multi_call_trans_enable =
 ##                                   Language Settings                               ##
 #######################################################################################
 ##It configures the language of the web user interface.
-static.lang.wui = 
+static.lang.wui = {$yealink_language_web} 
 
 ##It configures the language of the phone user interface.
 ##The default value is English.

--- a/resources/templates/provision/yealink/t58v/y000000000058.cfg
+++ b/resources/templates/provision/yealink/t58v/y000000000058.cfg
@@ -468,7 +468,7 @@ transfer.multi_call_trans_enable =
 ##                                   Language Settings                               ##
 #######################################################################################
 ##It configures the language of the web user interface.
-static.lang.wui = 
+static.lang.wui = {$yealink_language_web} 
 
 ##It configures the language of the phone user interface.
 ##The default value is English.

--- a/resources/templates/provision/yealink/t58w/y000000000150.cfg
+++ b/resources/templates/provision/yealink/t58w/y000000000150.cfg
@@ -508,11 +508,11 @@ transfer.dsskey_deal_type = {$yealink_dsskey_transfer_mode}
 ##                                   Language Settings                               ##
 #######################################################################################
 ##It configures the language of the web user interface.
-lang.wui = 
+lang.wui = {$yealink_language_web}
 
 ##It configures the language of the phone user interface.
 ##The default value is English.
-lang.gui = 
+lang.gui = {$yealink_language_gui}
 
 gui_lang.url = 
 gui_lang.delete = 

--- a/resources/templates/provision/yealink/t5x/y000000000096.cfg
+++ b/resources/templates/provision/yealink/t5x/y000000000096.cfg
@@ -1536,8 +1536,8 @@ wui_lang.delete=
 gui_input_method.delete=
 gui_lang.url=
 gui_lang.delete=
-lang.gui=
-lang.wui=
+lang.gui= {$yealink_language_gui}
+lang.wui= {$yealink_language_web}
 
 
 #######################################################################################

--- a/resources/templates/provision/yealink/t5x/y000000000097.cfg
+++ b/resources/templates/provision/yealink/t5x/y000000000097.cfg
@@ -1536,8 +1536,8 @@ wui_lang.delete=
 gui_input_method.delete=
 gui_lang.url=
 gui_lang.delete=
-lang.gui=
-lang.wui=
+lang.gui= {$yealink_language_gui}
+lang.wui= {$yealink_language_web}
 
 
 #######################################################################################

--- a/resources/templates/provision/yealink/vp59/y000000000091.cfg
+++ b/resources/templates/provision/yealink/vp59/y000000000091.cfg
@@ -447,11 +447,11 @@ transfer.multi_call_trans_enable =
 ##                                   Language Settings                               ##
 #######################################################################################
 ##It configures the language of the web user interface.
-lang.wui = 
+lang.wui = {$yealink_language_web}
 
 ##It configures the language of the phone user interface.
 ##The default value is English.
-lang.gui = 
+lang.gui = {$yealink_language_gui}
 
 gui_lang.url = 
 gui_lang.delete = 

--- a/resources/templates/provision/yealink/w52p/y000000000025.cfg
+++ b/resources/templates/provision/yealink/w52p/y000000000025.cfg
@@ -172,8 +172,14 @@ transfer.semi_attend_tran_enable = {$yealink_transfer_semi_attended}
 
 #Enable or disable the phone to complete the blind or attended transfer through on-hook;
 #0-Disabled (default), 1-Enabled;
-transfer.blind_tran_on_hook_enable =
-transfer.on_hook_trans_enable =
+transfer.blind_tran_on_hook_enable = {$yealink_transfer_blind_on_hook}
+transfer.on_hook_trans_enable = {$yealink_transfer_onhook}
+
+##It configures the DSS key behavior during an active call when user presses the DSS 
+##key and the DSS key is configured as a speed dial, transfer or BLF/BLF list key.
+##0-New Call,1-Attended Transfer,2-Blind Transfer.
+##The default value is 2.
+transfer.dsskey_deal_type = {$yealink_dsskey_transfer_mode}
 
 #Enable or disable to access the web user interface of phone using the http/https protocol;
 #0-Disabled,1-Enabled (default);
@@ -328,6 +334,8 @@ phone_setting.is_deal180 = 1
 
 #Enable or disable the phone to automatically dial out the dialed digits in the pre-dial interface; 0-Disabled (default), 1-Enabled;
 phone_setting.predial_autodial = 1
+
+features.remote_phonebook.enable = {$yealink_remote_phonebook_enable}
 
 #######################################################################################
 ##                                   Base_Upgrade                                    ##

--- a/resources/templates/provision/yealink/w56p/y000000000025.cfg
+++ b/resources/templates/provision/yealink/w56p/y000000000025.cfg
@@ -172,8 +172,14 @@ transfer.semi_attend_tran_enable = {$yealink_transfer_semi_attended}
 
 #Enable or disable the phone to complete the blind or attended transfer through on-hook;
 #0-Disabled (default), 1-Enabled;
-transfer.blind_tran_on_hook_enable =
-transfer.on_hook_trans_enable =
+transfer.blind_tran_on_hook_enable = {$yealink_transfer_blind_on_hook}
+transfer.on_hook_trans_enable = {$yealink_transfer_onhook}
+
+##It configures the DSS key behavior during an active call when user presses the DSS 
+##key and the DSS key is configured as a speed dial, transfer or BLF/BLF list key.
+##0-New Call,1-Attended Transfer,2-Blind Transfer.
+##The default value is 2.
+transfer.dsskey_deal_type = {$yealink_dsskey_transfer_mode}
 
 #Enable or disable to access the web user interface of phone using the http/https protocol;
 #0-Disabled,1-Enabled (default);
@@ -328,6 +334,8 @@ phone_setting.is_deal180 = 1
 
 #Enable or disable the phone to automatically dial out the dialed digits in the pre-dial interface; 0-Disabled (default), 1-Enabled;
 phone_setting.predial_autodial = 1
+
+features.remote_phonebook.enable = {$yealink_remote_phonebook_enable}
 
 #######################################################################################
 ##                                   Base_Upgrade                                    ##

--- a/resources/templates/provision/yealink/w60b/y000000000077.cfg
+++ b/resources/templates/provision/yealink/w60b/y000000000077.cfg
@@ -172,8 +172,14 @@ transfer.semi_attend_tran_enable = {$yealink_transfer_semi_attended}
 
 #Enable or disable the phone to complete the blind or attended transfer through on-hook;
 #0-Disabled (default), 1-Enabled;
-transfer.blind_tran_on_hook_enable =
-transfer.on_hook_trans_enable =
+transfer.blind_tran_on_hook_enable = {$yealink_transfer_blind_on_hook}
+transfer.on_hook_trans_enable = {$yealink_transfer_onhook}
+
+##It configures the DSS key behavior during an active call when user presses the DSS 
+##key and the DSS key is configured as a speed dial, transfer or BLF/BLF list key.
+##0-New Call,1-Attended Transfer,2-Blind Transfer.
+##The default value is 2.
+transfer.dsskey_deal_type = {$yealink_dsskey_transfer_mode}
 
 #Enable or disable to access the web user interface of phone using the http/https protocol;
 #0-Disabled,1-Enabled (default);
@@ -327,6 +333,8 @@ phone_setting.is_deal180 = 1
 
 #Enable or disable the phone to automatically dial out the dialed digits in the pre-dial interface; 0-Disabled (default), 1-Enabled;
 phone_setting.predial_autodial = 1
+
+features.remote_phonebook.enable = {$yealink_remote_phonebook_enable}
 
 #######################################################################################
 ##                                   Base_Upgrade                                    ##

--- a/resources/templates/provision/yealink/w70b/y000000000146.cfg
+++ b/resources/templates/provision/yealink/w70b/y000000000146.cfg
@@ -172,8 +172,14 @@ transfer.semi_attend_tran_enable = {$yealink_transfer_semi_attended}
 
 #Enable or disable the phone to complete the blind or attended transfer through on-hook;
 #0-Disabled (default), 1-Enabled;
-transfer.blind_tran_on_hook_enable =
-transfer.on_hook_trans_enable =
+transfer.blind_tran_on_hook_enable = {$yealink_transfer_blind_on_hook}
+transfer.on_hook_trans_enable = {$yealink_transfer_onhook}
+
+##It configures the DSS key behavior during an active call when user presses the DSS 
+##key and the DSS key is configured as a speed dial, transfer or BLF/BLF list key.
+##0-New Call,1-Attended Transfer,2-Blind Transfer.
+##The default value is 2.
+transfer.dsskey_deal_type = {$yealink_dsskey_transfer_mode}
 
 #Enable or disable to access the web user interface of phone using the http/https protocol;
 #0-Disabled,1-Enabled (default);
@@ -327,6 +333,8 @@ phone_setting.is_deal180 = 1
 
 #Enable or disable the phone to automatically dial out the dialed digits in the pre-dial interface; 0-Disabled (default), 1-Enabled;
 phone_setting.predial_autodial = 1
+
+features.remote_phonebook.enable = {$yealink_remote_phonebook_enable}
 
 #######################################################################################
 ##                                   Base_Upgrade                                    ##

--- a/resources/templates/provision/yealink/w7xp/y000000000146.cfg
+++ b/resources/templates/provision/yealink/w7xp/y000000000146.cfg
@@ -172,8 +172,14 @@ transfer.semi_attend_tran_enable = {$yealink_transfer_semi_attended}
 
 #Enable or disable the phone to complete the blind or attended transfer through on-hook;
 #0-Disabled (default), 1-Enabled;
-transfer.blind_tran_on_hook_enable =
-transfer.on_hook_trans_enable =
+transfer.blind_tran_on_hook_enable = {$yealink_transfer_blind_on_hook}
+transfer.on_hook_trans_enable = {$yealink_transfer_onhook}
+
+##It configures the DSS key behavior during an active call when user presses the DSS 
+##key and the DSS key is configured as a speed dial, transfer or BLF/BLF list key.
+##0-New Call,1-Attended Transfer,2-Blind Transfer.
+##The default value is 2.
+transfer.dsskey_deal_type = {$yealink_dsskey_transfer_mode}
 
 #Enable or disable to access the web user interface of phone using the http/https protocol;
 #0-Disabled,1-Enabled (default);
@@ -327,6 +333,8 @@ phone_setting.is_deal180 = 1
 
 #Enable or disable the phone to automatically dial out the dialed digits in the pre-dial interface; 0-Disabled (default), 1-Enabled;
 phone_setting.predial_autodial = 1
+
+features.remote_phonebook.enable = {$yealink_remote_phonebook_enable}
 
 #######################################################################################
 ##                                   Base_Upgrade                                    ##


### PR DESCRIPTION
Update Yealink provisioning templates.

- consistently use language vars yealink_language_gui and yealink_language_web
- use existing yealink_remote_phonebook_enable in Yealink Templates
- use existing yealink transfer variables