### PR TITLE
Force close port

### DIFF
--- a/app/sip_status/cmd.php
+++ b/app/sip_status/cmd.php
@@ -50,6 +50,26 @@
 	$profile_name = $database->select($sql, $parameters, 'column');
 	unset($sql, $parameters);
 
+//get the port from sip profile name
+	$sql = "select sip_profile_setting_value from v_sip_profile_settings ";
+	$sql .= "where sip_profile_uuid = (select sip_profile_uuid from v_sip_profiles where sip_profile_name = :profile_name limit 1) ";
+	$sql .= "and sip_profile_setting_name = 'sip-port' ";
+	$sql .= "and sip_profile_setting_enabled = 'true' ";
+	$sql .= "limit 1";
+	$parameters['profile_name'] = $profile;
+	$profile_port = $database->select($sql, $parameters, 'column');
+	unset($sql, $parameters);
+
+//get the tls port from sip profile name
+	$sql = "select sip_profile_setting_value from v_sip_profile_settings ";
+	$sql .= "where sip_profile_uuid = (select sip_profile_uuid from v_sip_profiles where sip_profile_name = :profile_name limit 1) ";
+	$sql .= "and sip_profile_setting_name = 'tls-sip-port' ";
+	$sql .= "and sip_profile_setting_enabled = 'true' ";
+	$sql .= "limit 1";
+	$parameters['profile_name'] = $profile;
+	$profile_tls_port = $database->select($sql, $parameters, 'column');
+	unset($sql, $parameters);
+
 //validate the gateway
 	if (!empty($_GET['gateway']) && is_uuid($_GET['gateway'])) {
 		$gateway_name = $_GET['gateway'];

--- a/app/sip_status/cmd.php
+++ b/app/sip_status/cmd.php
@@ -82,6 +82,9 @@
 			break;
 		case "start":
 			$command = "sofia profile '".$profile_name."' start";
+			//ensure there are no stuck ports before trying to start the profile
+			force_close_port($profile_port);
+			force_close_port($profile_tls_port);
 			break;
 		case "stop":
 			$command = "sofia profile '".$profile_name."' stop";


### PR DESCRIPTION
Create function to force a port to be closed. This requires the `--enable-debug` flag to be used when compiling freeswitch, sofia-sip, and spandsp. This also requires gdb, pidof, netstat, and lsof to be installed on the system. This will not work on a Windows system. Tested on a raspberrypi. Tested system only required lsof to be installed manually with `apt install -y lsof` as the other tools were preinstalled.