### PR TITLE
make time_condition_edit.php use time_format var for select options

### DIFF
--- a/app/time_conditions/time_condition_edit.php
+++ b/app/time_conditions/time_condition_edit.php
@@ -821,24 +821,48 @@
 						break;
 
 					case 'hour': //hours of day
-						for (h = 0; h <= 23; h++) {
-							sel_start.options[sel_start.options.length] = new Option(((h != 0) ? ((h >= 12) ? ((h == 12) ? h : (h - 12)) + ' PM' : h + ' AM') : '12 AM'), h);
-							sel_stop.options[sel_stop.options.length] = new Option(((h != 0) ? ((h >= 12) ? ((h == 12) ? h : (h - 12)) + ' PM' : h + ' AM') : '12 AM'), h);
+						<?php
+						if ( $_SESSION['domain']['time_format']['text'] =="24h") {
+						
+							for ($h = 0; $h <= 23; $h++) {
+								echo "sel_start.options[sel_start.options.length] = new Option(".$h.", ".$h.");\n";
+								echo "sel_stop.options[sel_stop.options.length] = new Option(".$h.", ".$h.");\n";
+							}
+
+						} else {
+
+							for ($h = 0; $h <= 23; $h++) {
+								echo "sel_start.options[sel_start.options.length] = new Option(((".$h." != 0) ? ((".$h." >= 12) ? ((".$h." == 12) ? ".$h." : (".$h." - 12)) + ' PM' : ".$h." + ' AM') : '12 AM'), ".$h.");\n";
+								echo "sel_stop.options[sel_stop.options.length] = new Option(((".$h." != 0) ? ((".$h." >= 12) ? ((".$h." == 12) ? ".$h." : (".$h." - 12)) + ' PM' : ".$h." + ' AM') : '12 AM'), ".$h.");\n";
+							}
 						}
+						?>
 						break;
 
 					case 'time-of-day': //time of day
-						for (h = 0; h <= 23; h++) {
-							for (m = 0; m <= 59; m += 1) {
-								sel_start.options[sel_start.options.length] = new Option(((h != 0) ? ((h >= 12) ? ((h == 12) ? h : (h - 12)) + ':' + pad(m, 2) + ' PM' : h + ':' + pad(m, 2) + ' AM') : '12:' + pad(m, 2) + ' AM'), pad(h, 2) + ':' + pad(m, 2));
-								sel_stop.options[sel_stop.options.length] = new Option(((h != 0) ? ((h >= 12) ? ((h == 12) ? h : (h - 12)) + ':' + pad(m, 2) + ' PM' : h + ':' + pad(m, 2) + ' AM') : '12:' + pad(m, 2) + ' AM'), pad(h, 2)  + ':' + pad(m, 2));
+						<?php
+						if ( $_SESSION['domain']['time_format']['text'] =="24h") {
+
+							for ($h = 0; $h <= 23; $h++) {
+								for ($m = 0; $m <= 59; $m++) {
+									echo "sel_start.options[sel_start.options.length] = new Option(('0'+'".$h."').slice(-2)+':'+('0'+'".$m."').slice(-2),pad('".$h."', 2)  + ':' + pad(".$m.", 2));\n";
+									echo "sel_stop.options[sel_stop.options.length] = new Option(('0'+'".$h."').slice(-2)+':'+('0'+'".$m."').slice(-2),pad('".$h."', 2)  + ':' + pad(".$m.", 2));\n";
+								}
 							}
+
+						} else {
+							for ($h = 0; $h <= 23; $h++) {
+								for ($m = 0; $m <= 59; $m++) {
+									echo "sel_start.options[sel_start.options.length] = new Option(((".$h." != 0) ? ((".$h." >= 12) ? ((".$h." == 12) ? ".$h." : (".$h." - 12)) + ':' + pad(".$m.", 2) + ' PM' : ".$h." + ':' + pad(".$m.", 2) + ' AM') : '12:' + pad(".$m.", 2) + ' AM'), pad(".$h.", 2) + ':' + pad(".$m.", 2));\n";
+									echo "sel_stop.options[sel_stop.options.length] = new Option(((".$h." != 0) ? ((".$h." >= 12) ? ((".$h." == 12) ? ".$h." : (".$h." - 12)) + ':' + pad(".$m.", 2) + ' PM' : ".$h." + ':' + pad(".$m.", 2) + ' AM') : '12:' + pad(".$m.", 2) + ' AM'), pad(".$h.", 2) + ':' + pad(".$m.", 2));\n";
+								}
+						}
 						}
 						//h = 23;
 						//m = 59;
 						//sel_stop.options[sel_stop.options.length] = new Option(((h != 0) ? ((h >= 12) ? ((h == 12) ? h : (h - 12)) + ':' + pad(m, 2) + ' PM' : h + ':' + pad(m, 2) + ' AM') : '12:' + pad(m, 2) + ' AM'), pad(h, 2)  + ':' + pad(m, 2));
+						?>
 						break;
-
 				}
 
 			}


### PR DESCRIPTION
Use the existing default Variable time_format to adjust the options of the selects of "hours of day" and "time of day" accordingly.

We have been operating FusionPBX for our customers in Germany for several years. Over time, we have noticed many small things that the main user base probably does not notice. The AM and PM times are very unusual in Germany. Therefore I hope that this change will be accepted. There is already a default variable that lets you choose the time format. In my opinion, a user who selects 24 hours and activates the variable should no longer find AM PM times on the interface. If you notice this elsewhere, I would also try to fix it.