### PR TITLE
added missing fax_email permission

### DIFF
--- a/app/fax/app_config.php
+++ b/app/fax/app_config.php
@@ -262,6 +262,11 @@
 		//$apps[$x]['permissions'][$y]['groups'][] = "superadmin";
 		//$apps[$x]['permissions'][$y]['groups'][] = "admin";
 		//$apps[$x]['permissions'][$y]['groups'][] = "fax";
+		$y++;
+		$apps[$x]['permissions'][$y]['name'] = "fax_email";
+		$apps[$x]['permissions'][$y]['groups'][] = "superadmin";
+		$apps[$x]['permissions'][$y]['groups'][] = "admin";
+		$apps[$x]['permissions'][$y]['groups'][] = "fax";
 
 	//default settings
 		$y=0;


### PR DESCRIPTION
This permission is referenced in the fax_edit.php code and allows you to enter a confirmation email for faxes that are sent. Without this permission it is no editable.