### PR TITLE
fix transcription bug showing when not enabled in default settings

### DIFF
--- a/app/extensions/extension_edit.php
+++ b/app/extensions/extension_edit.php
@@ -1788,7 +1788,7 @@
 		echo "</td>\n";
 		echo "</tr>\n";
 
-		if (permission_exists('voicemail_transcription_enabled')) {
+		if (permission_exists('voicemail_transcription_enabled') && ($_SESSION['voicemail']['transcribe_enabled']['boolean'] ?? '') == "true") {
 			echo "<tr>\n";
 			echo "<td class='vncell' valign='top' align='left' nowrap='nowrap'>\n";
 			echo "	".$text['label-voicemail_transcription_enabled']."\n";

--- a/app/voicemails/voicemail_edit.php
+++ b/app/voicemails/voicemail_edit.php
@@ -794,7 +794,7 @@
 		echo "</tr>\n";
 	}
 
-	if (permission_exists('voicemail_transcription_enabled') && !empty($_SESSION['voicemail']['transcribe_enabled']['boolean']) == "true") {
+	if (permission_exists('voicemail_transcription_enabled') && ($_SESSION['voicemail']['transcribe_enabled']['boolean'] ?? '') == "true") {
 		echo "<tr>\n";
 		echo "<td class='vncell' valign='top' align='left' nowrap='nowrap'>\n";
 		echo "	".$text['label-voicemail_transcription_enabled']."\n";


### PR DESCRIPTION
Voicemail transcribe always shows in the extensions even though it is disabled in default settings.