### PR TITLE
Remove fields to display the installed firmware version

### DIFF
--- a/resources/templates/provision/snom/PA1/{$mac}.cfg
+++ b/resources/templates/provision/snom/PA1/{$mac}.cfg
@@ -219,7 +219,6 @@
 <cancel_desktop perm="">off</cancel_desktop>
 <scroll_outgoing perm="">on</scroll_outgoing>
 <show_local_line perm="">off</show_local_line>
-<firmware_version perm="">snomPA1-SIP x.x.x</firmware_version>
 <redirect_ringing perm="">on</redirect_ringing>
 <auto_redial perm="">off</auto_redial>
 <auto_redial_value perm="">10</auto_redial_value>
@@ -354,7 +353,6 @@
 <dhcp_options_on_ip_aquire perm="">1 3 4 6 12 15 42 43 51 66 67 120 125 132 133</dhcp_options_on_ip_aquire>
 <dhcp_options_on_inform perm="">43 120 125</dhcp_options_on_inform>
 <use_NTLMv2 perm="">on</use_NTLMv2>
-<user_agent_string perm="">snomPA1/x.x.x</user_agent_string>
 <http_user_agent_string perm="">!User-Agent: Mozilla/4.0 (compatible; $(firmware_version) $(uboot_version) $(mac))</http_user_agent_string>
 <suppress_sip_messages perm=""/>
 <tr69_acs_url perm=""/>


### PR DESCRIPTION
Deleted elements which were making registrations page displaying device and firmware correctly. With the included elements the device and firmware displayed as "snomPA1/x.x.x". Removing the elements allows the device and firmware to display the installed firmware like "snomPA1/8.7.5.75".

![Firefox_Screenshot_2024-03-07T02-00-06 141Z](https://github.com/fusionpbx/fusionpbx/assets/14916599/cdbdefda-0295-4c45-a349-ada14696b17b)
