### PR TITLE
Remove dependencies on defined constants. Single line include

### DIFF
--- a/resources/classes/auto_loader.php
+++ b/resources/classes/auto_loader.php
@@ -88,6 +88,6 @@ class auto_loader {
 	}
 }
 
-new autoloader();
+new auto_loader();
 
 ?>

--- a/resources/classes/auto_loader.php
+++ b/resources/classes/auto_loader.php
@@ -31,7 +31,7 @@ class auto_loader {
 	}
 
 	public static function autoload_search(array $array) : string {
-		if (count($path) != 0) {
+		if (count($array) != 0) {
 			return '';
 		}
 		foreach($array as $path) {

--- a/resources/classes/auto_loader.php
+++ b/resources/classes/auto_loader.php
@@ -31,7 +31,7 @@ class auto_loader {
 	}
 
 	public static function autoload_search(array $array) : string {
-		if ($array && count($path) != 0) {
+		if (count($path) != 0) {
 			return '';
 		}
 		foreach($array as $path) {

--- a/resources/classes/auto_loader.php
+++ b/resources/classes/auto_loader.php
@@ -30,8 +30,8 @@ class auto_loader {
 		spl_autoload_register(array($this, 'loader'));
 	}
 
-	public static function autoload_search($array) : string {
-		if (!is_array($array) && count($path) != 0) {
+	public static function autoload_search(array $array) : string {
+		if ($array && count($path) != 0) {
 			return '';
 		}
 		foreach($array as $path) {
@@ -54,13 +54,16 @@ class auto_loader {
 		//sanitize the class name
 		$class_name = preg_replace('[^a-zA-Z0-9_]', '', $class_name);
 
+		$project_root = dirname(__DIR__, 2);
+
 		//use glob for a more extensive search for the classes (note: GLOB_BRACE doesn't work on some systems)
 		if (!class_exists($class_name)) {
 			//build the search path array
-			$search_path[] = glob($_SERVER["DOCUMENT_ROOT"] . PROJECT_PATH . "/resources/classes/".$class_name.".php");
-			$search_path[] = glob($_SERVER["DOCUMENT_ROOT"] . PROJECT_PATH . "/resources/interfaces/".$class_name.".php");
-			$search_path[] = glob($_SERVER["DOCUMENT_ROOT"] . PROJECT_PATH . "/*/*/resources/classes/".$class_name.".php");
-			$search_path[] = glob($_SERVER["DOCUMENT_ROOT"] . PROJECT_PATH . "/*/*/resources/interfaces/".$class_name.".php");
+			$search_path = [];
+			$search_path[] = glob($project_root . "/resources/classes/".$class_name.".php");
+			$search_path[] = glob($project_root . "/resources/interfaces/".$class_name.".php");
+			$search_path[] = glob($project_root . "/*/*/resources/classes/".$class_name.".php");
+			$search_path[] = glob($project_root . "/*/*/resources/interfaces/".$class_name.".php");
 
 			//find the path
 			$path = self::autoload_search($search_path);
@@ -84,5 +87,7 @@ class auto_loader {
 		return false;
 	}
 }
+
+new autoloader();
 
 ?>


### PR DESCRIPTION
It is very important to remove the dependencies on any defined project variables. This removes those dependencies without breaking backwards compatibility as it does not remove the class definition but instead, instantiates the loader object immediately at the end of the file. This will not break any other file that still creates a new auto_loader object as PHP permits more than one auto loader registration.

The following single line can now be used:

```
require_once 'resources/classes/auto_loader.php;
```