### PR TITLE
Removed unused dialplan is_loopback

### DIFF
--- a/app/dialplans/resources/switch/conf/dialplan/030_is_loopback.xml
+++ b/app/dialplans/resources/switch/conf/dialplan/030_is_loopback.xml
@@ -1,9 +1,0 @@
-<extension name="is_loopback" number="" context="global" continue="true" app_uuid="1dcf888f-c367-46b7-b809-f2de918c266c" global="true" order="30">
-	<condition field="${is_follow_me_loopback}" expression="true">
-		<action application="set" data="from_orig_user_exists=${user_exists id ${username} ${domain_name}}" inline="true"/>
-	</condition>
-	<condition field="${from_orig_user_exists}" expression="^true$">
-		<action application="set" data="outbound_caller_id_number=${user_data ${username}@${domain} var outbound_caller_id_number}" inline="true"/>
-		<action application="set" data="outbound_caller_id_name=${user_data ${username}@${domain} var outbound_caller_id_name}" inline="true"/>
-	</condition>
-</extension>


### PR DESCRIPTION
is_loopback dialplan was utilized by the dialstring follow me method. The code that generates the dialstring including the "is_follow_me_loopback" variable no longer exists, thus this dialplan will never be invoked.