### PR TITLE
Bug user_email missing from object properties

### DIFF
--- a/core/authentication/resources/classes/plugins/database.php
+++ b/core/authentication/resources/classes/plugins/database.php
@@ -42,6 +42,7 @@ class plugin_database {
 	public $password;
 	public $key;
 	public $debug;
+	public $user_email;
 
 	/**
 	 * database checks the local database to authenticate the user or key


### PR DESCRIPTION
Variable `$user_email` missing from the object properties. Line 238 has `$this->user_email` causing php warning for dynamic creation. This resolves that error.