### PR TITLE
after doing a database restore, the session may not yet exist

### DIFF
--- a/resources/classes/permissions.php
+++ b/resources/classes/permissions.php
@@ -46,7 +46,7 @@ if (!class_exists('permissions')) {
 		 * @var string $permission
 		 */
 		public function delete($permission, $type) {
-			if ($this->exists($permission)) {
+			if ($this->exists($permission) && !empty($_SESSION["permissions"][$permission])) {
 				if ($type === "temp") {
 					if ($_SESSION["permissions"][$permission] === "temp") {
 						unset($_SESSION["permissions"][$permission]);


### PR DESCRIPTION
The error can cause a stack trace to dump causing a very large data dump. This ensures the session array exists before testing for temp value