### PR TITLE
set to compare instead of assignment in the message error checking

### DIFF
--- a/resources/classes/database.php
+++ b/resources/classes/database.php
@@ -2500,7 +2500,7 @@
 																}
 																catch(PDOException $e) {
 																	$retval = false;
-																	if ($message["code"] = "200") {
+																	if ($message["code"] == "200") {
 																		$message["message"] = "Bad Request";
 																		$message["code"] = "400";
 																	}
@@ -2650,7 +2650,7 @@
 															}
 															catch(PDOException $e) {
 																$retval = false;
-																if ($message["code"] = "200") {
+																if ($message["code"] == "200") {
 																	$message["message"] = "Bad Request";
 																	$message["code"] = "400";
 																}


### PR DESCRIPTION
Should be comparing inside the if statement instead of assigning the variable. Minor fix but might return "200 OK" when it should be an error of "400 Bad Request" message.