### PR TITLE
fix $x was not initialized on first iteration of for loop

### DIFF
--- a/resources/classes/sounds.php
+++ b/resources/classes/sounds.php
@@ -48,13 +48,12 @@ class sounds {
 				$database = new database;
 				$recordings = $database->select($sql, $parameters, 'all');
 				if (is_array($recordings) && @sizeof($recordings) != 0) {
-					foreach ($recordings as &$row) {
+					foreach ($recordings as $x => &$row) {
 						$recording_name = $row["recording_name"];
 						$recording_filename = $row["recording_filename"];
 						$recording_path = !empty($this->full_path) && is_array($this->full_path) && in_array('recordings', $this->full_path) ? $_SESSION['switch']['recordings']['dir'].'/'.$_SESSION['domain_name'].'/' : null;
 						$array['recordings'][$x]['name'] = $recording_name;
 						$array['recordings'][$x]['value'] = $recording_path.$recording_filename;
-						$x++;
 					}
 				}
 				unset($sql, $parameters, $recordings, $row);


### PR DESCRIPTION
On first iteration of the foreach loop, the variable $x was not yet initialized causing warnings. This fix removes the manual increment and uses the key / value pair syntax as the row is already indexed by numeric values starting at zero and incrementing by one.