### PR TITLE
variable conference_center_greeting was not initialized causing warning

### DIFF
--- a/app/conference_centers/conference_center_edit.php
+++ b/app/conference_centers/conference_center_edit.php
@@ -54,6 +54,7 @@
 	$conference_center_name = '';
 	$conference_center_extension = '';
 	$conference_center_description = '';
+	$conference_center_greeting = '';
 
 //process the user data and save it to the database
 	if (!empty($_POST) && empty($_POST["persistformvar"])) {


### PR DESCRIPTION
variable $conference_center_greeting was not initialized causing a PHP warning when it was a null value and accessed on line 367.