### PR TITLE
variable expanded_all was not initialized causing warning

### DIFF
--- a/core/dashboard/index.php
+++ b/core/dashboard/index.php
@@ -174,8 +174,8 @@
 	<?php
 
 // determine initial state all button to display
+	$expanded_all = true;
 	if (is_array($dashboard) && @sizeof($dashboard) != 0) {
-		$expanded_all = true;
 		foreach ($dashboard as $row) {
 			if ($row['dashboard_details_state'] == 'contracted' || $row['dashboard_details_state'] == 'hidden') { $expanded_all = false; }
 		}
@@ -290,8 +290,7 @@
   .col-num { grid-column: span 2; }
 	<?php
 		foreach($dashboard as $row) {
-			$dashboard_name = strtolower($row['dashboard_name']);
-			$dashboard_name = str_replace(" ", "_", $dashboard_name);
+			$dashboard_name = str_replace(" ", "_", strtolower($row['dashboard_name']));
 			$dashboard_column_span = $row['dashboard_column_span'];
 			if (is_numeric($dashboard_column_span)) {
 				echo "#".$dashboard_name." {\n";


### PR DESCRIPTION
Variable is set only inside of an if block but is accessed on line 197 and 198 causing a PHP warning to display. Moving the default to outside the if block allows the variable to be accessed with the default value.