### PR TITLE
use a single database instead of using new database in user_edit

### DIFF
--- a/core/users/user_edit.php
+++ b/core/users/user_edit.php
@@ -33,6 +33,11 @@
 	$language = new text;
 	$text = $language->get();
 
+//create a single database object
+	$database = new database;
+	$database->app_name = 'users';
+	$database->app_uuid = '112124b3-95c2-5352-7e9d-d14c0b88f207';
+
 //get user uuid
 	if (!empty($_REQUEST["id"]) && ((is_uuid($_REQUEST["id"]) && permission_exists('user_edit')) || (is_uuid($_REQUEST["id"]) && $_REQUEST["id"] == $_SESSION['user_uuid']))) {
 		$user_uuid = $_REQUEST["id"];
@@ -54,7 +59,6 @@
 		$sql .= "from v_users ";
 		$sql .= "where domain_uuid = :domain_uuid ";
 		$parameters['domain_uuid'] = $_SESSION['domain_uuid'];
-		$database = new database;
 		$num_rows = $database->select($sql, $parameters, 'column');
 		unset($sql, $parameters);
 
@@ -87,9 +91,6 @@
 			$p = new permissions;
 			$p->add('user_group_delete', 'temp');
 
-			$database = new database;
-			$database->app_name = 'users';
-			$database->app_uuid = '112124b3-95c2-5352-7e9d-d14c0b88f207';
 			$database->delete($array);
 			unset($array);
 
@@ -199,7 +200,6 @@
 					$parameters['domain_uuid'] = $domain_uuid;
 				}
 				$parameters['username'] = $username;
-				$database = new database;
 				$num_rows = $database->select($sql, $parameters, 'column');
 				if ($num_rows > 0) {
 					message::add($text['message-username_exists'], 'negative', 7500);
@@ -276,7 +276,6 @@
 			$sql .= "and user_setting_subcategory = 'language' ";
 			$sql .= "and user_uuid = :user_uuid ";
 			$parameters['user_uuid'] = $user_uuid;
-			$database = new database;
 			$row = $database->select($sql, $parameters, 'row');
 			if (!empty($user_language) && (empty($row) || (!empty($row['user_setting_uuid']) && !is_uuid($row['user_setting_uuid'])))) {
 				//add user setting to array for insert
@@ -299,9 +298,6 @@
 					$p = new permissions;
 					$p->add('user_setting_delete', 'temp');
 
-					$database = new database;
-					$database->app_name = 'users';
-					$database->app_uuid = '112124b3-95c2-5352-7e9d-d14c0b88f207';
 					$database->delete($array_delete);
 					unset($array_delete);
 
@@ -328,7 +324,6 @@
 			$sql .= "and user_setting_subcategory = 'time_zone' ";
 			$sql .= "and user_uuid = :user_uuid ";
 			$parameters['user_uuid'] = $user_uuid;
-			$database = new database;
 			$row = $database->select($sql, $parameters, 'row');
 			if (!empty($user_time_zone) && (empty($row) || (!empty($row['user_setting_uuid']) && !is_uuid($row['user_setting_uuid'])))) {
 				//add user setting to array for insert
@@ -351,9 +346,6 @@
 					$p = new permissions;
 					$p->add('user_setting_delete', 'temp');
 
-					$database = new database;
-					$database->app_name = 'users';
-					$database->app_uuid = '112124b3-95c2-5352-7e9d-d14c0b88f207';
 					$database->delete($array_delete);
 					unset($array_delete);
 
@@ -381,7 +373,6 @@
 				$sql .= "and user_setting_subcategory = 'key' ";
 				$sql .= "and user_uuid = :user_uuid ";
 				$parameters['user_uuid'] = $user_uuid;
-				$database = new database;
 				$row = $database->select($sql, $parameters, 'row');
 				if (!empty($message_key) && (empty($row) || (!empty($row['user_setting_uuid']) && !is_uuid($row['user_setting_uuid'])))) {
 					//add user setting to array for insert
@@ -404,9 +395,6 @@
 						$p = new permissions;
 						$p->add('user_setting_delete', 'temp');
 
-						$database = new database;
-						$database->app_name = 'users';
-						$database->app_uuid = '112124b3-95c2-5352-7e9d-d14c0b88f207';
 						$database->delete($array_delete);
 						unset($array_delete);
 
@@ -440,7 +428,6 @@
 				$sql .= "and group_uuid = :group_uuid ";
 				$parameters['domain_uuid'] = $_SESSION['domain_uuid'];
 				$parameters['group_uuid'] = $group_uuid;
-				$database = new database;
 				$row = $database->select($sql, $parameters, 'row');
 				if ($row['group_level'] <= $_SESSION['user']['group_level']) {
 					$array['user_groups'][$n]['user_group_uuid'] = uuid();
@@ -459,7 +446,6 @@
 					$sql = "select user_group_uuid from v_user_groups ";
 					$sql .= "where user_uuid = :user_uuid ";
 					$parameters['user_uuid'] = $user_uuid;
-					$database = new database;
 					$result = $database->select($sql, $parameters, 'all');
 					if (is_array($result)) {
 						foreach ($result as $row) {
@@ -474,7 +460,6 @@
 					$sql = "select user_setting_uuid from v_user_settings ";
 					$sql .= "where user_uuid = :user_uuid ";
 					$parameters['user_uuid'] = $user_uuid;
-					$database = new database;
 					$result = $database->select($sql, $parameters);
 					if (is_array($result)) {
 						foreach ($result as $row) {
@@ -494,7 +479,6 @@
 					$sql .= ") ";
 					$parameters['domain_uuid'] = $_SESSION['domain_uuid'];
 					$parameters['user_uuid'] = $user_uuid;
-					$database = new database;
 					$database->execute($sql, $parameters);
 					unset($sql, $parameters);
 			}
@@ -563,9 +547,6 @@
 			$p->add('user_group_add', 'temp');
 
 		//save the data
-			$database = new database;
-			$database->app_name = 'users';
-			$database->app_uuid = '112124b3-95c2-5352-7e9d-d14c0b88f207';
 			$database->save($array);
 			//$message = $database->message;
 
@@ -583,7 +564,6 @@
 					$sql .= "and user_uuid = :user_uuid ";
 					$parameters['domain_uuid'] = $_SESSION['domain_uuid'];
 					$parameters['user_uuid'] = $user_uuid;
-					$database = new database;
 					$call_center_agent_uuid = $database->select($sql, $parameters, 'column');
 					unset($sql, $parameters);
 
@@ -632,7 +612,6 @@
 					$parameters['domain_uuid'] = $domain_uuid;
 				}
 				$parameters['user_uuid'] = $user_uuid;
-				$database = new database;
 				$row = $database->select($sql, $parameters, 'row');
 				if (is_array($row) && sizeof($row) > 0) {
 					$domain_uuid = $row["domain_uuid"];
@@ -660,7 +639,6 @@
 				$sql .= "where user_uuid = :user_uuid ";
 				$sql .= "and user_setting_enabled = 'true' ";
 				$parameters['user_uuid'] = $user_uuid;
-				$database = new database;
 				$result = $database->select($sql, $parameters, 'all');
 				if (is_array($result)) {
 					foreach($result as $row) {
@@ -826,7 +804,6 @@
 	echo "		<option value=''></option>\n";
 	//get all language codes from database
 	$sql = "select * from v_languages order by language asc ";
-	$database = new database;
 	$languages = $database->select($sql, null, 'all');
 	if (!empty($languages) && is_array($languages) && sizeof($languages) != 0) {
 		foreach ($languages as $row) {
@@ -930,7 +907,6 @@
 		$sql .= "lower(c.contact_name_given) asc, ";
 		$sql .= "lower(c.contact_nickname) asc ";
 		$parameters['domain_uuid'] = $_SESSION['domain_uuid'];
-		$database = new database;
 		$contacts = $database->select($sql, $parameters, 'all');
 		unset($parameters);
 		echo "<select name=\"contact_uuid\" id=\"contact_uuid\" class=\"formfld\">\n";
@@ -991,7 +967,6 @@
 		$sql .= "	g.group_name asc ";
 		$parameters['domain_uuid'] = $domain_uuid;
 		$parameters['user_uuid'] = $user_uuid;
-		$database = new database;
 		$user_groups = $database->select($sql, $parameters, 'all');
 		if (is_array($user_groups)) {
 			echo "<table cellpadding='0' cellspacing='0' border='0'>\n";
@@ -1023,7 +998,6 @@
 		}
 		$sql .= "order by domain_uuid desc, group_name asc ";
 		$parameters['domain_uuid'] = $domain_uuid;
-		$database = new database;
 		$groups = $database->select($sql, $parameters, 'all');
 		if (is_array($groups)) {
 			if (isset($assigned_groups)) { echo "<br />\n"; }


### PR DESCRIPTION
Currently, the user_edit.php uses `$database = new database;` for each database action. This causes the database to re-initialize each time resulting in more overhead for the same operations. This PR will result in a single database object that is used throughout the user_edit view page.