### PR TITLE
if_group caused no conferences to show when user not in the admin group

### DIFF
--- a/app/conference_centers/conference_room_edit.php
+++ b/app/conference_centers/conference_room_edit.php
@@ -635,7 +635,7 @@
 	echo "		</td>";
 	echo "	</tr>";
 
-	if (if_group("superadmin") || if_group("admin")) {
+	if (permission_exists('conference_room_edit')) {
 		echo "	<tr>";
 		echo "		<td class='vncell' valign='top'>".$text['label-users']."</td>";
 		echo "		<td class='vtable' align='left'>";

--- a/app/conferences/conferences.php
+++ b/app/conferences/conferences.php
@@ -100,7 +100,7 @@
 	}
 
 //prepare to page the results
-	if (if_group("superadmin") || if_group("admin")) {
+	if (permission_exists('conference_view')) {
 		//show all extensions
 		$sql = "select count(*) from v_conferences ";
 		$sql .= "where true ";


### PR DESCRIPTION
if_group was used conferences causing the conferences not to show up for users that were not in the admin group but were assigned the permission to view conferences.