### PR TITLE
Handle ERR no such channel during call intercepts

### DIFF
--- a/app/xml_cdr/resources/classes/xml_cdr.php
+++ b/app/xml_cdr/resources/classes/xml_cdr.php
@@ -645,8 +645,8 @@ if (!class_exists('xml_cdr')) {
 						if ($xml->variables->cc_member_uuid == '_undef_') { $xml->variables->cc_member_uuid = ''; }
 						if ($xml->variables->cc_member_session_uuid == '_undef_') { $xml->variables->cc_member_session_uuid = ''; }
 						if ($xml->variables->cc_agent_uuid == '_undef_') { $xml->variables->cc_agent_uuid = ''; }
-						if ($xml->variables->call_center_queue_uuid == '_undef_') { $xml->variables->call_center_queue_uuid = ''; }
-						if ($xml->variables->cc_queue_joined_epoch == '_undef_') { $xml->variables->cc_queue_joined_epoch = ''; }
+						if ( ($xml->variables->call_center_queue_uuid == '_undef_') || ( (!is_uuid($xml->variables->call_center_queue_uuid) ) ) ) { $xml->variables->call_center_queue_uuid = ''; }
+						if ( ($xml->variables->cc_queue_joined_epoch == '_undef_') || ( (!is_numeric($xml->variables->cc_queue_joined_epoch) ) ) ) { $xml->variables->cc_queue_joined_epoch = ''; }
 						$this->array[$key][0]['cc_side'] = urldecode($xml->variables->cc_side);
 						$this->array[$key][0]['cc_member_uuid'] = urldecode($xml->variables->cc_member_uuid);
 						$this->array[$key][0]['cc_queue'] = urldecode($xml->variables->cc_queue);


### PR DESCRIPTION
When call center is not enabled, during a standard call intercept sometimes we are seeing an error as follows: call_center_queue_uuid=-ERR%20No%20such%20channel!%0A cc_queue_joined_epoch=-ERR%20No%20such%20channel!%0A Normally it returns call_center_queue_uuid=_undef_ but occasionally shows the ERR message. When the epoch variable is set to this it causes the XML CDR service to continually stop and start at the same CDR which raises the CPU load on the server significantly until the CDR is deleted. This code fix will handle the ERR message in the same way as _undef_.