### PR TITLE
Add check for file fax_active.php to exist before showing link to page

### DIFF
--- a/app/fax/fax.php
+++ b/app/fax/fax.php
@@ -291,7 +291,7 @@
 			if (permission_exists('fax_log_view')) {
 				echo "		<a href='fax_logs.php?id=".urlencode($row['fax_uuid'])."'>".$text['label-log']."</a>&nbsp;&nbsp;";
 			}
-			if (permission_exists('fax_active_view') && isset($_SESSION['fax']['send_mode']['text']) && $_SESSION['fax']['send_mode']['text'] == 'queue') {
+			if (file_exists(__DIR__ . '/fax_active.php') && permission_exists('fax_active_view') && isset($_SESSION['fax']['send_mode']['text']) && $_SESSION['fax']['send_mode']['text'] == 'queue') {
 				echo "		<a href='fax_active.php?id=".urlencode($row['fax_uuid'])."'>".$text['label-active']."</a>&nbsp;&nbsp;";
 			}
 			if (permission_exists('fax_queue_view')) {


### PR DESCRIPTION
fax_active is no longer used however, when upgrading from an older version, the permissions still exists. This causes some confusion on whether or not an upgrade has broken fax functionality. This bug fix simply checks for the file to exist (it should no longer exist) and only shows the link if the file is still present.