### PR TITLE
Make extension concurrent outbound limit a default setting

### DIFF
--- a/app/extensions/app_config.php
+++ b/app/extensions/app_config.php
@@ -373,6 +373,14 @@
 		$apps[$x]['default_settings'][$y]['default_setting_value'] = "30";
 		$apps[$x]['default_settings'][$y]['default_setting_enabled'] = "true";
 		$apps[$x]['default_settings'][$y]['default_setting_description'] = "Set the ring time (delay in seconds) before sending a call to voicemail";
+		$y++;
+		$apps[$x]['default_settings'][$y]['default_setting_uuid'] = "dad8148d-e96b-45a3-973d-2746bed389a8";
+		$apps[$x]['default_settings'][$y]['default_setting_category'] = "extension";
+		$apps[$x]['default_settings'][$y]['default_setting_subcategory'] = "concurrent_outbound_limit";
+		$apps[$x]['default_settings'][$y]['default_setting_name'] = "numeric";
+		$apps[$x]['default_settings'][$y]['default_setting_value'] = "5";
+		$apps[$x]['default_settings'][$y]['default_setting_enabled'] = "true";
+		$apps[$x]['default_settings'][$y]['default_setting_description'] = "Set the maximum number of concurrent outbound calls allowed";
 
 	//cache details
 		$apps[$x]['cache']['key'] = "directory.\${extension}@\${domain_name}";

--- a/app/extensions/extension_edit.php
+++ b/app/extensions/extension_edit.php
@@ -1066,7 +1066,7 @@
 	if (empty($user_context)) { $user_context = $_SESSION['domain_name']; }
 	if (empty($max_registrations)) { $max_registrations = $_SESSION['extension']['max_registrations']['numeric'] ?? ''; }
 	if (empty($accountcode)) { $accountcode = get_accountcode(); }
-	if (empty($limit_max)) { $limit_max = '5'; }
+	if (empty($limit_max)) { $limit_max = $_SESSION['extension']['concurrent_outbound_limit']['numeric'] ?? 5; }
 	if (empty($limit_destination)) { $limit_destination = '!USER_BUSY'; }
 	if (empty($call_timeout)) { $call_timeout = $_SESSION['extension']['call_timeout']['numeric'] ?? 30; }
 	if (empty($call_screen_enabled)) { $call_screen_enabled = 'false'; }


### PR DESCRIPTION
The setting was hard coded. Moving it to be a default setting. If the default setting is not enabled or does not exist then extension edit page use the default behavior of value = 5.