### PR TITLE
Prevent deleting the email when fax sender is not authorized

### DIFF
--- a/app/fax/fax_emails.php
+++ b/app/fax/fax_emails.php
@@ -262,11 +262,13 @@ if (!empty($result) && @sizeof($result) != 0) {
 
 					//reset variables
 					unset($fax_numbers);
-				}
 
-				//delete email
-				if (imap_delete($connection, $email_id, FT_UID)) {
-					imap_expunge($connection);
+					//delete email
+					if (imap_delete($connection, $email_id, FT_UID)) {
+						imap_expunge($connection);
+					}
+				} else {
+					//unauthorized sender
 				}
 			}
 			unset($authorized_senders);

--- a/app/fax/fax_emails.php
+++ b/app/fax/fax_emails.php
@@ -267,7 +267,8 @@ if (!empty($result) && @sizeof($result) != 0) {
 					if (imap_delete($connection, $email_id, FT_UID)) {
 						imap_expunge($connection);
 					}
-				} else {
+				}
+				else {
 					//unauthorized sender
 				}
 			}


### PR DESCRIPTION
Fix: email should not be deleted when the sender is not authorized