### PR TITLE
update grandstream template to use NTP provisioning variable

### DIFF
--- a/resources/templates/provision/grandstream/dp715.sm/{$mac}.xml
+++ b/resources/templates/provision/grandstream/dp715.sm/{$mac}.xml
@@ -207,7 +207,11 @@
 <P277>0</P277>
 
 <!-- NTP Server -->
-<P30>us.pool.ntp.org</P30>
+{if isset($ntp_server_primary)}
+<P30>{$ntp_server_primary}</P30>
+{else}
+<P30>pool.ntp.org</P30>
+{/if}
 
 <!-- Allow DHCP Option 42 to override NTP server. 0 - No, 1 - Yes. Default is No. -->
 <!-- When set to Yes(1), it will override the configured NTP server. -->

--- a/resources/templates/provision/grandstream/dp715/{$mac}.xml
+++ b/resources/templates/provision/grandstream/dp715/{$mac}.xml
@@ -128,7 +128,11 @@
 		<!-- Disable Direct IP Call. 0 - No, 1 - Yes. -->
 		<P277>0</P277>
 		<!-- NTP Server -->
-		<P30>us.pool.ntp.org</P30>
+		{if isset($ntp_server_primary)}
+		<P30>{$ntp_server_primary}</P30>
+		{else}
+		<P30>pool.ntp.org</P30>
+		{/if}
 		<!-- Allow DHCP Option 42 to override NTP server. 0 - No, 1 - Yes. Default is No. -->
 		<!-- When set to Yes(1), it will override the configured NTP server. -->
 		<P144>0</P144>

--- a/resources/templates/provision/grandstream/grp2612/{$mac}.xml
+++ b/resources/templates/provision/grandstream/grp2612/{$mac}.xml
@@ -3754,12 +3754,19 @@
 		<!-- # System Settings -->
 		<!-- # NTP Server -->
 		<!-- Pvalue P30 -->
+		{if isset($ntp_server_primary)}
+		<item name="dateTime.ntp.server.1">{$ntp_server_primary}</item>
+		{else}
 		<item name="dateTime.ntp.server.1">pool.ntp.org</item>
+		{/if}
 
 		<!-- # Secondary NTP Server -->
 		<!-- # String -->
-		<!-- Pvalue P8333 -->
-		<item name="dateTime.ntp.server.2"></item>
+		{if isset($ntp_server_secondary)}
+		<item name="dateTime.ntp.server.2">{$ntp_server_secondary}</item>
+		{else}
+		<item name="dateTime.ntp.server.2">2.us.pool.ntp.org</item>
+		{/if}
 
 		<!-- # NTP Update Interval -->
 		<!-- # String -->

--- a/resources/templates/provision/grandstream/grp2612w/{$mac}.xml
+++ b/resources/templates/provision/grandstream/grp2612w/{$mac}.xml
@@ -3722,12 +3722,19 @@
 		<!-- # System Settings -->
 		<!-- # NTP Server -->
 		<!-- Pvalue P30 -->
+		{if isset($ntp_server_primary)}
+		<item name="dateTime.ntp.server.1">{$ntp_server_primary}</item>
+		{else}
 		<item name="dateTime.ntp.server.1">pool.ntp.org</item>
+		{/if}
 
 		<!-- # Secondary NTP Server -->
 		<!-- # String -->
-		<!-- Pvalue P8333 -->
-		<item name="dateTime.ntp.server.2"></item>
+		{if isset($ntp_server_secondary)}
+		<item name="dateTime.ntp.server.2">{$ntp_server_secondary}</item>
+		{else}
+		<item name="dateTime.ntp.server.2">2.us.pool.ntp.org</item>
+		{/if}
 
 		<!-- # NTP Update Interval -->
 		<!-- # String -->

--- a/resources/templates/provision/grandstream/grp2613/{$mac}.xml
+++ b/resources/templates/provision/grandstream/grp2613/{$mac}.xml
@@ -3754,12 +3754,19 @@
 		<!-- # System Settings -->
 		<!-- # NTP Server -->
 		<!-- Pvalue P30 -->
+		{if isset($ntp_server_primary)}
+		<item name="dateTime.ntp.server.1">{$ntp_server_primary}</item>
+		{else}
 		<item name="dateTime.ntp.server.1">pool.ntp.org</item>
+		{/if}
 
 		<!-- # Secondary NTP Server -->
 		<!-- # String -->
-		<!-- Pvalue P8333 -->
-		<item name="dateTime.ntp.server.2"></item>
+		{if isset($ntp_server_secondary)}
+		<item name="dateTime.ntp.server.2">{$ntp_server_secondary}</item>
+		{else}
+		<item name="dateTime.ntp.server.2">2.us.pool.ntp.org</item>
+		{/if}
 
 		<!-- # NTP Update Interval -->
 		<!-- # String -->

--- a/resources/templates/provision/grandstream/grp2614/{$mac}.xml
+++ b/resources/templates/provision/grandstream/grp2614/{$mac}.xml
@@ -3754,12 +3754,19 @@
 		<!-- # System Settings -->
 		<!-- # NTP Server -->
 		<!-- Pvalue P30 -->
+		{if isset($ntp_server_primary)}
+		<item name="dateTime.ntp.server.1">{$ntp_server_primary}</item>
+		{else}
 		<item name="dateTime.ntp.server.1">pool.ntp.org</item>
+		{/if}
 
 		<!-- # Secondary NTP Server -->
 		<!-- # String -->
-		<!-- Pvalue P8333 -->
-		<item name="dateTime.ntp.server.2"></item>
+		{if isset($ntp_server_secondary)}
+		<item name="dateTime.ntp.server.2">{$ntp_server_secondary}</item>
+		{else}
+		<item name="dateTime.ntp.server.2">2.us.pool.ntp.org</item>
+		{/if}
 
 		<!-- # NTP Update Interval -->
 		<!-- # String -->

--- a/resources/templates/provision/grandstream/grp2615/{$mac}.xml
+++ b/resources/templates/provision/grandstream/grp2615/{$mac}.xml
@@ -3754,12 +3754,19 @@
 		<!-- # System Settings -->
 		<!-- # NTP Server -->
 		<!-- Pvalue P30 -->
+		{if isset($ntp_server_primary)}
+		<item name="dateTime.ntp.server.1">{$ntp_server_primary}</item>
+		{else}
 		<item name="dateTime.ntp.server.1">pool.ntp.org</item>
+		{/if}
 
 		<!-- # Secondary NTP Server -->
 		<!-- # String -->
-		<!-- Pvalue P8333 -->
-		<item name="dateTime.ntp.server.2"></item>
+		{if isset($ntp_server_secondary)}
+		<item name="dateTime.ntp.server.2">{$ntp_server_secondary}</item>
+		{else}
+		<item name="dateTime.ntp.server.2">2.us.pool.ntp.org</item>
+		{/if}
 
 		<!-- # NTP Update Interval -->
 		<!-- # String -->

--- a/resources/templates/provision/grandstream/grp2616/{$mac}.xml
+++ b/resources/templates/provision/grandstream/grp2616/{$mac}.xml
@@ -3754,12 +3754,19 @@
 		<!-- # System Settings -->
 		<!-- # NTP Server -->
 		<!-- Pvalue P30 -->
+		{if isset($ntp_server_primary)}
+		<item name="dateTime.ntp.server.1">{$ntp_server_primary}</item>
+		{else}
 		<item name="dateTime.ntp.server.1">pool.ntp.org</item>
+		{/if}
 
 		<!-- # Secondary NTP Server -->
 		<!-- # String -->
-		<!-- Pvalue P8333 -->
-		<item name="dateTime.ntp.server.2"></item>
+		{if isset($ntp_server_secondary)}
+		<item name="dateTime.ntp.server.2">{$ntp_server_secondary}</item>
+		{else}
+		<item name="dateTime.ntp.server.2">2.us.pool.ntp.org</item>
+		{/if}
 
 		<!-- # NTP Update Interval -->
 		<!-- # String -->

--- a/resources/templates/provision/grandstream/gxp116x/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp116x/{$mac}.xml
@@ -1347,7 +1347,11 @@
 
 <!--  NTP Server -->
 <!--  String -->
-<P30>us.pool.ntp.org</P30>
+{if isset($ntp_server_primary)}
+<P30>{$ntp_server_primary}</P30>
+{else}
+<P30>pool.ntp.org</P30>
+{/if}
 
 <!--  Allow DHCP Option 42 to override NTP server. 0 - No, 1 - Yes. Default is 1 -->
 <!--  When set to Yes(1), it will override the configured NTP server -->

--- a/resources/templates/provision/grandstream/gxp140x/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp140x/{$mac}.xml
@@ -1596,7 +1596,11 @@
     <!--   Settings/Date and Time -->
     <!--  NTP Server -->
     <!--  String -->
-    <P30>us.pool.ntp.org</P30>
+    {if isset($ntp_server_primary)}
+	<P30>{$ntp_server_primary}</P30>
+	{else}
+	<P30>pool.ntp.org</P30>
+	{/if}
     <!--  Allow DHCP Option 42 to override NTP server. 0 - No, 1 - Yes. Default is 1 -->
     <!--  When set to Yes(1), it will override the configured NTP server -->
     <!--  Number: 0, 1 -->

--- a/resources/templates/provision/grandstream/gxp140xbk/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp140xbk/{$mac}.xml
@@ -1596,7 +1596,11 @@
     <!--   Settings/Date and Time -->
     <!--  NTP Server -->
     <!--  String -->
-    <P30>us.pool.ntp.org</P30>
+    {if isset($ntp_server_primary)}
+	<P30>{$ntp_server_primary}</P30>
+	{else}
+	<P30>pool.ntp.org</P30>
+	{/if}
     <!--  Allow DHCP Option 42 to override NTP server. 0 - No, 1 - Yes. Default is 1 -->
     <!--  When set to Yes(1), it will override the configured NTP server -->
     <!--  Number: 0, 1 -->

--- a/resources/templates/provision/grandstream/gxp1450/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp1450/{$mac}.xml
@@ -2129,7 +2129,11 @@
 
 <!-- NTP Server -->
 <!-- String -->
-<P30>us.pool.ntp.org</P30>
+{if isset($ntp_server_primary)}
+<P30>{$ntp_server_primary}</P30>
+{else}
+<P30>pool.ntp.org</P30>
+{/if}
 
 <!-- Allow DHCP Option 42 to override NTP server. 0 - No, 1 - Yes. Default is 1 -->
 <!-- When set to Yes(1), it will override the configured NTP server -->

--- a/resources/templates/provision/grandstream/gxp1450bk/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp1450bk/{$mac}.xml
@@ -1936,7 +1936,11 @@
 
 <!-- NTP Server -->
 <!-- String -->
-<P30>us.pool.ntp.org</P30>
+{if isset($ntp_server_primary)}
+<P30>{$ntp_server_primary}</P30>
+{else}
+<P30>pool.ntp.org</P30>
+{/if}
 
 <!-- Allow DHCP Option 42 to override NTP server. 0 - No, 1 - Yes. Default is 1 -->
 <!-- When set to Yes(1), it will override the configured NTP server -->

--- a/resources/templates/provision/grandstream/gxp17xx/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp17xx/{$mac}.xml
@@ -3958,7 +3958,11 @@
 <!-- ############################################################################## -->
 <!-- # NTP Server -->
 <!-- # String -->
-<P30>us.pool.ntp.org</P30>
+{if isset($ntp_server_primary)}
+<P30>{$ntp_server_primary}</P30>
+{else}
+<P30>pool.ntp.org</P30>
+{/if}
 
 <!-- # NTP Update Interval -->
 <!-- # String -->

--- a/resources/templates/provision/grandstream/gxp20xx/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp20xx/{$mac}.xml
@@ -210,7 +210,11 @@
 <P208>0</P208>
 
 <!--  NTP Server -->
-<P30>us.pool.ntp.org</P30>
+{if isset($ntp_server_primary)}
+<P30>{$ntp_server_primary}</P30>
+{else}
+<P30>pool.ntp.org</P30>
+{/if}
 
 <!--  Allow DHCP Option 42 to override NTP server. 0 - No, 1 - Yes. Default is No. -->
 <!--  When set to Yes(1), it will override the configured NTP server. -->

--- a/resources/templates/provision/grandstream/gxp2124/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp2124/{$mac}.xml
@@ -2356,7 +2356,11 @@
     <!--  Settings/Date and Time -->
     <!-- NTP Server -->
     <!-- String -->
-    <P30>us.pool.ntp.org</P30>
+    {if isset($ntp_server_primary)}
+	<P30>{$ntp_server_primary}</P30>
+	{else}
+	<P30>pool.ntp.org</P30>
+	{/if}
     <!-- Allow DHCP Option 42 to override NTP server. 0 - No, 1 - Yes. Default is 1 -->
     <!-- When set to Yes(1), it will override the configured NTP server -->
     <!-- Number: 0, 1 -->

--- a/resources/templates/provision/grandstream/gxp2130/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp2130/{$mac}.xml
@@ -2485,11 +2485,19 @@
 		<!-- ##  Settings/Preferences / Date and Time -->
 		<!-- ############################################################################## -->
 		<!-- # NTP Server -->
+		{if isset($ntp_server_primary)}
+		<item name="dateTime.ntp.server.1">{$ntp_server_primary}</item>
+		{else}
 		<item name="dateTime.ntp.server.1">pool.ntp.org</item>
+		{/if}
 
 		<!-- # Secondary NTP Server -->
 		<!-- # String -->
-		<item name="dateTime.ntp.server.2"/>
+		{if isset($ntp_server_secondary)}
+		<item name="dateTime.ntp.server.2">{$ntp_server_secondary}</item>
+		{else}
+		<item name="dateTime.ntp.server.2">2.us.pool.ntp.org</item>
+		{/if}
 
 		<!-- # NTP Update Interval -->
 		<!-- # String -->

--- a/resources/templates/provision/grandstream/gxp2135/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp2135/{$mac}.xml
@@ -2485,11 +2485,19 @@
 		<!-- ##  Settings/Preferences / Date and Time -->
 		<!-- ############################################################################## -->
 		<!-- # NTP Server -->
+		{if isset($ntp_server_primary)}
+		<item name="dateTime.ntp.server.1">{$ntp_server_primary}</item>
+		{else}
 		<item name="dateTime.ntp.server.1">pool.ntp.org</item>
+		{/if}
 
 		<!-- # Secondary NTP Server -->
 		<!-- # String -->
-		<item name="dateTime.ntp.server.2"/>
+		{if isset($ntp_server_secondary)}
+		<item name="dateTime.ntp.server.2">{$ntp_server_secondary}</item>
+		{else}
+		<item name="dateTime.ntp.server.2">2.us.pool.ntp.org</item>
+		{/if}
 
 		<!-- # NTP Update Interval -->
 		<!-- # String -->

--- a/resources/templates/provision/grandstream/gxp2140/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp2140/{$mac}.xml
@@ -2486,11 +2486,19 @@
 		<!-- ##  Settings/Preferences / Date and Time -->
 		<!-- ############################################################################## -->
 		<!-- # NTP Server -->
+		{if isset($ntp_server_primary)}
+		<item name="dateTime.ntp.server.1">{$ntp_server_primary}</item>
+		{else}
 		<item name="dateTime.ntp.server.1">pool.ntp.org</item>
+		{/if}
 
 		<!-- # Secondary NTP Server -->
 		<!-- # String -->
-		<item name="dateTime.ntp.server.2"/>
+		{if isset($ntp_server_secondary)}
+		<item name="dateTime.ntp.server.2">{$ntp_server_secondary}</item>
+		{else}
+		<item name="dateTime.ntp.server.2">2.us.pool.ntp.org</item>
+		{/if}
 
 		<!-- # NTP Update Interval -->
 		<!-- # String -->

--- a/resources/templates/provision/grandstream/gxp2160/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp2160/{$mac}.xml
@@ -2486,11 +2486,19 @@
 		<!-- ##  Settings/Preferences / Date and Time -->
 		<!-- ############################################################################## -->
 		<!-- # NTP Server -->
+		{if isset($ntp_server_primary)}
+		<item name="dateTime.ntp.server.1">{$ntp_server_primary}</item>
+		{else}
 		<item name="dateTime.ntp.server.1">pool.ntp.org</item>
+		{/if}
 
 		<!-- # Secondary NTP Server -->
 		<!-- # String -->
-		<item name="dateTime.ntp.server.2"/>
+		{if isset($ntp_server_secondary)}
+		<item name="dateTime.ntp.server.2">{$ntp_server_secondary}</item>
+		{else}
+		<item name="dateTime.ntp.server.2">2.us.pool.ntp.org</item>
+		{/if}
 
 		<!-- # NTP Update Interval -->
 		<!-- # String -->

--- a/resources/templates/provision/grandstream/gxp2170/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp2170/{$mac}.xml
@@ -2486,11 +2486,19 @@
 		<!-- ##  Settings/Preferences / Date and Time -->
 		<!-- ############################################################################## -->
 		<!-- # NTP Server -->
+		{if isset($ntp_server_primary)}
+		<item name="dateTime.ntp.server.1">{$ntp_server_primary}</item>
+		{else}
 		<item name="dateTime.ntp.server.1">pool.ntp.org</item>
+		{/if}
 
 		<!-- # Secondary NTP Server -->
 		<!-- # String -->
-		<item name="dateTime.ntp.server.2"/>
+		{if isset($ntp_server_secondary)}
+		<item name="dateTime.ntp.server.2">{$ntp_server_secondary}</item>
+		{else}
+		<item name="dateTime.ntp.server.2">2.us.pool.ntp.org</item>
+		{/if}
 
 		<!-- # NTP Update Interval -->
 		<!-- # String -->

--- a/resources/templates/provision/grandstream/gxp21xx/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp21xx/{$mac}.xml
@@ -3135,7 +3135,11 @@ Outgoing calls. 0 - No, 1 - Yes. Default is 0 -->
     <!-- Settings/Date and Time -->
     <!-- NTP Server -->
     <!-- String -->
-    <P30>us.pool.ntp.org</P30>
+    {if isset($ntp_server_primary)}
+	<P30>{$ntp_server_primary}</P30>
+	{else}
+	<P30>pool.ntp.org</P30>
+	{/if}
     <!-- Allow DHCP Option 42 to override NTP server. 0 - No, 1 - Yes. Default is 1 -->
     <!-- When set to Yes(1), it will override the configured NTP server -->
     <!-- Number: 0, 1 -->

--- a/resources/templates/provision/grandstream/gxp21xxbk/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp21xxbk/{$mac}.xml
@@ -3863,7 +3863,11 @@ Outgoing calls. 0 - No, 1 - Yes. Default is 0 -->
 
 <!-- NTP Server -->
 <!-- String -->
-<P30>us.pool.ntp.org</P30>
+{if isset($ntp_server_primary)}
+<P30>{$ntp_server_primary}</P30>
+{else}
+<P30>pool.ntp.org</P30>
+{/if}
 
 <!-- Allow DHCP Option 42 to override NTP server. 0 - No, 1 - Yes. Default is 1 -->
 <!-- When set to Yes(1), it will override the configured NTP server -->

--- a/resources/templates/provision/grandstream/gxp2200/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp2200/{$mac}.xml
@@ -2836,7 +2836,11 @@ Account 5 Codec Settings
 
 
 <!-- Assign NTP Server Address -->
-<P30>us.pool.ntp.org</P30>
+{if isset($ntp_server_primary)}
+<P30>{$ntp_server_primary}</P30>
+{else}
+<P30>pool.ntp.org</P30>
+{/if}
 
 <!-- DHCP Option 42 override NTP server. 0 - No, 1 - Yes. Default value is 1 -->
 <!-- When set to Yes (1), it will override the configured NTP server -->

--- a/resources/templates/provision/grandstream/gxp3240/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp3240/{$mac}.xml
@@ -3047,7 +3047,11 @@ Account 5 Codec Settings
 
 
 <!-- Assign NTP Server Address -->
-<P30>us.pool.ntp.org</P30>
+{if isset($ntp_server_primary)}
+<P30>{$ntp_server_primary}</P30>
+{else}
+<P30>pool.ntp.org</P30>
+{/if}
 
 <!-- DHCP Option 42 override NTP server. 0 - No, 1 - Yes. Default value is 1 -->
 <!-- When set to Yes (1), it will override the configured NTP server -->

--- a/resources/templates/provision/grandstream/gxv300x/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxv300x/{$mac}.xml
@@ -149,7 +149,11 @@
     <!-- 0 - NONE, 1 - DEBUG, 2 - INFO, 3 - WARNING, 4 - ERROR -->
     <P208>0</P208>
     <!-- NTP Server -->
-    <P30>us.pool.ntp.org</P30>
+    {if isset($ntp_server_primary)}
+	<P30>{$ntp_server_primary}</P30>
+	{else}
+	<P30>pool.ntp.org</P30>
+	{/if}
     <!-- Allow DHCP Option 42 to override NTP server. 0 - No, 1 - Yes. Default is No. -->
     <!-- When set to Yes(1), it will override the configured NTP server. -->
     <P144>0</P144>

--- a/resources/templates/provision/grandstream/gxv3370/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxv3370/{$mac}.xml
@@ -822,7 +822,18 @@
 		<item name="network.proxy.http"></item>
 		<!-- System Settings -->
 		<!-- Assign NTP Server Address -->
+		{if isset($ntp_server_primary)}
+		<item name="dateTime.ntp.server.1">{$ntp_server_primary}</item>
+		{else}
 		<item name="dateTime.ntp.server.1">pool.ntp.org</item>
+		{/if}
+		<!-- # Secondary NTP Server -->
+		<!-- # String -->
+		{if isset($ntp_server_secondary)}
+		<item name="dateTime.ntp.server.2">{$ntp_server_secondary}</item>
+		{else}
+		<item name="dateTime.ntp.server.2">2.us.pool.ntp.org</item>
+		{/if}
 		<!-- DHCP Option 42 Override NTP Server -->
 		<!-- Yes, No -->
 		<item name="dateTime.override.dhcp.allowOption42">Yes</item>

--- a/resources/templates/provision/grandstream/gxv3480/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxv3480/{$mac}.xml
@@ -836,7 +836,19 @@
 		<item name="network.proxy.http"></item>
 		<!-- System Settings -->
 		<!-- Assign NTP Server Address -->
+		{if isset($ntp_server_primary)}
+		<item name="dateTime.ntp.server.1">{$ntp_server_primary}</item>
+		{else}
 		<item name="dateTime.ntp.server.1">pool.ntp.org</item>
+		{/if}
+
+		<!-- # Secondary NTP Server -->
+		<!-- # String -->
+		{if isset($ntp_server_secondary)}
+		<item name="dateTime.ntp.server.2">{$ntp_server_secondary}</item>
+		{else}
+		<item name="dateTime.ntp.server.2">2.us.pool.ntp.org</item>
+		{/if}
 		<!-- DHCP Option 42 Override NTP Server -->
 		<!-- Yes, No -->
 		<item name="dateTime.override.dhcp.allowOption42">Yes</item>

--- a/resources/templates/provision/grandstream/gxw40xx/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxw40xx/{$mac}.xml
@@ -235,7 +235,11 @@
     <P4206></P4206>
     <!-- NTP Server -->
     <!-- String: serveraddress -->
-    <P30>us.pool.ntp.org</P30>
+    {if isset($ntp_server_primary)}
+	<P30>{$ntp_server_primary}</P30>
+	{else}
+	<P30>pool.ntp.org</P30>
+	{/if}
     <!-- NTP Update Interval in minutes(5-1440)(Default is set to 60 minutes) -->
     <!-- Number: 5 to 1440 -->
     <!-- Mandatory -->

--- a/resources/templates/provision/grandstream/gxw410x/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxw410x/{$mac}.xml
@@ -75,7 +75,11 @@
     <!--  0 - NONE, 1 - DEBUG, 2 - INFO, 3 - WARNING, 4 - ERROR -->
     <P208>0</P208>
     <!--  NTP Server -->
-    <P30>us.pool.ntp.org</P30>
+    {if isset($ntp_server_primary)}
+	<P30>{$ntp_server_primary}</P30>
+	{else}
+	<P30>pool.ntp.org</P30>
+	{/if}
     <!--  Allow DHCP Option 42 to override NTP server. 0 - No, 1 - Yes. Default is No. -->
     <!--  When set to Yes(1), it will override the configured NTP server. -->
     <P144>0</P144>

--- a/resources/templates/provision/grandstream/gxw42xx/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxw42xx/{$mac}.xml
@@ -366,7 +366,11 @@
 
 <!-- NTP Server -->
 <!-- String: serveraddress -->
-<P30>us.pool.ntp.org</P30>
+{if isset($ntp_server_primary)}
+<P30>{$ntp_server_primary}</P30>
+{else}
+<P30>pool.ntp.org</P30>
+{/if}
 
 <!-- NTP Update Interval in minutes(5-1440)(Default is set to 60 minutes) -->
 <!-- Number: 5 to 1440 -->

--- a/resources/templates/provision/grandstream/ht502/{$mac}.xml
+++ b/resources/templates/provision/grandstream/ht502/{$mac}.xml
@@ -174,7 +174,11 @@
 		<!-- Disable Direct IP Call. 0 - No, 1 - Yes. -->
 		<P277>0</P277>
 		<!-- NTP Server. Server address -->
-		<P30>us.pool.ntp.org</P30>
+		{if isset($ntp_server_primary)}
+		<P30>{$ntp_server_primary}</P30>
+		{else}
+		<P30>pool.ntp.org</P30>
+		{/if}
 		<!-- NTP Update Interval in minutes(5-1440)(Default is set to 60 minutes) -->
 		<!-- Number: 5 to 1440 -->
 		<P5005>1440</P5005>

--- a/resources/templates/provision/grandstream/ht503/{$mac}.xml
+++ b/resources/templates/provision/grandstream/ht503/{$mac}.xml
@@ -353,7 +353,11 @@
 
 <!--  NTP Server -->
 <!--  Server address -->
-<P30>us.pool.ntp.org</P30>
+{if isset($ntp_server_primary)}
+<P30>{$ntp_server_primary}</P30>
+{else}
+<P30>pool.ntp.org</P30>
+{/if}
 
 <!--  NTP Update Interval in minutes(5-1440)(Default is set to 60 minutes) -->
 <!--  Number: 5 to 1440 -->

--- a/resources/templates/provision/grandstream/ht701/{$mac}.xml
+++ b/resources/templates/provision/grandstream/ht701/{$mac}.xml
@@ -247,7 +247,11 @@
 
 <!-- NTP Server -->
 <!-- Server address -->
-<P30>us.pool.ntp.org</P30>
+{if isset($ntp_server_primary)}
+<P30>{$ntp_server_primary}</P30>
+{else}
+<P30>pool.ntp.org</P30>
+{/if}
 
 <!-- Allow DHCP Option 42 to override NTP server. 0 - No, 1 - Yes. Default is No. -->
 <!-- When set to Yes(1), it will override the configured NTP server. -->

--- a/resources/templates/provision/grandstream/ht702/{$mac}.xml
+++ b/resources/templates/provision/grandstream/ht702/{$mac}.xml
@@ -254,7 +254,11 @@
 
 <!-- NTP Server -->
 <!-- Server address -->
-<P30>us.pool.ntp.org</P30>
+{if isset($ntp_server_primary)}
+<P30>{$ntp_server_primary}</P30>
+{else}
+<P30>pool.ntp.org</P30>
+{/if}
 
 <!-- Allow DHCP Option 42 to override NTP server. 0 - No, 1 - Yes. Default is No. -->
 <!-- When set to Yes(1), it will override the configured NTP server. -->

--- a/resources/templates/provision/grandstream/ht704/{$mac}.xml
+++ b/resources/templates/provision/grandstream/ht704/{$mac}.xml
@@ -262,7 +262,11 @@
 
 <!-- NTP Server-->
 <!-- Server address-->
-<P30>us.pool.ntp.org</P30>
+{if isset($ntp_server_primary)}
+<P30>{$ntp_server_primary}</P30>
+{else}
+<P30>pool.ntp.org</P30>
+{/if}
 
 <!-- Syslog Server (name of the server, max length is 64 characters)-->
 <!-- Server address-->

--- a/resources/templates/provision/grandstream/ht801/{$mac}.xml
+++ b/resources/templates/provision/grandstream/ht801/{$mac}.xml
@@ -480,7 +480,11 @@
 
     <!-- # NTP Server -->
     <!-- # Server address -->
-    <P30>us.pool.ntp.org</P30>
+    {if isset($ntp_server_primary)}
+	<P30>{$ntp_server_primary}</P30>
+	{else}
+	<P30>pool.ntp.org</P30>
+	{/if}
 
     <!-- # Allow DHCP Option 42 to override NTP server. 0 - No, 1 - Yes. Default is No. -->
     <!-- # When set to Yes(1), it will override the configured NTP server. -->

--- a/resources/templates/provision/grandstream/ht802/{$mac}.xml
+++ b/resources/templates/provision/grandstream/ht802/{$mac}.xml
@@ -480,7 +480,11 @@
 
     <!-- # NTP Server -->
     <!-- # Server address -->
-    <P30>us.pool.ntp.org</P30>
+    {if isset($ntp_server_primary)}
+	<P30>{$ntp_server_primary}</P30>
+	{else}
+	<P30>pool.ntp.org</P30>
+	{/if}
 
     <!-- # Allow DHCP Option 42 to override NTP server. 0 - No, 1 - Yes. Default is No. -->
     <!-- # When set to Yes(1), it will override the configured NTP server. -->


### PR DESCRIPTION
NTP server variable was hard-coded to use either pool.ntp.org or us.pool.ntp.org. This will use the already available variable from default setting of ``{$ntp_server_primary}`` to set the ntp server primary and when available ntp secondary server.