### PR TITLE
do not exit when unable to connect to freeswitch socket

### DIFF
--- a/app/sip_status/sip_status.php
+++ b/app/sip_status/sip_status.php
@@ -238,7 +238,6 @@
 			}
 			catch(Exception $e) {
 				echo $e->getMessage();
-				exit;
 			}
 
 			echo "<div class='action_bar sub'>\n";


### PR DESCRIPTION
Exiting immediately causes the menu navigation to disappear and breaks the standard look of the page. By removing the exit statement the navigation is still available and the flash notification message shows to notify user that the connection is not available.