### PR TITLE
added emergency numbers default settings for Snom

### DIFF
--- a/app/snom/app_config.php
+++ b/app/snom/app_config.php
@@ -397,4 +397,12 @@
 		$apps[$x]['default_settings'][$y]['default_setting_value'] = "not_busy";
 		$apps[$x]['default_settings'][$y]['default_setting_enabled'] = "true";
 		$apps[$x]['default_settings'][$y]['default_setting_description'] = "The setting to auto-answer calls that have the Alert-Info SIP header. More info can be found here: https://service.snom.com/display/wiki/answer_after_policy";
+		$y++;
+		$apps[$x]['default_settings'][$y]['default_setting_uuid'] = "ba9bd041-343f-4253-9cba-8b0f0835675f";
+		$apps[$x]['default_settings'][$y]['default_setting_category'] = "provision";
+		$apps[$x]['default_settings'][$y]['default_setting_subcategory'] = "snom_emergency_numbers";
+		$apps[$x]['default_settings'][$y]['default_setting_name'] = "text";
+		$apps[$x]['default_settings'][$y]['default_setting_value'] = "911 112 110 999";
+		$apps[$x]['default_settings'][$y]['default_setting_enabled'] = "true";
+		$apps[$x]['default_settings'][$y]['default_setting_description'] = "These are the numbers that the phone will understand as emergency numbers. This means they can be dialled on the phone even if the phone is locked. Valid values are space separated. More info can be found here: https://service.snom.com/display/wiki/keyboard_lock_emergency";
 ?>

--- a/resources/templates/provision/snom/D712/{$mac}.xml
+++ b/resources/templates/provision/snom/D712/{$mac}.xml
@@ -19,6 +19,7 @@
     <show_ivr_digits perm="">off</show_ivr_digits>
     <cw_dialtone perm="">{if isset($snom_dialtone_on_hold)}{$snom_dialtone_on_hold}{else}true{/if}</cw_dialtone>
     <answer_after_policy perm="">{if isset($snom_answer_after_policy)}{$snom_answer_after_policy}{else}off{/if}</answer_after_policy>
+    <keyboard_lock_emergency perm="R">{if isset($snom_emergency_numbers)}{$snom_emergency_numbers}{else}911 112 110 999{/if}</keyboard_lock_emergency>
     <!-- Ringtones -->
     <alert_internal_ring_text perm="">alert-internal</alert_internal_ring_text>
     <alert_internal_ring_sound perm="">{if isset($snom_alert_internal)}{$snom_alert_internal}{else}Ringer1{/if}</alert_internal_ring_sound>

--- a/resources/templates/provision/snom/D715/{$mac}.xml
+++ b/resources/templates/provision/snom/D715/{$mac}.xml
@@ -19,6 +19,7 @@
     <show_ivr_digits perm="">off</show_ivr_digits>
     <cw_dialtone perm="">{if isset($snom_dialtone_on_hold)}{$snom_dialtone_on_hold}{else}true{/if}</cw_dialtone>
     <answer_after_policy perm="">{if isset($snom_answer_after_policy)}{$snom_answer_after_policy}{else}off{/if}</answer_after_policy>
+    <keyboard_lock_emergency perm="R">{if isset($snom_emergency_numbers)}{$snom_emergency_numbers}{else}911 112 110 999{/if}</keyboard_lock_emergency>
     <!-- Ringtones -->
     <alert_internal_ring_text perm="">alert-internal</alert_internal_ring_text>
     <alert_internal_ring_sound perm="">{if isset($snom_alert_internal)}{$snom_alert_internal}{else}Ringer1{/if}</alert_internal_ring_sound>

--- a/resources/templates/provision/snom/D717/{$mac}.xml
+++ b/resources/templates/provision/snom/D717/{$mac}.xml
@@ -18,8 +18,9 @@
     <dialnumber_us_format perm="">on</dialnumber_us_format>
     <show_ivr_digits perm="">off</show_ivr_digits>
     <cw_dialtone perm="">{if isset($snom_dialtone_on_hold)}{$snom_dialtone_on_hold}{else}true{/if}</cw_dialtone>
-    <smartlabel_idle_default perm="PERMISSIONFLAGS">{if isset($snom_smartlabel_idle)}{$snom_smartlabel_idle}{else}short{/if}</smartlabel_idle_default>
+    <smartlabel_idle_default perm="">{if isset($snom_smartlabel_idle)}{$snom_smartlabel_idle}{else}short{/if}</smartlabel_idle_default>
     <answer_after_policy perm="">{if isset($snom_answer_after_policy)}{$snom_answer_after_policy}{else}off{/if}</answer_after_policy>
+    <keyboard_lock_emergency perm="R">{if isset($snom_emergency_numbers)}{$snom_emergency_numbers}{else}911 112 110 999{/if}</keyboard_lock_emergency>
     <!-- Ringtones -->
     <alert_internal_ring_text perm="">alert-internal</alert_internal_ring_text>
     <alert_internal_ring_sound perm="">{if isset($snom_alert_internal)}{$snom_alert_internal}{else}Ringer1{/if}</alert_internal_ring_sound>

--- a/resources/templates/provision/snom/D725/{$mac}.xml
+++ b/resources/templates/provision/snom/D725/{$mac}.xml
@@ -19,6 +19,7 @@
     <show_ivr_digits perm="">off</show_ivr_digits>
     <cw_dialtone perm="">{if isset($snom_dialtone_on_hold)}{$snom_dialtone_on_hold}{else}true{/if}</cw_dialtone>
     <answer_after_policy perm="">{if isset($snom_answer_after_policy)}{$snom_answer_after_policy}{else}off{/if}</answer_after_policy>
+    <keyboard_lock_emergency perm="R">{if isset($snom_emergency_numbers)}{$snom_emergency_numbers}{else}911 112 110 999{/if}</keyboard_lock_emergency>
     <!-- Ringtones -->
     <alert_internal_ring_text perm="">alert-internal</alert_internal_ring_text>
     <alert_internal_ring_sound perm="">{if isset($snom_alert_internal)}{$snom_alert_internal}{else}Ringer1{/if}</alert_internal_ring_sound>

--- a/resources/templates/provision/snom/D735/{$mac}.xml
+++ b/resources/templates/provision/snom/D735/{$mac}.xml
@@ -18,8 +18,9 @@
     <dialnumber_us_format perm="">on</dialnumber_us_format>
     <show_ivr_digits perm="">off</show_ivr_digits>
     <cw_dialtone perm="">{if isset($snom_dialtone_on_hold)}{$snom_dialtone_on_hold}{else}false{/if}</cw_dialtone>
-    <smartlabel_idle_default perm="PERMISSIONFLAGS">{if isset($snom_smartlabel_idle)}{$snom_smartlabel_idle}{else}short{/if}</smartlabel_idle_default>
+    <smartlabel_idle_default perm="">{if isset($snom_smartlabel_idle)}{$snom_smartlabel_idle}{else}short{/if}</smartlabel_idle_default>
     <answer_after_policy perm="">{if isset($snom_answer_after_policy)}{$snom_answer_after_policy}{else}off{/if}</answer_after_policy>
+    <keyboard_lock_emergency perm="R">{if isset($snom_emergency_numbers)}{$snom_emergency_numbers}{else}911 112 110 999{/if}</keyboard_lock_emergency>
     <!-- Ringtones -->
     <alert_internal_ring_text perm="">alert-internal</alert_internal_ring_text>
     <alert_internal_ring_sound perm="">{if isset($snom_alert_internal)}{$snom_alert_internal}{else}Ringer1{/if}</alert_internal_ring_sound>

--- a/resources/templates/provision/snom/D745/{$mac}.xml
+++ b/resources/templates/provision/snom/D745/{$mac}.xml
@@ -19,6 +19,7 @@
     <show_ivr_digits perm="">off</show_ivr_digits>
     <cw_dialtone perm="">{if isset($snom_dialtone_on_hold)}{$snom_dialtone_on_hold}{else}true{/if}</cw_dialtone>
     <answer_after_policy perm="">{if isset($snom_answer_after_policy)}{$snom_answer_after_policy}{else}off{/if}</answer_after_policy>
+    <keyboard_lock_emergency perm="R">{if isset($snom_emergency_numbers)}{$snom_emergency_numbers}{else}911 112 110 999{/if}</keyboard_lock_emergency>
     <!-- Ringtones -->
     <alert_internal_ring_text perm="">alert-internal</alert_internal_ring_text>
     <alert_internal_ring_sound perm="">{if isset($snom_alert_internal)}{$snom_alert_internal}{else}Ringer1{/if}</alert_internal_ring_sound>

--- a/resources/templates/provision/snom/D765/{$mac}.xml
+++ b/resources/templates/provision/snom/D765/{$mac}.xml
@@ -19,6 +19,7 @@
     <show_ivr_digits perm="">off</show_ivr_digits>
     <cw_dialtone perm="">{if isset($snom_dialtone_on_hold)}{$snom_dialtone_on_hold}{else}true{/if}</cw_dialtone>
     <answer_after_policy perm="">{if isset($snom_answer_after_policy)}{$snom_answer_after_policy}{else}off{/if}</answer_after_policy>
+    <keyboard_lock_emergency perm="R">{if isset($snom_emergency_numbers)}{$snom_emergency_numbers}{else}911 112 110 999{/if}</keyboard_lock_emergency>
     <!-- Ringtones -->
     <alert_internal_ring_text perm="">alert-internal</alert_internal_ring_text>
     <alert_internal_ring_sound perm="">{if isset($snom_alert_internal)}{$snom_alert_internal}{else}Ringer1{/if}</alert_internal_ring_sound>

--- a/resources/templates/provision/snom/D785/{$mac}.xml
+++ b/resources/templates/provision/snom/D785/{$mac}.xml
@@ -19,6 +19,7 @@
     <show_ivr_digits perm="">off</show_ivr_digits>
     <cw_dialtone perm="">{if isset($snom_dialtone_on_hold)}{$snom_dialtone_on_hold}{else}false{/if}</cw_dialtone>
     <answer_after_policy perm="">{if isset($snom_answer_after_policy)}{$snom_answer_after_policy}{else}off{/if}</answer_after_policy>
+    <keyboard_lock_emergency perm="R">{if isset($snom_emergency_numbers)}{$snom_emergency_numbers}{else}911 112 110 999{/if}</keyboard_lock_emergency>
     <!-- Ringtones -->
     <alert_internal_ring_text perm="">alert-internal</alert_internal_ring_text>
     <alert_internal_ring_sound perm="">{if isset($snom_alert_internal)}{$snom_alert_internal}{else}Ringer1{/if}</alert_internal_ring_sound>

--- a/resources/templates/provision/snom/D812/{$mac}.xml
+++ b/resources/templates/provision/snom/D812/{$mac}.xml
@@ -19,6 +19,7 @@
     <show_ivr_digits perm="">off</show_ivr_digits>
     <cw_dialtone perm="">{if isset($snom_dialtone_on_hold)}{$snom_dialtone_on_hold}{else}false{/if}</cw_dialtone>
     <answer_after_policy perm="">{if isset($snom_answer_after_policy)}{$snom_answer_after_policy}{else}off{/if}</answer_after_policy>
+    <keyboard_lock_emergency perm="R">{if isset($snom_emergency_numbers)}{$snom_emergency_numbers}{else}911 112 110 999{/if}</keyboard_lock_emergency>
     <!-- Ringtones -->
     <alert_internal_ring_text perm="">alert-internal</alert_internal_ring_text>
     <alert_internal_ring_sound perm="">{if isset($snom_alert_internal)}{$snom_alert_internal}{else}Ringer1{/if}</alert_internal_ring_sound>

--- a/resources/templates/provision/snom/D815/{$mac}.xml
+++ b/resources/templates/provision/snom/D815/{$mac}.xml
@@ -19,6 +19,7 @@
     <show_ivr_digits perm="">off</show_ivr_digits>
     <cw_dialtone perm="">{if isset($snom_dialtone_on_hold)}{$snom_dialtone_on_hold}{else}false{/if}</cw_dialtone>
     <answer_after_policy perm="">{if isset($snom_answer_after_policy)}{$snom_answer_after_policy}{else}off{/if}</answer_after_policy>
+    <keyboard_lock_emergency perm="R">{if isset($snom_emergency_numbers)}{$snom_emergency_numbers}{else}911 112 110 999{/if}</keyboard_lock_emergency>
     <!-- Ringtones -->
     <alert_internal_ring_text perm="">alert-internal</alert_internal_ring_text>
     <alert_internal_ring_sound perm="">{if isset($snom_alert_internal)}{$snom_alert_internal}{else}Ringer1{/if}</alert_internal_ring_sound>

--- a/resources/templates/provision/snom/D862/{$mac}.xml
+++ b/resources/templates/provision/snom/D862/{$mac}.xml
@@ -19,6 +19,7 @@
     <show_ivr_digits perm="">off</show_ivr_digits>
     <cw_dialtone perm="">{if isset($snom_dialtone_on_hold)}{$snom_dialtone_on_hold}{else}false{/if}</cw_dialtone>
     <answer_after_policy perm="">{if isset($snom_answer_after_policy)}{$snom_answer_after_policy}{else}off{/if}</answer_after_policy>
+    <keyboard_lock_emergency perm="R">{if isset($snom_emergency_numbers)}{$snom_emergency_numbers}{else}911 112 110 999{/if}</keyboard_lock_emergency>
     <!-- Ringtones -->
     <alert_internal_ring_text perm="">alert-internal</alert_internal_ring_text>
     <alert_internal_ring_sound perm="">{if isset($snom_alert_internal)}{$snom_alert_internal}{else}Ringer1{/if}</alert_internal_ring_sound>

--- a/resources/templates/provision/snom/D865/{$mac}.xml
+++ b/resources/templates/provision/snom/D865/{$mac}.xml
@@ -19,6 +19,7 @@
     <show_ivr_digits perm="">off</show_ivr_digits>
     <cw_dialtone perm="">{if isset($snom_dialtone_on_hold)}{$snom_dialtone_on_hold}{else}false{/if}</cw_dialtone>
     <answer_after_policy perm="">{if isset($snom_answer_after_policy)}{$snom_answer_after_policy}{else}off{/if}</answer_after_policy>
+    <keyboard_lock_emergency perm="R">{if isset($snom_emergency_numbers)}{$snom_emergency_numbers}{else}911 112 110 999{/if}</keyboard_lock_emergency>
     <!-- Ringtones -->
     <alert_internal_ring_text perm="">alert-internal</alert_internal_ring_text>
     <alert_internal_ring_sound perm="">{if isset($snom_alert_internal)}{$snom_alert_internal}{else}Ringer1{/if}</alert_internal_ring_sound>


### PR DESCRIPTION
Snom phones by default display "emergency call" when you dial "911, 112, 110 or 999".

Since these are not emergency numbers everywhere, a setting has been made.

This setting allows emergency numbers to be dialed even when the phone is locked.

As an FYI, this settings change needs the phone to reboot to take effect.