### PR TITLE
Snom first and last name fix in directory

### DIFF
--- a/resources/templates/provision/snom/D712/{$mac}.xml
+++ b/resources/templates/provision/snom/D712/{$mac}.xml
@@ -99,7 +99,8 @@
   <tbook e="2" complete="true">
     {foreach $contacts as $row}
     <item context="active" type="{if $row.category == "extensions"}colleagues{else}none{/if}" index="{$row@index}">
-      <name>{$row.contact_name_given} {$row.contact_name_family}</name>
+      <first_name>{$row.contact_name_given}</first_name>
+      <last_name>{$row.contact_name_family}</last_name>
       <number>{if $row.category == "extensions"}{$row.phone_extension}{else}{$row.phone_number}{/if}</number>
     </item>
     {/foreach}

--- a/resources/templates/provision/snom/D715/{$mac}.xml
+++ b/resources/templates/provision/snom/D715/{$mac}.xml
@@ -99,7 +99,8 @@
   <tbook e="2" complete="true">
     {foreach $contacts as $row}
     <item context="active" type="{if $row.category == "extensions"}colleagues{else}none{/if}" index="{$row@index}">
-      <name>{$row.contact_name_given} {$row.contact_name_family}</name>
+      <first_name>{$row.contact_name_given}</first_name>
+      <last_name>{$row.contact_name_family}</last_name>
       <number>{if $row.category == "extensions"}{$row.phone_extension}{else}{$row.phone_number}{/if}</number>
     </item>
     {/foreach}

--- a/resources/templates/provision/snom/D717/{$mac}.xml
+++ b/resources/templates/provision/snom/D717/{$mac}.xml
@@ -106,7 +106,8 @@
   <tbook e="2" complete="true">
     {foreach $contacts as $row}
     <item context="active" type="{if $row.category == "extensions"}colleagues{else}none{/if}" index="{$row@index}">
-      <name>{$row.contact_name_given} {$row.contact_name_family}</name>
+      <first_name>{$row.contact_name_given}</first_name>
+      <last_name>{$row.contact_name_family}</last_name>
       <number>{if $row.category == "extensions"}{$row.phone_extension}{else}{$row.phone_number}{/if}</number>
     </item>
     {/foreach}

--- a/resources/templates/provision/snom/D725/{$mac}.xml
+++ b/resources/templates/provision/snom/D725/{$mac}.xml
@@ -99,7 +99,8 @@
   <tbook e="2" complete="true">
     {foreach $contacts as $row}
     <item context="active" type="{if $row.category == "extensions"}colleagues{else}none{/if}" index="{$row@index}">
-      <name>{$row.contact_name_given} {$row.contact_name_family}</name>
+      <first_name>{$row.contact_name_given}</first_name>
+      <last_name>{$row.contact_name_family}</last_name>
       <number>{if $row.category == "extensions"}{$row.phone_extension}{else}{$row.phone_number}{/if}</number>
     </item>
     {/foreach}

--- a/resources/templates/provision/snom/D735/{$mac}.xml
+++ b/resources/templates/provision/snom/D735/{$mac}.xml
@@ -114,7 +114,8 @@
   <tbook e="2" complete="true">
     {foreach $contacts as $row}
     <item context="active" type="{if $row.category == "extensions"}colleagues{else}none{/if}" index="{$row@index}">
-      <name>{$row.contact_name_given} {$row.contact_name_family}</name>
+      <first_name>{$row.contact_name_given}</first_name>
+      <last_name>{$row.contact_name_family}</last_name>
       <number>{if $row.category == "extensions"}{$row.phone_extension}{else}{$row.phone_number}{/if}</number>
     </item>
     {/foreach}

--- a/resources/templates/provision/snom/D745/{$mac}.xml
+++ b/resources/templates/provision/snom/D745/{$mac}.xml
@@ -104,7 +104,8 @@
   <tbook e="2" complete="true">
     {foreach $contacts as $row}
     <item context="active" type="{if $row.category == "extensions"}colleagues{else}none{/if}" index="{$row@index}">
-      <name>{$row.contact_name_given} {$row.contact_name_family}</name>
+      <first_name>{$row.contact_name_given}</first_name>
+      <last_name>{$row.contact_name_family}</last_name>
       <number>{if $row.category == "extensions"}{$row.phone_extension}{else}{$row.phone_number}{/if}</number>
     </item>
     {/foreach}

--- a/resources/templates/provision/snom/D765/{$mac}.xml
+++ b/resources/templates/provision/snom/D765/{$mac}.xml
@@ -103,7 +103,8 @@
   <tbook e="2" complete="true">
     {foreach $contacts as $row}
     <item context="active" type="{if $row.category == "extensions"}colleagues{else}none{/if}" index="{$row@index}">
-      <name>{$row.contact_name_given} {$row.contact_name_family}</name>
+      <first_name>{$row.contact_name_given}</first_name>
+      <last_name>{$row.contact_name_family}</last_name>
       <number>{if $row.category == "extensions"}{$row.phone_extension}{else}{$row.phone_number}{/if}</number>
     </item>
     {/foreach}

--- a/resources/templates/provision/snom/D785/{$mac}.xml
+++ b/resources/templates/provision/snom/D785/{$mac}.xml
@@ -102,7 +102,8 @@
   <tbook e="2" complete="true">
     {foreach $contacts as $row}
     <item context="active" type="{if $row.category == "extensions"}colleagues{else}none{/if}" index="{$row@index}">
-      <name>{$row.contact_name_given} {$row.contact_name_family}</name>
+      <first_name>{$row.contact_name_given}</first_name>
+      <last_name>{$row.contact_name_family}</last_name>
       <number>{if $row.category == "extensions"}{$row.phone_extension}{else}{$row.phone_number}{/if}</number>
     </item>
     {/foreach}

--- a/resources/templates/provision/snom/D812/{$mac}.xml
+++ b/resources/templates/provision/snom/D812/{$mac}.xml
@@ -102,7 +102,8 @@
   <tbook e="2" complete="true">
     {foreach $contacts as $row}
     <item context="active" type="{if $row.category == "extensions"}colleagues{else}none{/if}" index="{$row@index}">
-      <name>{$row.contact_name_given} {$row.contact_name_family}</name>
+      <first_name>{$row.contact_name_given}</first_name>
+      <last_name>{$row.contact_name_family}</last_name>
       <number>{if $row.category == "extensions"}{$row.phone_extension}{else}{$row.phone_number}{/if}</number>
     </item>
     {/foreach}

--- a/resources/templates/provision/snom/D815/{$mac}.xml
+++ b/resources/templates/provision/snom/D815/{$mac}.xml
@@ -102,7 +102,8 @@
   <tbook e="2" complete="true">
     {foreach $contacts as $row}
     <item context="active" type="{if $row.category == "extensions"}colleagues{else}none{/if}" index="{$row@index}">
-      <name>{$row.contact_name_given} {$row.contact_name_family}</name>
+      <first_name>{$row.contact_name_given}</first_name>
+      <last_name>{$row.contact_name_family}</last_name>
       <number>{if $row.category == "extensions"}{$row.phone_extension}{else}{$row.phone_number}{/if}</number>
     </item>
     {/foreach}

--- a/resources/templates/provision/snom/D862/{$mac}.xml
+++ b/resources/templates/provision/snom/D862/{$mac}.xml
@@ -102,7 +102,8 @@
   <tbook e="2" complete="true">
     {foreach $contacts as $row}
     <item context="active" type="{if $row.category == "extensions"}colleagues{else}none{/if}" index="{$row@index}">
-      <name>{$row.contact_name_given} {$row.contact_name_family}</name>
+      <first_name>{$row.contact_name_given}</first_name>
+      <last_name>{$row.contact_name_family}</last_name>
       <number>{if $row.category == "extensions"}{$row.phone_extension}{else}{$row.phone_number}{/if}</number>
     </item>
     {/foreach}

--- a/resources/templates/provision/snom/D865/{$mac}.xml
+++ b/resources/templates/provision/snom/D865/{$mac}.xml
@@ -102,7 +102,8 @@
   <tbook e="2" complete="true">
     {foreach $contacts as $row}
     <item context="active" type="{if $row.category == "extensions"}colleagues{else}none{/if}" index="{$row@index}">
-      <name>{$row.contact_name_given} {$row.contact_name_family}</name>
+      <first_name>{$row.contact_name_given}</first_name>
+      <last_name>{$row.contact_name_family}</last_name>
       <number>{if $row.category == "extensions"}{$row.phone_extension}{else}{$row.phone_number}{/if}</number>
     </item>
     {/foreach}


### PR DESCRIPTION
Snom's name directory was setup using <name>. This is considered to be the "nickname" on the phone.

Because of that, using Snom's directory to sort by first or last name never worked.

This PR will fix that by adding the <first_name> and <last_name> elements to the xml.

These elements became available in firmware version 8.2.16. This firmware is very old and is not even downloadable anymore from Snom so backwards compatibility wise we should be ok.