### PR TITLE
status message fix for emergency numbers Snom

### DIFF
--- a/resources/templates/provision/snom/D712/{$mac}.xml
+++ b/resources/templates/provision/snom/D712/{$mac}.xml
@@ -20,6 +20,7 @@
     <cw_dialtone perm="">{if isset($snom_dialtone_on_hold)}{$snom_dialtone_on_hold}{else}true{/if}</cw_dialtone>
     <answer_after_policy perm="">{if isset($snom_answer_after_policy)}{$snom_answer_after_policy}{else}off{/if}</answer_after_policy>
     <keyboard_lock_emergency perm="R">{if isset($snom_emergency_numbers)}{$snom_emergency_numbers}{else}911 112 110 999{/if}</keyboard_lock_emergency>
+    <status_msgs_that_are_blocked perm="R">{if isset($snom_emergency_numbers)}EmergencyCallNumbersMisconfigured{/if}</status_msgs_that_are_blocked>
     <!-- Ringtones -->
     <alert_internal_ring_text perm="">alert-internal</alert_internal_ring_text>
     <alert_internal_ring_sound perm="">{if isset($snom_alert_internal)}{$snom_alert_internal}{else}Ringer1{/if}</alert_internal_ring_sound>

--- a/resources/templates/provision/snom/D715/{$mac}.xml
+++ b/resources/templates/provision/snom/D715/{$mac}.xml
@@ -20,6 +20,7 @@
     <cw_dialtone perm="">{if isset($snom_dialtone_on_hold)}{$snom_dialtone_on_hold}{else}true{/if}</cw_dialtone>
     <answer_after_policy perm="">{if isset($snom_answer_after_policy)}{$snom_answer_after_policy}{else}off{/if}</answer_after_policy>
     <keyboard_lock_emergency perm="R">{if isset($snom_emergency_numbers)}{$snom_emergency_numbers}{else}911 112 110 999{/if}</keyboard_lock_emergency>
+    <status_msgs_that_are_blocked perm="R">{if isset($snom_emergency_numbers)}EmergencyCallNumbersMisconfigured{/if}</status_msgs_that_are_blocked>
     <!-- Ringtones -->
     <alert_internal_ring_text perm="">alert-internal</alert_internal_ring_text>
     <alert_internal_ring_sound perm="">{if isset($snom_alert_internal)}{$snom_alert_internal}{else}Ringer1{/if}</alert_internal_ring_sound>

--- a/resources/templates/provision/snom/D717/{$mac}.xml
+++ b/resources/templates/provision/snom/D717/{$mac}.xml
@@ -21,6 +21,7 @@
     <smartlabel_idle_default perm="">{if isset($snom_smartlabel_idle)}{$snom_smartlabel_idle}{else}short{/if}</smartlabel_idle_default>
     <answer_after_policy perm="">{if isset($snom_answer_after_policy)}{$snom_answer_after_policy}{else}off{/if}</answer_after_policy>
     <keyboard_lock_emergency perm="R">{if isset($snom_emergency_numbers)}{$snom_emergency_numbers}{else}911 112 110 999{/if}</keyboard_lock_emergency>
+    <status_msgs_that_are_blocked perm="R">{if isset($snom_emergency_numbers)}EmergencyCallNumbersMisconfigured{/if}</status_msgs_that_are_blocked>
     <!-- Ringtones -->
     <alert_internal_ring_text perm="">alert-internal</alert_internal_ring_text>
     <alert_internal_ring_sound perm="">{if isset($snom_alert_internal)}{$snom_alert_internal}{else}Ringer1{/if}</alert_internal_ring_sound>

--- a/resources/templates/provision/snom/D725/{$mac}.xml
+++ b/resources/templates/provision/snom/D725/{$mac}.xml
@@ -20,6 +20,7 @@
     <cw_dialtone perm="">{if isset($snom_dialtone_on_hold)}{$snom_dialtone_on_hold}{else}true{/if}</cw_dialtone>
     <answer_after_policy perm="">{if isset($snom_answer_after_policy)}{$snom_answer_after_policy}{else}off{/if}</answer_after_policy>
     <keyboard_lock_emergency perm="R">{if isset($snom_emergency_numbers)}{$snom_emergency_numbers}{else}911 112 110 999{/if}</keyboard_lock_emergency>
+    <status_msgs_that_are_blocked perm="R">{if isset($snom_emergency_numbers)}EmergencyCallNumbersMisconfigured{/if}</status_msgs_that_are_blocked>
     <!-- Ringtones -->
     <alert_internal_ring_text perm="">alert-internal</alert_internal_ring_text>
     <alert_internal_ring_sound perm="">{if isset($snom_alert_internal)}{$snom_alert_internal}{else}Ringer1{/if}</alert_internal_ring_sound>

--- a/resources/templates/provision/snom/D735/{$mac}.xml
+++ b/resources/templates/provision/snom/D735/{$mac}.xml
@@ -21,6 +21,7 @@
     <smartlabel_idle_default perm="">{if isset($snom_smartlabel_idle)}{$snom_smartlabel_idle}{else}short{/if}</smartlabel_idle_default>
     <answer_after_policy perm="">{if isset($snom_answer_after_policy)}{$snom_answer_after_policy}{else}off{/if}</answer_after_policy>
     <keyboard_lock_emergency perm="R">{if isset($snom_emergency_numbers)}{$snom_emergency_numbers}{else}911 112 110 999{/if}</keyboard_lock_emergency>
+    <status_msgs_that_are_blocked perm="R">{if isset($snom_emergency_numbers)}EmergencyCallNumbersMisconfigured{/if}</status_msgs_that_are_blocked>
     <!-- Ringtones -->
     <alert_internal_ring_text perm="">alert-internal</alert_internal_ring_text>
     <alert_internal_ring_sound perm="">{if isset($snom_alert_internal)}{$snom_alert_internal}{else}Ringer1{/if}</alert_internal_ring_sound>

--- a/resources/templates/provision/snom/D745/{$mac}.xml
+++ b/resources/templates/provision/snom/D745/{$mac}.xml
@@ -20,6 +20,7 @@
     <cw_dialtone perm="">{if isset($snom_dialtone_on_hold)}{$snom_dialtone_on_hold}{else}true{/if}</cw_dialtone>
     <answer_after_policy perm="">{if isset($snom_answer_after_policy)}{$snom_answer_after_policy}{else}off{/if}</answer_after_policy>
     <keyboard_lock_emergency perm="R">{if isset($snom_emergency_numbers)}{$snom_emergency_numbers}{else}911 112 110 999{/if}</keyboard_lock_emergency>
+    <status_msgs_that_are_blocked perm="R">{if isset($snom_emergency_numbers)}EmergencyCallNumbersMisconfigured{/if}</status_msgs_that_are_blocked>
     <!-- Ringtones -->
     <alert_internal_ring_text perm="">alert-internal</alert_internal_ring_text>
     <alert_internal_ring_sound perm="">{if isset($snom_alert_internal)}{$snom_alert_internal}{else}Ringer1{/if}</alert_internal_ring_sound>

--- a/resources/templates/provision/snom/D765/{$mac}.xml
+++ b/resources/templates/provision/snom/D765/{$mac}.xml
@@ -20,6 +20,7 @@
     <cw_dialtone perm="">{if isset($snom_dialtone_on_hold)}{$snom_dialtone_on_hold}{else}true{/if}</cw_dialtone>
     <answer_after_policy perm="">{if isset($snom_answer_after_policy)}{$snom_answer_after_policy}{else}off{/if}</answer_after_policy>
     <keyboard_lock_emergency perm="R">{if isset($snom_emergency_numbers)}{$snom_emergency_numbers}{else}911 112 110 999{/if}</keyboard_lock_emergency>
+    <status_msgs_that_are_blocked perm="R">{if isset($snom_emergency_numbers)}EmergencyCallNumbersMisconfigured{/if}</status_msgs_that_are_blocked>
     <!-- Ringtones -->
     <alert_internal_ring_text perm="">alert-internal</alert_internal_ring_text>
     <alert_internal_ring_sound perm="">{if isset($snom_alert_internal)}{$snom_alert_internal}{else}Ringer1{/if}</alert_internal_ring_sound>

--- a/resources/templates/provision/snom/D785/{$mac}.xml
+++ b/resources/templates/provision/snom/D785/{$mac}.xml
@@ -20,6 +20,7 @@
     <cw_dialtone perm="">{if isset($snom_dialtone_on_hold)}{$snom_dialtone_on_hold}{else}false{/if}</cw_dialtone>
     <answer_after_policy perm="">{if isset($snom_answer_after_policy)}{$snom_answer_after_policy}{else}off{/if}</answer_after_policy>
     <keyboard_lock_emergency perm="R">{if isset($snom_emergency_numbers)}{$snom_emergency_numbers}{else}911 112 110 999{/if}</keyboard_lock_emergency>
+    <status_msgs_that_are_blocked perm="R">{if isset($snom_emergency_numbers)}EmergencyCallNumbersMisconfigured{/if}</status_msgs_that_are_blocked>
     <!-- Ringtones -->
     <alert_internal_ring_text perm="">alert-internal</alert_internal_ring_text>
     <alert_internal_ring_sound perm="">{if isset($snom_alert_internal)}{$snom_alert_internal}{else}Ringer1{/if}</alert_internal_ring_sound>

--- a/resources/templates/provision/snom/D812/{$mac}.xml
+++ b/resources/templates/provision/snom/D812/{$mac}.xml
@@ -20,6 +20,7 @@
     <cw_dialtone perm="">{if isset($snom_dialtone_on_hold)}{$snom_dialtone_on_hold}{else}false{/if}</cw_dialtone>
     <answer_after_policy perm="">{if isset($snom_answer_after_policy)}{$snom_answer_after_policy}{else}off{/if}</answer_after_policy>
     <keyboard_lock_emergency perm="R">{if isset($snom_emergency_numbers)}{$snom_emergency_numbers}{else}911 112 110 999{/if}</keyboard_lock_emergency>
+    <status_msgs_that_are_blocked perm="R">{if isset($snom_emergency_numbers)}EmergencyCallNumbersMisconfigured{/if}</status_msgs_that_are_blocked>
     <!-- Ringtones -->
     <alert_internal_ring_text perm="">alert-internal</alert_internal_ring_text>
     <alert_internal_ring_sound perm="">{if isset($snom_alert_internal)}{$snom_alert_internal}{else}Ringer1{/if}</alert_internal_ring_sound>

--- a/resources/templates/provision/snom/D815/{$mac}.xml
+++ b/resources/templates/provision/snom/D815/{$mac}.xml
@@ -20,6 +20,7 @@
     <cw_dialtone perm="">{if isset($snom_dialtone_on_hold)}{$snom_dialtone_on_hold}{else}false{/if}</cw_dialtone>
     <answer_after_policy perm="">{if isset($snom_answer_after_policy)}{$snom_answer_after_policy}{else}off{/if}</answer_after_policy>
     <keyboard_lock_emergency perm="R">{if isset($snom_emergency_numbers)}{$snom_emergency_numbers}{else}911 112 110 999{/if}</keyboard_lock_emergency>
+    <status_msgs_that_are_blocked perm="R">{if isset($snom_emergency_numbers)}EmergencyCallNumbersMisconfigured{/if}</status_msgs_that_are_blocked>
     <!-- Ringtones -->
     <alert_internal_ring_text perm="">alert-internal</alert_internal_ring_text>
     <alert_internal_ring_sound perm="">{if isset($snom_alert_internal)}{$snom_alert_internal}{else}Ringer1{/if}</alert_internal_ring_sound>

--- a/resources/templates/provision/snom/D862/{$mac}.xml
+++ b/resources/templates/provision/snom/D862/{$mac}.xml
@@ -20,6 +20,7 @@
     <cw_dialtone perm="">{if isset($snom_dialtone_on_hold)}{$snom_dialtone_on_hold}{else}false{/if}</cw_dialtone>
     <answer_after_policy perm="">{if isset($snom_answer_after_policy)}{$snom_answer_after_policy}{else}off{/if}</answer_after_policy>
     <keyboard_lock_emergency perm="R">{if isset($snom_emergency_numbers)}{$snom_emergency_numbers}{else}911 112 110 999{/if}</keyboard_lock_emergency>
+    <status_msgs_that_are_blocked perm="R">{if isset($snom_emergency_numbers)}EmergencyCallNumbersMisconfigured{/if}</status_msgs_that_are_blocked>
     <!-- Ringtones -->
     <alert_internal_ring_text perm="">alert-internal</alert_internal_ring_text>
     <alert_internal_ring_sound perm="">{if isset($snom_alert_internal)}{$snom_alert_internal}{else}Ringer1{/if}</alert_internal_ring_sound>

--- a/resources/templates/provision/snom/D865/{$mac}.xml
+++ b/resources/templates/provision/snom/D865/{$mac}.xml
@@ -20,6 +20,7 @@
     <cw_dialtone perm="">{if isset($snom_dialtone_on_hold)}{$snom_dialtone_on_hold}{else}false{/if}</cw_dialtone>
     <answer_after_policy perm="">{if isset($snom_answer_after_policy)}{$snom_answer_after_policy}{else}off{/if}</answer_after_policy>
     <keyboard_lock_emergency perm="R">{if isset($snom_emergency_numbers)}{$snom_emergency_numbers}{else}911 112 110 999{/if}</keyboard_lock_emergency>
+    <status_msgs_that_are_blocked perm="R">{if isset($snom_emergency_numbers)}EmergencyCallNumbersMisconfigured{/if}</status_msgs_that_are_blocked>
     <!-- Ringtones -->
     <alert_internal_ring_text perm="">alert-internal</alert_internal_ring_text>
     <alert_internal_ring_sound perm="">{if isset($snom_alert_internal)}{$snom_alert_internal}{else}Ringer1{/if}</alert_internal_ring_sound>


### PR DESCRIPTION
This is a fix for when using the `$snom_emergency_numbers` default setting that was added in [PR6996](https://github.com/fusionpbx/fusionpbx/pull/6996).

More info can be found [here](https://service.snom.com/display/wiki/10.1.101.11+Release).

Snom basically produces a message on screen you do not have the default string. This PR makes it so that if the string is manually set, remove that message.