### PR TITLE
Acrobits vendor support added

### DIFF
--- a/app/devices/app_config.php
+++ b/app/devices/app_config.php
@@ -4313,4 +4313,10 @@
 		$vendors[$y]['name'] = "sipnetic";
 		$z=0;
 
+	//acrobits details
+		$y++;
+		$vendors[$y]['uuid'] = "9c616373-99fb-4f7d-8713-d5b1da9aaef3";
+		$vendors[$y]['name'] = "acrobits";
+		$z=0;
+
 ?>

--- a/app/devices/device_edit.php
+++ b/app/devices/device_edit.php
@@ -783,6 +783,9 @@
 	else if ($device_template == "sipnetic/default") {
 		$qr_code_enabled = true;
 	}
+	else if ($device_template == "acrobits/default") {
+		$qr_code_enabled = true;
+	}
 	else {
 		$qr_code_enabled = false;
 	}
@@ -861,6 +864,30 @@
 					$template = str_replace('{$sip_port}', $row['sip_port'], $template);
 					$content = $template;
 					unset($template);
+				}
+			}
+			//build content for acrobits
+			else if ($device_template == 'acrobits/default') {
+				//check custom template provision location
+				if (is_file('/usr/share/fusionpbx/templates/provision/'.$device_template.'/qr_template.txt')) {
+					$template = file_get_contents('/usr/share/fusionpbx/templates/provision/'.$device_template.'/qr_template.txt');
+				}
+				else if (is_file('/var/www/fusionpbx/resources/templates/provision/'.$device_template.'/qr_template.txt')) {
+					$template = file_get_contents('/var/www/fusionpbx/resources/templates/provision/'.$device_template.'/qr_template.txt');
+				}
+
+				//get the provision settings
+					$provision = new settings(["category" => "provision"]);
+					$acrobits_code = $provision->get('provision', 'acrobits_code');
+				
+				if (!empty($template) && isset($acrobits_code)) {
+					$template = str_replace('{$server_address}', $row['server_address'], $template);
+					$template = str_replace('{$user_id}', urlencode($row['user_id']), $template);
+					$template = str_replace('{$password}', urlencode(str_replace(';',';;',$row['password'])), $template);
+					$template = str_replace('{$code}', $acrobits_code, $template);
+					$content = trim($template, "\r\n");
+					unset($template);
+					unset($acrobits_code);
 				}
 			}
 

--- a/app/provision/app_config.php
+++ b/app/provision/app_config.php
@@ -390,5 +390,12 @@
 		$apps[$x]['default_settings'][$y]['default_setting_value'] = "";
 		$apps[$x]['default_settings'][$y]['default_setting_enabled'] = "false";
 		$apps[$x]['default_settings'][$y]['default_setting_description'] = "User level password for endpoint embedded web server.";
-
+		$y++;
+		$apps[$x]['default_settings'][$y]['default_setting_uuid'] = "e039d204-3682-4774-9b83-1603854ec05e";
+		$apps[$x]['default_settings'][$y]['default_setting_category'] = "provision";
+		$apps[$x]['default_settings'][$y]['default_setting_subcategory'] = "acrobits_code";
+		$apps[$x]['default_settings'][$y]['default_setting_name'] = "text";
+		$apps[$x]['default_settings'][$y]['default_setting_value'] = "";
+		$apps[$x]['default_settings'][$y]['default_setting_enabled'] = "false";
+		$apps[$x]['default_settings'][$y]['default_setting_description'] = "Enter your Acrobits application code here. This can be found in your Acrobits portal.";
 ?>

--- a/resources/templates/provision/acrobits/default/qr_template.txt
+++ b/resources/templates/provision/acrobits/default/qr_template.txt
@@ -1,0 +1,1 @@
+csc:{$user_id}@{$server_address}:{$password}@{$code}


### PR DESCRIPTION
This PR gives the ability to use Acrobits as a vendor and have Fusion generate a QR code on the device page.

Acrobits requires a default settings to be set for your global unique `CODE` which is acrobits specific.