### PR TITLE
added snom_ui_theme variable to snom templates

### DIFF
--- a/app/snom/app_config.php
+++ b/app/snom/app_config.php
@@ -410,7 +410,7 @@
 		$apps[$x]['default_settings'][$y]['default_setting_category'] = "provision";
 		$apps[$x]['default_settings'][$y]['default_setting_subcategory'] = "snom_ui_theme";
 		$apps[$x]['default_settings'][$y]['default_setting_name'] = "text";
-		$apps[$x]['default_settings'][$y]['default_setting_value'] = "";
-		$apps[$x]['default_settings'][$y]['default_setting_enabled'] = "false";
+		$apps[$x]['default_settings'][$y]['default_setting_value'] = "Dark";
+		$apps[$x]['default_settings'][$y]['default_setting_enabled'] = "true";
 		$apps[$x]['default_settings'][$y]['default_setting_description'] = "The UI theme defines the appearance of the phone UI on phones with color display with predefined color settings and depending on the theme a background image. Possible options are: Light, Dark, Colorful, Industrial";
 ?>

--- a/app/snom/app_config.php
+++ b/app/snom/app_config.php
@@ -405,4 +405,12 @@
 		$apps[$x]['default_settings'][$y]['default_setting_value'] = "911 112 110 999";
 		$apps[$x]['default_settings'][$y]['default_setting_enabled'] = "true";
 		$apps[$x]['default_settings'][$y]['default_setting_description'] = "These are the numbers that the phone will understand as emergency numbers. This means they can be dialled on the phone even if the phone is locked. Valid values are space separated. More info can be found here: https://service.snom.com/display/wiki/keyboard_lock_emergency";
+		$y++;
+		$apps[$x]['default_settings'][$y]['default_setting_uuid'] = "b6c3d142-1374-41b8-a947-05d69285f7d3";
+		$apps[$x]['default_settings'][$y]['default_setting_category'] = "provision";
+		$apps[$x]['default_settings'][$y]['default_setting_subcategory'] = "snom_ui_theme";
+		$apps[$x]['default_settings'][$y]['default_setting_name'] = "text";
+		$apps[$x]['default_settings'][$y]['default_setting_value'] = "";
+		$apps[$x]['default_settings'][$y]['default_setting_enabled'] = "false";
+		$apps[$x]['default_settings'][$y]['default_setting_description'] = "The UI theme defines the appearance of the phone UI on phones with color display with predefined color settings and depending on the theme a background image. Possible options are: Light, Dark, Colorful, Industrial";
 ?>

--- a/resources/templates/provision/snom/D717/{$mac}.xml
+++ b/resources/templates/provision/snom/D717/{$mac}.xml
@@ -22,6 +22,7 @@
     <answer_after_policy perm="">{if isset($snom_answer_after_policy)}{$snom_answer_after_policy}{else}off{/if}</answer_after_policy>
     <keyboard_lock_emergency perm="R">{if isset($snom_emergency_numbers)}{$snom_emergency_numbers}{else}911 112 110 999{/if}</keyboard_lock_emergency>
     <status_msgs_that_are_blocked perm="R">{if isset($snom_emergency_numbers)}EmergencyCallNumbersMisconfigured{/if}</status_msgs_that_are_blocked>
+    <ui_theme perm="RW">{if isset($snom_ui_theme)}{$snom_ui_theme}{/if}</ui_theme>
     <!-- Ringtones -->
     <alert_internal_ring_text perm="">alert-internal</alert_internal_ring_text>
     <alert_internal_ring_sound perm="">{if isset($snom_alert_internal)}{$snom_alert_internal}{else}Ringer1{/if}</alert_internal_ring_sound>

--- a/resources/templates/provision/snom/D725/{$mac}.xml
+++ b/resources/templates/provision/snom/D725/{$mac}.xml
@@ -21,6 +21,7 @@
     <answer_after_policy perm="">{if isset($snom_answer_after_policy)}{$snom_answer_after_policy}{else}off{/if}</answer_after_policy>
     <keyboard_lock_emergency perm="R">{if isset($snom_emergency_numbers)}{$snom_emergency_numbers}{else}911 112 110 999{/if}</keyboard_lock_emergency>
     <status_msgs_that_are_blocked perm="R">{if isset($snom_emergency_numbers)}EmergencyCallNumbersMisconfigured{/if}</status_msgs_that_are_blocked>
+    <ui_theme perm="RW">{if isset($snom_ui_theme)}{$snom_ui_theme}{/if}</ui_theme>
     <!-- Ringtones -->
     <alert_internal_ring_text perm="">alert-internal</alert_internal_ring_text>
     <alert_internal_ring_sound perm="">{if isset($snom_alert_internal)}{$snom_alert_internal}{else}Ringer1{/if}</alert_internal_ring_sound>

--- a/resources/templates/provision/snom/D735/{$mac}.xml
+++ b/resources/templates/provision/snom/D735/{$mac}.xml
@@ -22,6 +22,7 @@
     <answer_after_policy perm="">{if isset($snom_answer_after_policy)}{$snom_answer_after_policy}{else}off{/if}</answer_after_policy>
     <keyboard_lock_emergency perm="R">{if isset($snom_emergency_numbers)}{$snom_emergency_numbers}{else}911 112 110 999{/if}</keyboard_lock_emergency>
     <status_msgs_that_are_blocked perm="R">{if isset($snom_emergency_numbers)}EmergencyCallNumbersMisconfigured{/if}</status_msgs_that_are_blocked>
+    <ui_theme perm="RW">{if isset($snom_ui_theme)}{$snom_ui_theme}{/if}</ui_theme>
     <!-- Ringtones -->
     <alert_internal_ring_text perm="">alert-internal</alert_internal_ring_text>
     <alert_internal_ring_sound perm="">{if isset($snom_alert_internal)}{$snom_alert_internal}{else}Ringer1{/if}</alert_internal_ring_sound>

--- a/resources/templates/provision/snom/D745/{$mac}.xml
+++ b/resources/templates/provision/snom/D745/{$mac}.xml
@@ -21,6 +21,7 @@
     <answer_after_policy perm="">{if isset($snom_answer_after_policy)}{$snom_answer_after_policy}{else}off{/if}</answer_after_policy>
     <keyboard_lock_emergency perm="R">{if isset($snom_emergency_numbers)}{$snom_emergency_numbers}{else}911 112 110 999{/if}</keyboard_lock_emergency>
     <status_msgs_that_are_blocked perm="R">{if isset($snom_emergency_numbers)}EmergencyCallNumbersMisconfigured{/if}</status_msgs_that_are_blocked>
+    <ui_theme perm="RW">{if isset($snom_ui_theme)}{$snom_ui_theme}{/if}</ui_theme>
     <!-- Ringtones -->
     <alert_internal_ring_text perm="">alert-internal</alert_internal_ring_text>
     <alert_internal_ring_sound perm="">{if isset($snom_alert_internal)}{$snom_alert_internal}{else}Ringer1{/if}</alert_internal_ring_sound>

--- a/resources/templates/provision/snom/D765/{$mac}.xml
+++ b/resources/templates/provision/snom/D765/{$mac}.xml
@@ -21,6 +21,7 @@
     <answer_after_policy perm="">{if isset($snom_answer_after_policy)}{$snom_answer_after_policy}{else}off{/if}</answer_after_policy>
     <keyboard_lock_emergency perm="R">{if isset($snom_emergency_numbers)}{$snom_emergency_numbers}{else}911 112 110 999{/if}</keyboard_lock_emergency>
     <status_msgs_that_are_blocked perm="R">{if isset($snom_emergency_numbers)}EmergencyCallNumbersMisconfigured{/if}</status_msgs_that_are_blocked>
+    <ui_theme perm="RW">{if isset($snom_ui_theme)}{$snom_ui_theme}{/if}</ui_theme>
     <!-- Ringtones -->
     <alert_internal_ring_text perm="">alert-internal</alert_internal_ring_text>
     <alert_internal_ring_sound perm="">{if isset($snom_alert_internal)}{$snom_alert_internal}{else}Ringer1{/if}</alert_internal_ring_sound>

--- a/resources/templates/provision/snom/D785/{$mac}.xml
+++ b/resources/templates/provision/snom/D785/{$mac}.xml
@@ -21,6 +21,7 @@
     <answer_after_policy perm="">{if isset($snom_answer_after_policy)}{$snom_answer_after_policy}{else}off{/if}</answer_after_policy>
     <keyboard_lock_emergency perm="R">{if isset($snom_emergency_numbers)}{$snom_emergency_numbers}{else}911 112 110 999{/if}</keyboard_lock_emergency>
     <status_msgs_that_are_blocked perm="R">{if isset($snom_emergency_numbers)}EmergencyCallNumbersMisconfigured{/if}</status_msgs_that_are_blocked>
+    <ui_theme perm="RW">{if isset($snom_ui_theme)}{$snom_ui_theme}{/if}</ui_theme>
     <!-- Ringtones -->
     <alert_internal_ring_text perm="">alert-internal</alert_internal_ring_text>
     <alert_internal_ring_sound perm="">{if isset($snom_alert_internal)}{$snom_alert_internal}{else}Ringer1{/if}</alert_internal_ring_sound>

--- a/resources/templates/provision/snom/D812/{$mac}.xml
+++ b/resources/templates/provision/snom/D812/{$mac}.xml
@@ -21,6 +21,7 @@
     <answer_after_policy perm="">{if isset($snom_answer_after_policy)}{$snom_answer_after_policy}{else}off{/if}</answer_after_policy>
     <keyboard_lock_emergency perm="R">{if isset($snom_emergency_numbers)}{$snom_emergency_numbers}{else}911 112 110 999{/if}</keyboard_lock_emergency>
     <status_msgs_that_are_blocked perm="R">{if isset($snom_emergency_numbers)}EmergencyCallNumbersMisconfigured{/if}</status_msgs_that_are_blocked>
+    <ui_theme perm="RW">{if isset($snom_ui_theme)}{$snom_ui_theme}{/if}</ui_theme>
     <!-- Ringtones -->
     <alert_internal_ring_text perm="">alert-internal</alert_internal_ring_text>
     <alert_internal_ring_sound perm="">{if isset($snom_alert_internal)}{$snom_alert_internal}{else}Ringer1{/if}</alert_internal_ring_sound>

--- a/resources/templates/provision/snom/D815/{$mac}.xml
+++ b/resources/templates/provision/snom/D815/{$mac}.xml
@@ -21,6 +21,7 @@
     <answer_after_policy perm="">{if isset($snom_answer_after_policy)}{$snom_answer_after_policy}{else}off{/if}</answer_after_policy>
     <keyboard_lock_emergency perm="R">{if isset($snom_emergency_numbers)}{$snom_emergency_numbers}{else}911 112 110 999{/if}</keyboard_lock_emergency>
     <status_msgs_that_are_blocked perm="R">{if isset($snom_emergency_numbers)}EmergencyCallNumbersMisconfigured{/if}</status_msgs_that_are_blocked>
+    <ui_theme perm="RW">{if isset($snom_ui_theme)}{$snom_ui_theme}{/if}</ui_theme>
     <!-- Ringtones -->
     <alert_internal_ring_text perm="">alert-internal</alert_internal_ring_text>
     <alert_internal_ring_sound perm="">{if isset($snom_alert_internal)}{$snom_alert_internal}{else}Ringer1{/if}</alert_internal_ring_sound>

--- a/resources/templates/provision/snom/D862/{$mac}.xml
+++ b/resources/templates/provision/snom/D862/{$mac}.xml
@@ -21,6 +21,7 @@
     <answer_after_policy perm="">{if isset($snom_answer_after_policy)}{$snom_answer_after_policy}{else}off{/if}</answer_after_policy>
     <keyboard_lock_emergency perm="R">{if isset($snom_emergency_numbers)}{$snom_emergency_numbers}{else}911 112 110 999{/if}</keyboard_lock_emergency>
     <status_msgs_that_are_blocked perm="R">{if isset($snom_emergency_numbers)}EmergencyCallNumbersMisconfigured{/if}</status_msgs_that_are_blocked>
+    <ui_theme perm="RW">{if isset($snom_ui_theme)}{$snom_ui_theme}{/if}</ui_theme>
     <!-- Ringtones -->
     <alert_internal_ring_text perm="">alert-internal</alert_internal_ring_text>
     <alert_internal_ring_sound perm="">{if isset($snom_alert_internal)}{$snom_alert_internal}{else}Ringer1{/if}</alert_internal_ring_sound>

--- a/resources/templates/provision/snom/D865/{$mac}.xml
+++ b/resources/templates/provision/snom/D865/{$mac}.xml
@@ -21,6 +21,7 @@
     <answer_after_policy perm="">{if isset($snom_answer_after_policy)}{$snom_answer_after_policy}{else}off{/if}</answer_after_policy>
     <keyboard_lock_emergency perm="R">{if isset($snom_emergency_numbers)}{$snom_emergency_numbers}{else}911 112 110 999{/if}</keyboard_lock_emergency>
     <status_msgs_that_are_blocked perm="R">{if isset($snom_emergency_numbers)}EmergencyCallNumbersMisconfigured{/if}</status_msgs_that_are_blocked>
+    <ui_theme perm="RW">{if isset($snom_ui_theme)}{$snom_ui_theme}{/if}</ui_theme>
     <!-- Ringtones -->
     <alert_internal_ring_text perm="">alert-internal</alert_internal_ring_text>
     <alert_internal_ring_sound perm="">{if isset($snom_alert_internal)}{$snom_alert_internal}{else}Ringer1{/if}</alert_internal_ring_sound>


### PR DESCRIPTION
This variable allows you to set a colour theme for the phones.

Valid Values are:
"Light", "Dark", "Colorful", "Industrial"