### PR TITLE
blocked status messages on Snom for certain messages

### DIFF
--- a/resources/templates/provision/snom/D717/{$mac}.xml
+++ b/resources/templates/provision/snom/D717/{$mac}.xml
@@ -21,7 +21,7 @@
     <smartlabel_idle_default perm="">{if isset($snom_smartlabel_idle)}{$snom_smartlabel_idle}{else}short{/if}</smartlabel_idle_default>
     <answer_after_policy perm="">{if isset($snom_answer_after_policy)}{$snom_answer_after_policy}{else}off{/if}</answer_after_policy>
     <keyboard_lock_emergency perm="R">{if isset($snom_emergency_numbers)}{$snom_emergency_numbers}{else}911 112 110 999{/if}</keyboard_lock_emergency>
-    <status_msgs_that_are_blocked perm="R">{if isset($snom_emergency_numbers)}EmergencyCallNumbersMisconfigured{/if}</status_msgs_that_are_blocked>
+    <status_msgs_that_are_blocked perm="R">HidConnected UxmConnected{if isset($snom_emergency_numbers)} EmergencyCallNumbersMisconfigured{/if}</status_msgs_that_are_blocked>
     <ui_theme perm="RW">{if isset($snom_ui_theme)}{$snom_ui_theme}{/if}</ui_theme>
     <!-- Ringtones -->
     <alert_internal_ring_text perm="">alert-internal</alert_internal_ring_text>

--- a/resources/templates/provision/snom/D725/{$mac}.xml
+++ b/resources/templates/provision/snom/D725/{$mac}.xml
@@ -20,7 +20,7 @@
     <cw_dialtone perm="">{if isset($snom_dialtone_on_hold)}{$snom_dialtone_on_hold}{else}true{/if}</cw_dialtone>
     <answer_after_policy perm="">{if isset($snom_answer_after_policy)}{$snom_answer_after_policy}{else}off{/if}</answer_after_policy>
     <keyboard_lock_emergency perm="R">{if isset($snom_emergency_numbers)}{$snom_emergency_numbers}{else}911 112 110 999{/if}</keyboard_lock_emergency>
-    <status_msgs_that_are_blocked perm="R">{if isset($snom_emergency_numbers)}EmergencyCallNumbersMisconfigured{/if}</status_msgs_that_are_blocked>
+    <status_msgs_that_are_blocked perm="R">HidConnected UxmConnected{if isset($snom_emergency_numbers)} EmergencyCallNumbersMisconfigured{/if}</status_msgs_that_are_blocked>
     <ui_theme perm="RW">{if isset($snom_ui_theme)}{$snom_ui_theme}{/if}</ui_theme>
     <!-- Ringtones -->
     <alert_internal_ring_text perm="">alert-internal</alert_internal_ring_text>

--- a/resources/templates/provision/snom/D735/{$mac}.xml
+++ b/resources/templates/provision/snom/D735/{$mac}.xml
@@ -21,7 +21,7 @@
     <smartlabel_idle_default perm="">{if isset($snom_smartlabel_idle)}{$snom_smartlabel_idle}{else}short{/if}</smartlabel_idle_default>
     <answer_after_policy perm="">{if isset($snom_answer_after_policy)}{$snom_answer_after_policy}{else}off{/if}</answer_after_policy>
     <keyboard_lock_emergency perm="R">{if isset($snom_emergency_numbers)}{$snom_emergency_numbers}{else}911 112 110 999{/if}</keyboard_lock_emergency>
-    <status_msgs_that_are_blocked perm="R">{if isset($snom_emergency_numbers)}EmergencyCallNumbersMisconfigured{/if}</status_msgs_that_are_blocked>
+    <status_msgs_that_are_blocked perm="R">HidConnected UxmConnected{if isset($snom_emergency_numbers)} EmergencyCallNumbersMisconfigured{/if}</status_msgs_that_are_blocked>
     <ui_theme perm="RW">{if isset($snom_ui_theme)}{$snom_ui_theme}{/if}</ui_theme>
     <!-- Ringtones -->
     <alert_internal_ring_text perm="">alert-internal</alert_internal_ring_text>

--- a/resources/templates/provision/snom/D745/{$mac}.xml
+++ b/resources/templates/provision/snom/D745/{$mac}.xml
@@ -20,7 +20,7 @@
     <cw_dialtone perm="">{if isset($snom_dialtone_on_hold)}{$snom_dialtone_on_hold}{else}true{/if}</cw_dialtone>
     <answer_after_policy perm="">{if isset($snom_answer_after_policy)}{$snom_answer_after_policy}{else}off{/if}</answer_after_policy>
     <keyboard_lock_emergency perm="R">{if isset($snom_emergency_numbers)}{$snom_emergency_numbers}{else}911 112 110 999{/if}</keyboard_lock_emergency>
-    <status_msgs_that_are_blocked perm="R">{if isset($snom_emergency_numbers)}EmergencyCallNumbersMisconfigured{/if}</status_msgs_that_are_blocked>
+    <status_msgs_that_are_blocked perm="R">HidConnected UxmConnected{if isset($snom_emergency_numbers)} EmergencyCallNumbersMisconfigured{/if}</status_msgs_that_are_blocked>
     <ui_theme perm="RW">{if isset($snom_ui_theme)}{$snom_ui_theme}{/if}</ui_theme>
     <!-- Ringtones -->
     <alert_internal_ring_text perm="">alert-internal</alert_internal_ring_text>

--- a/resources/templates/provision/snom/D765/{$mac}.xml
+++ b/resources/templates/provision/snom/D765/{$mac}.xml
@@ -20,7 +20,7 @@
     <cw_dialtone perm="">{if isset($snom_dialtone_on_hold)}{$snom_dialtone_on_hold}{else}true{/if}</cw_dialtone>
     <answer_after_policy perm="">{if isset($snom_answer_after_policy)}{$snom_answer_after_policy}{else}off{/if}</answer_after_policy>
     <keyboard_lock_emergency perm="R">{if isset($snom_emergency_numbers)}{$snom_emergency_numbers}{else}911 112 110 999{/if}</keyboard_lock_emergency>
-    <status_msgs_that_are_blocked perm="R">{if isset($snom_emergency_numbers)}EmergencyCallNumbersMisconfigured{/if}</status_msgs_that_are_blocked>
+    <status_msgs_that_are_blocked perm="R">HidConnected UxmConnected{if isset($snom_emergency_numbers)} EmergencyCallNumbersMisconfigured{/if}</status_msgs_that_are_blocked>
     <ui_theme perm="RW">{if isset($snom_ui_theme)}{$snom_ui_theme}{/if}</ui_theme>
     <!-- Ringtones -->
     <alert_internal_ring_text perm="">alert-internal</alert_internal_ring_text>

--- a/resources/templates/provision/snom/D785/{$mac}.xml
+++ b/resources/templates/provision/snom/D785/{$mac}.xml
@@ -20,7 +20,7 @@
     <cw_dialtone perm="">{if isset($snom_dialtone_on_hold)}{$snom_dialtone_on_hold}{else}false{/if}</cw_dialtone>
     <answer_after_policy perm="">{if isset($snom_answer_after_policy)}{$snom_answer_after_policy}{else}off{/if}</answer_after_policy>
     <keyboard_lock_emergency perm="R">{if isset($snom_emergency_numbers)}{$snom_emergency_numbers}{else}911 112 110 999{/if}</keyboard_lock_emergency>
-    <status_msgs_that_are_blocked perm="R">{if isset($snom_emergency_numbers)}EmergencyCallNumbersMisconfigured{/if}</status_msgs_that_are_blocked>
+    <status_msgs_that_are_blocked perm="R">HidConnected UxmConnected{if isset($snom_emergency_numbers)} EmergencyCallNumbersMisconfigured{/if}</status_msgs_that_are_blocked>
     <ui_theme perm="RW">{if isset($snom_ui_theme)}{$snom_ui_theme}{/if}</ui_theme>
     <!-- Ringtones -->
     <alert_internal_ring_text perm="">alert-internal</alert_internal_ring_text>

--- a/resources/templates/provision/snom/D812/{$mac}.xml
+++ b/resources/templates/provision/snom/D812/{$mac}.xml
@@ -20,7 +20,7 @@
     <cw_dialtone perm="">{if isset($snom_dialtone_on_hold)}{$snom_dialtone_on_hold}{else}false{/if}</cw_dialtone>
     <answer_after_policy perm="">{if isset($snom_answer_after_policy)}{$snom_answer_after_policy}{else}off{/if}</answer_after_policy>
     <keyboard_lock_emergency perm="R">{if isset($snom_emergency_numbers)}{$snom_emergency_numbers}{else}911 112 110 999{/if}</keyboard_lock_emergency>
-    <status_msgs_that_are_blocked perm="R">{if isset($snom_emergency_numbers)}EmergencyCallNumbersMisconfigured{/if}</status_msgs_that_are_blocked>
+    <status_msgs_that_are_blocked perm="R">HidConnected UxmConnected{if isset($snom_emergency_numbers)} EmergencyCallNumbersMisconfigured{/if}</status_msgs_that_are_blocked>
     <ui_theme perm="RW">{if isset($snom_ui_theme)}{$snom_ui_theme}{/if}</ui_theme>
     <!-- Ringtones -->
     <alert_internal_ring_text perm="">alert-internal</alert_internal_ring_text>

--- a/resources/templates/provision/snom/D815/{$mac}.xml
+++ b/resources/templates/provision/snom/D815/{$mac}.xml
@@ -20,7 +20,7 @@
     <cw_dialtone perm="">{if isset($snom_dialtone_on_hold)}{$snom_dialtone_on_hold}{else}false{/if}</cw_dialtone>
     <answer_after_policy perm="">{if isset($snom_answer_after_policy)}{$snom_answer_after_policy}{else}off{/if}</answer_after_policy>
     <keyboard_lock_emergency perm="R">{if isset($snom_emergency_numbers)}{$snom_emergency_numbers}{else}911 112 110 999{/if}</keyboard_lock_emergency>
-    <status_msgs_that_are_blocked perm="R">{if isset($snom_emergency_numbers)}EmergencyCallNumbersMisconfigured{/if}</status_msgs_that_are_blocked>
+    <status_msgs_that_are_blocked perm="R">HidConnected UxmConnected{if isset($snom_emergency_numbers)} EmergencyCallNumbersMisconfigured{/if}</status_msgs_that_are_blocked>
     <ui_theme perm="RW">{if isset($snom_ui_theme)}{$snom_ui_theme}{/if}</ui_theme>
     <!-- Ringtones -->
     <alert_internal_ring_text perm="">alert-internal</alert_internal_ring_text>

--- a/resources/templates/provision/snom/D862/{$mac}.xml
+++ b/resources/templates/provision/snom/D862/{$mac}.xml
@@ -20,7 +20,7 @@
     <cw_dialtone perm="">{if isset($snom_dialtone_on_hold)}{$snom_dialtone_on_hold}{else}false{/if}</cw_dialtone>
     <answer_after_policy perm="">{if isset($snom_answer_after_policy)}{$snom_answer_after_policy}{else}off{/if}</answer_after_policy>
     <keyboard_lock_emergency perm="R">{if isset($snom_emergency_numbers)}{$snom_emergency_numbers}{else}911 112 110 999{/if}</keyboard_lock_emergency>
-    <status_msgs_that_are_blocked perm="R">{if isset($snom_emergency_numbers)}EmergencyCallNumbersMisconfigured{/if}</status_msgs_that_are_blocked>
+    <status_msgs_that_are_blocked perm="R">HidConnected UxmConnected{if isset($snom_emergency_numbers)} EmergencyCallNumbersMisconfigured{/if}</status_msgs_that_are_blocked>
     <ui_theme perm="RW">{if isset($snom_ui_theme)}{$snom_ui_theme}{/if}</ui_theme>
     <!-- Ringtones -->
     <alert_internal_ring_text perm="">alert-internal</alert_internal_ring_text>

--- a/resources/templates/provision/snom/D865/{$mac}.xml
+++ b/resources/templates/provision/snom/D865/{$mac}.xml
@@ -20,7 +20,7 @@
     <cw_dialtone perm="">{if isset($snom_dialtone_on_hold)}{$snom_dialtone_on_hold}{else}false{/if}</cw_dialtone>
     <answer_after_policy perm="">{if isset($snom_answer_after_policy)}{$snom_answer_after_policy}{else}off{/if}</answer_after_policy>
     <keyboard_lock_emergency perm="R">{if isset($snom_emergency_numbers)}{$snom_emergency_numbers}{else}911 112 110 999{/if}</keyboard_lock_emergency>
-    <status_msgs_that_are_blocked perm="R">{if isset($snom_emergency_numbers)}EmergencyCallNumbersMisconfigured{/if}</status_msgs_that_are_blocked>
+    <status_msgs_that_are_blocked perm="R">HidConnected UxmConnected{if isset($snom_emergency_numbers)} EmergencyCallNumbersMisconfigured{/if}</status_msgs_that_are_blocked>
     <ui_theme perm="RW">{if isset($snom_ui_theme)}{$snom_ui_theme}{/if}</ui_theme>
     <!-- Ringtones -->
     <alert_internal_ring_text perm="">alert-internal</alert_internal_ring_text>


### PR DESCRIPTION
Snom shows a warning whenever a headset is connected or when an expansion module is connected. This warning is presented above the missed calls notification which clutters up the view.

This warning is not needed and Snom provides a way to disable it. This should be disabled by default as there will likely be no one who wants a warning messaged that a peripheral has connected successfully.

This PR still allows the message to be present when there is an error connecting a peripheral.