### PR TITLE
smtp_from_name was accidentally set to smtp_from

### DIFF
--- a/app/email_queue/resources/command/send.php
+++ b/app/email_queue/resources/command/send.php
@@ -155,7 +155,7 @@
 //get the email queue settings
 	$setting = new settings(["domain_uuid" => $domain_uuid]);
 	$smtp_from = $setting->get('email', 'smtp_from');
-	$smtp_from_name = $setting->get('email', 'smtp_from');
+	$smtp_from_name = $setting->get('email', 'smtp_from_name', $smtp_from);
 	$save_response = $setting->get('email_queue', 'save_response');
 
 //debug information
@@ -246,9 +246,7 @@
 		$email->subject = $email_subject;
 		$email->body = $email_body;
 		$email->from_address = $smtp_from;
-		if (isset($smtp_from_name)) {
-			$email->from_name = $smtp_from_name;
-		}
+		$email->from_name = $smtp_from_name;
 		if (isset($email_attachments)) {
 			$email->attachments = $email_attachments;
 		}


### PR DESCRIPTION
This uses the settings default value to set smtp_from_name to be set to smtp_from if it does not have it's own value. The isset check on line 248 is no longer needed because smtp_from_name will always have a value