### PR TITLE
remove the manual inclusion of classes to let autoloader handle it

### DIFF
--- a/app/call_forward/call_forward_edit.php
+++ b/app/call_forward/call_forward_edit.php
@@ -165,11 +165,6 @@
 				return;
 			}
 
-		//include the classes
-			include "resources/classes/call_forward.php";
-			include "resources/classes/follow_me.php";
-			include "resources/classes/do_not_disturb.php";
-
 		//call forward config
 			if (permission_exists('call_forward')) {
 				//sanitize the destinations


### PR DESCRIPTION
By including the class manually with the include statement, the class has a possibility of loading twice. This will cause a fatal error if classes are already loaded.