### PR TITLE
fix for Avaya buttons

### DIFF
--- a/resources/templates/provision/avaya/J169/{$mac}.cfg
+++ b/resources/templates/provision/avaya/J169/{$mac}.cfg
@@ -183,19 +183,19 @@ SET SIMULTANEOUS_REGISTRATIONS 1
 {foreach $keys["line"] as $row}
 
 {if in_array($row.device_key_type, array("callfwd", "callfwdna", "callfwdbusy", "dnd" , "autoanswer"))}
-SET PHONEKEY "Key={$row.device_key_id+1};Type=feature;Name={$row.device_key_type};Label={$row.device_key_label};Forced"
+SET PHONEKEY "Key={$row.device_key_id+3};Type=feature;Name={$row.device_key_type};Label={$row.device_key_label};Forced"
 
 {elseif in_array($row.device_key_type, array("blf"))}
-SET PHONEKEY "Key={$row.device_key_id+1};Type=feature;Name={$row.device_key_type};Label={$row.device_key_label};attr1={$row.device_key_value};attr2={$row.device_key_value};Forced"
+SET PHONEKEY "Key={$row.device_key_id+3};Type=feature;Name={$row.device_key_type};Label={$row.device_key_label};attr1={$row.device_key_value};attr2={$row.device_key_value};Forced"
 
 {elseif in_array($row.device_key_type, array("lock", "logout", "screensaver"))}
-SET PHONEKEY "Key={$row.device_key_id+1};Type=application;Name={$row.device_key_type};Label={$row.device_key_label};Forced"
+SET PHONEKEY "Key={$row.device_key_id+3};Type=application;Name={$row.device_key_type};Label={$row.device_key_label};Forced"
 
 {elseif in_array($row.device_key_type, array("primary"))}
-SET PHONEKEY "Key={$row.device_key_id+1};Type=line;Name={$row.device_key_type};attr1={$row.device_key_line};Forced"
+SET PHONEKEY "Key={$row.device_key_id+3};Type=line;Name={$row.device_key_type};attr1={$row.device_key_line};Forced"
 
 {elseif in_array($row.device_key_type, array("autodial"))}
-SET PHONEKEY "Key={$row.device_key_id+1};Type=autodial;Name={$row.device_key_type};attr1={$row.device_key_value};Label={$row.device_key_label};Forced"
+SET PHONEKEY "Key={$row.device_key_id+3};Type=autodial;Name={$row.device_key_type};attr1={$row.device_key_value};Label={$row.device_key_label};Forced"
 
 {/if}
 {/foreach}

--- a/resources/templates/provision/avaya/J179/{$mac}.cfg
+++ b/resources/templates/provision/avaya/J179/{$mac}.cfg
@@ -183,19 +183,19 @@ SET SIMULTANEOUS_REGISTRATIONS 1
 {foreach $keys["line"] as $row}
 
 {if in_array($row.device_key_type, array("callfwd", "callfwdna", "callfwdbusy", "dnd" , "autoanswer"))}
-SET PHONEKEY "Key={$row.device_key_id+1};Type=feature;Name={$row.device_key_type};Label={$row.device_key_label};Forced"
+SET PHONEKEY "Key={$row.device_key_id+3};Type=feature;Name={$row.device_key_type};Label={$row.device_key_label};Forced"
 
 {elseif in_array($row.device_key_type, array("blf"))}
-SET PHONEKEY "Key={$row.device_key_id+1};Type=feature;Name={$row.device_key_type};Label={$row.device_key_label};attr1={$row.device_key_value};attr2={$row.device_key_value};Forced"
+SET PHONEKEY "Key={$row.device_key_id+3};Type=feature;Name={$row.device_key_type};Label={$row.device_key_label};attr1={$row.device_key_value};attr2={$row.device_key_value};Forced"
 
 {elseif in_array($row.device_key_type, array("lock", "logout", "screensaver"))}
-SET PHONEKEY "Key={$row.device_key_id+1};Type=application;Name={$row.device_key_type};Label={$row.device_key_label};Forced"
+SET PHONEKEY "Key={$row.device_key_id+3};Type=application;Name={$row.device_key_type};Label={$row.device_key_label};Forced"
 
 {elseif in_array($row.device_key_type, array("primary"))}
-SET PHONEKEY "Key={$row.device_key_id+1};Type=line;Name={$row.device_key_type};attr1={$row.device_key_line};Forced"
+SET PHONEKEY "Key={$row.device_key_id+3};Type=line;Name={$row.device_key_type};attr1={$row.device_key_line};Forced"
 
 {elseif in_array($row.device_key_type, array("autodial"))}
-SET PHONEKEY "Key={$row.device_key_id+1};Type=autodial;Name={$row.device_key_type};attr1={$row.device_key_value};Label={$row.device_key_label};Forced"
+SET PHONEKEY "Key={$row.device_key_id+3};Type=autodial;Name={$row.device_key_type};attr1={$row.device_key_value};Label={$row.device_key_label};Forced"
 
 {/if}
 {/foreach}

--- a/resources/templates/provision/avaya/J189/{$mac}.cfg
+++ b/resources/templates/provision/avaya/J189/{$mac}.cfg
@@ -188,19 +188,19 @@ SET SIMULTANEOUS_REGISTRATIONS 1
 {foreach $keys["line"] as $row}
 
 {if in_array($row.device_key_type, array("callfwd", "callfwdna", "callfwdbusy", "dnd" , "autoanswer"))}
-SET PHONEKEY "Key={$row.device_key_id+1};Type=feature;Name={$row.device_key_type};Label={$row.device_key_label};Forced"
+SET PHONEKEY "Key={$row.device_key_id+3};Type=feature;Name={$row.device_key_type};Label={$row.device_key_label};Forced"
 
 {elseif in_array($row.device_key_type, array("blf"))}
-SET PHONEKEY "Key={$row.device_key_id+1};Type=feature;Name={$row.device_key_type};Label={$row.device_key_label};attr1={$row.device_key_value};attr2={$row.device_key_value};Forced"
+SET PHONEKEY "Key={$row.device_key_id+3};Type=feature;Name={$row.device_key_type};Label={$row.device_key_label};attr1={$row.device_key_value};attr2={$row.device_key_value};Forced"
 
 {elseif in_array($row.device_key_type, array("lock", "logout", "screensaver"))}
-SET PHONEKEY "Key={$row.device_key_id+1};Type=application;Name={$row.device_key_type};Label={$row.device_key_label};Forced"
+SET PHONEKEY "Key={$row.device_key_id+3};Type=application;Name={$row.device_key_type};Label={$row.device_key_label};Forced"
 
 {elseif in_array($row.device_key_type, array("primary"))}
-SET PHONEKEY "Key={$row.device_key_id+1};Type=line;Name={$row.device_key_type};attr1={$row.device_key_line};Forced"
+SET PHONEKEY "Key={$row.device_key_id+3};Type=line;Name={$row.device_key_type};attr1={$row.device_key_line};Forced"
 
 {elseif in_array($row.device_key_type, array("autodial"))}
-SET PHONEKEY "Key={$row.device_key_id+1};Type=autodial;Name={$row.device_key_type};attr1={$row.device_key_value};Label={$row.device_key_label};Forced"
+SET PHONEKEY "Key={$row.device_key_id+3};Type=autodial;Name={$row.device_key_type};attr1={$row.device_key_value};Label={$row.device_key_label};Forced"
 
 {/if}
 {/foreach}


### PR DESCRIPTION
This pull request makes any buttons programmed for the Avaya phones always start on button 4.

Avaya phones insist on having 3 line keys. There is no way that I can find to stop this behaviour.

What this means is that if I program a BLF as button 2, Avaya phones will then put the following on the phone:

1. Line Key
2. BLF
3. Line Key
4. Line Key

This change makes it so that any BLFs etc added start on line 4 so that it would look like this:

1. Line Key
2. Line Key
3. Line Key
4. BLF