### PR TITLE
Ensure the 'transcribe_' is prepended to the class name

### DIFF
--- a/app/email_queue/resources/jobs/email_send.php
+++ b/app/email_queue/resources/jobs/email_send.php
@@ -230,7 +230,7 @@
 					$transcribe_engine = $settings->get('transcribe', 'engine', '');
 
 					//add the transcribe object and get the languages arrays
-					if (!empty($transcribe_engine) && class_exists($transcribe_engine)) {
+					if (!empty($transcribe_engine) && class_exists('transcribe_' . $transcribe_engine)) {
 						$transcribe = new transcribe($settings);
 
 						//transcribe the voicemail recording


### PR DESCRIPTION
Class name requires the transcribe_ prepended before PHP checks to see if the class actually exists as the engine must have 'transcribe_' in front of the classes.