### PR TITLE
Fix for BSDs core classes

### DIFF
--- a/core/install/resources/classes/install.php
+++ b/core/install/resources/classes/install.php
@@ -35,7 +35,10 @@ if (!class_exists('install')) {
 			//set the default config file location
 			$os = strtoupper(substr(PHP_OS, 0, 3));
 			switch ($os) {
-			case "BSD":
+				case "FRE":
+				case "OPE":
+				case "NET":
+				case "BSD":
 				$config_path = '/usr/local/etc/fusionpbx';
 				$config_file = $config_path.'/config.conf';
 				$document_root = '/usr/local/www/fusionpbx';


### PR DESCRIPTION
This is a fix for the install class for FreeBSD, NetBSD and OpenBSD.

The PHP_OS var does not return "BSD" on modern releases.