### PR TITLE
use loose comparison instead of strict comparison

### DIFF
--- a/app/database_transactions/resources/classes/database_transactions.php
+++ b/app/database_transactions/resources/classes/database_transactions.php
@@ -57,12 +57,14 @@ class database_transactions {
 				$sql = "delete from v_{$table} WHERE transaction_date < NOW() - INTERVAL '{$retention_days} days'"
 					. " and domain_uuid = '{$domain_uuid}'";
 				$database->execute($sql);
-				if ($database->message['code'] === 200) {
+				$code = $database->message['code'] ?? 0;
+				if ($code == 200) {
 					//success
-					maintenance_service::log_write(self::class, "Successfully removed database_transaction entries from $domain_name", $domain_uuid);
+					maintenance_service::log_write(self::class, "Successfully removed entries older than $retention_days", $domain_uuid);
 				} else {
 					//failure
-					maintenance_service::log_write(self::class, "Unable to remove records for domain $domain_name", $domain_uuid, maintenance_service::LOG_ERROR);
+					$message = $database->message['message'] ?? "An unknown error has occurred";
+					maintenance_service::log_write(self::class, "Unable to remove old database records. Error message: $message ($code)", $domain_uuid, maintenance_service::LOG_ERROR);
 				}
 			} else {
 				//report an invalid setting

--- a/app/fax_queue/resources/classes/fax_queue.php
+++ b/app/fax_queue/resources/classes/fax_queue.php
@@ -263,10 +263,12 @@ if (!class_exists('fax_queue')) {
 					$sql = "delete from v_fax_queue where fax_status = 'sent' and fax_date < NOW() - INTERVAL '$retention_days days'";
 					$sql .= " and domain_uuid = '$domain_uuid'";
 					$database->execute($sql);
-					if (!empty($database->message['code']) && $database->message['code'] == 200) {
-						maintenance_service::log_write(self::class, "removed successfully", $domain_uuid);
+					$code = $database->message['code'] ?? 0;
+					if ($code == 200) {
+						maintenance_service::log_write(self::class, "Successfully removed entries older than $retention_days", $domain_uuid);
 					} else {
-						maintenance_service::log_write(self::class, "Unable to remove database entries", $domain_uuid, maintenance_service::LOG_ERROR);
+						$message = $database->message['message'] ?? "An unknown error has occurred";
+						maintenance_service::log_write(self::class, "Unable to remove old database records. Error message: $message ($code)", $domain_uuid, maintenance_service::LOG_ERROR);
 					}
 				}
 			}

--- a/app/voicemails/resources/classes/voicemail.php
+++ b/app/voicemails/resources/classes/voicemail.php
@@ -1325,10 +1325,12 @@
 					$sql = "delete from v_{$table} WHERE to_timestamp(created_epoch) < NOW() - INTERVAL '{$retention_days} days'"
 					. " and domain_uuid = '{$domain_uuid}'";
 					$database->execute($sql);
-					if ($database->message['code'] === 200) {
-						maintenance_service::log_write(self::class, "Successfully removed voicemail entries from $domain_name", $domain_uuid);
+					$code = $database->message['code'] ?? 0;
+					if ($database->message['code'] == 200) {
+						maintenance_service::log_write(self::class, "Successfully removed entries older than $retention_days", $domain_uuid);
 					} else {
-						maintenance_service::log_write(self::class, "Unable to remove records for domain $domain_name", $domain_uuid, maintenance_service::LOG_ERROR);
+						$message = $database->message['message'] ?? "An unknown error has occurred";
+						maintenance_service::log_write(self::class, "Unable to remove old database records. Error message: $message ($code)", $domain_uuid, maintenance_service::LOG_ERROR);
 					}
 				}
 			}

--- a/app/xml_cdr/resources/classes/xml_cdr.php
+++ b/app/xml_cdr/resources/classes/xml_cdr.php
@@ -2117,12 +2117,13 @@ if (!class_exists('xml_cdr')) {
 					$sql = "delete from v_{$table} WHERE insert_date < NOW() - INTERVAL '{$xml_cdr_retention_days} days'"
 						. " and domain_uuid = '{$domain_uuid}'";
 					$database->execute($sql);
-
+					$code = $database->message['code'] ?? 0;
 					//record result
-					if ($database->message['code'] === 200) {
-						maintenance_service::log_write(self::class, "Successfully removed XML CDR entries from $domain_name", $domain_uuid);
+					if ($code == 200) {
+						maintenance_service::log_write(self::class, "Successfully removed entries older than $xml_cdr_retention_days", $domain_uuid);
 					} else {
-						maintenance_service::log_write(self::class, "Unable to remove XML CDR records for domain $domain_name", $domain_uuid, maintenance_service::LOG_ERROR);
+						$message = $database->message['message'] ?? "An unknown error has occurred";
+						maintenance_service::log_write(self::class, "XML CDR " . "Unable to remove old database records. Error message: $message ($code)", $domain_uuid, maintenance_service::LOG_ERROR);
 					}
 
 					//clear out old xml_cdr_flow records
@@ -2130,12 +2131,13 @@ if (!class_exists('xml_cdr')) {
 						$sql = "delete from v_xml_cdr_flow WHERE insert_date < NOW() - INTERVAL '{$xml_cdr_flow_retention_days} days'"
 							. " and domain_uuid = '{$domain_uuid}";
 						$database->execute($sql);
-
+						$code = $database->message['code'] ?? 0;
 						//record result
-						if ($database->message['code'] === 200) {
+						if ($database->message['code'] == 200) {
 							maintenance_service::log_write(self::class, "Successfully removed XML CDR FLOW entries from $domain_name", $domain_uuid);
 						} else {
-							maintenance_service::log_write(self::class, "Unable to remove XML CDR FLOW records for domain $domain_name", $domain_uuid, maintenance_service::LOG_ERROR);
+							$message = $database->message['message'] ?? "An unknown error has occurred";
+							maintenance_service::log_write(self::class, "XML CDR FLOW " . "Unable to remove old database records. Error message: $message ($code)", $domain_uuid, maintenance_service::LOG_ERROR);
 						}
 					}
 
@@ -2144,12 +2146,13 @@ if (!class_exists('xml_cdr')) {
 						$sql = "DELETE FROM v_xml_cdr_json WHERE insert_date < NOW() - INTERVAL '{$xml_cdr_json_retention_days} days'"
 							. " and domain_uuid = '{$domain_uuid}";
 						$database->execute($sql);
-
+						$code = $database->message['code'] ?? 0;
 						//record result
-						if ($database->message['code'] === 200) {
+						if ($database->message['code'] == 200) {
 							maintenance_service::log_write(self::class, "Successfully removed XML CDR JSON entries from $domain_name", $domain_uuid);
 						} else {
-							maintenance_service::log_write(self::class, "Unable to remove XML CDR JSON records for domain $domain_name", $domain_uuid, maintenance_service::LOG_ERROR);
+							$message = $database->message['message'] ?? "An unknown error has occurred";
+							maintenance_service::log_write(self::class, "XML CDR JSON " . "Unable to remove old database records. Error message: $message ($code)", $domain_uuid, maintenance_service::LOG_ERROR);
 						}
 					}
 
@@ -2158,12 +2161,13 @@ if (!class_exists('xml_cdr')) {
 						$sql = "DELETE FROM v_xml_cdr_logs WHERE insert_date < NOW() - INTERVAL '{$xml_cdr_logs_retention_days} days'"
 							. " and domain_uuid = '{$domain_uuid}'";
 						$database->execute($sql);
-
+						$code = $database->message['code'] ?? 0;
 						//record result
 						if ($database->message['code'] === 200) {
 							maintenance_service::log_write(self::class, "Successfully removed XML CDR LOG entries from $domain_name", $domain_uuid);
 						} else {
-							maintenance_service::log_write(self::class, "Unable to remove XML CDR LOG records for domain $domain_name", $domain_uuid, maintenance_service::LOG_ERROR);
+							$message = $database->message['message'] ?? "An unknown error has occurred";
+							maintenance_service::log_write(self::class, "XML CDR LOG " . "Unable to remove old database records. Error message: $message ($code)", $domain_uuid, maintenance_service::LOG_ERROR);
 						}
 					}
 				}

--- a/core/users/resources/classes/users.php
+++ b/core/users/resources/classes/users.php
@@ -304,7 +304,7 @@ if (!class_exists('users')) {
 					$database->execute($sql);
 					$code = $database->message['code'] ?? 0;
 					if ($code == 200) {
-						maintenance_service::log_write(self::class, "Removed database entries older than $retention_days", $domain_uuid);
+						maintenance_service::log_write(self::class, "Successfully removed entries older than $retention_days", $domain_uuid);
 					} else {
 						$message = $database->message['message'] ?? "An unknown error has occurred";
 						maintenance_service::log_write(self::class, "Unable to remove old database records. Error message: $message ($code)", $domain_uuid, maintenance_service::LOG_ERROR);


### PR DESCRIPTION
Update comparison checks when testing the database status and add unified log message with a more detailed message from the database when there is a failure