### PR TITLE
set fax failed when missing

### DIFF
--- a/app/fax_queue/resources/job/fax_send.php
+++ b/app/fax_queue/resources/job/fax_send.php
@@ -366,6 +366,7 @@
 			}
 			else {
 				echo "fax file missing: ".$fax_file."\n";
+				$fax_status = 'failed';
 			}
 
 	}


### PR DESCRIPTION
This PR sets the `$fax_status = 'failed'` when the file cannot be found. Not doing this causes faxes with missing files to never get taken out of the fax queue.