### PR TITLE
voicemail messages function is called twice. second call removes list

### DIFF
--- a/app/voicemails/voicemail_messages.php
+++ b/app/voicemails/voicemail_messages.php
@@ -285,7 +285,6 @@
 	$vm->order_by = $order_by;
 	$vm->order = $order;
 	$vm->offset = $offset;
-	$voicemails = $vm->messages();
 
 //count messages and detect if any transcriptions available
 	$new_messages = $num_rows = 0;


### PR DESCRIPTION
When voicemail is called the first time, it correctly displays the list of voicemail messages. When it is called a second time the function returns an empty array and gives an empty display. This removes the second call to method 'messages' in 'voicemail' object.