### PR TITLE
update voicemail constructor to use domain and user uuids for settings

### DIFF
--- a/app/voicemails/resources/classes/voicemail.php
+++ b/app/voicemails/resources/classes/voicemail.php
@@ -67,6 +67,20 @@
 
 		public function __construct(array $params = []) {
 
+			//set the domain_uuid if not provided
+				if (!empty($params['domain_uuid']) && is_uuid($params['domain_uuid'])) {
+					$this->domain_uuid = $params['domain_uuid'];
+				} else {
+					$this->domain_uuid = $_SESSION['domain_uuid'] ?? '';
+				}
+
+			//set the user_uuid if not provided
+				if (!empty($params['user_uuid']) && is_uuid($params['user_uuid'])) {
+					$this->user_uuid = $params['user_uuid'];
+				} else {
+					$this->user_uuid = $_SESSION['user_uuid'] ?? '';
+				}
+
 			//database connection
 				if (empty($params['database'])) {
 					$this->database = database::new();
@@ -75,11 +89,11 @@
 				}
 
 			//assign the settings object
-				if (isset($params['settings'])) {
-					$this->settings = $params['settings'];
+				if (empty($params['settings'])) {
+					$this->settings = new settings(['database' => $this->database, 'domain_uuid' => $this->domain_uuid, 'user_uuid' => $this->user_uuid]);
 				}
 				else {
-					$this->settings = new settings(["database" => $this->database]);
+					$this->settings = $params['settings'];
 				}
 
 			//assign private variables
@@ -92,15 +106,6 @@
 				$this->toggle_field = 'voicemail_enabled';
 				$this->toggle_values = ['true','false'];
 
-			//set the domain_uuid if not provided
-				if (empty($this->domain_uuid) || !is_uuid($this->domain_uuid)) {
-					$this->domain_uuid = $_SESSION['domain_uuid'];
-				}
-
-			//set the user_uuid if not provided
-				if (empty($this->user_uuid) || !is_uuid($this->user_uuid)) {
-					$this->user_uuid = $_SESSION['user_uuid'];
-				}
 		}
 
 		public function get_voicemail_id() {


### PR DESCRIPTION
If the settings object is not passed in the parameters the settings object that was created did not have the current domain uuid or user uuid set. This would cause default settings that were copied to the domain to be ignored. Ensuring the domain_uuid and user_uuid are initialized before the setting object and then passing them to the settings object constructor will make sure that the values would be returned when a request to the settings object is made.