### PR TITLE
add multiple line export feature

### DIFF
--- a/app/devices/app_languages.php
+++ b/app/devices/app_languages.php
@@ -7054,4 +7054,30 @@ $text['label-column_name']['zh-cn'] = "列名";
 $text['label-column_name']['ja-jp'] = "列名";
 $text['label-column_name']['ko-kr'] = "열 이름";
 
+$text['label-required']['en-us'] = "Required";
+$text['label-required']['en-gb'] = "Required";
+$text['label-required']['ar-eg'] = "مطلوب";
+$text['label-required']['de-at'] = "Erforderlich";
+$text['label-required']['de-ch'] = "Erforderlich";
+$text['label-required']['de-de'] = "Erforderlich";
+$text['label-required']['el-gr'] = "Απαιτείται";
+$text['label-required']['es-cl'] = "Requerido";
+$text['label-required']['es-mx'] = "Requerido";
+$text['label-required']['fr-ca'] = "Requis";
+$text['label-required']['fr-fr'] = "Requis";
+$text['label-required']['he-il'] = "נדרש";
+$text['label-required']['it-it'] = "Necessario";
+$text['label-required']['nl-nl'] = "Vereist";
+$text['label-required']['pl-pl'] = "Wymagany";
+$text['label-required']['pt-br'] = "Obrigatório";
+$text['label-required']['pt-pt'] = "Obrigatório";
+$text['label-required']['ro-ro'] = "Necesar";
+$text['label-required']['ru-ru'] = "Необходимый";
+$text['label-required']['sv-se'] = "Krav";
+$text['label-required']['uk-ua'] = "вимагається";
+$text['label-required']['tr-tr'] = "Gerekli";
+$text['label-required']['zh-cn'] = "必需的";
+$text['label-required']['ja-jp'] = "必要";
+$text['label-required']['ko-kr'] = "필수의";
+
 ?>

--- a/app/devices/device_download.php
+++ b/app/devices/device_download.php
@@ -37,22 +37,56 @@
 		exit;
 	}
 
+//set the current domain and user information
+	$domain_name = $_SESSION['domain_name'] ?? '';
+	$domain_uuid = $_SESSION['domain_uuid'] ?? '';
+	$user_uuid = $_SESSION['user_uuid'] ?? '';
+	$user_name = $_SESSION['username'] ?? '';
+
+//create database connection and settings object
+	$database = database::new();
+	$settings = new settings(['database' => $database, 'domain_uuid' => $domain_uuid, 'user_uuid' => $user_uuid]);
+
 //add multi-lingual support
 	$language = new text;
 	$text = $language->get();
+
+//define label
+	$label_required = $text['label-required'];
 
 //define the functions
 	function array2csv(array &$array) {
 		if (count($array) == 0) {
 			return null;
 		}
-		ob_start();
-		$df = fopen("php://output", 'w');
-		fputcsv($df, array_keys(reset($array)));
-		foreach ($array as $row) {
-			fputcsv($df, $row);
+
+		//get all headers as first device may not have all columns
+		$headers = [];
+		foreach ($array as $device) {
+			//get the column headers for this device
+			$columns = array_keys($device);
+			//check if there are more column headers than previous devices
+			if (count($columns) > count($headers)) {
+				//use the device with all columns
+				$headers = $columns;
+			}
 		}
-		fclose($df);
+
+		//find and remove the "|2" that denotes a duplicate header
+		foreach ($headers as &$header) {
+			$pos = strpos($header, '|');
+			if ($pos !== false) {
+				$header = substr($header, 0, $pos);
+			}
+		}
+
+		ob_start();
+		$file_pointer = fopen("php://output", 'w');
+		fputcsv($file_pointer, $headers);
+		foreach ($array as $row) {
+			fputcsv($file_pointer, $row);
+		}
+		fclose($file_pointer);
 		return ob_get_clean();
 	}
 
@@ -139,30 +173,41 @@
 		//iterate columns
 			if (is_array($column_group) && @sizeof($column_group) != 0) {
 
+				//device_uuid must be exported
+				$column_group['devices']['device_uuid'] = 'device_uuid';
+
 				$column_names = implode(", ", $column_group['devices']);
-				$sql = "select ".$column_names." from v_devices ";
+				$sql = "select ".$column_names." from v_devices";
 				$sql .= " where domain_uuid = :domain_uuid ";
 				$parameters['domain_uuid'] = $domain_uuid;
-				$database = new database;
 				$devices = $database->select($sql, $parameters, 'all');
 				unset($sql, $parameters, $column_names);
 
 				foreach($column_group as $table_name => $columns) {
 					if ($table_name !== 'devices') {
+						//device_uuid must be included in child table to match export row
+						$columns['device_uuid'] = 'device_uuid';
 						$column_names = implode(", ", $columns);
 						$sql = "select ".$column_names." from v_".$table_name." ";
 						$sql .= " where domain_uuid = :domain_uuid ";
 						$parameters['domain_uuid'] = $domain_uuid;
-						$database = new database;
-						$$table_name = $database->select($sql, $parameters, 'all');
+						$child_table_result = $database->select($sql, $parameters, 'all');
 						$x = 0;
 						foreach($devices as $device) {
-							foreach($$table_name as $row) {
+							$header_match_count = 1;
+							//find the matching device within the linked table
+							foreach($child_table_result as $row) {
 								if ($device['device_uuid'] == $row['device_uuid']) {
 									foreach($row as $key => $value) {
-										$devices[$x][$key] = $value;
+										//check for multi-line devices
+										if ($key != 'device_uuid' && array_key_exists($key, $devices[$x])) {
+											//create a new key so that we don't overwrite data
+											$devices[$x][$key . '|' . $header_match_count] = $value;
+										} else {
+											$devices[$x][$key] = $value;
+										}
 									}
-									break;
+									$header_match_count++;
 								}
 							}
 							$x++;
@@ -221,9 +266,18 @@
 				$list_row_onclick = "if (!this.checked) { document.getElementById('checkbox_all').checked = false; }";
 				echo "<tr class='list-row' href='".($list_row_url ?? '')."'>\n";
 				echo "	<td class='checkbox'>\n";
-				echo "		<input type='checkbox' class='checkbox_".$table_name."' name='column_group[".$table_name."][".$column_name."]' id='checkbox_".$x."' value=\"".$column_name."\" onclick=\"".$list_row_onclick."\">\n";
+				//device_uuid must be selected on devices to avoid duplication on import
+				if ($table_name == 'devices' && $column_name == 'device_uuid') {
+					echo "		<input type='checkbox' title='$label_required' class='disabled_checkbox_devices' name='column_group[$table_name][$column_name]' id='checkbox_$x' value='$column_name' checked='checked' onclick='return false;'>\n";
+				} else {
+					echo "		<input type='checkbox' class='checkbox_".$table_name."' name='column_group[".$table_name."][".$column_name."]' id='checkbox_".$x."' value=\"".$column_name."\" onclick=\"".$list_row_onclick."\">\n";
+				}
 				echo "	</td>\n";
-				echo "	<td onclick=\"document.getElementById('checkbox_".$x."').checked = document.getElementById('checkbox_".$x."').checked ? false : true; ".$list_row_onclick."\">".$column_name."</td>";
+				if ($table_name == 'devices' && $column_name == 'device_uuid') {
+					echo "	<td title='$label_required'>".$column_name."</td>";
+				} else {
+					echo "	<td onclick=\"document.getElementById('checkbox_".$x."').checked = document.getElementById('checkbox_".$x."').checked ? false : true; ".$list_row_onclick."\">".$column_name."</td>";
+				}
 				echo "</tr>";
 				$x++;
 			}
@@ -232,7 +286,7 @@
 			echo "</div>\n";
 		}
 	}
-	
+
 	//test the validation
 	//echo "		<input type='hidden' name='column_group[devices][xxx]'  value=\"xxx\">\n";
 	//echo "		<input type='hidden' name='column_group[device_lines][yyy]' value=\"yyy\">\n";

--- a/app/devices/device_download.php
+++ b/app/devices/device_download.php
@@ -177,8 +177,8 @@
 				$column_group['devices']['device_uuid'] = 'device_uuid';
 
 				$column_names = implode(", ", $column_group['devices']);
-				$sql = "select ".$column_names." from v_devices";
-				$sql .= " where domain_uuid = :domain_uuid ";
+				$sql = "select ".$column_names." from v_devices ";
+				$sql .= "where domain_uuid = :domain_uuid ";
 				$parameters['domain_uuid'] = $domain_uuid;
 				$devices = $database->select($sql, $parameters, 'all');
 				unset($sql, $parameters, $column_names);

--- a/app/devices/device_imports.php
+++ b/app/devices/device_imports.php
@@ -520,6 +520,7 @@
 	echo "    <select class='formfld' style='width:40px;' name='data_delimiter'>\n";
 	echo "    <option value=','>,</option>\n";
 	echo "    <option value='|'>|</option>\n";
+	echo "    <option value='	'>TAB</option>\n";
 	echo "    </select>\n";
 	echo "<br />\n";
 	echo $text['description-import_delimiter']."\n";

--- a/app/devices/devices.php
+++ b/app/devices/devices.php
@@ -38,7 +38,7 @@
 		exit;
 	}
 
-//set the domain and user information
+//set the current domain and user information
 	$domain_name = $_SESSION['domain_name'] ?? '';
 	$domain_uuid = $_SESSION['domain_uuid'] ?? '';
 	$user_uuid = $_SESSION['user_uuid'] ?? '';
@@ -213,7 +213,7 @@
 //get the list
 	$sql = "select d.*, d2.device_label as alternate_label, ";
 	$sql .= "to_char(timezone(:time_zone, d.device_provisioned_date), 'DD Mon YYYY') as provisioned_date_formatted, \n";
-	$sql .= "to_char(timezone(:time_zone, d.device_provisioned_date), 'HH12:MI:SS am') as provisioned_time_formatted \n";	
+	$sql .= "to_char(timezone(:time_zone, d.device_provisioned_date), 'HH12:MI:SS am') as provisioned_time_formatted \n";
 	$sql .= "from v_devices as d, v_devices as d2 ";
 	if (isset($_GET['show']) && $_GET['show'] == "all" && $has_device_all) {
 		$sql .= ", v_domains as d3 ";

--- a/app/devices/devices.php
+++ b/app/devices/devices.php
@@ -37,6 +37,20 @@
 		echo "access denied";
 		exit;
 	}
+	
+//create database connection
+	$database = database::new();
+
+//set all permissions
+	$has_device_import = permission_exists('device_import');
+	$has_device_edit = permission_exists('device_edit');
+	$has_device_all = permission_exists('device_all');
+	$has_device_delete = permission_exists('device_delete');
+	$has_device_domain_all = permission_exists('device_domain_all');
+	$has_device_export = permission_exists('device_export');
+	$has_device_vendor_view = permission_exists('device_vendor_view');
+	$has_device_profile_view = permission_exists('device_profile_view');
+	$has_device_add = permission_exists('device_add');
 
 //add multi-lingual support
 	$language = new text;
@@ -56,13 +70,13 @@
 	if (!empty($action) && !empty($devices) && is_array($devices) && @sizeof($devices) != 0) {
 		switch ($action) {
 			case 'toggle':
-				if (permission_exists('device_edit')) {
+				if ($has_device_edit) {
 					$obj = new device;
 					$obj->toggle($devices);
 				}
 				break;
 			case 'delete':
-				if (permission_exists('device_delete')) {
+				if ($has_device_delete) {
 					$obj = new device;
 					$obj->delete($devices);
 				}
@@ -88,12 +102,11 @@
 //get total devices count from the database
 	$sql = "select count(*) from v_devices ";
 	$sql .= "where domain_uuid = :domain_uuid ";
-	if (!permission_exists('device_all') && !permission_exists('device_domain_all')) {
+	if (!$has_device_all && !$has_device_domain_all) {
 		$sql .= "and device_user_uuid = :user_uuid ";
 		$parameters['user_uuid'] = $_SESSION['user_uuid'];
 	}
 	$parameters['domain_uuid'] = $_SESSION['domain_uuid'];
-	$database = new database;
 	$total_devices = $database->select($sql, $parameters, 'column');
 	unset($sql, $parameters);
 
@@ -101,13 +114,12 @@
 	$sql = "select * from v_device_profiles ";
 	$sql .= "where domain_uuid = :domain_uuid ";
 	$parameters['domain_uuid'] = $_SESSION['domain_uuid'];
-	$database = new database;
 	$device_profiles = $database->select($sql, $parameters, 'all');
 	unset($sql, $parameters);
 
 //prepare to page the results
 	$sql = "select count(*) from v_devices as d ";
-	if (isset($_GET['show']) && $_GET['show'] == "all" && permission_exists('device_all')) {
+	if (isset($_GET['show']) && $_GET['show'] == "all" && $has_device_all) {
 		if (!empty($search)) {
 			$sql .= "where ";
 		}
@@ -115,7 +127,7 @@
 	else {
 		$sql .= "where (";
 		$sql .= "	d.domain_uuid = :domain_uuid ";
-		if (permission_exists('device_all')) {
+		if ($has_device_all) {
 			$sql .= "	or d.domain_uuid is null ";
 		}
 		$sql .= ") ";
@@ -160,7 +172,6 @@
 		$sql .= ") ";
 		$parameters['search'] = '%'.strtolower($search).'%';
 	}
-	$database = new database;
 	$num_rows = $database->select($sql, $parameters ?? null, 'column');
 	unset($sql, $parameters);
 
@@ -171,7 +182,7 @@
 		$param = "&search=".$search;
 		$param .= "&fields=".$fields;
 	}
-	if (!empty($_GET['show']) && $_GET['show'] == "all" && permission_exists('device_all')) {
+	if (!empty($_GET['show']) && $_GET['show'] == "all" && $has_device_all) {
 		$param .= "&show=all";
 	}
 	$page = $_GET['page'] ?? 0;
@@ -184,7 +195,7 @@
 	$sql .= "to_char(timezone(:time_zone, d.device_provisioned_date), 'DD Mon YYYY') as provisioned_date_formatted, \n";
 	$sql .= "to_char(timezone(:time_zone, d.device_provisioned_date), 'HH12:MI:SS am') as provisioned_time_formatted \n";	
 	$sql .= "from v_devices as d, v_devices as d2 ";
-	if (isset($_GET['show']) && $_GET['show'] == "all" && permission_exists('device_all')) {
+	if (isset($_GET['show']) && $_GET['show'] == "all" && $has_device_all) {
 		$sql .= ", v_domains as d3 ";
 	}
 	$sql .= "where ( ";
@@ -194,19 +205,19 @@
 	$sql .= "		d.device_uuid = d2.device_uuid ";
 	$sql .= "	) ";
 	$sql .= ") ";
-	if (isset($_GET['show']) && $_GET['show'] == "all" && permission_exists('device_all')) {
+	if (isset($_GET['show']) && $_GET['show'] == "all" && $has_device_all) {
 		$sql .= " and d.domain_uuid = d3.domain_uuid ";
 	}
 	else {
 		$sql .= "and (";
 		$sql .= "	d.domain_uuid = :domain_uuid ";
-		if (permission_exists('device_all')) {
+		if ($has_device_all) {
 			$sql .= "	or d.domain_uuid is null ";
 		}
 		$sql .= ") ";
 		$parameters['domain_uuid'] = $domain_uuid;
 	}
-	if (!permission_exists('device_all') && !permission_exists('device_domain_all')) {
+	if (!$has_device_all && !$has_device_domain_all) {
 		$sql .= "and d.device_user_uuid = :user_uuid ";
 		$parameters['user_uuid'] = $_SESSION['user_uuid'];
 	}
@@ -254,7 +265,6 @@
 	}
 	$sql .= limit_offset($rows_per_page, $offset);
 	$parameters['time_zone'] = $time_zone;
-	$database = new database;
 	$devices = $database->select($sql, $parameters, 'all');
 	unset($sql, $parameters);
 
@@ -281,33 +291,33 @@
 	echo "<div class='action_bar' id='action_bar'>\n";
 	echo "	<div class='heading'><b>".$text['header-devices']." (".$num_rows.")</b></div>\n";
 	echo "	<div class='actions'>\n";
-	if (permission_exists('device_import')) {
+	if ($has_device_import) {
 		echo button::create(['type'=>'button','label'=>$text['button-import'],'icon'=>$_SESSION['theme']['button_icon_import'],'link'=>'device_imports.php']);
 	}
-	if (permission_exists('device_export')) {
+	if ($has_device_export) {
 		echo button::create(['type'=>'button','label'=>$text['button-export'],'icon'=>$_SESSION['theme']['button_icon_export'],'link'=>'device_download.php']);
 	}
-	if (permission_exists('device_vendor_view')) {
+	if ($has_device_vendor_view) {
 		echo button::create(['type'=>'button','label'=>$text['button-vendors'],'icon'=>'fax','link'=>'device_vendors.php']);
 	}
-	if (permission_exists('device_profile_view')) {
+	if ($has_device_profile_view) {
 		echo button::create(['type'=>'button','label'=>$text['button-profiles'],'icon'=>'clone','link'=>'device_profiles.php']);
 	}
-	$margin_left = permission_exists('device_import') || permission_exists('device_export') || permission_exists('device_vendor_view') || permission_exists('device_profile_view') ? "margin-left: 15px;" : null;
-	if (permission_exists('device_add') && (empty($_SESSION['limit']['devices']['numeric']) || ($total_devices < $_SESSION['limit']['devices']['numeric']))) {
+	$margin_left = $has_device_import || $has_device_export || $has_device_vendor_view || $has_device_profile_view ? "margin-left: 15px;" : null;
+	if ($has_device_add && (empty($_SESSION['limit']['devices']['numeric']) || ($total_devices < $_SESSION['limit']['devices']['numeric']))) {
 		echo button::create(['type'=>'button','label'=>$text['button-add'],'icon'=>$_SESSION['theme']['button_icon_add'],'id'=>'btn_add','style'=>$margin_left,'link'=>'device_edit.php']);
 		unset($margin_left);
 	}
-	if (permission_exists('device_edit') && $devices) {
+	if ($has_device_edit && $devices) {
 		echo button::create(['type'=>'button','label'=>$text['button-toggle'],'icon'=>$_SESSION['theme']['button_icon_toggle'],'id'=>'btn_toggle','name'=>'btn_toggle','style'=>'display: none; '.($margin_left ?? null),'onclick'=>"modal_open('modal-toggle','btn_toggle');"]);
 		unset($margin_left);
 	}
-	if (permission_exists('device_delete') && $devices) {
+	if ($has_device_delete && $devices) {
 		echo button::create(['type'=>'button','label'=>$text['button-delete'],'icon'=>$_SESSION['theme']['button_icon_delete'],'id'=>'btn_delete','name'=>'btn_delete','style'=>'display: none; '.($margin_left ?? null),'onclick'=>"modal_open('modal-delete','btn_delete');"]);
 		unset($margin_left);
 	}
 	echo 		"<form id='form_search' class='inline' method='get'>\n";
-	if (permission_exists('device_all')) {
+	if ($has_device_all) {
 		if (!empty($_GET['show']) && $_GET['show'] == 'all') {
 			echo "		<input type='hidden' name='show' value='all'>";
 		}
@@ -336,10 +346,10 @@
 	echo "	<div style='clear: both;'></div>\n";
 	echo "</div>\n";
 
-	if (permission_exists('device_edit') && $devices) {
+	if ($has_device_edit && $devices) {
 		echo modal::create(['id'=>'modal-toggle','type'=>'toggle','actions'=>button::create(['type'=>'button','label'=>$text['button-continue'],'icon'=>'check','id'=>'btn_toggle','style'=>'float: right; margin-left: 15px;','collapse'=>'never','onclick'=>"modal_close(); list_action_set('toggle'); list_form_submit('form_list');"])]);
 	}
-	if (permission_exists('device_delete') && $devices) {
+	if ($has_device_delete && $devices) {
 		echo modal::create(['id'=>'modal-delete','type'=>'delete','actions'=>button::create(['type'=>'button','label'=>$text['button-continue'],'icon'=>'check','id'=>'btn_delete','style'=>'float: right; margin-left: 15px;','collapse'=>'never','onclick'=>"modal_close(); list_action_set('delete'); list_form_submit('form_list');"])]);
 	}
 
@@ -353,12 +363,12 @@
 
 	echo "<table class='list'>\n";
 	echo "<tr class='list-header'>\n";
-	if (permission_exists('device_edit') || permission_exists('device_delete')) {
+	if ($has_device_edit || $has_device_delete) {
 		echo "	<th class='checkbox'>\n";
 		echo "		<input type='checkbox' id='checkbox_all' name='checkbox_all' onclick='list_all_toggle(); checkbox_on_change(this);' ".(empty($devices) ? "style='visibility: hidden;'" : null).">\n";
 		echo "	</th>\n";
 	}
-	if (!empty($_GET['show']) && $_GET['show'] == "all" && permission_exists('device_all')) {
+	if (!empty($_GET['show']) && $_GET['show'] == "all" && $has_device_all) {
 		echo th_order_by('domain_name', $text['label-domain'], $order_by, $order, null, null, $param);
 	}
 	echo th_order_by('device_address', $text['label-device_address'], $order_by, $order, null, null, $param ?? null);
@@ -372,7 +382,7 @@
 	echo th_order_by('device_enabled', $text['label-device_enabled'], $order_by, $order, null, "class='center'", $param ?? null);
 	echo th_order_by('device_provisioned_date', $text['label-device_status'], $order_by, $order, null, null, $param ?? null);
 	echo th_order_by('device_description', $text['label-device_description'], $order_by, $order, null, "class='hide-sm-dn'", $param ?? null);
-	if (permission_exists('device_edit') && !empty($_SESSION['theme']['list_row_edit_button']['boolean']) && $_SESSION['theme']['list_row_edit_button']['boolean'] == 'true') {
+	if ($has_device_edit && !empty($_SESSION['theme']['list_row_edit_button']['boolean']) && $_SESSION['theme']['list_row_edit_button']['boolean'] == 'true') {
 		echo "	<td class='action-button'>&nbsp;</td>\n";
 	}
 	echo "</tr>\n";
@@ -388,7 +398,7 @@
 				}
 			}
 
-			if (permission_exists('device_edit')) {
+			if ($has_device_edit) {
 				$list_row_url = "device_edit.php?id=".urlencode($row['device_uuid']);
 			}
 
@@ -403,17 +413,17 @@
 			}
 
 			echo "<tr class='list-row' href='".$list_row_url."'>\n";
-			if (permission_exists('device_edit') || permission_exists('device_delete')) {
+			if ($has_device_edit || $has_device_delete) {
 				echo "	<td class='checkbox'>\n";
 				echo "		<input type='checkbox' name='devices[$x][checked]' id='checkbox_".$x."' value='true' onclick=\"checkbox_on_change(this); if (!this.checked) { document.getElementById('checkbox_all').checked = false; }\">\n";
 				echo "		<input type='hidden' name='devices[$x][uuid]' value='".escape($row['device_uuid'])."' />\n";
 				echo "	</td>\n";
 			}
-			if (!empty($_GET['show']) && $_GET['show'] == "all" && permission_exists('device_all')) {
+			if (!empty($_GET['show']) && $_GET['show'] == "all" && $has_device_all) {
 				echo "	<td>".escape($_SESSION['domains'][$row['domain_uuid']]['domain_name'])."</td>\n";
 			}
 			echo "	<td class='no-wrap'>";
-			echo permission_exists('device_edit') ? "<a href='".$list_row_url."'>".escape(format_device_address($row['device_address']))."</a>" : escape(format_device_address($row['device_address']));
+			echo $has_device_edit ? "<a href='".$list_row_url."'>".escape(format_device_address($row['device_address']))."</a>" : escape(format_device_address($row['device_address']));
 			echo "	</td>\n";
 			echo "	<td>".escape($row['device_label'])."&nbsp;</td>\n";
 			if ($device_alternate) {
@@ -429,7 +439,7 @@
 			echo "	<td>".escape($row['device_vendor'])."&nbsp;</td>\n";
 			echo "	<td>".escape($row['device_template'])."&nbsp;</td>\n";
 			echo "	<td>".escape($device_profile_name)."&nbsp;</td>\n";
-			if (permission_exists('device_edit')) {
+			if ($has_device_edit) {
 				echo "	<td class='no-link center'>";
 				echo button::create(['type'=>'submit','class'=>'link','label'=>$text['label-'.$row['device_enabled']],'title'=>$text['button-toggle'],'onclick'=>"list_self_check('checkbox_".$x."'); list_action_set('toggle'); list_form_submit('form_list')"]);
 			}
@@ -440,7 +450,7 @@
 			echo "	</td>\n";
 			echo "	<td class='no-link'><a title='".escape($row['device_provisioned_agent'])."' href='javascript:void(0)'>".escape($row['provisioned_date_formatted'])." ".escape($row['provisioned_time_formatted'])."</a> &nbsp; ".escape($device_provisioned_method)." &nbsp; <a href='".escape($device_provisioned_method)."://".escape($row['device_provisioned_ip'])."' target='_blank'>".escape($row['device_provisioned_ip'])."</a>&nbsp;</td>\n";
 			echo "	<td class='description overflow hide-sm-dn'>".escape($row['device_description'])."&nbsp;</td>\n";
-			if (permission_exists('device_edit') && !empty($_SESSION['theme']['list_row_edit_button']['boolean']) && $_SESSION['theme']['list_row_edit_button']['boolean'] == 'true') {
+			if ($has_device_edit && !empty($_SESSION['theme']['list_row_edit_button']['boolean']) && $_SESSION['theme']['list_row_edit_button']['boolean'] == 'true') {
 				echo "	<td class='action-button'>";
 				echo button::create(['type'=>'button','title'=>$text['button-edit'],'icon'=>$_SESSION['theme']['button_icon_edit'],'link'=>$list_row_url]);
 				echo "	</td>\n";


### PR DESCRIPTION
Exporting devices with multiple lines did not show headers for extra columns if the first device listed only had a single line and the other devices had multiple lines. This adds a logical feature to export multiple lines for devices using the "duplicate column feature" so that the import feature can detect and import all lines for the device.