### PR TITLE
Yealink Wifi Settings variables

### DIFF
--- a/resources/templates/provision/yealink/t27g/y000000000069.cfg
+++ b/resources/templates/provision/yealink/t27g/y000000000069.cfg
@@ -29,6 +29,34 @@ network.pppoe.password =
 
 
 #######################################################################################
+##                                    Network WiFi                                   ##
+#######################################################################################
+##static.wifi.X.label=
+##static.wifi.X.ssid=
+##static.wifi.X.priority=
+##static.wifi.X.security_mode=
+##static.wifi.X.cipher_type=
+##static.wifi.X.password=
+##static.wifi.X.eap_type=
+##static.wifi.X.eap_user_name=
+##static.wifi.x.eap_password=
+##(X ranges from 1 to 5)
+##Only T54S/T52S/T48G/T48S/T46G/T46S/T42S/T41S/T29G/T27G Models support these parameters.
+
+static.wifi.enable = {$yealink_wifi_enable}
+static.wifi.1.label = {$yealink_wifi_1_label}
+static.wifi.1.ssid = {$yealink_wifi_1_ssid}
+static.wifi.1.priority = {$yealink_wifi_1_priority}
+static.wifi.1.security_mode = {$yealink_wifi_1_security}
+static.wifi.1.cipher_type = {$yealink_wifi_1_cipher}
+static.wifi.1.password = {$yealink_wifi_1_password}
+static.wifi.1.eap_type = {$yealink_wifi_1_type}
+static.wifi.1.eap_user_name = {$yealink_wifi_1_username}
+static.wifi.1.eap_password = {$yealink_wifi_1_password}
+static.wifi.show_scan_prompt = {$yealink_wifi_scan_prompt}
+
+
+#######################################################################################
 ##                                    Network Advanced                               ##
 #######################################################################################
 ##0-ipv4, 1-ipv6, 2-ipv4&ipv6

--- a/resources/templates/provision/yealink/t29g/y000000000046.cfg
+++ b/resources/templates/provision/yealink/t29g/y000000000046.cfg
@@ -29,6 +29,34 @@ network.pppoe.password =
 
 
 #######################################################################################
+##                                    Network WiFi                                   ##
+#######################################################################################
+##static.wifi.X.label=
+##static.wifi.X.ssid=
+##static.wifi.X.priority=
+##static.wifi.X.security_mode=
+##static.wifi.X.cipher_type=
+##static.wifi.X.password=
+##static.wifi.X.eap_type=
+##static.wifi.X.eap_user_name=
+##static.wifi.x.eap_password=
+##(X ranges from 1 to 5)
+##Only T54S/T52S/T48G/T48S/T46G/T46S/T42S/T41S/T29G/T27G Models support these parameters.
+
+static.wifi.enable = {$yealink_wifi_enable}
+static.wifi.1.label = {$yealink_wifi_1_label}
+static.wifi.1.ssid = {$yealink_wifi_1_ssid}
+static.wifi.1.priority = {$yealink_wifi_1_priority}
+static.wifi.1.security_mode = {$yealink_wifi_1_security}
+static.wifi.1.cipher_type = {$yealink_wifi_1_cipher}
+static.wifi.1.password = {$yealink_wifi_1_password}
+static.wifi.1.eap_type = {$yealink_wifi_1_type}
+static.wifi.1.eap_user_name = {$yealink_wifi_1_username}
+static.wifi.1.eap_password = {$yealink_wifi_1_password}
+static.wifi.show_scan_prompt = {$yealink_wifi_scan_prompt}
+
+
+#######################################################################################
 ##                                    Network Advanced                               ##
 #######################################################################################
 ##0-ipv4, 1-ipv6, 2-ipv4&ipv6

--- a/resources/templates/provision/yealink/t41s/y000000000068.cfg
+++ b/resources/templates/provision/yealink/t41s/y000000000068.cfg
@@ -37,17 +37,17 @@ static.network.ipv6_prefix =
 ##(X ranges from 1 to 5)
 ##Only T54S/T52S/T48G/T48S/T46G/T46S/T42S/T41S/T29G/T27G Models support these parameters.
 
-static.wifi.enable =
-static.wifi.1.label =
-static.wifi.1.ssid =
-static.wifi.1.priority =
-static.wifi.1.security_mode =
-static.wifi.1.cipher_type =
-static.wifi.1.password =
-static.wifi.1.eap_type =
-static.wifi.1.eap_user_name =
-static.wifi.1.eap_password =
-static.wifi.show_scan_prompt =
+static.wifi.enable = {$yealink_wifi_enable}
+static.wifi.1.label = {$yealink_wifi_1_label}
+static.wifi.1.ssid = {$yealink_wifi_1_ssid}
+static.wifi.1.priority = {$yealink_wifi_1_priority}
+static.wifi.1.security_mode = {$yealink_wifi_1_security}
+static.wifi.1.cipher_type = {$yealink_wifi_1_cipher}
+static.wifi.1.password = {$yealink_wifi_1_password}
+static.wifi.1.eap_type = {$yealink_wifi_1_type}
+static.wifi.1.eap_user_name = {$yealink_wifi_1_username}
+static.wifi.1.eap_password = {$yealink_wifi_1_password}
+static.wifi.show_scan_prompt = {$yealink_wifi_scan_prompt}
 
 
 #######################################################################################

--- a/resources/templates/provision/yealink/t42s/y000000000067.cfg
+++ b/resources/templates/provision/yealink/t42s/y000000000067.cfg
@@ -37,17 +37,17 @@ static.network.ipv6_prefix =
 ##(X ranges from 1 to 5)
 ##Only T54S/T52S/T48G/T48S/T46G/T46S/T42S/T41S/T29G/T27G Models support these parameters.
 
-static.wifi.enable =
-static.wifi.1.label =
-static.wifi.1.ssid =
-static.wifi.1.priority =
-static.wifi.1.security_mode =
-static.wifi.1.cipher_type =
-static.wifi.1.password =
-static.wifi.1.eap_type =
-static.wifi.1.eap_user_name =
-static.wifi.1.eap_password =
-static.wifi.show_scan_prompt =
+static.wifi.enable = {$yealink_wifi_enable}
+static.wifi.1.label = {$yealink_wifi_1_label}
+static.wifi.1.ssid = {$yealink_wifi_1_ssid}
+static.wifi.1.priority = {$yealink_wifi_1_priority}
+static.wifi.1.security_mode = {$yealink_wifi_1_security}
+static.wifi.1.cipher_type = {$yealink_wifi_1_cipher}
+static.wifi.1.password = {$yealink_wifi_1_password}
+static.wifi.1.eap_type = {$yealink_wifi_1_type}
+static.wifi.1.eap_user_name = {$yealink_wifi_1_username}
+static.wifi.1.eap_password = {$yealink_wifi_1_password}
+static.wifi.show_scan_prompt = {$yealink_wifi_scan_prompt}
 
 
 #######################################################################################

--- a/resources/templates/provision/yealink/t46g/y000000000028.cfg
+++ b/resources/templates/provision/yealink/t46g/y000000000028.cfg
@@ -27,6 +27,32 @@ network.secondary_dns = {$dns_server_secondary}
 network.pppoe.user =
 network.pppoe.password =
 
+#######################################################################################
+##                                    Network WiFi                                   ##
+#######################################################################################
+##static.wifi.X.label=
+##static.wifi.X.ssid=
+##static.wifi.X.priority=
+##static.wifi.X.security_mode=
+##static.wifi.X.cipher_type=
+##static.wifi.X.password=
+##static.wifi.X.eap_type=
+##static.wifi.X.eap_user_name=
+##static.wifi.x.eap_password=
+##(X ranges from 1 to 5)
+##Only T54S/T52S/T48G/T48S/T46G/T46S/T42S/T41S/T29G/T27G Models support these parameters.
+
+static.wifi.enable = {$yealink_wifi_enable}
+static.wifi.1.label = {$yealink_wifi_1_label}
+static.wifi.1.ssid = {$yealink_wifi_1_ssid}
+static.wifi.1.priority = {$yealink_wifi_1_priority}
+static.wifi.1.security_mode = {$yealink_wifi_1_security}
+static.wifi.1.cipher_type = {$yealink_wifi_1_cipher}
+static.wifi.1.password = {$yealink_wifi_1_password}
+static.wifi.1.eap_type = {$yealink_wifi_1_type}
+static.wifi.1.eap_user_name = {$yealink_wifi_1_username}
+static.wifi.1.eap_password = {$yealink_wifi_1_password}
+static.wifi.show_scan_prompt = {$yealink_wifi_scan_prompt}
 
 #######################################################################################
 ##                                    Network                                        ##

--- a/resources/templates/provision/yealink/t46s/y000000000066.cfg
+++ b/resources/templates/provision/yealink/t46s/y000000000066.cfg
@@ -37,18 +37,17 @@ static.network.ipv6_prefix =
 ##(X ranges from 1 to 5)
 ##Only T54S/T52S/T48G/T48S/T46G/T46S/T42S/T41S/T29G/T27G Models support these parameters.
 
-static.wifi.enable =
-static.wifi.1.label =
-static.wifi.1.ssid =
-static.wifi.1.priority =
-static.wifi.1.security_mode =
-static.wifi.1.cipher_type =
-static.wifi.1.password =
-static.wifi.1.eap_type =
-static.wifi.1.eap_user_name =
-static.wifi.1.eap_password =
-static.wifi.show_scan_prompt =
-
+static.wifi.enable = {$yealink_wifi_enable}
+static.wifi.1.label = {$yealink_wifi_1_label}
+static.wifi.1.ssid = {$yealink_wifi_1_ssid}
+static.wifi.1.priority = {$yealink_wifi_1_priority}
+static.wifi.1.security_mode = {$yealink_wifi_1_security}
+static.wifi.1.cipher_type = {$yealink_wifi_1_cipher}
+static.wifi.1.password = {$yealink_wifi_1_password}
+static.wifi.1.eap_type = {$yealink_wifi_1_type}
+static.wifi.1.eap_user_name = {$yealink_wifi_1_username}
+static.wifi.1.eap_password = {$yealink_wifi_1_password}
+static.wifi.show_scan_prompt = {$yealink_wifi_scan_prompt}
 
 #######################################################################################
 ##                                 Network Internet                                  ##

--- a/resources/templates/provision/yealink/t48g/y000000000035.cfg
+++ b/resources/templates/provision/yealink/t48g/y000000000035.cfg
@@ -27,6 +27,32 @@ network.secondary_dns = {$dns_server_secondary}
 network.pppoe.user =
 network.pppoe.password =
 
+#######################################################################################
+##                                    Network WiFi                                   ##
+#######################################################################################
+##static.wifi.X.label=
+##static.wifi.X.ssid=
+##static.wifi.X.priority=
+##static.wifi.X.security_mode=
+##static.wifi.X.cipher_type=
+##static.wifi.X.password=
+##static.wifi.X.eap_type=
+##static.wifi.X.eap_user_name=
+##static.wifi.x.eap_password=
+##(X ranges from 1 to 5)
+##Only T54S/T52S/T48G/T48S/T46G/T46S/T42S/T41S/T29G/T27G Models support these parameters.
+
+static.wifi.enable = {$yealink_wifi_enable}
+static.wifi.1.label = {$yealink_wifi_1_label}
+static.wifi.1.ssid = {$yealink_wifi_1_ssid}
+static.wifi.1.priority = {$yealink_wifi_1_priority}
+static.wifi.1.security_mode = {$yealink_wifi_1_security}
+static.wifi.1.cipher_type = {$yealink_wifi_1_cipher}
+static.wifi.1.password = {$yealink_wifi_1_password}
+static.wifi.1.eap_type = {$yealink_wifi_1_type}
+static.wifi.1.eap_user_name = {$yealink_wifi_1_username}
+static.wifi.1.eap_password = {$yealink_wifi_1_password}
+static.wifi.show_scan_prompt = {$yealink_wifi_scan_prompt}
 
 #######################################################################################
 ##                                    Network                                        ##

--- a/resources/templates/provision/yealink/t48s/y000000000065.cfg
+++ b/resources/templates/provision/yealink/t48s/y000000000065.cfg
@@ -40,17 +40,17 @@ static.network.ipv6_prefix =
 ##(X ranges from 1 to 5)
 ##Only T54S/T52S/T48G/T48S/T46G/T46S/T42S/T41S/T29G/T27G Models support these parameters.
 
-static.wifi.enable =
-static.wifi.1.label =
-static.wifi.1.ssid =
-static.wifi.1.priority =
-static.wifi.1.security_mode =
-static.wifi.1.cipher_type =
-static.wifi.1.password =
-static.wifi.1.eap_type =
-static.wifi.1.eap_user_name =
-static.wifi.1.eap_password =
-static.wifi.show_scan_prompt =
+static.wifi.enable = {$yealink_wifi_enable}
+static.wifi.1.label = {$yealink_wifi_1_label}
+static.wifi.1.ssid = {$yealink_wifi_1_ssid}
+static.wifi.1.priority = {$yealink_wifi_1_priority}
+static.wifi.1.security_mode = {$yealink_wifi_1_security}
+static.wifi.1.cipher_type = {$yealink_wifi_1_cipher}
+static.wifi.1.password = {$yealink_wifi_1_password}
+static.wifi.1.eap_type = {$yealink_wifi_1_type}
+static.wifi.1.eap_user_name = {$yealink_wifi_1_username}
+static.wifi.1.eap_password = {$yealink_wifi_1_password}
+static.wifi.show_scan_prompt = {$yealink_wifi_scan_prompt}
 
 
 #######################################################################################


### PR DESCRIPTION
These variables are used to set the Wifi credentials and settings on the below-listed Yealink models.

Only T54S/T52S/T48G/T48S/T46G/T46S/T42S/T41S/T29G/T27G Models support these parameters.

The variables were already configured for a couple of models, I just added them for all supported models.