### PR TITLE
remove all $_SESSION references and use single database object

### DIFF
--- a/secure/fax_to_email.php
+++ b/secure/fax_to_email.php
@@ -26,7 +26,7 @@
 */
 
 //file or console
-	$output_type = "file"; 
+	$output_type = "file";
 
 //only allow command line
 	if (!defined('STDIN')) {
@@ -92,11 +92,11 @@ if (!function_exists('tiff2pdf')) {
 		//convert the tif to a pdf
 		//Ubuntu: apt-get install libtiff-tools
 
-		global $IS_WINDOWS;
+		global $settings, $IS_WINDOWS;
 
-		if (!file_exists($tiff_file_name)) {
-			echo "tiff file does not exists";
-			return false; // "tiff file does not exists";
+		if (!file_exists($tiff_file_name) || !is_file($tiff_file_name)) {
+			echo "tiff file does not exist\n";
+			return false; // "tiff file does not exist";
 		}
 
 		$GS = $IS_WINDOWS ? 'gswin32c' : 'gs';
@@ -109,22 +109,22 @@ if (!function_exists('tiff2pdf')) {
 			return $pdf_file_name;
 		}
 
-		$dir_fax_temp = $_SESSION['server']['temp']['dir'];
+		$dir_fax_temp = $settings->get('server', 'temp', sys_get_temp_dir());
 		if (!$dir_fax_temp) {
 			$dir_fax_temp = path_join(dirname($dir_fax), 'temp');
 		}
 
 		if (!file_exists($dir_fax_temp)) {
-			echo "can not create temporary directory";
-			return false; //
+			echo "cannot create temporary directory\n";
+			return false; //cannot create temporary directory
 		}
 
 		$cmd  = "tiffinfo " . correct_path($tiff_file_name) . ' | grep "Resolution:"';
 		$ok   = false;
 		$resp = exec_in_dir($dir_fax, $cmd, $ok);
 		if (!$ok) {
-			echo "can not find fax resoulution";
-			return false; // "can not find fax resoulution"
+			echo "cannot find fax resoulution\n";
+			return false; // "cannot find fax resoulution"
 		}
 
 		$ppi_w = 0;
@@ -172,7 +172,7 @@ if (!function_exists('tiff2pdf')) {
 		$page_width  = sprintf('%.4f', $page_width);
 		$page_height = sprintf('%.4f', $page_height);
 
-		$cmd = implode(' ', array('tiff2pdf', 
+		$cmd = implode(' ', array('tiff2pdf',
 			'-o', correct_path($pdf_file_name),
 			correct_path($tiff_file_name),
 		));
@@ -209,73 +209,95 @@ if (!function_exists('fax_split_dtmf')) {
 	ini_set('max_execution_time', 900); //15 minutes
 	ini_set('memory_limit', '96M');
 
-//start the to cache the output
+//add a delimeter to the log
+	echo "\n---------------------------------\n";
+
+//get the parameters and save them as variables in the request superglobal
+	if (empty($_REQUEST)) {
+		foreach ($_SERVER['argv'] as $arg) {
+			if (strpos($arg, '=') !== false) {
+				[$key, $value] = explode('=', $arg, 2);
+				$_REQUEST[$key] = $value;
+			}
+		}
+	}
+
+	//use a foreach loop so order doesn't matter
+	foreach ($_REQUEST as $key => $value) {
+		if (strpos($value, '=') !== false) {
+			$arg = explode('=', $value);
+			if (count($arg) > 1) {
+				$key = $arg[0];
+				$value = $arg[1];
+			}
+		}
+		switch($key) {
+			case 'email':
+				$fax_email = $value;
+				break;
+			case 'extension':
+				$fax_extension = $value;
+				break;
+			case 'name':
+				$fax_file = $value;
+				break;
+			case 'messages':
+				$fax_messages = $value;
+				break;
+			case 'domain':
+				//domain_name is global for all functions
+				$domain_name = $value;
+				break;
+			case 'retry':
+				$fax_relay = $value;
+				break;
+			case 'mailfrom_address':
+				$mail_from_address = $value;
+				break;
+			case 'debug':
+				$output_type = 'console';
+				break;
+			case 'config':
+				$config_file = $value;
+				break;
+			case 'caller_id_name':
+			case 'caller_id_number':
+			case 'fax_relay':
+			case 'fax_prefix':
+			case 'domain_name':
+			case 'mail_from_address':
+			case 'output_type':
+			case 'fax_extension':
+			case 'debug_level':
+			case 'config_file':
+				//tansform the name of the key into the name of the variable using $$
+				$$key = $value;
+				break;
+		}
+	}
+
+//mark global variables for all functions
+	global $output_type, $config, $database, $domain_name, $domains, $settings, $domain_uuid, $debug_level;
+
+//run shutdown function on exit
+	register_shutdown_function('shutdown');
+
+//start to cache the output
 	if ($output_type == "file") {
 		ob_end_clean();
 		ob_start();
 	}
 
-//add a delimeter to the log
-	echo "\n---------------------------------\n";
+//find and load the config file
+	$config = config::load($config_file ?? '');		//use the config_file option from command line if available
 
-//get the parameters and save them as variables
-	$php_version = substr(phpversion(), 0, 1);
-	if ($php_version == '4') {
-		$domain_name = $_REQUEST["domain"];
-		$fax_email = $_REQUEST["email"];
-		$fax_extension = $_REQUEST["extension"];
-		$fax_file = $_REQUEST["name"];
-		$fax_messages = $_REQUEST["messages"];
-		$caller_id_name = $_REQUEST["caller_id_name"];
-		$caller_id_number = $_REQUEST["caller_id_number"];
-		$fax_relay = $_REQUEST["retry"];
-		$mail_from_address = $_REQUEST["mailfrom_address"];
+//stop if no config
+	if ($config->is_empty()) {
+		exit("Unable to find config file\n");
 	}
-	else {
-		$tmp_array = explode("=", $_SERVER["argv"][1]);
-		$fax_email = $tmp_array[1];
-		unset($tmp_array);
 
-		$tmp_array = explode("=", $_SERVER["argv"][2]);
-		$fax_extension = $tmp_array[1];
-		unset($tmp_array);
-
-		$tmp_array = explode("=", $_SERVER["argv"][3]);
-		$fax_file = $tmp_array[1];
-		unset($tmp_array);
-
-		$tmp_array = explode("=", $_SERVER["argv"][4]);
-		$fax_messages = $tmp_array[1];
-		unset($tmp_array);
-
-		$tmp_array = explode("=", $_SERVER["argv"][5]);
-		$domain_name = $tmp_array[1];
-		unset($tmp_array);
-
-		$tmp_array = explode("=", $_SERVER["argv"][6]);
-		$caller_id_name = $tmp_array[1];
-		unset($tmp_array);
-
-		$tmp_array = explode("=", $_SERVER["argv"][7]);
-		$caller_id_number = $tmp_array[1];
-		unset($tmp_array);
-
-		$tmp_array = explode("=", $_SERVER["argv"][8]);
-		$fax_relay = $tmp_array[1];
-		unset($tmp_array);
-
-		$tmp_array = explode("=", $_SERVER["argv"][9]);
-		$fax_prefix = $tmp_array[1];
-		unset($tmp_array);
-
-		$tmp_array = explode("=", $_SERVER["argv"][10]);
-		$mail_from_address = $tmp_array[1];
-		unset($tmp_array);
-
-		//$tmp_array = explode("=", $_SERVER["argv"][10]);
-		//$destination_number = $tmp_array[1];
-		//unset($tmp_array);
-	}
+//create a single database object
+	$database = database::new(['config' => $config]);
 
 //get the fax file name (only) if a full path
 	$fax_path = pathinfo($fax_file);
@@ -283,34 +305,37 @@ if (!function_exists('fax_split_dtmf')) {
 	$fax_file_name = $fax_path['filename'];
 	$dir_fax = $fax_path['dirname'];
 
-//get the domain_uuid from the database
-	$sql = "select * from v_domains ";
-	$sql .= "where domain_name = :domain_name ";
-	$parameters['domain_name'] = $domain_name;
-	$database = new database;
-	$result = $database->select($sql, $parameters, 'all');
+//get the enabled domains from the database
+	//$domains = domains::fetch($database);
+	$domains = [];
+	$result = $database->select("select domain_uuid, domain_name from v_domains where domain_enabled = 'true'");
 	if (is_array($result) && @sizeof($result) != 0) {
-		foreach ($result as &$row) {
+		foreach ($result as $row) {
 			//set the domain variables
-				$domain_uuid = $row["domain_uuid"];
-				$_SESSION["domain_uuid"] = $row["domain_uuid"];
-				$_SESSION["domain_name"] = $domain_name;
-			//set the setting arrays
-				$domain = new domains();
-				$domain->set();
+			$domains[$row["domain_uuid"]] = $row["domain_name"];
 		}
 	}
-	unset($sql, $parameters, $result);
+	unset($result, $row);
+
+//set the global variable domain_uuid using domain_name passed on command line
+	$domain_uuid = array_search($domain_name, $domains);
+
+//ensure we have a domain_uuid
+	if (empty($domain_uuid)) {
+		exit("Domain '$domain_name' not found\n");
+}
+
+//ensure we have a fax extension
+	if (empty($fax_extension)) {
+		exit("No fax extension set\n");
+	}
+
+//now that we have the domain_name and uuid, create a settings object for the domain
+	$settings = new settings(['database' => $database, 'domain_uuid' => $domain_uuid]);
 
 //prepare smtp server settings
-	$email_from_address = $_SESSION['email']['smtp_from']['text'];
-	$email_from_name = $_SESSION['email']['smtp_from_name']['text'];
-	if (isset($_SESSION['fax']['smtp_from']['text']) && !empty($_SESSION['fax']['smtp_from']['text'])) {
-		$email_from_address = $_SESSION['fax']['smtp_from']['text'];
-	}
-	if (isset($_SESSION['fax']['smtp_from_name']['text']) && !empty($_SESSION['fax']['smtp_from_name']['text'])) {
-		$email_from_name = $_SESSION['fax']['smtp_from_name']['text'];
-	}
+	$email_from_address = $settings->get('fax','smtp_from', $settings->get('email', 'smtp_from', ''));
+	$email_from_name = $settings->get('fax', 'smtp_from_name', $settings->get('email', 'smtp_from_name', $email_from_address));
 
 //get the fax settings from the database
 	$sql = "select * from v_fax ";
@@ -318,7 +343,6 @@ if (!function_exists('fax_split_dtmf')) {
 	$sql .= "and fax_extension = :fax_extension ";
 	$parameters['domain_uuid'] = $domain_uuid;
 	$parameters['fax_extension'] = $fax_extension;
-	$database = new database;
 	$row = $database->select($sql, $parameters, 'row');
 	if (is_array($row) && @sizeof($row) != 0) {
 		$fax_email = $row["fax_email"];
@@ -337,9 +361,10 @@ if (!function_exists('fax_split_dtmf')) {
 
 //set the fax directory
 	if (!file_exists($dir_fax) || !file_exists(path_join($dir_fax, $fax_file_only))) {
-		$dir_fax = $_SESSION['switch']['storage']['dir'].'/fax/'.$domain_name.'/'.$fax_extension.'/inbox';
+		$switch_dir = $settings->get('switch', 'storage', '/var/lib/freeswitch/storage');
+		$dir_fax = "$switch_dir/fax/$domain_name/$fax_extension/inbox";
 		if (!file_exists($dir_fax) || !file_exists(path_join($dir_fax, $fax_file_only))) {
-			$dir_fax = $_SESSION['switch']['storage']['dir'].'/fax/'.$fax_extension.'/inbox';
+			$dir_fax = "$switch_dir/fax/$fax_extension/inbox";
 		}
 	}
 	$fax_file = path_join($dir_fax, $fax_file_only);
@@ -356,16 +381,17 @@ if (!function_exists('fax_split_dtmf')) {
 	$pdf_file = tiff2pdf($fax_file);
 	echo "file: $pdf_file \n";
 	if (!$pdf_file) {
-		$fax_file_warning = 'warning: Fax image not available on server.';
+		$fax_file_warning = "warning: Fax image not available on server.";
 	}
 	else{
 		$fax_file_warning = '';
 	}
 
+	echo "fax file warning(s): $fax_file_warning\n";
 	echo "pdf file: $pdf_file\n";
 
 //forward the fax
-	if (file_exists($fax_file)) {
+	if (file_exists($fax_file) && is_file($fax_file)) {
 		if (strpos($fax_file_name,'#') !== false) {
 			$tmp = explode("#",$fax_file_name);
 			$fax_forward_number = $fax_prefix.$tmp[0];
@@ -397,14 +423,13 @@ if (!function_exists('fax_split_dtmf')) {
 				$p->add('fax_queue_add', 'temp');
 
 				//save the data
-				$database = new database;
-				$database->app_name = 'fax queue';
+				$database->app_name = 'fax_queue';
 				$database->app_uuid = '3656287f-4b22-4cf1-91f6-00386bf488f4';
 				$database->save($array);
 
 				//remove temporary permisison
 				$p->delete('fax_queue_add', 'temp');
-				
+
 				//add message to show in the browser
 				message::add($text['confirm-queued']);
 
@@ -415,10 +440,10 @@ if (!function_exists('fax_split_dtmf')) {
 	if (!empty($fax_email) && file_exists($fax_file)) {
 
 		//get the language code
-			$language_code = $_SESSION['domain']['language']['code'];
+			$language_code = $settings->get('domain', 'language', 'en-us');
 
 		//get the template subcategory
-			if ($fax_relay == 'true') {
+			if (!empty($fax_relay) && $fax_relay == 'true') {
 				$template_subcategory = 'relay';
 			}
 			else {
@@ -426,7 +451,7 @@ if (!function_exists('fax_split_dtmf')) {
 			}
 
 		//get the email template from the database
-			if (isset($fax_email) && !empty($fax_email)) {
+			if (!empty($fax_email) && !empty($domain_uuid)) {
 				$sql = "select template_subject, template_body from v_email_templates ";
 				$sql .= "where (domain_uuid = :domain_uuid or domain_uuid is null) ";
 				$sql .= "and template_language = :template_language ";
@@ -439,7 +464,6 @@ if (!function_exists('fax_split_dtmf')) {
 				$parameters['template_category'] = 'fax';
 				$parameters['template_subcategory'] = $template_subcategory;
 				$parameters['template_type'] = 'html';
-				$database = new database;
 				$row = $database->select($sql, $parameters, 'row');
 				if (is_array($row)) {
 					$email_subject = $row['template_subject'];
@@ -515,17 +539,36 @@ if (!function_exists('fax_split_dtmf')) {
 			}
 	}
 
-//open the file for writing
+//when the exit is called, capture the statements
+function shutdown() {
+	//bring variables in to function scope
+	global $output_type, $settings, $debug_level;
+
+	//open the file for writing
 	if ($output_type == "file") {
+		//ensure we can access the settings object
+		if (class_exists('settings') && $settings instanceof settings) {
+			//temporary directory in default settings or use the system temp directory
+			$temp_dir = $settings->get('server', 'temp', sys_get_temp_dir());
+		} else {
+			//settings is not available
+			$temp_dir = sys_get_temp_dir();
+		}
 		//open the file
-			$fp = fopen($_SESSION['server']['temp']['dir']."/fax_to_email.log", "w");
+		$fp = fopen("$temp_dir/fax_to_email.log", "w");
 		//get the output from the buffer
-			$content = ob_get_contents();
+		$content = ob_get_contents();
 		//clean the buffer
-			ob_end_clean();
+		ob_end_clean();
 		//write the contents of the buffer
-			fwrite($fp, $content);
-			fclose($fp);
+		fwrite($fp, $content);
+		//close the file pointer
+		fclose($fp);
+	} else {
+		if ($debug_level > 2) {
+			var_dump($_REQUEST);
+		}
 	}
+}
 
 ?>


### PR DESCRIPTION
Updates:
- use config object to find and load config file
- use single database object with config passed in constructor
- use settings object with database passed in constructor
- parse command line options with for loop so order no longer matters
- store all passed options in the super global $_REQUEST array for easy reference and debugging
- add debug and debug_level options for command line
- allow dumping the command line arguments when debug_level is 3 or higher
- add config option in command line to set location of config file
- add a shutdown function to allow for the exit command to be used but still output to either console or file
- add extra checks for options that are needed during runtime
- remove old PHP version 4 code
- add is_file check when checking for a valid .tiff file because file_exists returns true if it's a directory or file