### PR TITLE
fix authentication logging of cidr fail

### DIFF
--- a/core/authentication/resources/classes/authentication.php
+++ b/core/authentication/resources/classes/authentication.php
@@ -211,7 +211,7 @@ class authentication {
 						if (!$found) {
 
 							//log the failed attempt
-							$login_result = $_SESSION['authentication']['plugin'];
+							$plugin_classname = substr($class_name, 7);
 							user_logs::add($_SESSION['authentication']['plugin'][$plugin_classname]);
 
 							//destroy session


### PR DESCRIPTION
Correct variable name to use when logging a cidr failed login attempt