### PR TITLE
Use isset in permission exists for improved efficiency

### DIFF
--- a/resources/classes/permissions.php
+++ b/resources/classes/permissions.php
@@ -127,21 +127,12 @@ if (!class_exists('permissions')) {
 				return true;
 			}
 
-			//set default to false
-			$result = false;
-
 			//search for the permission
-			if (!empty($this->permissions) && !empty($permission_name)) {
-				foreach($this->permissions as $key => $value) {
-					if ($key == $permission_name) {
-						$result = true;
-						break;
-					}
-				}
+			if (!empty($permission_name)) {
+				return isset($this->permissions[$permission_name]);
 			}
 
-			//return the result
-			return $result;
+			return false;
 		}
 
 		/**


### PR DESCRIPTION
The foreach loop must iterate over each item in the list to find the match. Using isset on the key name of the array allows it to use a hash table lookup to improve the lookup times for a permission. Currently, the permission name is not set if it does not exist for the current user.