### PR TITLE
fix fax caller id number empty

### DIFF
--- a/app/fax/fax_advanced.php
+++ b/app/fax/fax_advanced.php
@@ -290,12 +290,12 @@
 							$array['fax'][0]['fax_email_outbound_subject_tag'] = $fax_email_outbound_subject_tag;
 							$array['fax'][0]['fax_email_outbound_authorized_senders'] = $fax_email_outbound_authorized_senders;
 						}
-						if (permission_exists('fax_caller_id_name')) {
-							$array['fax'][0]['fax_caller_id_name'] = $fax_caller_id_name;
-						}
-						if (permission_exists('fax_caller_id_number')) {
-							$array['fax'][0]['fax_caller_id_number'] = $fax_caller_id_number;
-						}
+//						if (permission_exists('fax_caller_id_name')) {
+//							$array['fax'][0]['fax_caller_id_name'] = $fax_caller_id_name;
+//						}
+//						if (permission_exists('fax_caller_id_number')) {
+//							$array['fax'][0]['fax_caller_id_number'] = $fax_caller_id_number;
+//						}
 						if (permission_exists('fax_toll_allow')) {
 							$array['fax'][0]['fax_toll_allow'] = $fax_toll_allow;
 						}


### PR DESCRIPTION
Resolves if you add or remove an email address from the authorized senders in Advanced. The caller ID and Number disappear from the Fax Server configuration screen.