### PR TITLE
add existing multicast options from default settings to yealink t46s

### DIFF
--- a/resources/templates/provision/yealink/t46s/y000000000066.cfg
+++ b/resources/templates/provision/yealink/t46s/y000000000066.cfg
@@ -5,8 +5,8 @@
 #######################################################################################
 ##                                    Network CDP                                    ##
 #######################################################################################
-static.network.cdp.enable =
-static.network.cdp.packet_interval =
+static.network.cdp.enable = {$yealink_cdp_enable}
+static.network.cdp.packet_interval = {$yealink_cdp_packet_interval}
 
 
 #######################################################################################
@@ -20,7 +20,6 @@ static.network.ipv6_internet_port.gateway =
 static.network.ipv6_internet_port.ip =
 static.network.ipv6_internet_port.type =
 static.network.ipv6_prefix =
-
 
 #######################################################################################
 ##                                    Network WiFi                                   ##
@@ -55,8 +54,8 @@ static.wifi.show_scan_prompt = {$yealink_wifi_scan_prompt}
 static.network.ip_address_mode = {$yealink_ip_address_mode}
 static.network.span_to_pc_port =
 static.network.vlan.pc_port_mode =
-static.network.static_dns_enable =
-static.network.pc_port.enable =
+{if isset($dns_server_primary)}static.network.static_dns_enable = 1{else}static.network.static_dns_enable = 0{/if}
+static.network.pc_port.enable = 1
 static.network.primary_dns = {$dns_server_primary}
 static.network.secondary_dns = {$dns_server_secondary}
 static.network.internet_port.gateway =
@@ -88,8 +87,8 @@ static.network.internet_port.speed_duplex =
 #######################################################################################
 ##                                   Network LLDP                                    ##
 #######################################################################################
-static.network.lldp.enable =
-static.network.lldp.packet_interval =
+static.network.lldp.enable = {$yealink_lldp_enable}
+static.network.lldp.packet_interval = {$yealink_lldp_packet_interval}
 
 
 #######################################################################################
@@ -135,11 +134,11 @@ static.auto_provision.custom.upload_method =
 #######################################################################################
 ##                                    ZERO Touch                                     ##
 #######################################################################################
-static.zero_touch.enable =
-static.zero_touch.wait_time =
-static.features.hide_zero_touch_url.enable =
-static.zero_touch.network_fail_delay_times =
-static.zero_touch.network_fail_wait_times =
+static.zero_touch.enable = {$yealink_zero_touch_enable}
+static.zero_touch.wait_time = {$yealink_zero_touch_wait_time}
+static.features.hide_zero_touch_url.enable = {$yealink_zero_touch_hide}
+static.zero_touch.network_fail_delay_times = {$yealink_zero_touch_delay}
+static.zero_touch.network_fail_wait_times = {$yealink_zero_touch_wait}
 
 
 #######################################################################################
@@ -153,18 +152,18 @@ static.auto_provision.server.password = {$http_auth_password}
 #######################################################################################
 ##                                   Autop Weekly                                    ##
 #######################################################################################
-static.auto_provision.weekly.enable =
-static.auto_provision.weekly.dayofweek =
-static.auto_provision.weekly.end_time =
-static.auto_provision.weekly.begin_time =
-static.auto_provision.weekly_upgrade_interval =
+static.auto_provision.weekly.enable = {$yealink_autop_weekly_enable}
+static.auto_provision.weekly.dayofweek = {$yealink_autop_weekly_dayofweek}
+static.auto_provision.weekly.end_time = {$yealink_autop_weekly_end_time}
+static.auto_provision.weekly.begin_time = {$yealink_autop_weekly_begin_time}
+static.auto_provision.weekly_upgrade_interval = {$yealink_autop_weekly_interval}
 
 
 #######################################################################################
 ##                                   Autop Repeat                                    ##
 #######################################################################################
-static.auto_provision.repeat.enable =
-static.auto_provision.repeat.minutes =
+static.auto_provision.repeat.enable = {$yealink_autop_repeat_enable}
+static.auto_provision.repeat.minutes = {$yealink_autop_repeat_minutes}
 
 
 #######################################################################################
@@ -177,7 +176,7 @@ static.auto_provision.dhcp_option.enable =
 #######################################################################################
 ##                                   Autop Mode                                      ##
 #######################################################################################
-static.auto_provision.power_on =
+static.auto_provision.power_on = {$yealink_autop_power_on}
 
 
 #######################################################################################
@@ -218,7 +217,7 @@ features.custom_version_info =
 #######################################################################################
 ##                                   Autop PNP                                       ##
 #######################################################################################
-static.auto_provision.pnp_enable =
+static.auto_provision.pnp_enable = {$yealink_autop_pnp}
 
 
 #######################################################################################
@@ -385,13 +384,13 @@ static.auto_provision.encryption.config =
 #######################################################################################
 ##                                   Transfer                                        ##
 #######################################################################################
-features.transfer_type=
-dialplan.transfer.mode =
-transfer.on_hook_trans_enable =
-transfer.tran_others_after_conf_enable =
-transfer.blind_tran_on_hook_enable =
+features.transfer_type= {$yealink_transfer_type}
+dialplan.transfer.mode = {$yealink_transfer_mode}
+transfer.on_hook_trans_enable = {$yealink_transfer_onhook}
+transfer.tran_others_after_conf_enable = {$yealink_transfer_after_conf}
+transfer.blind_tran_on_hook_enable = {$yealink_transfer_blind_on_hook}
 transfer.semi_attend_tran_enable = {$yealink_transfer_semi_attended}
-phone_setting.call_appearance.transfer_via_new_linekey=
+phone_setting.call_appearance.transfer_via_new_linekey= {$yealink_transfer_via_new_linekey}
 
 
 #######################################################################################
@@ -472,8 +471,8 @@ custom_softkey_call_failed.url=
 ##                                   Features Bluetooth                              ##
 #######################################################################################
 ##Only T54S/T52S/T48G/T48S/T46G/T46S/T42S/T41S/T29G/T27G Models support the parameter.
-features.bluetooth_enable=
-features.bluetooth_adapter_name=
+features.bluetooth_enable= {$yealink_bluetooth_enable}
+features.bluetooth_adapter_name= {$yealink_bluetooth_name}
 
 
 #######################################################################################
@@ -519,15 +518,15 @@ voice.tone.secondary_dial=
 #######################################################################################
 ##                                   Jitter Buffer                                   ##
 #######################################################################################
-voice.jib.normal=
-voice.jib.max =
-voice.jib.min =
-voice.jib.adaptive =
+voice.jib.normal= {$yealink_jib_normal}
+voice.jib.max = {$yealink_jib_max}
+voice.jib.min = {$yealink_jib_min}
+voice.jib.adaptive = {$yealink_jib_adaptive}
 
-voice.jib.wifi.normal=
-voice.jib.wifi.max=
-voice.jib.wifi.min=
-voice.jib.wifi.adaptive=
+voice.jib.wifi.normal= {$yealink_jib_wifi_normal}
+voice.jib.wifi.max= {$yealink_jib_wifi_max}
+voice.jib.wifi.min= {$yealink_jib_wifi_min}
+voice.jib.wifi.adaptive= {$yealink_jib_wifi_adaptive}
 
 
 #######################################################################################
@@ -584,7 +583,6 @@ sip.timer_t4=
 sip.listen_mode=
 
 {if isset($yealink_sip_listen_port)}sip.listen_port = {$yealink_sip_listen_port}{else}sip.listen_port = 5060{/if}
-
 sip.tls_listen_port=
 sip.tcp_port_random_mode=
 sip.escape_characters.enable=
@@ -649,37 +647,36 @@ features.rtp_symmetric.enable=
 #######################################################################################
 ##                                 RTCP-XR                                           ##
 #######################################################################################
-voice.rtcp.enable=
-voice.rtcp_cname=
-voice.rtcp_xr.enable=
-phone_setting.vq_rtcpxr_display_symm_oneway_delay.enable=
-phone_setting.vq_rtcpxr_display_round_trip_delay.enable=
-phone_setting.vq_rtcpxr_display_moscq.enable=
-phone_setting.vq_rtcpxr_display_moslq.enable = 
-phone_setting.vq_rtcpxr_display_packets_lost.enable=
-phone_setting.vq_rtcpxr_display_jitter_buffer_max.enable=
-phone_setting.vq_rtcpxr_display_jitter.enable=
-phone_setting.vq_rtcpxr_display_remote_codec.enable=
-phone_setting.vq_rtcpxr_display_local_codec.enable=
-phone_setting.vq_rtcpxr_display_remote_call_id.enable=
-phone_setting.vq_rtcpxr_display_local_call_id.enable=
-phone_setting.vq_rtcpxr_display_stop_time.enable=
-phone_setting.vq_rtcpxr_display_start_time.enable=
-phone_setting.vq_rtcpxr_interval_period=
-phone_setting.vq_rtcpxr_delay_threshold_critical=
-phone_setting.vq_rtcpxr_delay_threshold_warning=
-phone_setting.vq_rtcpxr_moslq_threshold_critical=
-phone_setting.vq_rtcpxr_moslq_threshold_warning=
-phone_setting.vq_rtcpxr.interval_report.enable=
-phone_setting.vq_rtcpxr.states_show_on_gui.enable=
-phone_setting.vq_rtcpxr.states_show_on_web.enable=
-phone_setting.vq_rtcpxr.session_report.enable=
+voice.rtcp.enable= {$yealink_rtcp_enable}
+voice.rtcp_cname= {$yealink_rtcp_cname}
+voice.rtcp_xr.enable= {$yealink_rtcpxr_enable}
+phone_setting.vq_rtcpxr_display_symm_oneway_delay.enable= {$yealink_rtcpxr_disp_enable}
+phone_setting.vq_rtcpxr_display_round_trip_delay.enable= {$yealink_rtcpxr_disp_enable}
+phone_setting.vq_rtcpxr_display_moscq.enable= {$yealink_rtcpxr_disp_enable}
+phone_setting.vq_rtcpxr_display_moslq.enable = {$yealink_rtcpxr_disp_enable}
+phone_setting.vq_rtcpxr_display_packets_lost.enable= {$yealink_rtcpxr_disp_enable}
+phone_setting.vq_rtcpxr_display_jitter_buffer_max.enable= {$yealink_rtcpxr_disp_enable}
+phone_setting.vq_rtcpxr_display_jitter.enable= {$yealink_rtcpxr_disp_enable}
+phone_setting.vq_rtcpxr_display_remote_codec.enable= {$yealink_rtcpxr_disp_enable}
+phone_setting.vq_rtcpxr_display_local_codec.enable= {$yealink_rtcpxr_disp_enable}
+phone_setting.vq_rtcpxr_display_remote_call_id.enable= {$yealink_rtcpxr_disp_enable}
+phone_setting.vq_rtcpxr_display_local_call_id.enable= {$yealink_rtcpxr_disp_enable}
+phone_setting.vq_rtcpxr_display_stop_time.enable= {$yealink_rtcpxr_disp_enable}
+phone_setting.vq_rtcpxr_display_start_time.enable= {$yealink_rtcpxr_disp_enable}
+phone_setting.vq_rtcpxr_interval_period= {$yealink_rtcpxr_interval}
+phone_setting.vq_rtcpxr_delay_threshold_critical= {$yealink_rtcpxr_delay_threshold_critical}
+phone_setting.vq_rtcpxr_delay_threshold_warning= {$yealink_rtcpxr_delay_threshold_warning}
+phone_setting.vq_rtcpxr_moslq_threshold_critical= {$yealink_rtcpxr_mos_threshold_critical}
+phone_setting.vq_rtcpxr_moslq_threshold_warning= {$yealink_rtcpxr_mos_threshold_warning}
+phone_setting.vq_rtcpxr.interval_report.enable= {$yealink_rtcpxr_interval_report_enable}
+phone_setting.vq_rtcpxr.states_show_on_gui.enable= {$yealink_rtcpxr_show_gui_enable}
+phone_setting.vq_rtcpxr.states_show_on_web.enable= {$yealink_rtcpxr_show_web_enable}
+phone_setting.vq_rtcpxr.session_report.enable= {$yealink_rtcpxr_report_enable}
 
 
 #######################################################################################
 ##                                   Contact                                         ##
 #######################################################################################
-
 static.directory_setting.url= https://{if isset($http_auth_username)}{$http_auth_username}:{$http_auth_password}@{/if}{$domain_name}/app/provision/?file=favorite_setting.xml
 
 super_search.url = {$yealink_super_search_url}
@@ -688,7 +685,7 @@ local_contact.data.url=
 local_contact.data.delete=
 
 ##Only T54S/T52S/T48G/T48S/T46G/T46S/T29G Models support the parameter
-phone_setting.contact_photo_display.enable = 0
+phone_setting.contact_photo_display.enable= {$yealink_contact_photo_enable}
 
 phone_setting.incoming_call.horizontal_roll_interval=
 
@@ -937,7 +934,7 @@ expansion_module.2.key.{$row.device_key_id}.xml_phonebook =
 ####################################################################################### 
 ##EDK Soft Keys(X ranges from 1 to 10)
 
-features.enhanced_dss_keys.enable=
+features.enhanced_dss_keys.enable = {$yealink_enhanced_dss_keys}
 edk.id_mode.enable=
 softkey.1.position=
 softkey.1.use.dialing=
@@ -1250,18 +1247,38 @@ multicast.codec=
 multicast.paging_address.1.channel=
 multicast.paging_address.1.label=
 multicast.paging_address.1.ip_address=
-multicast.receive_priority.enable=
-multicast.receive_priority.priority=
 
-multicast.receive.use_speaker=
-multicast.receive.enhance_volume=
-multicast.receive.ignore_dnd.priority=
+multicast.receive_priority.enable = {$yealink_multicast_receive_priority_enable}
+multicast.receive_priority.priority = {$yealink_multicast_receive_priority_priority}
 
-multicast.listen_address.1.channel=
-multicast.listen_address.1.label=
-multicast.listen_address.1.ip_address=
-multicast.listen_address.1.volume=
+multicast.receive.use_speaker = {$yealink_multicast_receive_use_speaker}
+multicast.receive.enhance_volume = {$yealink_multicast_receive_enhance_volume}
+multicast.receive.ignore_dnd.priority = {$yealink_multicast_receive_ignore_dnd_priority}
 
+multicast.listen_address.1.channel  = {$yealink_multicast_listen_address_1_channel}
+multicast.listen_address.1.label = {$yealink_multicast_listen_address_1_label}
+multicast.listen_address.1.ip_address = {$yealink_multicast_listen_address_1_ip_address}
+multicast.listen_address.1.volume = {$yealink_multicast_listen_address_1_volume}
+
+multicast.listen_address.2.channel  = {$yealink_multicast_listen_address_2_channel}
+multicast.listen_address.2.label = {$yealink_multicast_listen_address_2_label}
+multicast.listen_address.2.ip_address = {$yealink_multicast_listen_address_2_ip_address}
+multicast.listen_address.2.volume = {$yealink_multicast_listen_address_2_volume}
+
+multicast.listen_address.3.channel  = {$yealink_multicast_listen_address_3_channel}
+multicast.listen_address.3.label = {$yealink_multicast_listen_address_3_label}
+multicast.listen_address.3.ip_address = {$yealink_multicast_listen_address_3_ip_address}
+multicast.listen_address.3.volume = {$yealink_multicast_listen_address_3_volume}
+
+multicast.listen_address.4.channel  = {$yealink_multicast_listen_address_4_channel}
+multicast.listen_address.4.label = {$yealink_multicast_listen_address_4_label}
+multicast.listen_address.4.ip_address = {$yealink_multicast_listen_address_4_ip_address}
+multicast.listen_address.4.volume = {$yealink_multicast_listen_address_4_volume}
+
+multicast.listen_address.5.channel  = {$yealink_multicast_listen_address_5_channel}
+multicast.listen_address.5.label = {$yealink_multicast_listen_address_5_label}
+multicast.listen_address.5.ip_address = {$yealink_multicast_listen_address_5_ip_address}
+multicast.listen_address.5.volume = {$yealink_multicast_listen_address_5_volume}
 
 #######################################################################################
 ##                           Preference&Status                                       ##
@@ -1287,8 +1304,8 @@ ringtone.delete= {$yealink_ringtone_delete}
 phone_setting.ring_type= {$yealink_ring_type}
 phone_setting.inter_digit_time= {$yealink_inter_digit_time}
 
-##Only T54S Model supports the parameter
-phone_setting.idle_clock_display.enable =
+## T54S/T54W Model supports the parameter
+phone_setting.idle_clock_display.enable = {$yealink_idle_clock}
 
 
 #######################################################################################
@@ -1399,15 +1416,15 @@ static.lang.wui=
 #######################################################################################
 ##                                   Screensaver                                     ##
 #######################################################################################
-screensaver.type=
-screensaver.delete=
-screensaver.upload_url=
+screensaver.type= {$yealink_screensaver_type}
+screensaver.delete= {$yealink_screensaver_delete}
+screensaver.upload_url= {$yealink_screensaver_upload_url}
 features.blf_active_backlight.enable= {$yealink_blf_active_backlight}
-screensaver.display_clock.enable=
-screensaver.clock_move_interval=
-screensaver.picture_change_interval=
+screensaver.display_clock.enable= {$yealink_screensaver_clock}
+screensaver.clock_move_interval= {$yealink_screensaver_clock_interval}
+screensaver.picture_change_interval= {$yealink_screensaver_pic_interval}
 screensaver.wait_time= {$yealink_screensaver_wait}
-screensaver.xml_browser.url=
+screensaver.xml_browser.url= {$yealink_screensaver_xml_url}
 
 
 #######################################################################################
@@ -1471,10 +1488,10 @@ phone_setting.backgrounds =  Config:yealink_t46s_wallpaper.png
 {/if}
 
 ## phone_setting.backgrounds_with_dsskey_unfold(Only support T48G/S)
-phone_setting.backgrounds_with_dsskey_unfold=
+phone_setting.backgrounds_with_dsskey_unfold= {$yealink_wallpaper_dsskey_unfold}
 
 ##expansion_module.backgrounds(Only support T54S/T52S)
-expansion_module.backgrounds=
+expansion_module.backgrounds= {$yealink_wallpaper_expansion}
 
 
 #######################################################################################
@@ -1636,7 +1653,7 @@ features.call_decline.enable =
 #######################################################################################
 ##                         BLF Ring Type                                             ##
 #######################################################################################
-features.blf.ring_type =
+features.blf.ring_type = {$yealink_blf_ring_type}
 
 
 #######################################################################################

--- a/resources/templates/provision/yealink/t54w/y000000000096.cfg
+++ b/resources/templates/provision/yealink/t54w/y000000000096.cfg
@@ -612,8 +612,8 @@ voice.jib.wifi.adaptive= {$yealink_jib_wifi_adaptive}
 ##                                   Echo Cancellation                               ##       
 #######################################################################################
 voice.echo_cancellation = {$yealink_echo_cancellation}
-voice.cng = {$yealink_cng}
-voice.vad = {$yealink_vad}
+voice.cng = {$yealink_voice_cng}
+voice.vad = {$yealink_voice_vad}
 
 
 ##V84 Add
@@ -662,9 +662,9 @@ sip.timer_t1=
 sip.timer_t2=
 sip.timer_t4=
 
-sip.listen_mode= {if isset($yealink_sip_listen_port)}sip.listen_port = {$yealink_sip_listen_port}{else}sip.listen_port = 5060{/if}
+sip.listen_mode=
 
-sip.listen_port=
+{if isset($yealink_sip_listen_port)}sip.listen_port = {$yealink_sip_listen_port}{else}sip.listen_port = 5060{/if}
 sip.tls_listen_port=
 sip.tcp_port_random_mode=
 sip.escape_characters.enable=
@@ -1196,7 +1196,7 @@ features.voice_mail_alert.enable=
 features.voice_mail_popup.enable = {$yealink_voice_mail_popup_enable}
 features.voice_mail_tone_enable=
 features.hide_feature_access_codes.enable = {$yealink_hide_feature_access_codes_enable}
-voice_mail.number.1=
+voice_mail.number.1={$voicemail_number}
 
 
 #######################################################################################  
@@ -1233,7 +1233,7 @@ voice.handset_send=
 voice.handfree_send =
 voice.headset_send =
 features.intercom.headset_prior.enable=
-features.ringer_device.is_use_headset=
+features.ringer_device.is_use_headset={$yealink_headset_ringer}
 features.intercom.barge_in_dialing.enable=
 
 
@@ -1505,7 +1505,7 @@ dialplan_replace_rule.url=
 dialplan.replace.line_id.1=
 dialplan.replace.replace.1=
 dialplan.replace.prefix.1=
-phone_setting.dialnow_delay=
+phone_setting.dialnow_delay={$yealink_dialplan_dialnow_delay}
 dialplan_dialnow.url=
 dialplan.dialnow.line_id.1=
 


### PR DESCRIPTION
Comparing the t46s to the t54w, there were a lot of missing settings beyond the original multicast options that were missing. The two templates have been reconciled with differences and any missing options already available to the t46s that were defined in the t54w have been added.