### PR TITLE
contacts appear by default in templates

### DIFF
--- a/app/provision/app_config.php
+++ b/app/provision/app_config.php
@@ -277,7 +277,7 @@
 		$apps[$x]['default_settings'][$y]['default_setting_subcategory'] = "contact_users";
 		$apps[$x]['default_settings'][$y]['default_setting_name'] = "boolean";
 		$apps[$x]['default_settings'][$y]['default_setting_value'] = "true";
-		$apps[$x]['default_settings'][$y]['default_setting_enabled'] = "false";
+		$apps[$x]['default_settings'][$y]['default_setting_enabled'] = "true";
 		$apps[$x]['default_settings'][$y]['default_setting_description'] = "";
 		$y++;
 		$apps[$x]['default_settings'][$y]['default_setting_uuid'] = "c5196771-f408-40b3-81c7-b4ce525620c3";
@@ -285,7 +285,7 @@
 		$apps[$x]['default_settings'][$y]['default_setting_subcategory'] = "contact_groups";
 		$apps[$x]['default_settings'][$y]['default_setting_name'] = "boolean";
 		$apps[$x]['default_settings'][$y]['default_setting_value'] = "true";
-		$apps[$x]['default_settings'][$y]['default_setting_enabled'] = "false";
+		$apps[$x]['default_settings'][$y]['default_setting_enabled'] = "true";
 		$apps[$x]['default_settings'][$y]['default_setting_description'] = "";
 		$y++;
 		$apps[$x]['default_settings'][$y]['default_setting_uuid'] = "8854358d-c6a4-4eeb-b21b-37ced80a4fbb";
@@ -293,7 +293,7 @@
 		$apps[$x]['default_settings'][$y]['default_setting_subcategory'] = "contact_extensions";
 		$apps[$x]['default_settings'][$y]['default_setting_name'] = "boolean";
 		$apps[$x]['default_settings'][$y]['default_setting_value'] = "true";
-		$apps[$x]['default_settings'][$y]['default_setting_enabled'] = "false";
+		$apps[$x]['default_settings'][$y]['default_setting_enabled'] = "true";
 		$apps[$x]['default_settings'][$y]['default_setting_description'] = "allow extensions to be provisioned as contacts in provision templates";
 		$y++;
 		$apps[$x]['default_settings'][$y]['default_setting_uuid'] = "d157078e-b363-4f34-a6d4-8a86990a40b7";


### PR DESCRIPTION
This PR is to make contacts appear by default in all templates. Most users will find it confusing why contacts are not appearing when the web interface seems to be configured correctly.