### PR TITLE
Fix CDR Recording Playback - Update xml_cdr.php

### DIFF
--- a/app/xml_cdr/resources/classes/xml_cdr.php
+++ b/app/xml_cdr/resources/classes/xml_cdr.php
@@ -1952,7 +1952,7 @@ if (!class_exists('xml_cdr')) {
 				else {
 					$range  = explode('-', $range);
 					$c_start = $range[0];
-					$c_end   = (isset($range[1]) && is_numeric((int)$range[1])) ? $range[1] : $size;
+					$c_end   = (isset($range[1]) && is_numeric($range[1])) ? $range[1] : $size;
 				}
 				/* Check the range and make sure it's treated according to the specs.
 				* http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html


### PR DESCRIPTION
Fixed CDR recording playback - casting an empty string to an int is breaking the if statement. This cast isn't required anyways because is_numeric will already find whether a variable is a number or a numeric string 

See https://php.net/manual/en/function.is-numeric.php