### PR TITLE
fix waveform image background

### DIFF
--- a/themes/default/css.php
+++ b/themes/default/css.php
@@ -2064,7 +2064,7 @@ else { //default: white
 		overflow: hidden;
 		<?php if ($audio_player_waveform_enabled === 'true') { ?>
 			padding-bottom: 3px;
-			background-size: 100% 100%;
+			background-size: 100% 100% !important;
 			background-repeat: no-repeat;
 			cursor: pointer;
 		<?php } ?>


### PR DESCRIPTION
This fixes the waveform image when hovering over it. Previously, it would zoom when hovering over it.

Here is an image when hovering on the waveform **BEFORE**:
![image](https://github.com/user-attachments/assets/5b0f5976-2ef1-49d2-94e2-8fb15b560edb)


Here is an image when hovering on the waveform **AFTER**:
![image](https://github.com/user-attachments/assets/048fdc62-6d05-43a4-af60-cb57d4c99123)
