### PR TITLE
Fix Avaya BLF issue on reSUBSCRIBE

### DIFF
--- a/app/avaya/app_config.php
+++ b/app/avaya/app_config.php
@@ -192,5 +192,13 @@
 		$apps[$x]['default_settings'][$y]['default_setting_enabled'] = "false";
 		$apps[$x]['default_settings'][$y]['default_setting_description'] = "";
 		$y++;
+		$apps[$x]['default_settings'][$y]['default_setting_uuid'] = "4f4641c3-7398-421e-a0b3-5d7960813728";
+		$apps[$x]['default_settings'][$y]['default_setting_category'] = "provision";
+		$apps[$x]['default_settings'][$y]['default_setting_subcategory'] = "avaya_blf_subscription_expiry";
+		$apps[$x]['default_settings'][$y]['default_setting_name'] = "text";
+		$apps[$x]['default_settings'][$y]['default_setting_value'] = "60";
+		$apps[$x]['default_settings'][$y]['default_setting_enabled'] = "false";
+		$apps[$x]['default_settings'][$y]['default_setting_description'] = "The expiry that Avaya phones will populate in their SUBSCRIBE messages. This should be set to equal or less than the nonce-ttl value that is set in your SIP profile.";
+		$y++;
 
 ?>

--- a/resources/templates/provision/avaya/J139/{$mac}.cfg
+++ b/resources/templates/provision/avaya/J139/{$mac}.cfg
@@ -11,6 +11,11 @@ SET ENABLE_OOD_RESET_NOTIFY 1
 ## Do not require TLS to accept Out-Of-Dialog REFER messages
 SET ENABLE_OOD_MSG_TLS_ONLY 0
 
+# Set the default SUBSCRIBE expiry time
+# This needs to be set to a value equal to or lower than the 'nonce-ttl' that is in your SIP Profile
+# The defaule for 'nonce-ttl' is 60
+SET OUTBOUND_SUBSCRIPTION_REQUEST_DURATION {if isset($avaya_blf_subscription_expiry)}{$avaya_blf_subscription_expiry}{else}60{/if}
+
 ## Trust public certs rather than the phone downloading a trusted cert from the server
 SET ENABLE_PUBLIC_CA_CERTS 1
 

--- a/resources/templates/provision/avaya/J169/{$mac}.cfg
+++ b/resources/templates/provision/avaya/J169/{$mac}.cfg
@@ -11,6 +11,11 @@ SET ENABLE_OOD_RESET_NOTIFY 1
 ## Do not require TLS to accept Out-Of-Dialog REFER messages
 SET ENABLE_OOD_MSG_TLS_ONLY 0
 
+# Set the default SUBSCRIBE expiry time
+# This needs to be set to a value equal to or lower than the 'nonce-ttl' that is in your SIP Profile
+# The defaule for 'nonce-ttl' is 60
+SET OUTBOUND_SUBSCRIPTION_REQUEST_DURATION {if isset($avaya_blf_subscription_expiry)}{$avaya_blf_subscription_expiry}{else}60{/if}
+
 ## Trust public certs rather than the phone downloading a trusted cert from the server
 SET ENABLE_PUBLIC_CA_CERTS 1
 

--- a/resources/templates/provision/avaya/J179/{$mac}.cfg
+++ b/resources/templates/provision/avaya/J179/{$mac}.cfg
@@ -11,6 +11,11 @@ SET ENABLE_OOD_RESET_NOTIFY 1
 ## Do not require TLS to accept Out-Of-Dialog REFER messages
 SET ENABLE_OOD_MSG_TLS_ONLY 0
 
+# Set the default SUBSCRIBE expiry time
+# This needs to be set to a value equal to or lower than the 'nonce-ttl' that is in your SIP Profile
+# The defaule for 'nonce-ttl' is 60
+SET OUTBOUND_SUBSCRIPTION_REQUEST_DURATION {if isset($avaya_blf_subscription_expiry)}{$avaya_blf_subscription_expiry}{else}60{/if}
+
 ## Trust public certs rather than the phone downloading a trusted cert from the server
 SET ENABLE_PUBLIC_CA_CERTS 1
 

--- a/resources/templates/provision/avaya/J189/{$mac}.cfg
+++ b/resources/templates/provision/avaya/J189/{$mac}.cfg
@@ -11,6 +11,11 @@ SET ENABLE_OOD_RESET_NOTIFY 1
 ## Do not require TLS to accept Out-Of-Dialog REFER messages
 SET ENABLE_OOD_MSG_TLS_ONLY 0
 
+# Set the default SUBSCRIBE expiry time
+# This needs to be set to a value equal to or lower than the 'nonce-ttl' that is in your SIP Profile
+# The defaule for 'nonce-ttl' is 60
+SET OUTBOUND_SUBSCRIPTION_REQUEST_DURATION {if isset($avaya_blf_subscription_expiry)}{$avaya_blf_subscription_expiry}{else}60{/if}
+
 ## Trust public certs rather than the phone downloading a trusted cert from the server
 SET ENABLE_PUBLIC_CA_CERTS 1
 
@@ -95,7 +100,7 @@ SET LANGUAGES Mlf_J189_CanadianFrench.xml,Mlf_J189_LatinAmericanSpanish.xml,Mlf_
 ## 0 - Automatic
 ## 1 - Manual
 SET DIALING_MODE_DEFAULT 0
-## Dialplan
+## Dialplan30h)
 ## |: This character is used to separate each different number pattern.
 ## X: This character is a wildcard for any single digit match.
 ## [ ]- Square brackets can be used to contain possible specific single digit matches. For example:

--- a/resources/templates/provision/avaya/J189/{$mac}.cfg
+++ b/resources/templates/provision/avaya/J189/{$mac}.cfg
@@ -100,7 +100,7 @@ SET LANGUAGES Mlf_J189_CanadianFrench.xml,Mlf_J189_LatinAmericanSpanish.xml,Mlf_
 ## 0 - Automatic
 ## 1 - Manual
 SET DIALING_MODE_DEFAULT 0
-## Dialplan30h)
+## Dialplan
 ## |: This character is used to separate each different number pattern.
 ## X: This character is a wildcard for any single digit match.
 ## [ ]- Square brackets can be used to contain possible specific single digit matches. For example:


### PR DESCRIPTION
This PR is to fix an issue with Avaya J series phones and BLFs.

When phones were configured to set their expiry past the freeswitch SIP profile's `nonce-ttl`, they would get 401'd.

This sets the expiry to 60 to match what Freeswitch works with. It is recommended to change the `nonce-ttl` on the SIP profile that the Avaya phones are registering to.

There is a default settings that allows this to be configured across all systems.