### PR TITLE
pass database object to settings object

### DIFF
--- a/app/fax/fax_emails.php
+++ b/app/fax/fax_emails.php
@@ -38,7 +38,7 @@ $sql .= "where fax_email_connection_host <> '' ";
 $sql .= "and f.domain_uuid = d.domain_uuid ";
 $sql .= "and fax_email_connection_host is not null ";
 $sql .= "and fax_email_outbound_subject_tag is not null ";
-$database = new database;
+$database = database::new();
 $result = $database->select($sql, null, 'all');
 unset($sql);
 
@@ -80,7 +80,7 @@ if (!empty($result) && @sizeof($result) != 0) {
 		$fax_toll_allow = $row["fax_toll_allow"];
 
 		//get event socket connection parameters
-		$setting = new settings(["domain_uuid" => $domain_uuid]);
+		$setting = new settings(["database" => $database, "domain_uuid" => $domain_uuid]);
 
 		//send the domain name to the command line output
 		if (!empty($fax_email_connection_host) && !empty($fax_email_connection_username)) {


### PR DESCRIPTION
Use the singleton database object with database::new syntax Pass the connected database object to the settings object so settings object does not have to create another connection