### PR TITLE
add left and right padding to the dashboard applets

### DIFF
--- a/themes/default/css.php
+++ b/themes/default/css.php
@@ -2792,6 +2792,7 @@ else { //default: white
 		}
 
 	span.hud_title {
+		padding: 0px 5px 0px 5px;
 		display: block;
 		width: 100%;
 		font-family: <?=$dashboard_label_text_font?>;


### PR DESCRIPTION
This helps when applying themes. The header of the applets need to be padded.

![image](https://github.com/user-attachments/assets/2c377a63-c3d1-415a-b997-912c1d20fd5a)
