### PR TITLE
Create 465_transfer_to_me.xml

### DIFF
--- a/app/dialplans/resources/switch/conf/dialplan/465_transfer_to_me.xml
+++ b/app/dialplans/resources/switch/conf/dialplan/465_transfer_to_me.xml
@@ -1,0 +1,24 @@
+<extension name="transfer_to_me" context="global" continue="false" uuid="ccf52820-f471-406b-83c9-cbbbe597513e" global="true" enabled="true" order=465>
+	<condition field="destination_number" expression="^\*63$" break="never"/>
+	<condition field="${sip_h_Referred-By}" expression="sip:(.*)@.*" break="never">
+		<action application="set" data="referred_by_user=$1" inline="true"/>
+	</condition>
+	<condition field="destination_number" expression="^\*63$" break="never">
+		<action application="set" data="park_in_use=false" inline="true"/>
+		<action application="set" data="park_lot=${referred_by_user}-${domain_name}" inline="true"/>
+		<action application="info" data=""/>
+	</condition>
+	<condition field="destination_number" expression="^\*63$"/>
+	<condition field="${referred_by_user}" expression="^.+$" break="never">
+		<action application="set" data="valet_info_park=${valet_info park@${domain_name}}|\*${park_lot}" inline="true"/>
+		<action application="set" data="park_in_use=${regex ${valet_info park@${domain_name}}|\*${park_lot}}" inline="true"/>
+	</condition>
+	<condition field="${park_in_use}" expression="true" break="never">
+		<action application="transfer" data="${referred_by_user} XML ${context}"/>
+		<anti-action application="set" data="effective_caller_id_name=${caller_id_name}" inline="true"/>
+		<anti-action application="set" data="valet_parking_timeout=5"/>
+		<anti-action application="set" data="valet_hold_music=${hold_music}"/>
+		<anti-action application="set" data="valet_parking_orbit_exten=${referred_by_user}"/>
+		<anti-action application="valet_park" data="park@${domain_name} *${park_lot}"/>
+	</condition>
+</extension>


### PR DESCRIPTION
The purpose of this dialplan is to allow the user to transfer their existing call back to themselves so they can answer the call with a different device. Transfer from desk phone to software phone to home office phone, etc.

This dialplan has been designed to be global and there will be no 'parking lot' collisions as each extension across all domains will have their own uniquely identified parking lot/park ID if the form of "<extension>-<domain_name>". Example: 101-customer45.pbxdomain.com, where extension = 101 and the domain = customer45.pbxdomain.com.

Following the example above, extension 101 will Transfer or Blind Transfer a call to *63 (which spells *me). Their extension 101 will hangup and display something to the effect of "transfer complete" (phone make & model dependent). After 5 seconds all of the user's extension 101 devices will ring. The user answers the call with their desired registered extension 101.

The park_lot variable will display as the example above in the CDR details.