### PR TITLE
update cpm_ans to be cpm_answered

### DIFF
--- a/app/xml_cdr/xml_cdr_statistics.php
+++ b/app/xml_cdr/xml_cdr_statistics.php
@@ -329,7 +329,7 @@
 		}
 		echo "	<td>".escape($row['volume'])."&nbsp;</td>\n";
 		echo "	<td>".escape(round($row['minutes'] ?? 0, 2))."&nbsp;</td>\n";
-		echo "	<td>".escape(round($row['avg_min'] ?? 0, 2))."&nbsp;/&nbsp;".escape(round($row['cpm_ans'] ?? 0, 2))."&nbsp;</td>\n";
+		echo "	<td>".escape(round($row['avg_min'] ?? 0, 2))."&nbsp;/&nbsp;".escape(round($row['cpm_answered'] ?? 0, 2))."&nbsp;</td>\n";
 		echo "	<td class='center'><a href=\"xml_cdr.php?call_result=missed&direction=".$direction."&start_epoch=".escape($row['start_epoch'] ?? '')."&stop_epoch=".escape($row['stop_epoch'] ?? '')."\">".escape($row['missed'] ?? '')."</a>&nbsp;</td>\n";
 		echo "	<td>".escape(round($row['asr'] ?? 0, 2))."&nbsp;</td>\n";
 		echo "	<td>".escape(round($row['aloc'] ?? 0, 2))."&nbsp;</td>\n";


### PR DESCRIPTION
The sql aliases the calculation as cpm_answered. Without this change the CDR Statistics Call Per Minute will always be zero.

The Error:
![Firefox_Screenshot_2024-12-23T23-24-52 660Z](https://github.com/user-attachments/assets/7e63d638-700c-4aad-a12d-d7bdc48f0385)


The Fix:
![Firefox_Screenshot_2024-12-23T23-31-11 175Z](https://github.com/user-attachments/assets/b9af7cf2-534a-4fcb-82a6-b6c3aad333dc)
