### PR TITLE
xml_cdr catch edge case of failed import when no start stamp is present

### DIFF
--- a/app/xml_cdr/resources/classes/xml_cdr.php
+++ b/app/xml_cdr/resources/classes/xml_cdr.php
@@ -639,6 +639,15 @@ if (!class_exists('xml_cdr')) {
 
 					//time
 						$start_epoch = urldecode($xml->variables->start_epoch);
+						//catch invalid cdr
+						if (empty($start_epoch)) {
+							//empty the array so it can't save
+							$this->array = null;
+							//move the file to failed location
+							$this->move_to_failed($this->file);
+							//stop processing
+							return;
+						}
 						$this->array[$key][0]['start_epoch'] = $start_epoch;
 						$this->array[$key][0]['start_stamp'] = is_numeric((int)$start_epoch) ? date('c', $start_epoch) : null;
 						$answer_epoch = urldecode($xml->variables->answer_epoch);

--- a/app/xml_cdr/resources/classes/xml_cdr.php
+++ b/app/xml_cdr/resources/classes/xml_cdr.php
@@ -1486,6 +1486,15 @@ if (!class_exists('xml_cdr')) {
 			}
 		}
 
+		public function moved_to_failed($failed_file) {
+			$xml_cdr_dir = $this->setting->get('switch', 'log', '/var/log/freeswitch').'/xml_cdr';
+			if (!file_exists($xml_cdr_dir.'/failed')) {
+				if (!mkdir($xml_cdr_dir.'/failed', 0660, true)) {
+					die('Failed to create '.$xml_cdr_dir.'/failed');
+				}
+			}
+			rename($xml_cdr_dir.'/'.$failed_file, $xml_cdr_dir.'/failed/'.$failed_file);
+		}
 
 		/**
 		 * get xml from the filesystem and save it to the database

--- a/app/xml_cdr/resources/classes/xml_cdr.php
+++ b/app/xml_cdr/resources/classes/xml_cdr.php
@@ -638,16 +638,18 @@ if (!class_exists('xml_cdr')) {
 						$this->array[$key][0]['status'] = $status;
 
 					//time
-						$start_epoch = urldecode($xml->variables->start_epoch);
-						//catch invalid cdr
-						if (empty($start_epoch)) {
+						//catch invalid call detail records
+						if (empty($xml->variables->start_epoch)) {
 							//empty the array so it can't save
 							$this->array = null;
-							//move the file to failed location
+
+							//move the file to the failed location
 							$this->move_to_failed($this->file);
+
 							//stop processing
 							return;
 						}
+						$start_epoch = urldecode($xml->variables->start_epoch);
 						$this->array[$key][0]['start_epoch'] = $start_epoch;
 						$this->array[$key][0]['start_stamp'] = is_numeric((int)$start_epoch) ? date('c', $start_epoch) : null;
 						$answer_epoch = urldecode($xml->variables->answer_epoch);


### PR DESCRIPTION
xml_cdr service will crash when importing a record that does not contain a start epoch timestamp. This causes xml_cdr records to build up in the filesystem with occasional records being imported.