### PR TITLE
yealink power savings description clarity

### DIFF
--- a/app/yealink/app_config.php
+++ b/app/yealink/app_config.php
@@ -1577,7 +1577,7 @@
 		$apps[$x]['default_settings'][$y]['default_setting_name'] = "text";
 		$apps[$x]['default_settings'][$y]['default_setting_value'] = "0";
 		$apps[$x]['default_settings'][$y]['default_setting_enabled'] = "true";
-		$apps[$x]['default_settings'][$y]['default_setting_description'] = "Saving Enabled. Options: 0-Disabled, 1-Enabled";	
+		$apps[$x]['default_settings'][$y]['default_setting_description'] = "Power Saving Enabled. Options: 0-Disabled, 1-Enabled";	
 		$y++;
 
 ?>


### PR DESCRIPTION
It was unclear as to what 'saving enabled' is. Updated to 'power saving enabled'. Yealink setting `features.power_saving.enable`