### PR TITLE
fix missing variable in default template

### DIFF
--- a/resources/footer.php
+++ b/resources/footer.php
@@ -27,6 +27,12 @@
 //includes files
 	require_once __DIR__ . "/require.php";
 
+//database and settings
+	$domain_uuid = $_SESSION['domain_uuid'] ?? '';
+	$user_uuid = $_SESSION['user_uuid'] ?? '';
+	$database = database::new();
+	$settings = new settings(['database' => $database, 'domain_uuid' => $domain_uuid, 'user_uuid' => $user_uuid]);
+
 //set variables if not set
 	//if (!isset($_SESSION["template_content"])) { $_SESSION["template_content"] = null; }
 	if (!isset($document)) { $document = null; }
@@ -154,7 +160,7 @@
 				$settings_array['theme']['footer'] = isset($settings_array['theme']['footer']) ? $settings_array['theme']['footer'] : '&copy; '.$text['theme-label-copyright'].' 2008 - '.date('Y')." <a href='http://www.fusionpbx.com' class='footer' target='_blank'>fusionpbx.com</a> ".$text['theme-label-all_rights_reserved'];
 				$settings_array['theme']['menu_side_item_main_sub_icon_contract'] = !empty($settings_array['theme']['menu_side_item_main_sub_icon_contract']) ? explode(' ', $settings_array['theme']['menu_side_item_main_sub_icon_contract'])[1] : null;
 				$settings_array['theme']['menu_side_item_main_sub_icon_expand'] = !empty($settings_array['theme']['menu_side_item_main_sub_icon_expand']) ? explode(' ', $settings_array['theme']['menu_side_item_main_sub_icon_expand'])[1] : null;
-
+				$settings_array['theme']['menu_brand_type'] = $settings->get('theme', 'menu_brand_type', '');
 			//assign the setings
 				$view->assign('settings', $settings_array);
 		}

--- a/resources/header.php
+++ b/resources/header.php
@@ -33,6 +33,9 @@
 		session_start();
 	}
 
+//connect to the database if not initialized
+	$database = database::new();
+
 //set the domains session
 	if (!isset($_SESSION['domains'])) {
 		$domain = new domains();
@@ -79,11 +82,6 @@
 	}
 	else {
 		$content = '';
-	}
-
-//connect to the database if not initialized
-	if (!($database instanceof database)) {
-		$database = new database();
 	}
 
 //get the parent id


### PR DESCRIPTION
When 'dev' or 'all' error level is set in the config.conf file, the menu will fail to expand or contract. This commit adds the missing variable causing a PHP warning responsible for the behavior.