### PR TITLE
add the apcu caching ability for performance

### DIFF
--- a/app/sip_status/sip_status.php
+++ b/app/sip_status/sip_status.php
@@ -331,4 +331,3 @@
 	require_once "resources/footer.php";
 
 ?>
-

--- a/core/default_settings/default_settings_reload.php
+++ b/core/default_settings/default_settings_reload.php
@@ -46,7 +46,7 @@ $search = $_REQUEST['search'] ?? '';
 $domain_uuid = $_GET['id'] ?? null;
 
 //reload default settings
-require "resources/classes/domains.php";
+settings::clear_cache();
 $domain = new domains();
 $domain->set();
 

--- a/core/domain_settings/domain_setting_edit.php
+++ b/core/domain_settings/domain_setting_edit.php
@@ -307,6 +307,9 @@
 						}
 					}
 
+				//clear domain apcu cache due to changes
+					settings::clear_cache('domain');
+
 				//redirect the browser
 					if ($action == "update") {
 						message::add($text['message-update']);

--- a/core/user_settings/user_setting_edit.php
+++ b/core/user_settings/user_setting_edit.php
@@ -298,6 +298,9 @@ if (!empty($_POST) && empty($_POST["persistformvar"])) {
 					}
 				}
 
+			//clear the user settings cache
+				settings::clear_cache('user');
+
 			//redirect the browser
 				if ($action == "update") {
 					message::add($text['message-update']);

--- a/resources/classes/auto_loader.php
+++ b/resources/classes/auto_loader.php
@@ -27,10 +27,21 @@
 class auto_loader {
 
 	const FILE = 'autoloader_cache.php';
+	const CACHE_KEY = 'autoloader_classes';
 
 	private $classes;
 
+	/**
+	 * Tracks the APCu extension for caching to RAM drive across requests
+	 * @var bool
+	 */
+	private $apcu_enabled;
+
 	public function __construct($project_path = '') {
+
+		//set if we can use RAM cache
+		$this->apcu_enabled = function_exists('apcu_enabled') && apcu_enabled();
+
 		//classes must be loaded before this object is registered
 		if (!$this->load_cache()) {
 			//cache miss so load them
@@ -43,34 +54,49 @@ class auto_loader {
 	}
 
 	public function update_cache(string $file = ''): bool {
+		//guard against writing an empty file
+		if (!empty($this->classes)) {
+			return false;
+		}
+
+		//update RAM cache when available
+		if ($this->apcu_enabled) {
+			apcu_store(self::CACHE_KEY, $this->classes);
+		}
+
 		//ensure we have somewhere to put the file
 		if (empty($file)) {
 			$file = sys_get_temp_dir() . '/' . self::FILE;
 		}
 
-		//guard against writing an empty file
-		if (!empty($this->classes)) {
-			//export the classes array using PHP engine
-			$data = var_export($this->classes, true);
+		//export the classes array using PHP engine
+		$data = var_export($this->classes, true);
 
-			//put the array in a form that it can be loaded directly to an array
-			$result = file_put_contents($file, "<?php\n return " . $data . ";\n");
-			if ($result !== false) {
-				return true;
-			}
-			$error_array = error_get_last();
-			//send to syslog when debugging
-			if (!empty($_REQUEST['debug']) && $_REQUEST['debug'] == 'true') {
-				openlog("PHP", LOG_PID | LOG_PERROR, LOG_LOCAL0);
-				syslog(LOG_WARNING, "[php][auto_loader] " . $error_array['message']);
-				closelog();
-			}
+		//put the array in a form that it can be loaded directly to an array
+		$result = file_put_contents($file, "<?php\n return " . $data . ";\n");
+		if ($result !== false) {
+			return true;
 		}
+		$error_array = error_get_last();
+		//send to syslog when debugging
+		if (!empty($_REQUEST['debug']) && $_REQUEST['debug'] == 'true') {
+			openlog("PHP", LOG_PID | LOG_PERROR, LOG_LOCAL0);
+			syslog(LOG_WARNING, "[php][auto_loader] " . $error_array['message']);
+			closelog();
+		}
+
 		return false;
 	}
 
 	public function load_cache(string $file = ''): bool {
 		$this->classes = [];
+
+		//use apcu when available
+		if ($this->apcu_enabled && apcu_exists(self::CACHE_KEY)) {
+			$this->classes = apcu_fetch(self::CACHE_KEY, $success);
+			if ($success) return true;
+		}
+
 		//use a standard file
 		if (empty($file)) {
 			$file = sys_get_temp_dir() . '/'. self::FILE;
@@ -81,6 +107,10 @@ class auto_loader {
 		}
 		//assign to an array
 		if (!empty($this->classes)) {
+			//cache edge case of first time using apcu cache
+			if ($this->apcu_enabled) {
+				apcu_store(self::CACHE_KEY, $this->classes);
+			}
 			return true;
 		}
 		return false;
@@ -123,6 +153,11 @@ class auto_loader {
 
 			//return boolean
 			return true;
+		}
+
+		//Smarty has it's own autoloader so reject the request
+		if ($class_name === 'Smarty_Autoloader') {
+			return false;
 		}
 
 		//cache miss
@@ -185,5 +220,11 @@ class auto_loader {
 			}
 		}
 		return '';
+	}
+
+	public static function clear_cache() {
+		if (function_exists('apcu_enabled') && apcu_enabled()) {
+			apcu_delete(self::CACHE_KEY);
+		}
 	}
 }

--- a/resources/classes/cache.php
+++ b/resources/classes/cache.php
@@ -187,6 +187,17 @@ class cache {
 				closelog();
 			}
 
+		//check for apcu extension
+			if (function_exists('apcu_enabled') && apcu_enabled()) {
+				//flush everything
+				apcu_clear_cache();
+			}
+
+		//remove the autoloader file cache
+			if (file_exists(sys_get_temp_dir() . '/' . auto_loader::FILE)) {
+				@unlink(sys_get_temp_dir() . '/' . auto_loader::FILE);
+			}
+
 		//cache method memcache
 			if ($this->method === "memcache") {
 				// connect to event socket

--- a/resources/classes/settings.php
+++ b/resources/classes/settings.php
@@ -224,7 +224,7 @@ class settings {
 	private function default_settings() {
 
 		//set the key for global defaults
-		$key = 'settings_default_' . $this->category;
+		$key = 'settings_global_' . $this->category;
 
 		//if the apcu extension is loaded get the already parsed array
 		if ($this->apcu_enabled && apcu_exists($key)) {
@@ -456,7 +456,7 @@ class settings {
 
 	/**
 	 * Clears the settings cache
-	 * @param string $type Empty clears all settings. Values can be default, domain, or user.
+	 * @param string $type Empty clears all settings. Values can be global, domain, or user.
 	 */
 	public static function clear_cache(string $type = '') {
 		if (function_exists('apcu_enabled') && apcu_enabled()) {
@@ -466,7 +466,7 @@ class settings {
 				default:
 					$type = "";
 					break;
-				case 'default':
+				case 'global':
 				case 'domain':
 				case 'user':
 					$type .= "_";


### PR DESCRIPTION
When the PHP extension APCu is loaded, the settings class and the auto_loader will cache their results across requests in RAM. For more information about the APCu extension visit the PHP page: https://www.php.net/apcu