### PR TITLE
fix email category misspelling

### DIFF
--- a/app/switch/resources/scripts/app/emergency/index.lua
+++ b/app/switch/resources/scripts/app/emergency/index.lua
@@ -94,7 +94,7 @@ local sql = "SELECT * FROM v_email_templates ";
 	sql = sql .. "WHERE template_category = :category ";
 	sql = sql .. "AND template_subcategory = :subcategory ";
 	sql = sql .. "AND template_enabled = :status ";
-	local params = {category = 'plugins', subcategory = 'emergency', status = 'true'}
+	local params = {category = 'plugin', subcategory = 'emergency', status = 'true'}
 	dbh:query(sql, params, function(row)
 		subject = row.template_subject;
 		body = row.template_body;


### PR DESCRIPTION
Sending an email with the email templates will never work if the email template category is misspelled.

Search this URL for 'emergency' to confirm singular versus plural misspelling

https://github.com/fusionpbx/fusionpbx/blob/f3986290eaf3e3b65b792da803e21ff4969c0113/core/email_templates/app_defaults.php#L28