### PR TITLE
update grandstream template loop

### DIFF
--- a/resources/templates/provision/grandstream/grp2612/{$mac}.xml
+++ b/resources/templates/provision/grandstream/grp2612/{$mac}.xml
@@ -4565,7 +4565,7 @@
 
 		<!-- MPK Value -->
 		<!-- Pvalue P303 -->
-		<item name="pks.mpk.{$row.device_key_id}.value"></item>
+		<item name="pks.mpk.{$row.device_key_id}.value">{$row.device_key_value}</item>
 
 {/foreach}
 

--- a/resources/templates/provision/grandstream/grp2612w/{$mac}.xml
+++ b/resources/templates/provision/grandstream/grp2612w/{$mac}.xml
@@ -4560,7 +4560,7 @@
 
 		<!-- MPK Value -->
 		<!-- Pvalue P303 -->
-		<item name="pks.mpk.{$row.device_key_id}.value"></item>
+		<item name="pks.mpk.{$row.device_key_id}.value">{$row.device_key_value}</item>
 
 {/foreach}
 

--- a/resources/templates/provision/grandstream/grp2613/{$mac}.xml
+++ b/resources/templates/provision/grandstream/grp2613/{$mac}.xml
@@ -4566,7 +4566,7 @@
 
 		<!-- MPK Value -->
 		<!-- Pvalue P303 -->
-		<item name="pks.mpk.{$row.device_key_id}.value"></item>
+		<item name="pks.mpk.{$row.device_key_id}.value">{$row.device_key_value}</item>
 
 {/foreach}
 

--- a/resources/templates/provision/grandstream/grp2614/{$mac}.xml
+++ b/resources/templates/provision/grandstream/grp2614/{$mac}.xml
@@ -4565,7 +4565,7 @@
 
 		<!-- MPK Value -->
 		<!-- Pvalue P303 -->
-		<item name="pks.mpk.{$row.device_key_id}.value"></item>
+		<item name="pks.mpk.{$row.device_key_id}.value">{$row.device_key_value}</item>
 
 {/foreach}
 

--- a/resources/templates/provision/grandstream/grp2615/{$mac}.xml
+++ b/resources/templates/provision/grandstream/grp2615/{$mac}.xml
@@ -4558,7 +4558,7 @@
 
 		<!-- MPK Value -->
 		<!-- Pvalue P303 -->
-		<item name="pks.mpk.{$row.device_key_id}.value"></item>
+		<item name="pks.mpk.{$row.device_key_id}.value">{$row.device_key_value}</item>
 
 {/foreach}
 

--- a/resources/templates/provision/grandstream/grp2616/{$mac}.xml
+++ b/resources/templates/provision/grandstream/grp2616/{$mac}.xml
@@ -4565,7 +4565,7 @@
 
 		<!-- MPK Value -->
 		<!-- Pvalue P303 -->
-		<item name="pks.mpk.{$row.device_key_id}.value"></item>
+		<item name="pks.mpk.{$row.device_key_id}.value">{$row.device_key_value}</item>
 
 {/foreach}
 


### PR DESCRIPTION
The loop used to populate the keys was using the incorrect variables. Updating the variable to same variables used for the memory keys 8 and higher resolved the issue of blank keys being set for keys 1 - 7.