### PR TITLE
fix wrong logical check

### DIFF
--- a/resources/classes/auto_loader.php
+++ b/resources/classes/auto_loader.php
@@ -55,7 +55,7 @@ class auto_loader {
 
 	public function update_cache(string $file = ''): bool {
 		//guard against writing an empty file
-		if (!empty($this->classes)) {
+		if (empty($this->classes)) {
 			return false;
 		}
 


### PR DESCRIPTION
Forgot to remove the '!' (not) operator from the cache check when re-organizing the update cache function