### PR TITLE
add new active calls permissions

### DIFF
--- a/app/calls_active/app_config.php
+++ b/app/calls_active/app_config.php
@@ -56,5 +56,16 @@
 		$y++;
 		$apps[$x]['permissions'][$y]['name'] = "call_active_all";
 		$apps[$x]['permissions'][$y]['groups'][] = "superadmin";
-
+		$y++;
+		$apps[$x]['permissions'][$y]['name'] = "call_active_profile";
+		$apps[$x]['permissions'][$y]['groups'][] = "superadmin";
+		$y++;
+		$apps[$x]['permissions'][$y]['name'] = "call_active_application";
+		$apps[$x]['permissions'][$y]['groups'][] = "superadmin";
+		$y++;
+		$apps[$x]['permissions'][$y]['name'] = "call_active_codec";
+		$apps[$x]['permissions'][$y]['groups'][] = "superadmin";
+		$y++;
+		$apps[$x]['permissions'][$y]['name'] = "call_active_secure";
+		$apps[$x]['permissions'][$y]['groups'][] = "superadmin";
 ?>


### PR DESCRIPTION
Add new permissions to the active calls page so the fields can be removed from an admin permissions group to simplify the page, hiding more technical fields they probably will not find helpful.