### PR TITLE
Fix user id instead of auth id used in grandstream template

### DIFF
--- a/resources/templates/provision/grandstream/grp2612/{$mac}.xml
+++ b/resources/templates/provision/grandstream/grp2612/{$mac}.xml
@@ -76,7 +76,7 @@
 
 		<!-- SIP Authentication ID -->
 		<!-- Pvalue P36 -->
-		<item name="account.{$row.line_number}.sip.subscriber.userid">{$row.user_id}</item>
+		<item name="account.{$row.line_number}.sip.subscriber.userid">{$row.auth_id}</item>
 
 		<!-- SIP Authentication Password -->
 		<!-- Pvalue P34 -->

--- a/resources/templates/provision/grandstream/grp2612w/{$mac}.xml
+++ b/resources/templates/provision/grandstream/grp2612w/{$mac}.xml
@@ -76,7 +76,7 @@
 
 		<!-- SIP Authentication ID -->
 		<!-- Pvalue P36 -->
-		<item name="account.{$row.line_number}.sip.subscriber.userid">{$row.user_id}</item>
+		<item name="account.{$row.line_number}.sip.subscriber.userid">{$row.auth_id}</item>
 
 		<!-- SIP Authentication Password -->
 		<!-- Pvalue P34 -->

--- a/resources/templates/provision/grandstream/grp2613/{$mac}.xml
+++ b/resources/templates/provision/grandstream/grp2613/{$mac}.xml
@@ -76,7 +76,7 @@
 
 		<!-- SIP Authentication ID -->
 		<!-- Pvalue P36 -->
-		<item name="account.{$row.line_number}.sip.subscriber.userid">{$row.user_id}</item>
+		<item name="account.{$row.line_number}.sip.subscriber.userid">{$row.auth_id}</item>
 
 		<!-- SIP Authentication Password -->
 		<!-- Pvalue P34 -->

--- a/resources/templates/provision/grandstream/grp2614/{$mac}.xml
+++ b/resources/templates/provision/grandstream/grp2614/{$mac}.xml
@@ -76,7 +76,7 @@
 
 		<!-- SIP Authentication ID -->
 		<!-- Pvalue P36 -->
-		<item name="account.{$row.line_number}.sip.subscriber.userid">{$row.user_id}</item>
+		<item name="account.{$row.line_number}.sip.subscriber.userid">{$row.auth_id}</item>
 
 		<!-- SIP Authentication Password -->
 		<!-- Pvalue P34 -->

--- a/resources/templates/provision/grandstream/grp2615/{$mac}.xml
+++ b/resources/templates/provision/grandstream/grp2615/{$mac}.xml
@@ -76,7 +76,7 @@
 
 		<!-- SIP Authentication ID -->
 		<!-- Pvalue P36 -->
-		<item name="account.{$row.line_number}.sip.subscriber.userid">{$row.user_id}</item>
+		<item name="account.{$row.line_number}.sip.subscriber.userid">{$row.auth_id}</item>
 
 		<!-- SIP Authentication Password -->
 		<!-- Pvalue P34 -->

--- a/resources/templates/provision/grandstream/grp2616/{$mac}.xml
+++ b/resources/templates/provision/grandstream/grp2616/{$mac}.xml
@@ -76,7 +76,7 @@
 
 		<!-- SIP Authentication ID -->
 		<!-- Pvalue P36 -->
-		<item name="account.{$row.line_number}.sip.subscriber.userid">{$row.user_id}</item>
+		<item name="account.{$row.line_number}.sip.subscriber.userid">{$row.auth_id}</item>
 
 		<!-- SIP Authentication Password -->
 		<!-- Pvalue P34 -->

--- a/resources/templates/provision/grandstream/gxp2130/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp2130/{$mac}.xml
@@ -65,7 +65,7 @@
 		<item name="account.{$row.line_number}.sip.userid">{$row.user_id}</item>
 
 		<!-- SIP Authentication ID -->
-		<item name="account.{$row.line_number}.sip.subscriber.userid">{$row.user_id}</item>
+		<item name="account.{$row.line_number}.sip.subscriber.userid">{$row.auth_id}</item>
 
 		<!-- SIP Authentication Password -->
 		<item name="account.{$row.line_number}.sip.subscriber.password">{$row.password}</item>

--- a/resources/templates/provision/grandstream/gxp2135/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp2135/{$mac}.xml
@@ -69,7 +69,7 @@
 		<item name="account.{$row.line_number}.sip.userid">{$row.user_id}</item>
 
 		<!-- SIP Authentication ID -->
-		<item name="account.{$row.line_number}.sip.subscriber.userid">{$row.user_id}</item>
+		<item name="account.{$row.line_number}.sip.subscriber.userid">{$row.auth_id}</item>
 
 		<!-- SIP Authentication Password -->
 		<item name="account.{$row.line_number}.sip.subscriber.password">{$row.password}</item>

--- a/resources/templates/provision/grandstream/gxp2140/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp2140/{$mac}.xml
@@ -65,7 +65,7 @@
 		<item name="account.{$row.line_number}.sip.userid">{$row.user_id}</item>
 
 		<!-- SIP Authentication ID -->
-		<item name="account.{$row.line_number}.sip.subscriber.userid">{$row.user_id}</item>
+		<item name="account.{$row.line_number}.sip.subscriber.userid">{$row.auth_id}</item>
 
 		<!-- SIP Authentication Password -->
 		<item name="account.{$row.line_number}.sip.subscriber.password">{$row.password}</item>

--- a/resources/templates/provision/grandstream/gxp2160/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp2160/{$mac}.xml
@@ -65,7 +65,7 @@
 		<item name="account.{$row.line_number}.sip.userid">{$row.user_id}</item>
 
 		<!-- SIP Authentication ID -->
-		<item name="account.{$row.line_number}.sip.subscriber.userid">{$row.user_id}</item>
+		<item name="account.{$row.line_number}.sip.subscriber.userid">{$row.auth_id}</item>
 
 		<!-- SIP Authentication Password -->
 		<item name="account.{$row.line_number}.sip.subscriber.password">{$row.password}</item>

--- a/resources/templates/provision/grandstream/gxp2170/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp2170/{$mac}.xml
@@ -65,7 +65,7 @@
 		<item name="account.{$row.line_number}.sip.userid">{$row.user_id}</item>
 
 		<!-- SIP Authentication ID -->
-		<item name="account.{$row.line_number}.sip.subscriber.userid">{$row.user_id}</item>
+		<item name="account.{$row.line_number}.sip.subscriber.userid">{$row.auth_id}</item>
 
 		<!-- SIP Authentication Password -->
 		<item name="account.{$row.line_number}.sip.subscriber.password">{$row.password}</item>


### PR DESCRIPTION
Original template uses the user_id field instead of the auth_id field to fill the value for authentication ID - which are usually the same value. However, this is not always the case so this patch will use the auth_id field to match in the UI.