### PR TITLE
Fix exception thrown for order by used in count devices clause

### DIFF
--- a/app/extensions/extension_edit.php
+++ b/app/extensions/extension_edit.php
@@ -228,7 +228,6 @@
 					$sql .= "and device_user_uuid = :user_uuid ";
 					$parameters['user_uuid'] = $user_uuid;
 				}
-				$sql .= "order by device_address asc ";
 				$parameters['domain_uuid'] = $domain_uuid;
 				$total_devices = $database->select($sql, $parameters, 'column');
 				unset($sql, $parameters);


### PR DESCRIPTION
Using 'order by' in statement is not needed as the query only requires a single column of count. This causes an exception to be thrown and the $total_devices returned is an invalid result.