### PR TITLE
unset the parameters array

### DIFF
--- a/core/default_settings/default_settings.php
+++ b/core/default_settings/default_settings.php
@@ -198,7 +198,7 @@
 			}
 		}
 	}
-	unset($sql, $rows, $row);
+	unset($sql, $rows, $row, $parameters);
 
 //get the list of categories
 	if (!empty($default_setting_categories)) {


### PR DESCRIPTION
The $parameters array is not unset causing other $parameters arrays in the global namespace to have the 'search' parameter (line 188) to always be added to the query.