### PR TITLE
Check outbound_proxy and server_address for array with drop-down field

### DIFF
--- a/app/devices/device_edit.php
+++ b/app/devices/device_edit.php
@@ -1319,10 +1319,11 @@
 
 				if (permission_exists('device_line_server_address_primary')) {
 					echo "			<td valign='top' align='left' nowrap='nowrap'>\n";
-					if (!empty($settings->get('provision', 'server_address_primary', '')) && is_array($settings->get('provision', 'server_address_primary', ''))) {
+					$provision_server_address_primary = $settings->get('provision', 'server_address_primary');
+					if (!empty($provision_server_address_primary) && is_array($provision_server_address_primary)) {
 						echo "				<select class='formfld' style='width: 75px;' name='device_lines[".$x."][server_address_primary]'>\n";
 						echo "					<option value=''></option>\n";
-						foreach($settings->get('provision', 'server_address_primary', '') as $field) {
+						foreach($provision_server_address_primary as $field) {
 							echo "					<option value='".$field."' ".(($row['server_address_primary'] == $field) ? "selected" : null).">".$field."</option>\n";
 						}
 						echo "				</select>\n";
@@ -1335,10 +1336,11 @@
 
 				if (permission_exists('device_line_server_address_secondary')) {
 					echo "			<td valign='top' align='left' nowrap='nowrap'>\n";
-					if (!empty($settings->get('provision', 'server_address_secondary', '')) && is_array($settings->get('provision', 'server_address_secondary', ''))) {
+					$provision_server_address_primary = $settings->get('provision', 'server_address_secondary');
+					if (!empty($provision_server_address_primary) && is_array($provision_server_address_primary)) {
 						echo "				<select class='formfld' style='width: 75px;' name='device_lines[".$x."][server_address_secondary]'>\n";
 						echo "					<option value=''></option>\n";
-						foreach($settings->get('provision', 'server_address_secondary', '') as $field) {
+						foreach($provision_server_address_primary as $field) {
 							echo "					<option value='".$field."' ".(($row['server_address_secondary'] == $field) ? "selected" : null).">".$field."</option>\n";
 						}
 						echo "				</select>\n";
@@ -1351,10 +1353,11 @@
 
 				if (permission_exists('device_line_outbound_proxy_primary')) {
 					echo "			<td align='left'>\n";
-					if (!empty($settings->get('provision', 'outbound_proxy_primary', ''))) {
+					$provision_outbound_proxy_primary = $settings->get('provision', 'outbound_proxy_primary');
+					if (!empty($provision_outbound_proxy_primary) && is_array($provision_outbound_proxy_primary)) {
 						echo "				<select class='formfld' style='width: 75px;' name='device_lines[".$x."][outbound_proxy_primary]'>\n";
 						echo "					<option value=''></option>\n";
-						foreach($settings->get('provision', 'outbound_proxy_primary', '') as $field) {
+						foreach($provision_outbound_proxy_primary as $field) {
 							echo "					<option value='".$field."' ".(($row['outbound_proxy_primary'] == $field) ? "selected" : null).">".$field."</option>\n";
 						}
 						echo "				</select>\n";
@@ -1367,10 +1370,11 @@
 
 				if (permission_exists('device_line_outbound_proxy_secondary')) {
 					echo "			<td align='left'>\n";
-					if (!empty($settings->get('provision', 'outbound_proxy_secondary', ''))) {
+					$provision_outbound_proxy_secondary = $settings->get('provision', 'outbound_proxy_secondary');
+					if (!empty($provision_outbound_proxy_secondary) && is_array($provision_outbound_proxy_secondary)) {
 						echo "				<select class='formfld' style='width: 75px;' name='device_lines[".$x."][outbound_proxy_secondary]'>\n";
 						echo "					<option value=''></option>\n";
-						foreach($settings->get('provision', 'outbound_proxy_secondary', '') as $field) {
+						foreach($provision_outbound_proxy_secondary as $field) {
 							echo "					<option value='".$field."' ".(($row['outbound_proxy_secondary'] == $field) ? "selected" : null).">".$field."</option>\n";
 						}
 						echo "				</select>\n";


### PR DESCRIPTION
- Check the outbound_proxy_primary and outbound_proxy_secondary default value for an array value so the drop-down field on the device edit page can be filled.
- Use a variable to get the value from the settings class for server_address_primary and server_address_secondary instead of calling the settings class three times for each value.