### PR TITLE
Update clear cache method for settings object

### DIFF
--- a/resources/classes/settings.php
+++ b/resources/classes/settings.php
@@ -450,11 +450,20 @@ class settings implements clear_cache {
 		if (function_exists('apcu_enabled') && apcu_enabled()) {
 			$cache = apcu_cache_info(false);
 			if (!empty($cache['cache_list'])) {
+				//clear apcu cache
 				foreach ($cache['cache_list'] as $entry) {
 					$key = $entry['info'];
 					if (str_starts_with($key, 'settings_')) {
 						apcu_delete($key);
 					}
+				}
+				global $settings, $domain_uuid, $user_uuid;
+				//check there is a settings object
+				if (!empty($settings) && ($settings instanceof settings)) {
+					$domain_uuid = $settings->get_domain_uuid();
+					$user_uuid = $settings->get_user_uuid();
+					//recreate the settings object to reload all settings from database
+					$settings = new settings(['database' => database::new(), 'domain_uuid' => $domain_uuid, 'user_uuid' => $user_uuid]);
 				}
 			}
 		}

--- a/resources/classes/settings.php
+++ b/resources/classes/settings.php
@@ -457,13 +457,14 @@ class settings implements clear_cache {
 						apcu_delete($key);
 					}
 				}
-				global $settings, $domain_uuid, $user_uuid;
+				global $settings;
 				//check there is a settings object
 				if (!empty($settings) && ($settings instanceof settings)) {
+					$database = $settings->database();
 					$domain_uuid = $settings->get_domain_uuid();
 					$user_uuid = $settings->get_user_uuid();
 					//recreate the settings object to reload all settings from database
-					$settings = new settings(['database' => database::new(), 'domain_uuid' => $domain_uuid, 'user_uuid' => $user_uuid]);
+					$settings = new settings(['database' => $database, 'domain_uuid' => $domain_uuid, 'user_uuid' => $user_uuid]);
 				}
 			}
 		}


### PR DESCRIPTION
After the clear cache static method is called, re-create the settings object so the settings object remains available and settings are re-cached for subsequent calls