### PR TITLE
Bug Fix: Music on hold path

### DIFF
--- a/resources/switch.php
+++ b/resources/switch.php
@@ -989,13 +989,12 @@ if(!function_exists('path_join')) {
 		}
 
 		$prefix = null;
-		foreach ($paths as $path) {
+		foreach ($paths as $index => $path) {
 			if($prefix === null && !empty($path)) {
 				if(substr($path, 0, 1) == '/') $prefix = '/';
 				else $prefix = '';
 			}
-			$path = trim( $path, '/' );
-			$path = trim( $path, '\\' );
+			$paths[$index] = trim($path, '/\\');
 		}
 
 		if($prefix === null){


### PR DESCRIPTION
I found that whenever a music on hold file is added, there is an extra `/` added to the beginning of the folder.

Here is a screenshot of the upload form:
![image](https://github.com/user-attachments/assets/fc31a51d-b027-4453-bd7f-645ccbd73387)

Then click here:
![image](https://github.com/user-attachments/assets/fafdc127-1f19-4dc1-b80a-e50b4c28a465)

Here is the issue:
![image](https://github.com/user-attachments/assets/701ccc3d-2c72-4313-87bc-b3eb23ce822a)
