### PR TITLE
Fix plugin class name mismatch in auto loader

### DIFF
--- a/resources/classes/auto_loader.php
+++ b/resources/classes/auto_loader.php
@@ -134,6 +134,7 @@ class auto_loader {
 		$search_path[] = glob($project_path . "/*/*/resources/interfaces/" . $class_name . ".php");
 		$search_path[] = glob($project_path . "/*/*/resources/traits/" . $class_name . ".php");
 		$search_path[] = glob($project_path . "/*/*/resources/classes/" . $class_name . ".php");
+
 		//fix class names in the plugins directory prefixed with 'plugin_'
 		if (str_starts_with($class_name, 'plugin_')) {
 			$class_name = substr($class_name, 7);

--- a/resources/classes/auto_loader.php
+++ b/resources/classes/auto_loader.php
@@ -134,6 +134,10 @@ class auto_loader {
 		$search_path[] = glob($project_path . "/*/*/resources/interfaces/" . $class_name . ".php");
 		$search_path[] = glob($project_path . "/*/*/resources/traits/" . $class_name . ".php");
 		$search_path[] = glob($project_path . "/*/*/resources/classes/" . $class_name . ".php");
+		//fix class names in the plugins directory prefixed with 'plugin_'
+		if (str_starts_with($class_name, 'plugin_')) {
+			$class_name = substr($class_name, 7);
+		}
 		$search_path[] = glob($project_path . "/core/authentication/resources/classes/plugins/" . $class_name . ".php");
 
 		//collapse all entries to only the matched entry


### PR DESCRIPTION
When matching the file name of the plugins in the authentication plugin folder they do not match. This causes auto loader not to find and load the class.