### PR TITLE
Add clear settings object cache when modifying or adding setting

### DIFF
--- a/core/default_settings/default_setting_edit.php
+++ b/core/default_settings/default_setting_edit.php
@@ -139,6 +139,15 @@
 				// fix null
 				$default_setting_order = ($default_setting_order != '') ? $default_setting_order : 'null';
 
+				//reset the cache for settings object
+				settings::clear_cache();
+
+				//reset others
+				$classes_to_clear = array_filter($autoload->get_interface_list('clear_cache'), function ($class) { return $class !== 'settings'; });
+				foreach ($classes_to_clear as $class_name) {
+					$class_name::clear_cache();
+				}
+
 				//update switch timezone variables
 				if ($default_setting_category == "domain" && $default_setting_subcategory == "time_zone" && $default_setting_name == "name" ) {
 					//get the dialplan_uuid


### PR DESCRIPTION
When a setting is modified, the settings cache can be reloaded allowing the setting that was modified or added to take immediate effect. The call to allow any other clear cache methods to be called will allow any new features to have their settings also take effect. The settings are first cleared though so that any of the other classes that may require updated settings to work with, ensure that they have the newest default setting values.