### PR TITLE
Add yealink_backlight_time to default settings -> provision section

### DIFF
--- a/app/yealink/app_config.php
+++ b/app/yealink/app_config.php
@@ -72,6 +72,14 @@
 		$apps[$x]['default_settings'][$y]['default_setting_enabled'] = "false";
 		$apps[$x]['default_settings'][$y]['default_setting_description'] = "0-WWW MMM DD (default), 1-DD-MMM-YY, 2-YYYY-MM-DD, 3-DD/MM/YYYY, 4-MM/DD/YY, 5-DD MMM YYYY, 6-WWW DD MMM";
 		$y++;
+		$apps[$x]['default_settings'][$y]['default_setting_uuid'] = "a3ab8042-059f-438c-870c-845db8e629ed";
+		$apps[$x]['default_settings'][$y]['default_setting_category'] = "provision";
+		$apps[$x]['default_settings'][$y]['default_setting_subcategory'] = "yealink_backlight_time";
+		$apps[$x]['default_settings'][$y]['default_setting_name'] = "text";
+		$apps[$x]['default_settings'][$y]['default_setting_value'] = "60";
+		$apps[$x]['default_settings'][$y]['default_setting_enabled'] = "false";
+		$apps[$x]['default_settings'][$y]['default_setting_description'] = "the delay time (in seconds) to change the intensity of the LCD screen when the IP phone is inactive.";
+		$y++;
 		$apps[$x]['default_settings'][$y]['default_setting_uuid'] = "05bcbb47-06f6-4c81-a1c9-cdf2982d60a7";
 		$apps[$x]['default_settings'][$y]['default_setting_category'] = "provision";
 		$apps[$x]['default_settings'][$y]['default_setting_subcategory'] = "yealink_rport";


### PR DESCRIPTION
This variable allows automatic provisioned Yealink devices to dim the backlight after X seconds. Disabled by default for same operations as without the default setting variable. The Yealink automatic provisioning templates have this variable defined as:

`phone_setting.backlight_time = {$yealink_backlight_time}`