### PR TITLE
Fix two character directory name lookup

### DIFF
--- a/app/switch/resources/scripts/directory.lua
+++ b/app/switch/resources/scripts/directory.lua
@@ -406,15 +406,29 @@
 			end
 		--get the digits
 			if (first_name) then
-				if (string.len(first_name) > 0) then
-					--freeswitch.consoleLog("notice", "[directory] first_name: --" .. first_name .. "--\n");
-					first_name_digits = dialpad_to_digit(string.sub(first_name, 1, 1))..dialpad_to_digit(string.sub(first_name, 2, 2))..dialpad_to_digit(string.sub(first_name, 3, 3));
-				end
+				--freeswitch.consoleLog("notice", "[directory] first_name: --" .. first_name .. "--\n");
+					if (string.len(first_name) > 0) then
+							first_name_digits = dialpad_to_digit(string.sub(first_name, 1, 1));
+					end
+					if (string.len(first_name) > 1) then
+							first_name_digits = first_name_digits .. dialpad_to_digit(string.sub(first_name, 2, 2));
+					end
+					if (string.len(first_name) > 2) then
+							first_name_digits = first_name_digits .. dialpad_to_digit(string.sub(first_name, 3, 3));
+					end
 			end
 			if (last_name) then
 				if (string.len(last_name) > 0) then
 					--freeswitch.consoleLog("notice", "[directory] last_name: --" .. last_name .. "--\n");
-					last_name_digits = dialpad_to_digit(string.sub(last_name, 1, 1))..dialpad_to_digit(string.sub(last_name, 2, 2))..dialpad_to_digit(string.sub(last_name, 3, 3));
+					if (string.len(last_name) > 0) then
+						last_name_digits = dialpad_to_digit(string.sub(last_name, 1, 1));
+					end
+					if (string.len(last_name) > 1) then
+						last_name_digits = last_name_digits..dialpad_to_digit(string.sub(last_name, 2, 2));
+					end
+					if (string.len(last_name) > 2) then
+						last_name_digits = last_name_digits..dialpad_to_digit(string.sub(last_name, 3, 3));
+					end
 				end
 			end
 


### PR DESCRIPTION
When the directory name set the extension is two characters such as DJ or Yu, the lookup will fail to match the name. This will adjust the script so that the first and last name will match on the number of characters in the directory.