### PR TITLE
Do not create a new socket when one is provided

### DIFF
--- a/resources/classes/event_socket.php
+++ b/resources/classes/event_socket.php
@@ -144,8 +144,11 @@ class event_socket {
 		$port = $port ?? $conf['switch.event_socket.port'] ?? $conf['event_socket.port'] ?? '8021';
 		$password = $password ?? $conf['switch.event_socket.password'] ?? $conf['event_socket.password'] ?? 'ClueCon';
 
-		//open the socket connection
-		$this->fp = @fsockopen($host, $port, $errno, $errdesc, 3);
+		//if a socket was provided in the constructor then don't create a new one
+		if ($this->fp === false) {
+			//open the socket connection
+			$this->fp = @fsockopen($host, $port, $errno, $errdesc, 3);
+		}
 
 		if (!$this->connected()) {
 			return false;


### PR DESCRIPTION
Check that the current socket in the object is false before trying to create a new socket