### PR TITLE
Fix: Ensure proper absolute_codec_string for fax_queue

### DIFF
--- a/app/fax_queue/resources/job/fax_send.php
+++ b/app/fax_queue/resources/job/fax_send.php
@@ -396,7 +396,7 @@
 			//$dial_string .= "fax_retry_sleep=180,";
 			$dial_string .= "fax_verbose=true,";
 			//$dial_string .= "fax_use_ecm=off,";
-			$dial_string .= "absolute_codec_string=PCMU,PCMA,";
+			$dial_string .= "absolute_codec_string=\'PCMU,PCMA\',";
 			$dial_string .= "api_hangup_hook='lua app/fax/resources/scripts/hangup_tx.lua'";
 
 		//connect to event socket and send the command


### PR DESCRIPTION
The `absolute_codec_string` parameter for FreeSWITCH was being incorrectly formatted, causing issues with fax transmissions, particularly in regions preferring the PCMA codec.

Without proper quoting, the comma-separated codec list `PCMU,PCMA` was being parsed incorrectly by FreeSWITCH. The second codec `PCMA` was misinterpreted as a separate dial string parameter, resulting in `absolute_codec_string` being set to only `PCMU`. This led to negotiation failures when the receiving end required PCMA.

This commit resolves this by enclosing the codec list within *escaped* single quotes `\'PCMU,PCMA\'`. **Crucially, without this escaping, FreeSWITCH would not correctly interpret the quoted string.** The literal quotes are necessary to ensure that `PCMU,PCMA` is treated as a single value.

By implementing this change, we guarantee that both PCMU and PCMA are correctly included in the codec negotiation, resolving the fax transmission failures in PCMA-dominant regions.