### PR TITLE
Fix FreeBSD system memory calculation

### DIFF
--- a/resources/functions.php
+++ b/resources/functions.php
@@ -2516,7 +2516,7 @@ if (!function_exists('get_memory_details')) {
 				// calculate memory usage percentage
 				$array['memory_usage'] = ($array['used_memory'] / $array['total_memory']) * 100;
 
-				$array['memory_percent'] = round($array['memory_usage'], 2) . '%';
+				$array['memory_percent'] = round($array['memory_usage'], 2);
 				return $array;
 			}
 		}


### PR DESCRIPTION
FreeBSD verison of get_memory_details() incorrectly append a '%' sign, which breaks the round() call in system status dashboard