### PR TITLE
Expanded system_services dashboard card with more info

### DIFF
--- a/app/system/app_config.php
+++ b/app/system/app_config.php
@@ -170,5 +170,13 @@
 		$apps[$x]['default_settings'][$y]['default_setting_value'] = "1";
 		$apps[$x]['default_settings'][$y]['default_setting_enabled'] = "true";
 		$apps[$x]['default_settings'][$y]['default_setting_description'] = "Number of days to keep PHP session files on the server until the maintenance application deletes them";
+		$y++;
+		$apps[$x]['default_settings'][$y]['default_setting_uuid'] = "746334ab-a3a9-453d-aab6-edf6671f880a";
+		$apps[$x]['default_settings'][$y]['default_setting_category'] = "theme";
+		$apps[$x]['default_settings'][$y]['default_setting_subcategory'] = "dashboard_extra_system_services";
+		$apps[$x]['default_settings'][$y]['default_setting_name'] = "text";
+		$apps[$x]['default_settings'][$y]['default_setting_value'] = "freeswitch, nginx, postgresql, sshd";
+		$apps[$x]['default_settings'][$y]['default_setting_enabled'] = "true";
+		$apps[$x]['default_settings'][$y]['default_setting_description'] = "A comma separated list of additional system services to monitor the status of in the system services dashboard card";
 
 ?>

--- a/app/system/resources/dashboard/system_services.php
+++ b/app/system/resources/dashboard/system_services.php
@@ -153,6 +153,16 @@ echo "			);\n";
 echo "		</script>\n";
 
 if ($dashboard_details_state != 'disabled') {
+        // Define friendly names for known system services
+	$service_friendly_names = [
+		'email_queue'         => 'Email Queue',
+		'event_guard'         => 'Event Guard',
+		'fax_queue'           => 'Fax Queue',
+		'maintenance_service' => 'Maintenance Service',
+		'message_events'      => 'Message Events',
+		'message_queue'       => 'Message Queue',
+		'xml_cdr'             => 'XML CDR'
+	];
 echo "	<div class='hud_details hud_box' id='hud_system_services_details'>\n";
 echo "		<table class='tr_hover' width='100%' cellpadding='0' cellspacing='0' border='0'>\n";
 echo "			<tr>\n";
@@ -163,8 +173,10 @@ echo "			</tr>\n";
 		$row_style[true] = "row_style1";
 		$c = true;
 		foreach ($services as $name => $enabled) {
+			// Use mapped friendly name, or fall back to default formatting
+			$display_name = $service_friendly_names[$name] ?? ucwords(str_replace('_', ' ', $name));
 			echo "  <tr>\n";
-			echo "    <td valign='top' class='{$row_style[$c]}' hud_text>$name</td>\n";
+			echo "    <td valign='top' class='{$row_style[$c]}' hud_text>$display_name</td>\n";
 			echo "    <td valign='top' class='{$row_style[$c]}' hud_text style='text-align: center;'>" . ($enabled ? $text['label-yes'] ?? 'Yes' : $text['label-no'] ?? 'No') . "</td>\n";
 			echo "  </tr>\n";
 			$c = !$c;

--- a/app/system/resources/dashboard/system_services.php
+++ b/app/system/resources/dashboard/system_services.php
@@ -55,41 +55,103 @@
 		}
 	}
 
-//function to check for running process
+//function to check for running process: returns [running, pid, etime]
 	if (!function_exists('is_running')) {
-		function is_running(string $name) {
-			$output = '';
+                function is_running(string $name) {
+                        $name = escapeshellarg($name);
+                        $pid = trim(shell_exec("ps -aux | grep $name | grep -v grep | awk '{print \$2}' | head -n 1"));
+                        if ($pid && is_numeric($pid)) {
+                                $etime = trim(shell_exec("ps -p $pid -o etime= | tr -d '\n'"));
+                                return ['running' => true, 'pid' => $pid, 'etime' => $etime];
+                        }
+                        return ['running' => false, 'pid' => null, 'etime' => null];
+                }
+        }
 
-			//escape for better safety
-			$name = escapeshellarg($name);
+//function to format etime into friendly display
+        if (!function_exists('format_etime')) {
+                function format_etime($etime) {
+                                        // Format: [[dd-]hh:]mm:ss
+                                        if (empty($etime)) return '-';
 
-		    // Use pgrep to search for the program by its name
-			$output = shell_exec("ps -aux | grep $name | grep -v grep");
+                                        $days = 0; $hours = 0; $minutes = 0; $seconds = 0;
 
-			// If there is a process id then the program is running
-			return ($output !== null && strlen($output) > 0);
-		}
-	}
+                                        // Handle dd-hh:mm:ss
+                                        if (preg_match('/^(\d+)-(\d+):(\d+):(\d+)$/', $etime, $m)) {
+                                                [$_, $days, $hours, $minutes, $seconds] = $m;
+                                        }
+                                        // Handle hh:mm:ss
+                                        elseif (preg_match('/^(\d+):(\d+):(\d+)$/', $etime, $m)) {
+                                                [$_, $hours, $minutes, $seconds] = $m;
+                                        }
+                                        // Handle mm:ss
+                                        elseif (preg_match('/^(\d+):(\d+)$/', $etime, $m)) {
+                                                [$_, $minutes, $seconds] = $m;
+                                        }
 
-//load installed services
-	$files = glob(PROJECT_ROOT . '/*/*/resources/service/*.service');
-	$services = [];
-	$total_running = 0;
-	foreach ($files as $file) {
-		$service = get_classname($file);
-		//check if the service name was found
-		if (!empty($service)) {
-			$basename = basename($service, '.php');
-			//clean up the name
-			//$basename = ucwords(str_replace('_', ' ', $basename));
-			//check if service is running
-			$services[$basename] = is_running($service);
-			//keep total count for charts
-			if ($services[$basename]) {
-				++$total_running;
-			}
-		}
-	}
+                                        $out = [];
+                                        if ($days)    $out[] = $days . 'd';
+                                        if ($hours)   $out[] = $hours . 'h';
+                                        if ($minutes) $out[] = $minutes . 'm';
+                                        if ($seconds || empty($out)) $out[] = $seconds . 's';
+
+                                        return implode(' ', $out);
+                                }
+        }
+
+//friendly labels
+        $service_labels = [
+                'email_queue'         => 'Email Queue',
+                'event_guard'         => 'Event Guard',
+                'fax_queue'           => 'Fax Queue',
+                'maintenance_service' => 'Maintenance Service',
+                'message_events'      => 'Message Events',
+                'message_queue'       => 'Message Queue',
+                'xml_cdr'             => 'XML CDR',
+                'freeswitch'          => 'FreeSWITCH',
+                'nginx'               => 'Nginx',
+                'postgresql'          => 'PostgreSQL',
+                'event_guard'         => 'Event Guard',
+                'sshd'                => 'SSH Server'
+        ];
+
+        $files = glob(PROJECT_ROOT . '/*/*/resources/service/*.service');
+        $services = [];
+        $total_running = 0;
+
+        // load FusionPBX installed services
+        foreach ($files as $file) {
+                $service = get_classname($file);
+                //check if the service name was found
+                if (!empty($service)) {
+                        $basename = basename($service, '.php');
+                        $info = is_running($service);
+                        $info['label'] = $service_labels[$basename] ?? ucwords(str_replace('_', ' ', $basename));
+                        $services[$basename] = $info;
+                        if ($info['running']) $total_running++;
+                }
+        }
+
+        // Get extra system services from default settings
+        $extra_services_string = $settings->get('theme', 'dashboard_extra_system_services');
+
+        // Only proceed if the setting is not empty
+        if (!empty($extra_services_string) && is_string($extra_services_string)) {
+                // Convert comma-separated list to array
+                $extra_services = array_filter(array_map('trim', explode(',', $extra_services_string)));
+
+                // Loop through extra services if array is not empty
+                if (!empty($extra_services)) {
+                        foreach ($extra_services as $extra) {
+                                if (!isset($services[$extra])) {
+                                        $info = is_running($extra);
+                                        $info['label'] = $service_labels[$extra] ?? ucwords($extra);
+                                        $services[$extra] = $info;
+                                        if ($info['running']) $total_running++;
+                                }
+                        }
+                }
+        }
 
 //track total installed services for charts
 	$total_services = count($services);
@@ -99,89 +161,90 @@
 
 //show the results
 echo "<div class='hud_box'>\n";
-echo "	<div class='hud_content' ".($dashboard_details_state == 'disabled' ?: "onclick=\"$('#hud_system_services_details').slideToggle('fast'); toggle_grid_row_end('$dashboard_name')\""). ">\n";
-echo "		<span class='hud_title'>System Services</span>\n";
-echo "		<div class='hud_chart' style='width: 250px;'><canvas id='system_services_chart'></canvas></div>\n";
-echo "	</div>\n";
-echo "		<script>\n";
-echo "			const system_services_chart = new Chart (\n";
-echo "				document.getElementById('system_services_chart').getContext('2d'),\n";
-echo "				{\n";
-echo "					type: 'doughnut',\n";
-echo "					data: {\n";
-echo "						labels: ['Active: $total_running' , 'Inactive: ".$total_services-$total_running."'],\n";
-echo "						datasets: [{\n";
-echo "								data: ['5','".$total_services-$total_running."'],\n";
-echo "								backgroundColor: [\n";
-echo "									'".$settings->get('theme', 'dashboard_system_counts_chart_main_color','#2a9df4')."',\n";
-echo "									'".$settings->get('theme', 'dashboard_system_counts_chart_sub_color','#d4d4d4')."'\n";
-echo "								],\n";
-echo "								borderColor: '".$settings->get('theme', 'dashboard_chart_border_color')."',\n";
-echo "								borderWidth: '".$settings->get('theme', 'dashboard_chart_border_width')."'\n";
-echo "						}]\n";
-echo "					},\n";
-echo "					options: {\n";
-echo "						plugins: {\n";
-echo "							chart_number: {\n";
-echo "								text: '$total_services'\n";
-echo "							},\n";
-echo "							legend: {\n";
-echo "								display: true,\n";
-echo "								position: 'right',\n";
-echo "								labels: {\n";
-echo "									usePointStyle: true,\n";
-echo "									pointStyle: 'rect',\n";
-echo "									color: '$dashboard_heading_text_color'\n";
-echo "								}\n";
-echo "							}\n";
-echo "						}\n";
-echo "					},\n";
-echo "					plugins: [{\n";
-echo "						id: 'chart_number',\n";
-echo "						beforeDraw(chart, args, options) {\n";
-echo "							const {ctx, chartArea: {top, right, bottom, left, width, height} } = chart;\n";
-echo "							ctx.font = chart_text_size + ' ' + chart_text_font;\n";
-echo "							ctx.textBaseline = 'middle';\n";
-echo "							ctx.textAlign = 'center';\n";
-echo "							ctx.fillStyle = '$dashboard_number_text_color';\n";
-echo "							ctx.fillText(options.text, width / 2, top + (height / 2));\n";
-echo "							ctx.save();\n";
-echo "						}\n";
-echo "					}]\n";
-echo "				}\n";
-echo "			);\n";
-echo "		</script>\n";
+echo "  <div class='hud_content' ".($dashboard_details_state == 'disabled' ?: "onclick=\"$('#hud_system_services_details').slideToggle('fast'); toggle_grid_row_end('$dashboard_name')\""). ">\n";
+echo "          <span class='hud_title'>System Services</span>\n";
+echo "          <div class='hud_chart' style='width: 250px;'><canvas id='system_services_chart'></canvas></div>\n";
+echo "  </div>\n";
+echo "          <script>\n";
+echo "                  const system_services_chart = new Chart (\n";
+echo "                          document.getElementById('system_services_chart').getContext('2d'),\n";
+echo "                          {\n";
+echo "                                  type: 'doughnut',\n";
+echo "                                  data: {\n";
+echo "                                          labels: ['Active: $total_running' , 'Inactive: ".$total_services-$total_running."'],\n";
+echo "                                          datasets: [{\n";
+echo "                                                          data: ['5','".$total_services-$total_running."'],\n";
+echo "                                                          backgroundColor: [\n";
+echo "                                                                  '".$settings->get('theme', 'dashboard_system_counts_chart_main_color','#2a9df4')."',\n";
+echo "                                                                  '".$settings->get('theme', 'dashboard_system_counts_chart_sub_color','#d4d4d4')."'\n";
+echo "                                                          ],\n";
+echo "                                                          borderColor: '".$settings->get('theme', 'dashboard_chart_border_color')."',\n";
+echo "                                                          borderWidth: '".$settings->get('theme', 'dashboard_chart_border_width')."'\n";
+echo "                                          }]\n";
+echo "                                  },\n";
+echo "                                  options: {\n";
+echo "                                          plugins: {\n";
+echo "                                                  chart_number: {\n";
+echo "                                                          text: '$total_services'\n";
+echo "                                                  },\n";
+echo "                                                  legend: {\n";
+echo "                                                          display: true,\n";
+echo "                                                          position: 'right',\n";
+echo "                                                          labels: {\n";
+echo "                                                                  usePointStyle: true,\n";
+echo "                                                                  pointStyle: 'rect',\n";
+echo "                                                                  color: '$dashboard_heading_text_color'\n";
+echo "                                                          }\n";
+echo "                                                  }\n";
+echo "                                          }\n";
+echo "                                  },\n";
+echo "                                  plugins: [{\n";
+echo "                                          id: 'chart_number',\n";
+echo "                                          beforeDraw(chart, args, options) {\n";
+echo "                                                  const {ctx, chartArea: {top, right, bottom, left, width, height} } = chart;\n";
+echo "                                                  ctx.font = chart_text_size + ' ' + chart_text_font;\n";
+echo "                                                  ctx.textBaseline = 'middle';\n";
+echo "                                                  ctx.textAlign = 'center';\n";
+echo "                                                  ctx.fillStyle = '$dashboard_number_text_color';\n";
+echo "                                                  ctx.fillText(options.text, width / 2, top + (height / 2));\n";
+echo "                                                  ctx.save();\n";
+echo "                                          }\n";
+echo "                                  }]\n";
+echo "                          }\n";
+echo "                  );\n";
+echo "          </script>\n";
+
 
 if ($dashboard_details_state != 'disabled') {
-        // Define friendly names for known system services
-	$service_friendly_names = [
-		'email_queue'         => 'Email Queue',
-		'event_guard'         => 'Event Guard',
-		'fax_queue'           => 'Fax Queue',
-		'maintenance_service' => 'Maintenance Service',
-		'message_events'      => 'Message Events',
-		'message_queue'       => 'Message Queue',
-		'xml_cdr'             => 'XML CDR'
-	];
-echo "	<div class='hud_details hud_box' id='hud_system_services_details'>\n";
-echo "		<table class='tr_hover' width='100%' cellpadding='0' cellspacing='0' border='0'>\n";
-echo "			<tr>\n";
-echo "				<th class='hud_heading' width='50%'>".($text['label-service'] ?? 'Service')."</th>\n";
-echo "				<th class='hud_heading' width='50%' style='text-align: center; padding-left: 0; padding-right: 0;'>".($text['label-running'] ?? 'Running')."</th>\n";
-echo "			</tr>\n";
-		$row_style[false] = "row_style0";
-		$row_style[true] = "row_style1";
-		$c = true;
-		foreach ($services as $name => $enabled) {
-			// Use mapped friendly name, or fall back to default formatting
-			$display_name = $service_friendly_names[$name] ?? ucwords(str_replace('_', ' ', $name));
-			echo "  <tr>\n";
-			echo "    <td valign='top' class='{$row_style[$c]}' hud_text>$display_name</td>\n";
-			echo "    <td valign='top' class='{$row_style[$c]}' hud_text style='text-align: center;'>" . ($enabled ? $text['label-yes'] ?? 'Yes' : $text['label-no'] ?? 'No') . "</td>\n";
-			echo "  </tr>\n";
-			$c = !$c;
-		}
-echo "		</table>\n";
-echo "	</div>\n";
+echo "  <div class='hud_details hud_box' id='hud_system_services_details'>\n";
+echo "    <table class='tr_hover' width='100%' cellpadding='0' cellspacing='0' border='0'>\n";
+echo "      <tr>\n";
+echo "        <th class='hud_heading' width='40%'>".($text['label-service'] ?? 'Service')."</th>\n";
+echo "        <th class='hud_heading' width='10%' style='text-align: center;'>".($text['label-running'] ?? 'Running')."</th>\n";
+echo "        <th class='hud_heading' width='35%' style='text-align: center;'>".($text['label-runtime'] ?? 'Runtime')."</th>\n";
+echo "      </tr>\n";
+
+        $row_style[false] = "row_style0";
+        $row_style[true] = "row_style1";
+        $c = true;
+        foreach ($services as $info) {
+		$label = $info['label'];
+                $status = $info['running']
+                        ? "<span style='background-color: #28a745; color: white; padding: 2px 8px; border-radius: 10px;'>Yes</span>"
+                        : "<span style='background-color: #dc3545; color: white; padding: 2px 8px; border-radius: 10px;'>No</span>";
+		$etime = isset($info['etime']) ? format_etime($info['etime']) : '-';
+                $pid = $info['pid'] ?? '';
+		$tooltip_attr = $pid ? "title='PID: $pid'" : '';
+				
+                echo "      <tr>\n";
+                echo "        <td class='{$row_style[$c]}' hud_text $tooltip_attr>$label</td>\n";
+		echo "        <td class='{$row_style[$c]}' hud_text style='text-align: center;' $tooltip_attr>$status</td>\n";
+		echo "        <td class='{$row_style[$c]}' hud_text style='text-align: center;' $tooltip_attr>$etime</td>\n";
+                echo "      </tr>\n";
+                $c = !$c;
+        }
+
+echo "    </table>\n";
+echo "  </div>\n";
 }
 echo "</div>\n";

--- a/app/system/resources/dashboard/system_services.php
+++ b/app/system/resources/dashboard/system_services.php
@@ -219,8 +219,8 @@ if ($dashboard_details_state != 'disabled') {
 echo "  <div class='hud_details hud_box' id='hud_system_services_details'>\n";
 echo "    <table class='tr_hover' width='100%' cellpadding='0' cellspacing='0' border='0'>\n";
 echo "      <tr>\n";
-echo "        <th class='hud_heading' width='40%'>".($text['label-service'] ?? 'Service')."</th>\n";
-echo "        <th class='hud_heading' width='10%' style='text-align: center;'>".($text['label-running'] ?? 'Running')."</th>\n";
+echo "        <th class='hud_heading' width='45%'>".($text['label-service'] ?? 'Service')."</th>\n";
+echo "        <th class='hud_heading' width='20%' style='text-align: center;'>".($text['label-running'] ?? 'Running')."</th>\n";
 echo "        <th class='hud_heading' width='35%' style='text-align: center;'>".($text['label-runtime'] ?? 'Runtime')."</th>\n";
 echo "      </tr>\n";
 


### PR DESCRIPTION
This PR supersedes the previous PR ([7363](https://github.com/fusionpbx/fusionpbx/pull/7363)) with all the changes ported over

- Expanded the system_services card with an additional column for 'Runtime', showing how long the service has been running for
- Added a hover tooltip showing the PID of the service to all three columns
- Added the ability to fetch for additional services string from default settings to show in the system_services card
- Added a new default setting (theme -> dashboard_extra_system_services) for defining additional system services to monitor in the system_services dashboard card
- Default setting is enabled by default with a string value of 'freeswitch, nginx, postgresql, sshd'
- Added a $service_labels array
- For each service, tries to find a match in the array and sets the label value
- If no match found in the array, it falls back to prettifying the name automatically (replace underscore with space and capitalize the first letter of each word) so future services don't break the display

![image](https://github.com/user-attachments/assets/e821cdc7-ab95-42b3-82f9-3c05ff3c341c)
