### PR TITLE
Add variable for speaker phone volume

### DIFF
--- a/resources/templates/provision/yealink/t34w/y000000000171.cfg
+++ b/resources/templates/provision/yealink/t34w/y000000000171.cfg
@@ -495,6 +495,8 @@ features.station_name.scrolling_display =
 voice.headset.autoreset_spk_vol =
 voice.handset.autoreset_spk_vol =
 voice.handfree.autoreset_spk_vol =
+#Speaker phone volume. 0-15 (lowest to highest)
+voice.handfree.spk_vol = {$yealink_handsfree_speaker_vol}
 features.headset.ctrl_call.enable =
 phone_setting.incoming_call.reject.enable =
 


### PR DESCRIPTION
Add variable to provision speaker phone volume. Helpful when phones are primarily used as intercom devices. Values are 0-15, 15 being the loudest.