### PR TITLE
Allow device to not revert back to DHCP on reboot and keep manually entered static IP.

### DIFF
--- a/resources/templates/provision/grandstream/ht802/{$mac}.xml
+++ b/resources/templates/provision/grandstream/ht802/{$mac}.xml
@@ -2448,7 +2448,7 @@
     <!-- # IP Address. 0 - DHCP, 2 - PPPoE, 1 - Static IP -->
     <!-- # Number: 0, 1, 2 -->
     <!-- # Mandatory -->
-    <P8>0</P8>
+    {if isset($grandstream_ip_mode)}<P8>{$grandstream_ip_mode}</P8>{else}<P8>0</P8>{/if}</P8>
 
     <!-- ################################################################################# -->
     <!-- # DHCP -->


### PR DESCRIPTION
Allow device to not revert back to DHCP on reboot and keep manually entered static IP.