### PR TITLE
Force Groundwire to use GSM/LTE for emergency calls

### DIFF
--- a/resources/templates/provision/groundwire/default/{$mac}.xml
+++ b/resources/templates/provision/groundwire/default/{$mac}.xml
@@ -13,6 +13,27 @@
         <voicemailNumber>*97</voicemailNumber>
         <subscribeForVoicemail>1</subscribeForVoicemail>
         <wsContactsUrl>https://{$row.server_address}/app/provision/index.php?address={$mac}&file=directory.json</wsContactsUrl>
+
+      <rewriting>
+    <rule>
+      <conditions>
+        <condition type="equals" param="933"/>
+      </conditions>
+      <actions>
+        <action type="overrideDialAction" param="gsmCall"/>
+      </actions>
+    </rule>
+
+    <rule>
+      <conditions>
+        <condition type="equals" param="911"/>
+      </conditions>
+      <actions>
+        <action type="overrideDialAction" param="gsmCall"/>
+      </actions>
+    </rule>
+  </rewriting>
 </account>
+
 {if $row@index eq 1}{break}{/if}
 {/foreach}


### PR DESCRIPTION
This applies to users in the United States. When a user dials 911 or 933 (commonly used for 911 testing) from the Groundwire app, the call is automatically placed using the device's cellular service. This approach can enhance location accuracy for emergency services and ensure more reliable call completion.