### PR TITLE
Prevent orphaned data in voicemail destinations

### DIFF
--- a/app/voicemails/resources/classes/voicemail.php
+++ b/app/voicemails/resources/classes/voicemail.php
@@ -412,6 +412,9 @@
 											$array['voicemail_greetings'][$x]['domain_uuid'] = $this->domain_uuid;
 										}
 										$x++;
+										$array['voicemail_destinations'][$x]['voicemail_uuid_copy'] = $voicemail_uuid;
+										$array['voicemail_destinations'][$x]['domain_uuid'] = $this->domain_uuid;
+										$x++;
 								}
 							}
 


### PR DESCRIPTION
This PR is to prevent orphaned data when deleting a voicemail box that is used as a forward destination in another voicemail box.