### PR TITLE
Add Grandstream variable for IP mode (DHCP, Static, Etc)

### DIFF
--- a/resources/templates/provision/grandstream/ht818/{$mac}.xml
+++ b/resources/templates/provision/grandstream/ht818/{$mac}.xml
@@ -1798,7 +1798,7 @@
     <!-- # IP Address. 0 - DHCP, 2 - PPPoE, 1 - Static IP -->
     <!-- # Number: 0, 1, 2 -->
     <!-- # Mandatory -->
-    <P8>0</P8>
+    {if isset($grandstream_ip_mode)}<P8>{$grandstream_ip_mode}</P8>{else}<P8>0</P8>{/if}
 
     <!-- ################################################################################# -->
     <!-- # DHCP -->


### PR DESCRIPTION
Allows variable to be set to prevent device from reverting back to DHCP on reboot if a static IP was manually set. 