### PR TITLE
Fix CDR HTTP authentication logic bug

### DIFF
--- a/app/xml_cdr/resources/classes/xml_cdr.php
+++ b/app/xml_cdr/resources/classes/xml_cdr.php
@@ -1703,7 +1703,7 @@
 
 				//if http enabled is set to false then deny access
 					if (!defined('STDIN')) {
-						if ($this->settings->get('cdr', 'http_enabled', false)) {
+						if (!$this->settings->get('cdr', 'http_enabled', false)) {
 							openlog('FusionPBX', LOG_NDELAY, LOG_AUTH);
 							syslog(LOG_WARNING, '['.$_SERVER['REMOTE_ADDR'].'] XML CDR import default setting http_enabled is not enabled. Line: '.__line__);
 							closelog();


### PR DESCRIPTION
## Problem

Within my environment, CDR's stopped being written to the db after a `git pull` on 12-April-2025. Under the hood, CDR imports appear to have been silently failing when `http_enabled` is set to `true` due to inverted authentication logic. 

## Root Cause  

Line 1706 was checking `if (http_enabled)` when it should check `if (!http_enabled)` to deny access only when HTTP is 
disabled.

## Proposed Solution

Added missing negation operator (`!`) to fix the authentication logic.

## Testing

- Proposed fix resolves silent CDR import failures
- Tested with both staging and production environments
- Confirmed HTTP POST authentication now works correctly

## Impact

This affects at least one FusionPBX installation using HTTP POST for CDR imports with `http_enabled=true`. I do not have access to enough systems to know if "flipping the bit" might introduce issues for other users, but I can say with confidence that this resolved my own CDR issue.