### PR TITLE
Add SNMP configuration support for Grandstream HT801,HT802 and GXP2135

### DIFF
--- a/app/grandstream/app_config.php
+++ b/app/grandstream/app_config.php
@@ -1208,5 +1208,29 @@
 		$apps[$x]['default_settings'][$y]['default_setting_enabled'] = "false";
 		$apps[$x]['default_settings'][$y]['default_setting_description'] = "Use Random Port. 0 - No, 1 - Yes. Default is 0";
 		$y++;
+		$apps[$x]['default_settings'][$y]['default_setting_uuid'] = "f1e8c4a5-9b2d-4f7e-8c3a-1d5e6f9a8b7c";
+		$apps[$x]['default_settings'][$y]['default_setting_category'] = "provision";
+		$apps[$x]['default_settings'][$y]['default_setting_subcategory'] = "grandstream_snmp_enable";
+		$apps[$x]['default_settings'][$y]['default_setting_name'] = "numeric";
+		$apps[$x]['default_settings'][$y]['default_setting_value'] = "0";
+		$apps[$x]['default_settings'][$y]['default_setting_enabled'] = "true";
+		$apps[$x]['default_settings'][$y]['default_setting_description'] = "Enable SNMP. 0 - No, 1 - Yes. Default is 0 (disabled).";
+		$y++;
+		$apps[$x]['default_settings'][$y]['default_setting_uuid'] = "a2b3c4d5-6e7f-8a9b-0c1d-2e3f4a5b6c7d";
+		$apps[$x]['default_settings'][$y]['default_setting_category'] = "provision";
+		$apps[$x]['default_settings'][$y]['default_setting_subcategory'] = "grandstream_snmp_version";
+		$apps[$x]['default_settings'][$y]['default_setting_name'] = "numeric";
+		$apps[$x]['default_settings'][$y]['default_setting_value'] = "2";
+		$apps[$x]['default_settings'][$y]['default_setting_enabled'] = "true";
+		$apps[$x]['default_settings'][$y]['default_setting_description'] = "SNMP Version. 1 - Version 1, 2 - Version 2c, 3 - Version 3. Default is 2 (Version 2c).";
+		$y++;
+		$apps[$x]['default_settings'][$y]['default_setting_uuid'] = "b3c4d5e6-7f8a-9b0c-1d2e-3f4a5b6c7d8e";
+		$apps[$x]['default_settings'][$y]['default_setting_category'] = "provision";
+		$apps[$x]['default_settings'][$y]['default_setting_subcategory'] = "grandstream_snmp_community";
+		$apps[$x]['default_settings'][$y]['default_setting_name'] = "text";
+		$apps[$x]['default_settings'][$y]['default_setting_value'] = "public";
+		$apps[$x]['default_settings'][$y]['default_setting_enabled'] = "true";
+		$apps[$x]['default_settings'][$y]['default_setting_description'] = "SNMPv1/v2c Community string. Default is 'public'.";
+		$y++;
 
 ?>

--- a/app/grandstream/app_config.php
+++ b/app/grandstream/app_config.php
@@ -1213,7 +1213,7 @@
 		$apps[$x]['default_settings'][$y]['default_setting_subcategory'] = "grandstream_snmp_enable";
 		$apps[$x]['default_settings'][$y]['default_setting_name'] = "numeric";
 		$apps[$x]['default_settings'][$y]['default_setting_value'] = "0";
-		$apps[$x]['default_settings'][$y]['default_setting_enabled'] = "true";
+		$apps[$x]['default_settings'][$y]['default_setting_enabled'] = "false";
 		$apps[$x]['default_settings'][$y]['default_setting_description'] = "Enable SNMP. 0 - No, 1 - Yes. Default is 0 (disabled).";
 		$y++;
 		$apps[$x]['default_settings'][$y]['default_setting_uuid'] = "a2b3c4d5-6e7f-8a9b-0c1d-2e3f4a5b6c7d";
@@ -1221,7 +1221,7 @@
 		$apps[$x]['default_settings'][$y]['default_setting_subcategory'] = "grandstream_snmp_version";
 		$apps[$x]['default_settings'][$y]['default_setting_name'] = "numeric";
 		$apps[$x]['default_settings'][$y]['default_setting_value'] = "2";
-		$apps[$x]['default_settings'][$y]['default_setting_enabled'] = "true";
+		$apps[$x]['default_settings'][$y]['default_setting_enabled'] = "false";
 		$apps[$x]['default_settings'][$y]['default_setting_description'] = "SNMP Version. 1 - Version 1, 2 - Version 2c, 3 - Version 3. Default is 2 (Version 2c).";
 		$y++;
 		$apps[$x]['default_settings'][$y]['default_setting_uuid'] = "b3c4d5e6-7f8a-9b0c-1d2e-3f4a5b6c7d8e";
@@ -1229,7 +1229,7 @@
 		$apps[$x]['default_settings'][$y]['default_setting_subcategory'] = "grandstream_snmp_community";
 		$apps[$x]['default_settings'][$y]['default_setting_name'] = "text";
 		$apps[$x]['default_settings'][$y]['default_setting_value'] = "public";
-		$apps[$x]['default_settings'][$y]['default_setting_enabled'] = "true";
+		$apps[$x]['default_settings'][$y]['default_setting_enabled'] = "false";
 		$apps[$x]['default_settings'][$y]['default_setting_description'] = "SNMPv1/v2c Community string. Default is 'public'.";
 		$y++;
 

--- a/resources/templates/provision/grandstream/gxp2135/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp2135/{$mac}.xml
@@ -1057,10 +1057,24 @@
 		<!-- ## Network/SNMP Settings                     ## -->
 		<!-- ############################################################################## -->
 		<!-- # Enable SNMP. Yes or No -->
+{if isset($grandstream_snmp_enable) && $grandstream_snmp_enable == '1'}
+		<item name="network.snmp.enable">Yes</item>
+{else}
 		<item name="network.snmp.enable">No</item>
+{/if}
 
 		<!-- # Version. Version1, Version2, Version3. Default is Version3 -->
+{if isset($grandstream_snmp_version)}
+	{if $grandstream_snmp_version == '1'}
+		<item name="network.snmp.version">Version1</item>
+	{elseif $grandstream_snmp_version == '2'}
+		<item name="network.snmp.version">Version2</item>
+	{else}
 		<item name="network.snmp.version">Version3</item>
+	{/if}
+{else}
+		<item name="network.snmp.version">Version2</item>
+{/if}
 
 		<!-- # Port -->
 		<!-- # Number. Default is 161. -->
@@ -1068,7 +1082,11 @@
 
 		<!-- # Community -->
 		<!-- # String -->
-		<item name="network.snmp.community"/>
+{if isset($grandstream_snmp_community)}
+		<item name="network.snmp.community">{$grandstream_snmp_community}</item>
+{else}
+		<item name="network.snmp.community">public</item>
+{/if}
 
 		<!-- # SNMP Trap Version -->
 		<!-- # Version1, Version2, Version3. -->

--- a/resources/templates/provision/grandstream/ht801/{$mac}.xml
+++ b/resources/templates/provision/grandstream/ht801/{$mac}.xml
@@ -274,12 +274,20 @@
     <!-- # Enable SNMP. 0 - No, 1 - Yes, default value is 0. -->
     <!-- # Number: 0, 1 -->
     <!-- # Mandatory -->
+{if isset($grandstream_snmp_enable)}
+    <P21896>{$grandstream_snmp_enable}</P21896>
+    {else}
     <P21896>0</P21896>
+{/if}
 
     <!-- # SNMP Version. 1 - Version 1, 2 - Version 2c, 3 - Version 3. Default value is 3. -->
     <!-- # Nmuber: 1, 2, 3 -->
     <!-- # Mandatory -->
-    <P21904>3</P21904>
+{if isset($grandstream_snmp_version)}
+    <P21904>{$grandstream_snmp_version}</P21904>
+    {else}
+    <P21904>2</P21904>
+{/if}
 
     <!-- # SNMP Port. Default is port 162 -->
     <!-- # Number: 162 or 1025 to 65535 -->
@@ -305,7 +313,11 @@
 
     <!-- # SNMPv1/v2c Community -->
     <!-- # Max Character Number: 64 -->
-    <P21902></P21902>
+{if isset($grandstream_snmp_community)}
+    <P21902>{$grandstream_snmp_community}</P21902>
+    {else}
+    <P21902>public</P21902>
+{/if}
 
     <!-- # SNMP Trap Community -->
     <!-- # Max String Length: 64 -->

--- a/resources/templates/provision/grandstream/ht802/{$mac}.xml
+++ b/resources/templates/provision/grandstream/ht802/{$mac}.xml
@@ -274,12 +274,20 @@
     <!-- # Enable SNMP. 0 - No, 1 - Yes, default value is 0. -->
     <!-- # Number: 0, 1 -->
     <!-- # Mandatory -->
+{if isset($grandstream_snmp_enable)}
+    <P21896>{$grandstream_snmp_enable}</P21896>
+    {else}
     <P21896>0</P21896>
+{/if}
 
     <!-- # SNMP Version. 1 - Version 1, 2 - Version 2c, 3 - Version 3. Default value is 3. -->
     <!-- # Nmuber: 1, 2, 3 -->
     <!-- # Mandatory -->
-    <P21904>3</P21904>
+{if isset($grandstream_snmp_version)}
+    <P21904>{$grandstream_snmp_version}</P21904>
+    {else}
+    <P21904>2</P21904>
+{/if}
 
     <!-- # SNMP Port. Default is port 162 -->
     <!-- # Number: 162 or 1025 to 65535 -->
@@ -305,7 +313,11 @@
 
     <!-- # SNMPv1/v2c Community -->
     <!-- # Max Character Number: 64 -->
-    <P21902></P21902>
+{if isset($grandstream_snmp_community)}
+    <P21902>{$grandstream_snmp_community}</P21902>
+    {else}
+    <P21902>public</P21902>
+{/if}
 
     <!-- # SNMP Trap Community -->
     <!-- # Max String Length: 64 -->


### PR DESCRIPTION
Added configurable SNMP settings to Grandstream HT801, HT802, and GXP2135 provisioning template. Includes enable/disable toggle, SNMP version selection (default v2c), and community string configuration. SNMP is disabled by default
for security.