### PR TITLE
Fix: restore device auto-insert functionality during provisioning

### DIFF
--- a/app/provision/index.php
+++ b/app/provision/index.php
@@ -243,7 +243,7 @@
 	$provision = $settings->get('provision', null, []);
 
 //check for a valid match
-	if (empty($device_uuid) && $settings->get('provision', 'auto_insert_enabled', false)) {
+	if (empty($device_uuid) && !$settings->get('provision', 'auto_insert_enabled', false)) {
 		http_error(403);
 	}
 


### PR DESCRIPTION
**Problem**

The auto-insert feature for devices during provisioning was not working as expected. Even when the auto_insert_enabled setting was explicitly enabled in FusionPBX, the condition in index.php was incorrectly preventing devices from being inserted automatically.

This was due to both if conditions using http_error(403) regardless of the setting's value, effectively blocking insertion in all cases where device_uuid was empty.
✅ Solution

The logic was corrected to properly check the value of auto_insert_enabled. Now:

    If device_uuid is empty and auto_insert_enabled is false, provisioning is blocked (403).

    If device_uuid is empty and auto_insert_enabled is true, the device is auto-inserted.

This ensures that provisioning behaves according to the admin-configured setting.

**Testing**

The fix was tested and confirmed working on the following devices:

    Yealink T46G

    Yealink T46S

    Fanvil X6

Auto-insert worked as expected when enabled, and was correctly blocked when disabled.