### PR TITLE
Fix closing tag on if/else

### DIFF
--- a/resources/templates/provision/grandstream/ht801/{$mac}.xml
+++ b/resources/templates/provision/grandstream/ht801/{$mac}.xml
@@ -91,6 +91,7 @@
     <P212>{$grandstream_firmware_upgrade_protocol}</P212>
     {else}
     <P212>2</P212>
+    {/if}
 
     <!-- Firmware Server Path -->
     <!-- Server address -->

--- a/resources/templates/provision/grandstream/ht802/{$mac}.xml
+++ b/resources/templates/provision/grandstream/ht802/{$mac}.xml
@@ -91,6 +91,7 @@
     <P212>{$grandstream_firmware_upgrade_protocol}</P212>
     {else}
     <P212>2</P212>
+    {/if}
 
     <!-- Firmware Server Path -->
     <!-- Server address -->


### PR DESCRIPTION
The firmware download section was missing the closing {/if}

Please also accept this small change in 5.3.8 as well.