### PR TITLE
Remove setting name and uuid for groups object

### DIFF
--- a/resources/classes/groups.php
+++ b/resources/classes/groups.php
@@ -63,10 +63,6 @@
 				$this->database = new database;
 			}
 
-			//set the application name and uuid
-			$this->database->app_name = $this->app_name;
-			$this->database->app_uuid = $this->app_uuid;
-
 			//set the domain_uuid
 			if (is_uuid($domain_uuid)) {
 				$this->domain_uuid = $domain_uuid;


### PR DESCRIPTION
Setting the name and uuid when the groups object is created causes the database transactions to almost always show that it was the groups object that made the changes.