### PR TITLE
Call to undefined method menu::restore() in menu.php

### DIFF
--- a/resources/classes/menu.php
+++ b/resources/classes/menu.php
@@ -1098,7 +1098,7 @@
 						$p->delete('menu_add', 'temp');
 
 					//add the menu items
-						$this->restore();
+						$this->restore_default();
 				}
 		}
 


### PR DESCRIPTION
An addendum to the changes made in [ee16644](https://github.com/fusionpbx/fusionpbx/commit/ee16644). Tested in a fresh installation and confirmed working. 

```
PHP Fatal error: Uncaught Error: Call to undefined method menu::restore() in /var/www/fusionpbx/resources/classes/menu.php:1101
Stack trace:
#0 /var/www/fusionpbx/core/menu/app_defaults.php(30): menu->menu_default()
#1 /var/www/fusionpbx/resources/classes/domains.php(650): include('...')
#2 /var/www/fusionpbx/core/upgrade/upgrade_domains.php(51): domains->upgrade()
#3 {main}
  thrown in /var/www/fusionpbx/resources/classes/menu.php on line 1101
```