### PR TITLE
improve system information class

### DIFF
--- a/app/system/resources/classes/linux_system_information.php
+++ b/app/system/resources/classes/linux_system_information.php
@@ -37,6 +37,25 @@ class linux_system_information extends system_information {
 		return $cpu_cores;
 	}
 
+	public function get_disk_usage(): array {
+		return disk_free_space("/") !== false ? [
+			'total' => disk_total_space("/"),
+			'free' => disk_free_space("/"),
+			'used' => disk_total_space("/") - disk_free_space("/")
+				] : [];
+	}
+
+	public function get_memory_details(): array {
+		$data = file_get_contents("/proc/meminfo");
+		preg_match('/MemTotal:\s+(\d+)/', $data, $total);
+		preg_match('/MemAvailable:\s+(\d+)/', $data, $available);
+		return [
+			'total' => (int) ($total[1] ?? 0) * 1024,
+			'available' => (int) ($available[1] ?? 0) * 1024,
+			'used' => ((int) ($total[1] ?? 0) - (int) ($available[1] ?? 0)) * 1024
+		];
+	}
+
 	//get the CPU details
 	public function get_cpu_percent(): float {
 		$stat1 = file_get_contents('/proc/stat');

--- a/app/system/resources/classes/solaris_system_information.php
+++ b/app/system/resources/classes/solaris_system_information.php
@@ -1,0 +1,118 @@
+<?php
+
+/*
+ * The MIT License
+ *
+ * Copyright 2025 Tim Fry <tim@fusionpbx.com>.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+/**
+ * Description of solaris_system_information
+ *
+ * @author Tim Fry <tim@fusionpbx.com>
+ */
+class solaris_system_information extends system_information {
+
+	public function get_disk_usage(): array {
+		return [
+			'total' => disk_total_space("/"),
+			'free' => disk_free_space("/"),
+			'used' => disk_total_space("/") - disk_free_space("/")
+		];
+	}
+
+	public function get_memory_details(): array {
+		$total = (int) shell_exec("prtconf | grep Memory | awk '{print $3 * 1024 * 1024}'");
+		$free = (int) shell_exec("vmstat 1 2 | tail -1 | awk '{print $5 * 1024}'");
+		$used = $total - $free;
+
+		return [
+			'total' => $total,
+			'available' => $free,
+			'used' => $used
+		];
+	}
+
+	public function get_uptime(): string {
+		$uptime = shell_exec("uptime");
+		if (preg_match('/up ([^,]+),/', $uptime, $matches)) {
+			return trim($matches[1]);
+		}
+		return 'unknown';
+	}
+
+	public function get_cpu_cores(): int {
+		return (int) shell_exec("psrinfo | wc -l");
+	}
+
+	public function get_cpu_percent(): float {
+		$output = shell_exec("mpstat 1 1 | tail -1");
+		if (preg_match('/\s+(\d+\.\d+)\s*$/', $output, $matches)) {
+			$idle = (float) $matches[1];
+			return round(100 - $idle, 2);
+		}
+		return 0.0;
+	}
+
+	public function get_cpu_percent_per_core(): array {
+		$output = shell_exec("mpstat -P ALL 1 1");
+		$lines = explode("\n", $output);
+		$results = [];
+
+		foreach ($lines as $line) {
+			if (preg_match('/^\s*(\d+)\s+\d+\.\d+\s+\d+\.\d+\s+\d+\.\d+\s+\d+\.\d+\s+(\d+\.\d+)/', $line, $m)) {
+				$core = (int) $m[1];
+				$idle = (float) $m[2];
+				$results[$core] = round(100 - $idle, 2);
+			}
+		}
+		return $results;
+	}
+
+	public function get_network_speed(string $interface = 'eth0'): array {
+		static $last = [];
+
+		$netstat = shell_exec("kstat -p -c net -n {$interface} | grep bytes");
+		$rx = $tx = 0;
+
+		foreach (explode("\n", $netstat) as $line) {
+			if (strpos($line, "rbytes64") !== false) {
+				$rx = (int) explode("\t", $line)[1];
+			}
+			if (strpos($line, "obytes64") !== false) {
+				$tx = (int) explode("\t", $line)[1];
+			}
+		}
+
+		$now = microtime(true);
+		if (!isset($last[$interface])) {
+			$last[$interface] = ['rx' => $rx, 'tx' => $tx, 'time' => $now];
+			return ['rx_bps' => 0, 'tx_bps' => 0];
+		}
+
+		$dt = $now - $last[$interface]['time'];
+		$drx = $rx - $last[$interface]['rx'];
+		$dtx = $tx - $last[$interface]['tx'];
+		$last[$interface] = ['rx' => $rx, 'tx' => $tx, 'time' => $now];
+
+		return ['rx_bps' => $drx / $dt, 'tx_bps' => $dtx / $dt];
+	}
+}

--- a/app/system/resources/classes/system_information.php
+++ b/app/system/resources/classes/system_information.php
@@ -36,18 +36,98 @@ abstract class system_information {
 	abstract public function get_cpu_percent(): float;
 	abstract public function get_cpu_percent_per_core(): array;
 	abstract public function get_network_speed(string $interface = 'eth0'): array;
+	abstract public function get_disk_usage(): array;
+	abstract public function get_memory_details(): array;
 
 	public function get_load_average() {
 		return sys_getloadavg();
 	}
 
+	public function get_disk_used_terabytes() {
+		return $this->get_disk_used_gigabytes() / 1024;
+	}
+
+	public function get_disk_used_gigabytes() {
+		return $this->get_disk_used_megabytes() / 1024;
+	}
+
+	public function get_disk_used_megabytes() {
+		return $this->get_disk_used_kilobytes() / 1024;
+	}
+
+	public function get_disk_used_kilobytes() {
+		return ($this->get_disk_usage())['used'] / 1024;
+	}
+
+	public function get_disk_free_terabytes() {
+		return $this->get_disk_free_gigabytes() / 1024;
+	}
+
+	public function get_disk_free_gigabytes() {
+		return $this->get_disk_free_megabytes() / 1024;
+	}
+
+	public function get_disk_free_megabytes() {
+		return $this->get_disk_free_kilobytes() / 1024;
+	}
+
+	public function get_disk_free_kilobytes() {
+		return ($this->get_disk_usage())['free'] / 1024;
+	}
+
+	public function get_disk_total_terabytes() {
+		return $this->get_disk_total_gigabytes() / 1024;
+	}
+
+	public function get_disk_total_gigabytes() {
+		return $this->get_disk_total_megabytes() / 1024;
+	}
+
+	public function get_disk_total_megabytes() {
+		return $this->get_disk_total_kilobytes() / 1024;
+	}
+
+	public function get_disk_total_kilobytes() {
+		return ($this->get_disk_usage())['total'] / 1024;
+	}
+
+	/**
+	 * Returns the OS family as a lowercase string independent of the PHP version
+	 * @return string Lowercase name of the detected family
+	 * @final
+	 */
+	public static final function get_os_family(): string {
+		// PHP 7.2+
+		if (defined(PHP_OS_FAMILY)) {
+			return strtolower(PHP_OS_FAMILY);
+		}
+		// PHP < 7.2
+		if (stripos(PHP_OS, 'LINUX') !== false) return 'linux';
+		if (stripos(PHP_OS, 'BSD') !== false) return 'bsd';
+		if (stripos(PHP_OS, 'DARWIN') !== false) return 'darwin';
+		if (stripos(PHP_OS, 'WIN') !== false) return 'windows';
+		if (stripos(PHP_OS, 'SUNOS') !== false || stripos(PHP_OS, 'SOLARIS') !== false) return 'solaris';
+		return '';
+	}
+
+	/**
+	 * Returns a new system information object based on the current OS
+	 * @return system_information|null
+	 */
 	public static function new(): ?system_information {
-		if (stristr(PHP_OS, 'BSD')) {
-			return new bsd_system_information();
+
+		// Get OS family as a lowercase string independent of the PHP version
+		$os = self::get_os_family();
+
+		// Ensure we have the OS family
+		if(empty($os)) {
+			return null;
 		}
-		if (stristr(PHP_OS, 'Linux')) {
-			return new linux_system_information();
-		}
-		return null;
+
+		// Set the class name based on the OS
+		$class = "{$os}_system_information";
+
+		// Create an instance of the system information object matching the current OS
+		return new $class();
 	}
 }

--- a/app/system/resources/classes/windows_system_information.php
+++ b/app/system/resources/classes/windows_system_information.php
@@ -1,0 +1,112 @@
+<?php
+
+/*
+ * The MIT License
+ *
+ * Copyright 2025 Tim Fry <tim@fusionpbx.com>.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+/**
+ * Description of windows_system_information
+ *
+ * @author Tim Fry <tim@fusionpbx.com>
+ */
+class windows_system_information extends system_information {
+
+	public function get_disk_usage(): array {
+		return [
+			'total' => disk_total_space("C:"),
+			'free' => disk_free_space("C:"),
+			'used' => disk_total_space("C:") - disk_free_space("C:")
+		];
+	}
+
+	public function get_memory_details(): array {
+		$info = shell_exec('wmic OS get FreePhysicalMemory,TotalVisibleMemorySize /Value');
+		preg_match('/TotalVisibleMemorySize=(\d+)/', $info, $total);
+		preg_match('/FreePhysicalMemory=(\d+)/', $info, $free);
+		$total = (int) ($total[1] ?? 0) * 1024;
+		$free = (int) ($free[1] ?? 0) * 1024;
+		return [
+			'total' => $total,
+			'available' => $free,
+			'used' => $total - $free
+		];
+	}
+
+	public function get_uptime(): string {
+		$boot = shell_exec('wmic os get LastBootUpTime /Value');
+		if (preg_match('/LastBootUpTime=(\d{14})/', $boot, $matches)) {
+			$boot_time = DateTime::createFromFormat('YmdHis', substr($matches[1], 0, 14));
+			if ($boot_time) {
+				$interval = (new DateTime())->diff($boot_time);
+				return $interval->format('%a days %h hours %i minutes %s seconds');
+			}
+		}
+		return 'unknown';
+	}
+
+	public function get_cpu_cores(): int {
+		$output = shell_exec('wmic CPU Get NumberOfLogicalProcessors /Value');
+		if (preg_match('/NumberOfLogicalProcessors=(\d+)/', $output, $matches)) {
+			return (int) $matches[1];
+		}
+		return 0;
+	}
+
+	public function get_cpu_percent(): float {
+		$output = shell_exec('powershell -Command "Get-Counter \'\\Processor(_Total)\\% Processor Time\' | Select-Object -ExpandProperty CounterSamples | ForEach-Object { $_.CookedValue }"');
+		return is_numeric(trim($output)) ? round((float) $output, 2) : 0.0;
+	}
+
+	public function get_cpu_percent_per_core(): array {
+		$output = shell_exec('powershell -Command "Get-Counter \'\\Processor(*)\\% Processor Time\' | Select -ExpandProperty CounterSamples | ForEach-Object { $_.InstanceName + \':\' + $_.CookedValue }"');
+		$lines = explode("\n", trim($output));
+		$results = [];
+
+		foreach ($lines as $line) {
+			if (preg_match('/^(\d+):([\d\.]+)/', trim($line), $m)) {
+				$results[(int) $m[1]] = round((float) $m[2], 2);
+			}
+		}
+
+		return $results;
+	}
+
+	public function get_network_speed(string $interface = 'eth0'): array {
+		// Get first interface if none provided
+		if ($interface === null) {
+			$list = shell_exec('powershell "Get-NetAdapter | Select -First 1 -ExpandProperty Name"');
+			$interface = trim($list);
+		}
+
+		$output = shell_exec("powershell -Command \"Get-Counter -Counter '\\Network Interface({$interface})\\Bytes Received/sec','\\Network Interface({$interface})\\Bytes Sent/sec' | ForEach-Object { \$_.CounterSamples.CookedValue }\"");
+		$parts = explode("\n", trim($output));
+		if (count($parts) >= 2) {
+			return [
+				'rx_bps' => round((float) trim($parts[0]), 2),
+				'tx_bps' => round((float) trim($parts[1]), 2)
+			];
+		}
+
+		return ['rx_bps' => 0, 'tx_bps' => 0];
+	}
+}


### PR DESCRIPTION
Added new OS family types for each family that can be returned from PHP_OS_FAMILY to maintain consistent behavior.

Example usage:

```php

$system_information = system_information::new();

// Print the array
print_r($system_information->get_disk_usage());

// Print total
$total = $system_information->get_disk_total_gigabytes();
echo "Total GB: $total\n";

// Print used GB
$usage = $system_information->get_disk_used_gigabytes();
echo "Used GB: $usage\n";

// Print free GB
$free = $system_information->get_disk_free_gigabytes();
echo "Free GB: $free\n";
exit();

```
