### PR TITLE
call_forward fix saving proccess with empty inputs

### DIFF
--- a/app/call_forward/call_forward_edit.php
+++ b/app/call_forward/call_forward_edit.php
@@ -112,13 +112,13 @@
 
 		//get http post variables and set them to php variables
 			if (!empty($_POST)) {
-				$forward_all_enabled = $_POST["forward_all_enabled"];
+				$forward_all_enabled = !empty($_POST["forward_all_destination"]) ? $_POST["forward_all_enabled"] : 'false';
 				$forward_all_destination = $_POST["forward_all_destination"];
-				$forward_busy_enabled = $_POST["forward_busy_enabled"];
+				$forward_busy_enabled = !empty($_POST["forward_busy_destination"]) ? $_POST["forward_busy_enabled"] : 'false';
 				$forward_busy_destination = $_POST["forward_busy_destination"];
-				$forward_no_answer_enabled = $_POST["forward_no_answer_enabled"];
+				$forward_no_answer_enabled = !empty($_POST["forward_no_answer_destination"]) ? $_POST["forward_no_answer_enabled"] : 'false';
 				$forward_no_answer_destination = $_POST["forward_no_answer_destination"];
-				$forward_user_not_registered_enabled = $_POST["forward_user_not_registered_enabled"];
+				$forward_user_not_registered_enabled = !empty($_POST["forward_user_not_registered_destination"]) ? $_POST["forward_user_not_registered_enabled"] : 'false';
 				$forward_user_not_registered_destination = $_POST["forward_user_not_registered_destination"];
 
 				$cid_name_prefix = $_POST["cid_name_prefix"] ?? '';


### PR DESCRIPTION
We are currently saving the empty fields for the destination for each switch, but it's not functioning correctly. Now, we are simply preventing saving when there is no destination.

https://github.com/user-attachments/assets/e340f9ba-ac94-468d-8018-9edf99c2bfb4

