### PR TITLE
Update debian-websockets.service

### DIFF
--- a/core/websockets/resources/service/debian-websockets.service
+++ b/core/websockets/resources/service/debian-websockets.service
@@ -9,9 +9,8 @@
 Description=Websocket Router Service
 
 [Service]
-PermissionsStartOnly=true
-ExecStartPre=mkdir -p /var/run/fusionpbx
-ExecStartPre=chown www-data:www-data /var/run/fusionpbx
+ExecStartPre=+mkdir -p /var/run/fusionpbx
+ExecStartPre=+chown www-data:www-data /var/run/fusionpbx
 ExecStart=/usr/bin/php /var/www/fusionpbx/core/websockets/resources/service/websockets.php --no-fork
 User=www-data
 Group=www-data


### PR DESCRIPTION
Replace the deprecated PermissionsStartOnly option in favour of the supported method of elevating the exec commands.

https://github.com/systemd/systemd/pull/10802#issuecomment-439446299