### PR TITLE
fix websocket service exit on invalid handshake

### DIFF
--- a/core/websockets/resources/classes/invalid_handshake_exception.php
+++ b/core/websockets/resources/classes/invalid_handshake_exception.php
@@ -27,15 +27,12 @@
  */
 
 /**
- * General socket exception class
+ * Description of invalid_handshake_exception
  *
  * @author Tim Fry <tim@fusionpbx.com>
  */
-class socket_exception extends \Exception {
-	public $id;
-	public function __construct($id = null, string $message = "", int $code = 0, ?\Throwable $previous = null) {
-		$this->id = $id;
-		return parent::__construct($message, $code, $previous);
+class invalid_handshake_exception extends \socket_exception {
+	public function __construct($id = null, string $message = "Invalid handshake", int $code = 0, ?\Throwable $previous = null) {
+		return parent::__construct($id, $message, $code, $previous);
 	}
-	public function getResourceId() { return $this->id; }
 }

--- a/core/websockets/resources/classes/websocket_server.php
+++ b/core/websockets/resources/classes/websocket_server.php
@@ -345,7 +345,7 @@ class websocket_server {
 			}
 		}
 		if (!preg_match("/Sec-WebSocket-Key: (.*)\r\n/", $request_header, $matches)) {
-			throw new \RuntimeException("Invalid WebSocket handshake");
+			throw new \invalid_handshake_exception($socket, "Invalid WebSocket handshake");
 		}
 		$key = trim($matches[1]);
 		$accept_key = base64_encode(


### PR DESCRIPTION
websocket_service would exit with a zero status code if an invalid handshake was encountered preventing systemctl from restarting the service automatically. This fix adjusts the service so it handles it gracefully.