### PR TITLE
Fix call block save call detail record condition

### DIFF
--- a/app/xml_cdr/resources/classes/xml_cdr.php
+++ b/app/xml_cdr/resources/classes/xml_cdr.php
@@ -375,19 +375,20 @@
 				}
 
 			//skip call detail records for calls blocked by call block
-				if (isset($xml->variables->call_block) && !empty($this->settings->get('call_block', 'save_call_detail_record'))) {
-					if ($xml->variables->call_block == 'true' && $this->settings->get('call_block', 'save_call_detail_record', false) !== true) {
-						//delete the xml cdr file
-						if (!empty($this->settings->get('switch', 'log'))) {
-							$xml_cdr_dir = $this->settings->get('switch', 'log').'/xml_cdr';
-							if (file_exists($xml_cdr_dir.'/'.$this->file)) {
-								unlink($xml_cdr_dir.'/'.$this->file);
-							}
+				if (isset($xml->variables->call_block)
+					&& $xml->variables->call_block == 'true'
+					&& !$this->settings->get('call_block', 'save_call_detail_record', true)
+					) {
+					//delete the xml cdr file
+					if (!empty($this->settings->get('switch', 'log'))) {
+						$xml_cdr_dir = $this->settings->get('switch', 'log').'/xml_cdr';
+						if (file_exists($xml_cdr_dir.'/'.$this->file)) {
+							unlink($xml_cdr_dir.'/'.$this->file);
 						}
-
-						//return without saving
-						return false;
 					}
+
+					//return without saving
+					return false;
 				}
 
 			//check for duplicate call uuid's


### PR DESCRIPTION
When a call is blocked, it was still showing in the CDRs. This fix corrects the condition used to check for call block in default settings.