### PR TITLE
Fix bug by adding 'tries' counter so reading websocket data can return

### DIFF
--- a/app/active_calls/resources/classes/active_calls_service.php
+++ b/app/active_calls/resources/classes/active_calls_service.php
@@ -404,9 +404,11 @@ class active_calls_service extends service implements websocket_service_interfac
 
 						// Web socket event
 						if ($resource === $this->ws_client->socket()) {
-							$this->handle_websocket_event($this->ws_client);
+							$this->handle_websocket_event();
 							continue;
 						}
+
+						$this->debug('Unknown Event from ' . $resource);
 					}
 				}
 			}

--- a/core/websockets/resources/classes/base_websocket_system_service.php
+++ b/core/websockets/resources/classes/base_websocket_system_service.php
@@ -165,7 +165,7 @@ abstract class base_websocket_system_service extends service implements websocke
 
 	/**
 	 * Connects to the web socket server using a websocket_client object
-	 * @return bool
+	 * @return bool True if connected and False if not able to connect
 	 */
 	protected function connect_to_ws_server(): bool {
 		if ($this->ws_client !== null && $this->ws_client->is_connected()) return true;

--- a/core/websockets/resources/classes/websocket_service.php
+++ b/core/websockets/resources/classes/websocket_service.php
@@ -260,7 +260,7 @@ class websocket_service extends service {
 			foreach ($send_to as $subscriber) {
 				try {
 					// Notify of the message we are broadcasting
-					$this->debug("Broadcasting message '" . $message->payload['event_name'] . "' for service '" . $message->service_name . "' to subscriber $subscriber->id");
+					$this->debug("Broadcasting message '" . $message->topic() . "' for service '" . $message->service_name . "' to subscriber $subscriber->id");
 					$subscriber->send_message($message);
 				} catch (subscriber_token_expired_exception $ste) {
 					$this->info("Subscriber $ste->id token expired");
@@ -806,6 +806,7 @@ class websocket_service extends service {
 		// Ensure we have the correct number of bytes
 		if (strlen($hdr) !== 2) {
 			$this->warning('Header is empty!');
+			$this->debug('Header content: ' . bin2hex($hdr) . '(' . strlen($hdr) . ' bytes)');
 			$this->update_connected_clients();
 			return '';
 		}
@@ -884,7 +885,6 @@ class websocket_service extends service {
 	 */
 	public static function send($resource, ?string $payload): bool {
 		if (!is_resource($resource)) {
-			self::log("Cannot send: invalid resource", LOG_ERR);
 			return false;
 		}
 


### PR DESCRIPTION
When reading web socket data, the loop will run forever if there is no more data available in a chunk. This fix will add a counter to how many times it tries to read before a timeout is reached.
Fixed a problem where the constructor parameter for permission_filter was not being fulfilled. This can cause a crash also leading to the read of web socket data to begin looping.
Added better debugging information by using the topic of the websocket_message instead of the payload data. This would cause some messages to appear empty when they were not.
Added a wait state for re-connecting to the web socket server for system status service so it would not exit immediately when the websocket server exited.
Added more PHPDoc Block information.