### PR TITLE
fix undeclared variable warning in fax_send

### DIFF
--- a/app/fax_queue/resources/job/fax_send.php
+++ b/app/fax_queue/resources/job/fax_send.php
@@ -63,7 +63,9 @@
 
 //shutdown call back function
 	function shutdown() {
+		//add global variables
 		global $database, $fax_queue_uuid;
+
 		//when the fax status is still sending
 		//then set the fax status to trying
 		$sql = "update v_fax_queue ";


### PR DESCRIPTION
When the shutdown function is called, the database object and fax_queue_uuid are not in scope causing the shutdown function to emit warnings.