### PR TITLE
Fix session.cookie_secure setting logic

### DIFF
--- a/resources/require.php
+++ b/resources/require.php
@@ -101,7 +101,7 @@
 	global $no_session;
 	if (!defined('STDIN') && empty($no_session) && session_status() === PHP_SESSION_NONE) {
 		ini_set('session.cookie_httponly', !isset($conf['session.cookie_httponly']) ? 'true' : (!empty($config->get('session.cookie_httponly')) ? 'true' : 'false'));
-		ini_set('session.cookie_secure', !isset($conf['session.cookie_secure']) ? 'true' : (!empty($config->get('session.cookie_secure')) ? 'true' : 'false'));
+		ini_set('session.cookie_secure', !isset($conf['session.cookie_secure']) ? 'true' : (!empty($config->get('session.cookie_secure')) ? 'false' : 'true'));
 		ini_set('session.cookie_samesite', $config->get('session.cookie_samesite', 'Lax'));
 		session_start();
 	}


### PR DESCRIPTION
Accommodate HTTP interface access on new install
When set to true, access to frontend failing 

```
Cookie "PHPSESSID" has been rejected because a non-HTTPS cookie can't be set as "secure".

```