### PR TITLE
Fix date-time conditions to respect domain timezone by converting to/from UTC

### DIFF
--- a/app/time_conditions/time_condition_edit.php
+++ b/app/time_conditions/time_condition_edit.php
@@ -307,8 +307,8 @@
 								//convert to 24 hour time and UTC for date-time conditions (FreeSWITCH evaluates date-time in UTC)
 								if (!empty($cond_start) && $cond_var == 'date-time') {
 								    $format = $settings->get('domain', 'time_format') == '24h' ? 'Y-m-d H:i' : 'Y-m-d h:i a';
-								    $user_timezone = $_SESSION['domain']['time_zone']['name'] ?? date_default_timezone_get();
-
+								    $user_timezone = $settings->get('domain', 'time_zone', date_default_timezone_get());
+								    
 								    $dt = DateTime::createFromFormat($format, $cond_start, new DateTimeZone($user_timezone));
 								    if ($dt !== false) {
 								        $dt->setTimezone(new DateTimeZone('UTC'));
@@ -317,8 +317,8 @@
 								}
 								if (!empty($cond_stop) && $cond_var == 'date-time') {
 								    $format = $settings->get('domain', 'time_format') == '24h' ? 'Y-m-d H:i' : 'Y-m-d h:i a';
-								    $user_timezone = $_SESSION['domain']['time_zone']['name'] ?? date_default_timezone_get();
-
+								    $user_timezone = $settings->get('domain', 'time_zone', date_default_timezone_get());
+								    
 								    $dt = DateTime::createFromFormat($format, $cond_stop, new DateTimeZone($user_timezone));
 								    if ($dt !== false) {
 								        $dt->setTimezone(new DateTimeZone('UTC'));
@@ -1095,9 +1095,10 @@ if ($action == 'update') {
 						if ($cond_var == 'date-time') {
 							echo "	change_to_input(document.getElementById('value_".$group_id."_' + condition_id + '_start'));\n";
 							echo "	change_to_input(document.getElementById('value_".$group_id."_' + condition_id + '_stop'));\n";
+							
 							//convert from UTC to user timezone and format appropriately
-							$user_timezone = $_SESSION['domain']['time_zone']['name'] ?? date_default_timezone_get();
-
+							$user_timezone = $settings->get('domain', 'time_zone', date_default_timezone_get());
+							
 							$dt_start = DateTime::createFromFormat('Y-m-d H:i', $cond_val_start, new DateTimeZone('UTC'));
 							if ($dt_start !== false) {
 							    $dt_start->setTimezone(new DateTimeZone($user_timezone));
@@ -1107,7 +1108,7 @@ if ($action == 'update') {
 							        $cond_val_start = $dt_start->format('Y-m-d H:i');
 							    }
 							}
-
+							
 							if (!empty($cond_val_stop)) {
 							    $dt_stop = DateTime::createFromFormat('Y-m-d H:i', $cond_val_stop, new DateTimeZone('UTC'));
 							    if ($dt_stop !== false) {
@@ -1119,6 +1120,7 @@ if ($action == 'update') {
 							        }
 							    }
 							}
+							
 							echo "	$('#value_".$group_id."_' + condition_id + '_start').val('".$cond_val_start."');\n";
 							echo "	$('#value_".$group_id."_' + condition_id + '_stop').val('".$cond_val_stop."');\n";
 						}

--- a/app/time_conditions/time_condition_edit.php
+++ b/app/time_conditions/time_condition_edit.php
@@ -326,7 +326,6 @@
 								    }
 								}
 
-
 								//convert time-of-day to minute-of-day (due to inconsistencies with time-of-day on some systems)
 								if ($cond_var == 'time-of-day') {
 									$cond_var = 'minute-of-day';
@@ -338,7 +337,6 @@
 										$cond_stop = ($array_cond_stop[0] * 60) + $array_cond_stop[1];
 									}
 								}
-
 								$cond_value = $cond_start;
 								if ($cond_stop != '') {
 									$range_indicator = ($cond_var == 'date-time') ? '~' : '-';
@@ -1107,8 +1105,7 @@ if ($action == 'update') {
 							    } else {
 							        $cond_val_start = $dt_start->format('Y-m-d H:i');
 							    }
-							}
-							
+							}		
 							if (!empty($cond_val_stop)) {
 							    $dt_stop = DateTime::createFromFormat('Y-m-d H:i', $cond_val_stop, new DateTimeZone('UTC'));
 							    if ($dt_stop !== false) {

--- a/app/time_conditions/time_condition_edit.php
+++ b/app/time_conditions/time_condition_edit.php
@@ -1105,7 +1105,8 @@ if ($action == 'update') {
 							    } else {
 							        $cond_val_start = $dt_start->format('Y-m-d H:i');
 							    }
-							}		
+							}
+							
 							if (!empty($cond_val_stop)) {
 							    $dt_stop = DateTime::createFromFormat('Y-m-d H:i', $cond_val_stop, new DateTimeZone('UTC'));
 							    if ($dt_stop !== false) {


### PR DESCRIPTION
Fixes date-time conditions to properly convert between the domain timezone and UTC.

Issue:
Date-time conditions triggered at the wrong times because FreeSWITCH evaluates them in UTC, but the user input was not being converted.

Solution:
    Convert user timezone → UTC when saving
    Convert UTC → user timezone when displaying
    Use settings object cascading for timezone (user → domain → global → default)
    Handle both 12h and 24h formats

Testing:
Set time condition for 9:00 AM in America/New_York timezone - should trigger at 9:00 AM local time, not UTC.