### PR TITLE
Add record navigation buttons

### DIFF
--- a/app/xml_cdr/xml_cdr_details.php
+++ b/app/xml_cdr/xml_cdr_details.php
@@ -460,27 +460,21 @@
 //get the header
 	require_once "resources/header.php";
 
-//page title and description
-	echo "<table width='100%' border='0' cellpadding='0' cellspacing='0'>\n";
-	echo "<tr>\n";
-	echo "<td width='30%' align='left' valign='top' nowrap='nowrap'><b>".$text['title2']."</b><br><br></td>\n";
-	echo "<td width='70%' align='right' valign='top'>\n";
-	echo button::create(['type'=>'button','label'=>$text['button-back'],'icon'=>$settings->get('theme', 'button_icon_back'),'link'=>'xml_cdr.php'.(!empty($_SESSION['xml_cdr']['last_query']) ? '?'.urlencode($_SESSION['xml_cdr']['last_query']) : null)]);
+//page title, buttons and description
+	echo "<div class='action_bar' id='action_bar'>\n";
+	echo "	<div class='heading'><b>".$text['title2']."</b></div>\n";
+	echo "	<div class='actions'>\n";
+	echo button::create(['type'=>'button','label'=>$text['button-back'],'icon'=>$settings->get('theme', 'button_icon_back'),'id'=>'btn_back','link'=>'xml_cdr.php'.(!empty($_SESSION['xml_cdr']['last_query']) ? '?'.urlencode($_SESSION['xml_cdr']['last_query']) : null)]);
 	if (permission_exists('xml_cdr_call_log') && $call_log_enabled && isset($log_content) && !empty($log_content)) {
-		echo button::create(['type'=>'button','label'=>$text['button-call_log'],'icon'=>$settings->get('theme', 'button_icon_search'),'style'=>'margin-left: 15px;','link'=>'xml_cdr_log.php?id='.$uuid]);
+		echo button::create(['type'=>'button','label'=>$text['button-call_log'],'icon'=>$settings->get('theme', 'button_icon_search'),'link'=>'xml_cdr_log.php?id='.$uuid]);
 	}
 	if ($transcribe_enabled && !empty($transcribe_engine) && !empty($record_path) && !empty($record_name) && file_exists($record_path.'/'.$record_name)) {
-		echo button::create(['type'=>'button','label'=>$text['button-transcribe'],'icon'=>'quote-right','id'=>'btn_transcribe','name'=>'btn_transcribe','collapse'=>'hide-xs','style'=>'margin-left: 15px;','onclick'=>"window.location.href='?id=".$uuid."&action=transcribe';"]);
+		echo button::create(['type'=>'button','label'=>$text['button-transcribe'],'icon'=>'quote-right','id'=>'btn_transcribe','name'=>'btn_transcribe','collapse'=>'hide-xs','onclick'=>"window.location.href='?id=".$uuid."&action=transcribe';"]);
 	}
-	echo "</td>\n";
-	echo "</tr>\n";
-	echo "<tr>\n";
-	echo "<td align='left' colspan='2'>\n";
-	echo "	".$text['description-details']."\n";
-	echo "</td>\n";
-	echo "</tr>\n";
-	echo "</table>\n";
-	echo "<br /><br />\n";
+	echo "	</div>\n";
+	echo "	<div style='clear: both;'></div>\n";
+	echo "</div>\n";
+	echo "<p>".$text['description-details']."</p>\n";
 
 //show the content
 	echo "<table width='100%' border='0' cellpadding='0' cellspacing='0'>\n";

--- a/resources/record_nav.js
+++ b/resources/record_nav.js
@@ -1,0 +1,172 @@
+/**
+ * FusionPBX Record Navigation
+ *
+ * Provides previous/next record navigation on edit pages.
+ *
+ * On list pages: captures the ordered set of record URLs from tr.list-row[href]
+ * and saves them to sessionStorage (tab-scoped).
+ *
+ * On edit pages: reads the stored set, locates the current record by ?id=,
+ * and injects a prev/counter/next widget into div#action_bar > div.actions.
+ */
+(function () {
+	'use strict';
+
+	/**
+	 * Extract the value of a named query parameter from a URL string.
+	 */
+	function getParam(url, name) {
+		var idx = url.indexOf('?');
+		if (idx === -1) { return null; }
+		var pairs = url.slice(idx + 1).split('&');
+		for (var i = 0; i < pairs.length; i++) {
+			var parts = pairs[i].split('=');
+			if (decodeURIComponent(parts[0]) === name) {
+				return parts.length > 1 ? decodeURIComponent(parts[1].replace(/\+/g, ' ')) : '';
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Extract the script filename from a relative URL (e.g. "extension_edit.php").
+	 */
+	function getBasename(url) {
+		var path = url.split('?')[0];
+		return path.substring(path.lastIndexOf('/') + 1);
+	}
+
+	/**
+	 * Build the sessionStorage key for a given edit-page basename.
+	 */
+	function storageKey(basename) {
+		return 'record_nav_' + basename;
+	}
+
+	/**
+	 * LIST PAGE: collect all tr.list-row[href] entries and save to sessionStorage.
+	 */
+	function captureList() {
+		var rows = document.querySelectorAll('tr.list-row[href]');
+		if (!rows.length) { return; }
+
+		var records = [];
+		var editBase = null;
+
+		for (var i = 0; i < rows.length; i++) {
+			var href = rows[i].getAttribute('href');
+			if (!href) { continue; }
+			// Only capture rows that have an ?id= param (edit links, not void/empty hrefs)
+			if (getParam(href, 'id') === null) { continue; }
+			records.push(href);
+			if (!editBase) {
+				editBase = getBasename(href);
+			}
+		}
+
+		if (!editBase || !records.length) { return; }
+
+		var data = {
+			editBase: editBase,
+			listUrl: window.location.pathname.substring(window.location.pathname.lastIndexOf('/') + 1)
+				+ (window.location.search || ''),
+			records: records
+		};
+
+		try {
+			sessionStorage.setItem(storageKey(editBase), JSON.stringify(data));
+		} catch (e) {
+			// sessionStorage unavailable (private mode quota, etc.) — silently skip
+		}
+	}
+
+	/**
+	 * EDIT PAGE: read sessionStorage and inject the nav widget into the action bar.
+	 */
+	function injectNav() {
+		var currentId = getParam(window.location.search, 'id');
+		if (!currentId) { return; }
+
+		var currentBase = getBasename(window.location.pathname);
+		var key = storageKey(currentBase);
+
+		var raw;
+		try {
+			raw = sessionStorage.getItem(key);
+		} catch (e) {
+			return;
+		}
+		if (!raw) { return; }
+
+		var data;
+		try {
+			data = JSON.parse(raw);
+		} catch (e) {
+			return;
+		}
+		if (!data.records || !data.records.length) { return; }
+
+		// Find the current record index by matching the ?id= parameter
+		var idx = -1;
+		for (var i = 0; i < data.records.length; i++) {
+			if (getParam(data.records[i], 'id') === currentId) {
+				idx = i;
+				break;
+			}
+		}
+		if (idx === -1) { return; }
+
+		var actionsDiv = document.querySelector('div#action_bar > div.actions');
+		if (!actionsDiv) { return; }
+
+		var total   = data.records.length;
+		var prevUrl = idx > 0             ? data.records[idx - 1] : null;
+		var nextUrl = idx < total - 1     ? data.records[idx + 1] : null;
+
+		// Build the widget HTML using existing FusionPBX btn classes + Font Awesome icons
+		var prevBtn = prevUrl
+			? "<a href='" + escHtml(prevUrl) + "'>"
+				+ "<button type='button' class='btn btn-default' title='Previous record'>"
+				+ "<span class='fa-solid fa-chevron-left fa-fw'></span>"
+				+ "</button></a>"
+			: "<button type='button' class='btn btn-default disabled' disabled title='No previous record'>"
+				+ "<span class='fa-solid fa-chevron-left fa-fw'></span>"
+				+ "</button>";
+
+		var nextBtn = nextUrl
+			? "<a href='" + escHtml(nextUrl) + "'>"
+				+ "<button type='button' class='btn btn-default' title='Next record'>"
+				+ "<span class='fa-solid fa-chevron-right fa-fw'></span>"
+				+ "</button></a>"
+			: "<button type='button' class='btn btn-default disabled' disabled title='No next record'>"
+				+ "<span class='fa-solid fa-chevron-right fa-fw'></span>"
+				+ "</button>";
+
+		var counter = "<span class='record-nav-pos'>" + (idx + 1) + " / " + total + "</span>";
+
+		var widget = "<div class='record-nav'>" + prevBtn + counter + nextBtn + "</div>";
+
+		// Insert as first child of div.actions so it appears at the far-right edge
+		actionsDiv.insertAdjacentHTML('afterbegin', widget);
+	}
+
+	function escHtml(str) {
+		return str
+			.replace(/&/g, '&amp;')
+			.replace(/'/g, '&#39;')
+			.replace(/"/g, '&quot;');
+	}
+
+	// Run after the DOM is ready
+	if (document.readyState === 'loading') {
+		document.addEventListener('DOMContentLoaded', init);
+	} else {
+		init();
+	}
+
+	function init() {
+		captureList(); // no-op on non-list pages
+		injectNav();   // no-op on non-edit pages (or when no sessionStorage data exists)
+	}
+
+}());

--- a/themes/default/css.php
+++ b/themes/default/css.php
@@ -3540,6 +3540,33 @@ else { //default: white
 		overflow: hidden;
 		}
 
+	div.action_bar > div.actions > div.record-nav {
+		display: inline-flex;
+		align-items: center;
+		margin-left: 6px;
+		vertical-align: middle;
+		}
+
+	div.action_bar > div.actions > div.record-nav .record-nav-pos {
+		display: inline-block;
+		min-width: 52px;
+		text-align: center;
+		font-size: 87%;
+		color: inherit;
+		padding: 0 4px;
+		vertical-align: middle;
+		}
+
+	div.action_bar > div.actions > div.record-nav .btn {
+		padding: 4px 7px;
+		}
+
+	div.action_bar > div.actions > div.record-nav .btn.disabled,
+	div.action_bar > div.actions > div.record-nav .btn[disabled] {
+		opacity: 0.35;
+		cursor: not-allowed;
+		}
+
 	div.action_bar > div.actions > div.unsaved {
 		display: inline-block;
 		margin-right: 30px;

--- a/themes/default/template.php
+++ b/themes/default/template.php
@@ -41,6 +41,7 @@
 	<script language='JavaScript' type='text/javascript' src='{$project_path}/resources/bootstrap/js/bootstrap-pwstrength.min.js.php'></script>
 	<script language='JavaScript' type='text/javascript'>{literal}window.FontAwesomeConfig = { autoReplaceSvg: false }{/literal}</script>
 	<script language='JavaScript' type='text/javascript' src='{$project_path}/resources/fontawesome/js/all.min.js.php' defer></script>
+	<script language='JavaScript' type='text/javascript' src='{$project_path}/resources/record_nav.js'></script>
 
 {*//web font loader *}
 	{if isset($settings.theme.font_loader) && $settings.theme.font_loader == 'true'}


### PR DESCRIPTION
Provides previous/next record navigation on the following pages:
Accounts:
 -Devices    -Extensions    -Gateways
 -Providers  -Users
Dialplan:
 -Destinations     -Dialplan Manager
 -Inbound Routes   -Outbound Routes
Applications:
 -Bridges              -Call Block           -Call Centers
 -Call Broadcast       -Call Detail Records  -Call Flows
 -Call Forward         -Conference Centers   -Conference Controls
 -Conference Profiles  -Conferences          -Contacts
 -Fax Server           -Follow me            -IVR Menu
 -Phrases              -Queues               -Recordings
 -Ring Groups          -Streams              -Time Conditions
 -Voicemail
Status:
 -Device Logs      -Email Queue
 -Fax Queue        -SIP Status
Advanced:
 -Access Controls   -Databases             -Default Settings
 -Domains           -Group Manager         -Menu Manager
 -Modules           -Number Translations   -SIP Profiles
 -Transactions      -Variables

On list pages: captures the ordered set of record URLs from tr.list-row[href]
and saves them to sessionStorage (tab-scoped).
On edit pages: reads the stored set, locates the current record by ?id=,
and injects a prev/counter/next widget into div#action_bar > div.actions.

By ClearConverse, Inc.