### PR TITLE
Update MN_{$mac}.cfg configuration parameters

### DIFF
--- a/resources/templates/provision/mitel/5330/MN_{$mac}.cfg
+++ b/resources/templates/provision/mitel/5330/MN_{$mac}.cfg
@@ -62,7 +62,7 @@
 	<pbIndex>0</pbIndex>
 	<adminId>admin</adminId>
 	<admin_dispname>Administrator</admin_dispname>
-	<admin_passwd>{$admin_password}</admin_passwd>
+	<admin_passwd>29c4a0e4ef7d1969a94a5f4aadd20690</admin_passwd>
 	<busy_fwd_mode>0</busy_fwd_mode>
 	<busy_fwd_addr></busy_fwd_addr>
 	<always_fwd_mode>0</always_fwd_mode>
@@ -103,7 +103,7 @@
 	<dtringtype11>0</dtringtype11>
 	<dtringtype12>0</dtringtype12>
 	<http_task_enable>1</http_task_enable>
-	<https_task_enable>0</https_task_enable>
+	<https_task_enable>1</https_task_enable>
 	<httpport>80</httpport>
 	<httpsport>443</httpsport>
 	<telnet_task_enable>1</telnet_task_enable>
@@ -116,10 +116,9 @@
 	<stunip>213.192.59.75</stunip>
 	<fwWanDurl></fwWanDurl>
 	<fwMode>0</fwMode>
-	<start_port>20000</start_port>
-	<end_port>20998</end_port>
+	<start_port>50000</start_port>
+	<end_port>50511</end_port>
 	<multi_user_enable>0</multi_user_enable>
-	<upgrade>0</upgrade>
 	<bksrvtm>3</bksrvtm>
 	<ntfcfg>0</ntfcfg>
 	<lancode>en_US</lancode>
@@ -133,12 +132,11 @@
 	<dseday>1</dseday>
 	<ds_transition_time>2</ds_transition_time>
 	<flashVer>201</flashVer>
-	<http_download>{$domain_name}/app/provision</http_download>
 	<tftp></tftp>
 	<downloadtype>1</downloadtype>
 	<dialpl></dialpl>
-	<gtEnable>0</gtEnable>
-	<dtimer>3</dtimer>
+	<gtEnable>{$mitel_auto_dial}</gtEnable>
+	<dtimer>{$mitel_inter_digit_time}</dtimer>
 	<autoanswer>0</autoanswer>
 	<ringPitch>0</ringPitch>
 	<keysys_enable>0</keysys_enable>
@@ -295,10 +293,6 @@
 	<firmware_abs_timer_hr>23</firmware_abs_timer_hr>
 	<firmware_abs_timer_min>59</firmware_abs_timer_min>
 	<firmware_abs_enable>1</firmware_abs_enable>
-	<installer_passcode></installer_passcode>
-	<user_passwd>{$user_password}</user_passwd>
-	<web_logo1></web_logo1>
-	<!--<web_logo1>&lt;img src="http://sipdnld.mitel.com/mitel.gif" alt="Mitel" width="143" height="43" hspace="0" align="left" /&gt;</web_logo1>-->
 	<sip_mode>sip</sip_mode>
 	<voicemail_key>{$voicemail_number}</voicemail_key>
 	<html_enable>1</html_enable>
@@ -311,16 +305,15 @@
 		DispName="{$row.display_name}"
 		Pwd="{$row.password}"
 		AuthName="{$row.auth_id}"
-		Realm=""
 		RegSvr="{$row.server_address}"
 		RegPort="{$row.sip_port}"
-		RegScheme="2"
+		RegScheme="1"
 		ProxySvr="{$row.server_address}"
 		ProxyPort="{$row.sip_port}"
-		ProxyScheme="2"
+		ProxyScheme="1"
 		VMSvr="{$row.server_address}"
 		VMPort="{$row.sip_port}"
-		VMScheme="2"
+		VMScheme="1"
 		{if isset($row.outbound_proxy)}OutSvr = "{$row.outbound_proxy}"{else}OutSvr=""{/if}
 		OutPort="{$row.sip_port}"
 		OutCtr="0"
@@ -328,14 +321,15 @@
 		Line="0"
 		EventSvr=""
 		EventPort="{$row.sip_port}"
-		EventScheme="2"
+		EventScheme="1"
+		BlfGroup="share_presence"
 		NatMode="0"
 		NatType="option"
 		NatIp="0">
 		</User>
 		{/foreach}
 		<!--
-		<User State="1" ID="user" DispName="disp username" Pwd="hello" AuthName="user" Realm="" RegSvr="" RegPort="5060" RegScheme="2" ProxySvr="" ProxyPort="5060" ProxyScheme="2" VMSvr="" VMPort="5060" VMScheme="2" OutSvr="" OutPort="5060" OutCtr="0" Ring="1" Line="0" EventSvr="" EventPort="5060" EventScheme="2" NatMode="0" NatType="option" NatIp="0"></User>
+		<User State="1" ID="user" DispName="disp username" Pwd="hello" AuthName="user" Realm="" RegSvr="" RegPort="5060" RegScheme="1" ProxySvr="" ProxyPort="5060" ProxyScheme="1" VMSvr="" VMPort="5060" VMScheme="1" OutSvr="" OutPort="5060" OutCtr="0" Ring="1" Line="0" EventSvr="" EventPort="5060" EventScheme="1" NatMode="0" NatType="option" NatIp="0"></User>
 		-->
 	</user_list>
 

--- a/resources/templates/provision/mitel/5330/MN_{$mac}.cfg
+++ b/resources/templates/provision/mitel/5330/MN_{$mac}.cfg
@@ -32,7 +32,7 @@
 	<rss_feed></rss_feed>
 	<host_ip>{$domain_name}</host_ip>
 	<video_ip>{$domain_name}</video_ip>
-	<sntp>0.us.pool.ntp.org</sntp>
+	<sntp>{$ntp_server_primary}</sntp>
 	<time_zone>{$mitel_time_zone}</time_zone>
 	<auth_method>2</auth_method>
 	<register_expire>120</register_expire>

--- a/resources/templates/provision/mitel/5330/MN_{$mac}.cfg
+++ b/resources/templates/provision/mitel/5330/MN_{$mac}.cfg
@@ -62,7 +62,7 @@
 	<pbIndex>0</pbIndex>
 	<adminId>admin</adminId>
 	<admin_dispname>Administrator</admin_dispname>
-	<admin_passwd>29c4a0e4ef7d1969a94a5f4aadd20690</admin_passwd>
+	<admin_passwd>{$admin_password|@md5}</admin_passwd>
 	<busy_fwd_mode>0</busy_fwd_mode>
 	<busy_fwd_addr></busy_fwd_addr>
 	<always_fwd_mode>0</always_fwd_mode>


### PR DESCRIPTION
The string "29c4a0e4ef7d1969a94a5f4aadd20690" is an MD5 hash representing the password "admin1234" RegScheme= 1-TCP 2-UDP No Luck with BLF Status working