### PR TITLE
Add Fanvil V-series provisioning templates (V62, V62 Pro, V63, V64, V65)

### DIFF
--- a/resources/templates/provision/fanvil/v62-pro/{$mac}.cfg
+++ b/resources/templates/provision/fanvil/v62-pro/{$mac}.cfg
@@ -1,0 +1,2013 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sysConf>
+    <Version>2.0000000000</Version>
+    <net>
+        <WANTYPE>0</WANTYPE>
+        <WANIP></WANIP>
+        <WANSubnetMask>255.255.255.0</WANSubnetMask>
+        <WANGateway></WANGateway>
+        <DomainName></DomainName>
+        <PrimaryDNS>{if isset($dns_server_primary)}{$dns_server_primary}{else}9.9.9.9{/if}</PrimaryDNS>
+        <SecondaryDNS>{if isset($dns_server_secondary)}{$dns_server_secondary}{else}1.1.1.1{/if}</SecondaryDNS>
+        <EnableDHCP>1</EnableDHCP>
+        <DHCPAutoDNS>1</DHCPAutoDNS>
+        <DHCPAutoTime>1</DHCPAutoTime>
+        <DHCPOption100-101>1</DHCPOption100-101>
+        <UseVendorClassID>0</UseVendorClassID>
+        <VendorClassID>Fanvil</VendorClassID>
+        <EnablePPPoE>0</EnablePPPoE>
+        <PPPoEUser>user123</PPPoEUser>
+        <PPPoEPassword>password</PPPoEPassword>
+        <ARPCacheLife>2</ARPCacheLife>
+        <MTU>1500</MTU>
+        <PPPoEAutoConnect>0</PPPoEAutoConnect>
+        <PPPoEAutoRecnct>0</PPPoEAutoRecnct>
+        <WAN6IP></WAN6IP>
+        <WAN6IPPREFIX></WAN6IPPREFIX>
+        <WAN6Gateway></WAN6Gateway>
+        <Domain6Name></Domain6Name>
+        <PrimaryDNS6></PrimaryDNS6>
+        <SecondaryDNS6></SecondaryDNS6>
+        <EnableDHCP6>1</EnableDHCP6>
+        <DHCP6AutoDNS>1</DHCP6AutoDNS>
+        <DHCP6AutoTime>0</DHCP6AutoTime>
+        <UseVendor6ClassID>0</UseVendor6ClassID>
+        <Vendor6ClassID></Vendor6ClassID>
+    </net>
+    <mm>
+        <G723BitRate>1</G723BitRate>
+        <ILBCPayloadType>97</ILBCPayloadType>
+        <ILBCPayloadLen>20</ILBCPayloadLen>
+        <AMRPayloadType>108</AMRPayloadType>
+        <AMRWBPayloadType>109</AMRWBPayloadType>
+        <G726-16PayloadType>103</G726-16PayloadType>
+        <G726-24PayloadType>104</G726-24PayloadType>
+        <G726-32PayloadType>102</G726-32PayloadType>
+        <G726-40PayloadType>105</G726-40PayloadType>
+        <DtmfPayloadType>101</DtmfPayloadType>
+        <OpusPayloadType>107</OpusPayloadType>
+        <OpusSampleRate>0</OpusSampleRate>
+        <VAD>0</VAD>
+        <H264PayloadType>117</H264PayloadType>
+        <H264PacketMode>0</H264PacketMode>
+        <H264Profile>0</H264Profile>
+        <ResvAudioBand>0</ResvAudioBand>
+        <H265PayloadType>98</H265PayloadType>
+        <RTPInitialPort>16384</RTPInitialPort>
+        <RTPPortQuantity>16384</RTPPortQuantity>
+        <RTPKeepAlive>0</RTPKeepAlive>
+        <RTPRelay>0</RTPRelay>
+        <RTCPCNAMEUser></RTCPCNAMEUser>
+        <RTCPCNAMEHost></RTCPCNAMEHost>
+        <SelectYourTone>{if isset($fanvil_country_toneset)}{$fanvil_country_toneset}{else}11{/if}</SelectYourTone>
+        <SidetoneGAIN>1</SidetoneGAIN>
+        <PlayEgressDTMF>0</PlayEgressDTMF>
+        <DialTone>350+440/0</DialTone>
+        <RingbackTone>440+480/2000,0/4000</RingbackTone>
+        <BusyTone>480+620/500,0/500</BusyTone>
+        <CongestionTone></CongestionTone>
+        <CallwaitingTone>440/300,0/10000,440/300,0/10000,0/0</CallwaitingTone>
+        <HoldingTone></HoldingTone>
+        <ErrorTone></ErrorTone>
+        <StutterTone></StutterTone>
+        <InformationTone></InformationTone>
+        <DialRecallTone>350+440/100,0/100,350+440/100,0/100,350+440/100,0/100,350+440/0</DialRecallTone>
+        <MessageTone></MessageTone>
+        <HowlerTone></HowlerTone>
+        <NumberUnobtainable>400/500,0/6000</NumberUnobtainable>
+        <WarningTone>1400/500,0/0</WarningTone>
+        <RecordTone>440/500,0/5000</RecordTone>
+        <AutoAnswerTone></AutoAnswerTone>
+        <capability>
+            <AudioCodecSets>G722,PCMU,PCMA,OPUS</AudioCodecSets>
+            <VideoCodecSets>{if isset($fanvil_video_codec)}{$fanvil_video_codec}{else}H264{/if}</VideoCodecSets>
+            <VideoFrameRate>30</VideoFrameRate>
+            <VideoBitRate>2000000</VideoBitRate>
+            <VideoResolution>7</VideoResolution>
+            <VideoNegotiateDir>0</VideoNegotiateDir>
+        </capability>
+    </mm>
+    <sip>
+        <SIPPort>{$sip_port}</SIPPort>
+        <STUNServer>{$fanvil_stun_server}</STUNServer>
+        <STUNPort>{$fanvil_stun_port}</STUNPort>
+        <STUNRefreshTime>50</STUNRefreshTime>
+        <SIPWaitStunTime>800</SIPWaitStunTime>
+        <ExternNATAddrs></ExternNATAddrs>
+        <RegFailInterval>32</RegFailInterval>
+        <StrictBranchPrefix>0</StrictBranchPrefix>
+        <VideoMuteAttr>0</VideoMuteAttr>
+        <EnableGroupBackup>0</EnableGroupBackup>
+        <EnableRFC4475>1</EnableRFC4475>
+        <StrictUAMatch>1</StrictUAMatch>
+        <CSTAEnable>0</CSTAEnable>
+        <NotifyReboot>1</NotifyReboot>
+	{foreach $lines as $row}
+        <line index="{$row.device_key_id}">
+            <PhoneNumber>{$row.user_id}</PhoneNumber>
+            <DisplayName>{$row.display_name}</DisplayName>
+            <SipName></SipName>
+            <RegisterAddr>{$row.server_address}</RegisterAddr>
+            <RegisterPort>{$row.sip_port}</RegisterPort>
+            <RegisterUser>{$row.auth_id}</RegisterUser>
+            <RegisterPswd>{$row.password}</RegisterPswd>
+            <RegisterTTL>{$row.register_expires}</RegisterTTL>
+            <BackupAddr></BackupAddr>
+            <BackupPort>5060</BackupPort>
+            <BackupTransport>0</BackupTransport>
+            <BackupTTL>3600</BackupTTL>
+            <EnableReg>0</EnableReg>
+            <EnableReg>{if isset($row.password)}1{else}0{/if}</EnableReg>
+            <ProxyAddr>{$row.outbound_proxy_primary}</ProxyAddr>
+            <ProxyPort>{$row.sip_port}</ProxyPort>
+            <ProxyUser>{$row.auth_id}</ProxyUser>
+            <ProxyPswd>{$row.password}</ProxyPswd>
+            <ProxyNeedRegOn>0</ProxyNeedRegOn>
+            <BakProxyAddr>{$row.outbound_proxy_secondary}</BakProxyAddr>
+            <BakProxyPort>{$row.sip_port}</BakProxyPort>
+            <BakProxyNeedRegOn>0</BakProxyNeedRegOn>
+            <EnableFailback>{if isset($row.outbound_proxy_secondary)}1{else}0{/if}</EnableFailback>
+            <FailbackInterval>1800</FailbackInterval>
+            <SignalFailback>0</SignalFailback>
+            <SignalRetryCounts>3</SignalRetryCounts>
+            <SigCryptoKey></SigCryptoKey>
+            <EnableOSRTP>0</EnableOSRTP>
+            <MediaCrypto>0</MediaCrypto>
+            <MedCryptoKey></MedCryptoKey>
+            <SRTPAuth-Tag>0</SRTPAuth-Tag>
+            <EnableRFC5939>0</EnableRFC5939>
+            <LocalDomain></LocalDomain>
+            <AlwaysFWD>0</AlwaysFWD>
+            <BusyFWD>0</BusyFWD>
+            <NoAnswerFWD>0</NoAnswerFWD>
+            <AlwaysFWDNum></AlwaysFWDNum>
+            <BusyFWDNum></BusyFWDNum>
+            <NoAnswerFWDNum></NoAnswerFWDNum>
+            <FWDTimer>5</FWDTimer>
+            <HotlineNum></HotlineNum>
+            <EnableHotline>0</EnableHotline>
+            <WarmLineTime>0</WarmLineTime>
+            <PickupNum></PickupNum>
+            <JoinNum></JoinNum>
+            <IntercomNum></IntercomNum>
+            <RingType>{if isset($fanvil_ringtone_line1)}{$fanvil_ringtone_line1}{else}default{/if}</RingType>
+            <NATUDPUpdate>2</NATUDPUpdate>
+            <UDPUpdateTTL>30</UDPUpdateTTL>
+            <ServerType>0</ServerType>
+            <UserAgent></UserAgent>
+            <PRACK>0</PRACK>
+            <KeepAUTH>0</KeepAUTH>
+            <SessionTimer>0</SessionTimer>
+            <STimerExpires>0</STimerExpires>
+            <EnableGRUU>0</EnableGRUU>
+            <DTMFMode>3</DTMFMode>
+            <DTMFInfoMode>0</DTMFInfoMode>
+            <NATType>0</NATType>
+            <EnableRport>1</EnableRport>
+            <Subscribe>{if isset($row.user_id)}1{else}{/if}</Subscribe>
+            <SubExpire>{$row.register_expires}</SubExpire>
+            <SingleCodec>0</SingleCodec>
+            <CLIR>0</CLIR>
+            <StrictProxy>1</StrictProxy>
+            <DirectContact>0</DirectContact>
+            <HistoryInfo>0</HistoryInfo>
+            {if $row.sip_transport == 'dns srv'}<DNSSRV>1</DNSSRV>{/if}
+            {if $row.sip_transport == 'dns srv'}<DNSMode>1</DNSMode>{/if}
+            <XFERExpire>0</XFERExpire>
+            <BanAnonymous>0</BanAnonymous>
+            <DialOffLine>0</DialOffLine>
+            <QuotaName>0</QuotaName>
+            <PresenceMode>0</PresenceMode>
+            <RFCVer>1</RFCVer>
+            <PhonePort>0</PhonePort>
+            <SignalPort>5060</SignalPort>
+            {if $row.sip_transport == 'udp'}<Transport>0</Transport>{/if}
+            {if $row.sip_transport == 'tcp'}<Transport>1</Transport>{/if}
+            {if $row.sip_transport == 'tls'}<Transport>3</Transport>{/if}
+            <UseSRVMixer>0</UseSRVMixer>
+            <SRVMixerUri></SRVMixerUri>
+            <LongContact>0</LongContact>
+            <AutoTCP>1</AutoTCP>
+            <UriEscaped>1</UriEscaped>
+            <ClicktoTalk>0</ClicktoTalk>
+            <MwiNo></MwiNo>
+            <MWINum>{if isset($row.user_id)}{$voicemail_number}{else}{/if}</MWINum>
+            <ParkNo></ParkNo>
+            <CallParkNum></CallParkNum>
+            <RetrieveNum></RetrieveNum>
+            <HelpNo></HelpNo>
+            <MSRPHelpNum></MSRPHelpNum>
+            <UserIsPhone>0</UserIsPhone>
+            <AutoAnswer>0</AutoAnswer>
+            <NoAnswerTime>5</NoAnswerTime>
+            <MissedCallLog>1</MissedCallLog>
+            <ParkMode></ParkMode>
+            <SvcCodeMode>0</SvcCodeMode>
+            <DNDOnSvcCode></DNDOnSvcCode>
+            <DNDOffSvcCode></DNDOffSvcCode>
+            <CFUOnSvcCode></CFUOnSvcCode>
+            <CFUOffSvcCode></CFUOffSvcCode>
+            <CFBOnSvcCode></CFBOnSvcCode>
+            <CFBOffSvcCode></CFBOffSvcCode>
+            <CFNOnSvcCode></CFNOnSvcCode>
+            <CFNOffSvcCode></CFNOffSvcCode>
+            <ANCOnSvcCode></ANCOnSvcCode>
+            <ANCOffSvcCode></ANCOffSvcCode>
+            <SendANOnCode></SendANOnCode>
+            <SendANOffCode></SendANOffCode>
+            <CWOnCode></CWOnCode>
+            <CWOffCode></CWOffCode>
+            <VoiceCodecMap>OPUS,G722,PCMU,PCMA</VoiceCodecMap>
+            <VideoCodecMap>{if isset($fanvil_video_codec)}{$fanvil_video_codec}{else}{/if}</VideoCodecMap>
+            <BLFListUri></BLFListUri>
+            <BLFServer></BLFServer>
+            <Respond182>0</Respond182>
+            <EnableBLFList>0</EnableBLFList>
+            <CallerIdType>4</CallerIdType>
+            <SynClockTime>0</SynClockTime>
+            <MohServer></MohServer>
+            <UseVPN>1</UseVPN>
+            <EnableDND>0</EnableDND>
+            <InactiveHold>0</InactiveHold>
+            <ReqWithPort>1</ReqWithPort>
+            <UpdateRegExpire>1</UpdateRegExpire>
+            <EnableSCA>0</EnableSCA>
+            <SubCallPark>0</SubCallPark>
+            <SubCCStatus>0</SubCCStatus>
+            <FeatureSync>0</FeatureSync>
+            <EnableXferBack>1</EnableXferBack>
+            <XferBackTime>35</XferBackTime>
+            <UseTelCall>0</UseTelCall>
+            <EnablePreview>0</EnablePreview>
+            <PreviewMode>1</PreviewMode>
+            <TLSVersion>2</TLSVersion>
+            <CSTANumber></CSTANumber>
+            <EnableChgPort>0</EnableChgPort>
+            <VQName></VQName>
+            <VQServer></VQServer>
+            <VQServerPort>5060</VQServerPort>
+            <VQHTTPServer></VQHTTPServer>
+            <FlashMode>0</FlashMode>
+            <ContentType></ContentType>
+            <ContentBody></ContentBody>
+            <UnregisterOnBoot>0</UnregisterOnBoot>
+            <EnableMACHeader>0</EnableMACHeader>
+            <EnableRegisterMAC>0</EnableRegisterMAC>
+            <RecordStart>Record:on</RecordStart>
+            <RecordStop>Record:off</RecordStop>
+            <BLFDialogMatch>1</BLFDialogMatch>
+            <Ptime>0</Ptime>
+            <EnableDeal180>1</EnableDeal180>
+            <KeepSingleContact>0</KeepSingleContact>
+            <SessionTimerT1>500</SessionTimerT1>
+            <SessionTimerT2>4000</SessionTimerT2>
+            <SessionTimerT4>5000</SessionTimerT4>
+            <UnavailableMode>0</UnavailableMode>
+            <TCPUseRetryTimer>0</TCPUseRetryTimer>
+        </line>
+	{/foreach}
+        <p2p>
+            <SIPP2PEnableAutoAnswer>0</SIPP2PEnableAutoAnswer>
+            <SIPP2PAutoAnswerDelay>30</SIPP2PAutoAnswerDelay>
+            <SIPP2PDtmfMode>1</SIPP2PDtmfMode>
+            <SIPP2PSipInfoDtmfMode>0</SIPP2PSipInfoDtmfMode>
+            <SIPP2PEnablePreview>0</SIPP2PEnablePreview>
+            <SIPP2PPreviewMode>0</SIPP2PPreviewMode>
+            <SIPP2PUseVPN>1</SIPP2PUseVPN>
+        </p2p>
+    </sip>
+    <call>
+        <port index="1">
+            <EnableXferDPlan>1</EnableXferDPlan>
+            <EnableFwdDPlan>1</EnableFwdDPlan>
+            <EnablePreDPlan>0</EnablePreDPlan>
+            <IPDialPrefix>.</IPDialPrefix>
+            <EnableDND>1</EnableDND>
+            <DNDMode>0</DNDMode>
+            <EnableSpaceDND>0</EnableSpaceDND>
+            <DNDStartTime>1500</DNDStartTime>
+            <DNDEndTime>1730</DNDEndTime>
+            <EnableWhiteList>0</EnableWhiteList>
+            <EnableBlackList>0</EnableBlackList>
+            <EnableCallBar>0</EnableCallBar>
+            <MuteRinging>0</MuteRinging>
+            <BanDialOut>0</BanDialOut>
+            <BanEmptyCID>0</BanEmptyCID>
+            <EnableCLIP>1</EnableCLIP>
+            <CallWaiting>1</CallWaiting>
+            <CallTransfer>1</CallTransfer>
+            <CallSemiXfer>1</CallSemiXfer>
+            <CallConference>1</CallConference>
+            <AutoPickupNext>0</AutoPickupNext>
+            <BusyNoLine>1</BusyNoLine>
+            <AutoOnhook>1</AutoOnhook>
+            <AutoOnhookTime>3</AutoOnhookTime>
+            <EnableIntercom>1</EnableIntercom>
+            <IntercomMute>0</IntercomMute>
+            <IntercomTone>1</IntercomTone>
+            <IntercomBarge>0</IntercomBarge>
+            <UseAutoRedial>0</UseAutoRedial>
+            <RedialEnterCallLog>0</RedialEnterCallLog>
+            <AutoRedialDelay>30</AutoRedialDelay>
+            <AutoRedialTimes>5</AutoRedialTimes>
+            <CallComplete>0</CallComplete>
+            <CHoldingTone>1</CHoldingTone>
+            <CWaitingTone>1</CWaitingTone>
+            <HideDTMFType>0</HideDTMFType>
+            <TalkDTMFTone>1</TalkDTMFTone>
+            <DialDTMFTone>1</DialDTMFTone>
+            <PswDialMode>0</PswDialMode>
+            <PswDialLength>0</PswDialLength>
+            <PswDialPrefix></PswDialPrefix>
+            <EnableMultiLine>1</EnableMultiLine>
+            <AllowIPCall>1</AllowIPCall>
+            <CallerNameType>0</CallerNameType>
+            <MuteForRing>0</MuteForRing>
+            <AutoHandleVideo>0</AutoHandleVideo>
+            <DefaultAnsMode>{$fanvil_default_answer_mode}</DefaultAnsMode>
+            <DefaultDialMode>{$fanvil_default_dial_mode}</DefaultDialMode>
+            <HoldToTransfer>0</HoldToTransfer>
+            <EnablePreDial>1</EnablePreDial>
+            <DefaultExtLine>1</DefaultExtLine>
+            <EnableDefLine>1</EnableDefLine>
+            <EnableSelLine>1</EnableSelLine>
+            <RinginHeadset>0</RinginHeadset>
+            <AutoHeadset>0</AutoHeadset>
+            <DNDReturnCode>480</DNDReturnCode>
+            <BusyReturnCode>486</BusyReturnCode>
+            <RejectReturnCode>603</RejectReturnCode>
+            <ContactType>0</ContactType>
+            <EnableCountryCode>0</EnableCountryCode>
+            <CountryCode></CountryCode>
+            <CallAreaCode></CallAreaCode>
+            <NumberPrivacy>0</NumberPrivacy>
+            <PrivacyRule></PrivacyRule>
+            <TransfDTMFCode></TransfDTMFCode>
+            <HoldDTMFCode></HoldDTMFCode>
+            <ConfDTMFCode></ConfDTMFCode>
+            <DisableDialSearch>0</DisableDialSearch>
+            <CallNumberFilter></CallNumberFilter>
+            <AutoResumeCurrent>0</AutoResumeCurrent>
+            <CallTimeout>120</CallTimeout>
+            <RingTimeout>120</RingTimeout>
+            <RingPriority>1</RingPriority>
+        </port>
+        <basic>
+            <DialbyPound>1</DialbyPound>
+            <BTransferbyPound>0</BTransferbyPound>
+            <OnhooktoBXfer>0</OnhooktoBXfer>
+            <OnhooktoAXfer>0</OnhooktoAXfer>
+            <ConfOnhooktoXfer>0</ConfOnhooktoXfer>
+            <DialFixedLength>0</DialFixedLength>
+            <FixedLengthNums>11</FixedLengthNums>
+            <DialbyTimeout>1</DialbyTimeout>
+            <DialTimeoutvalue>10</DialTimeoutvalue>
+            <EnableEOneSixFour>0</EnableEOneSixFour>
+        </basic>
+        <alertInfo index="1">
+            <Text></Text>
+            <Line>-1</Line>
+            <RingType>Type 1</RingType>
+        </alertInfo>
+        <alertInfo index="2">
+            <Text></Text>
+            <Line>-1</Line>
+            <RingType>Type 1</RingType>
+        </alertInfo>
+        <alertInfo index="3">
+            <Text></Text>
+            <Line>-1</Line>
+            <RingType>Type 1</RingType>
+        </alertInfo>
+        <alertInfo index="4">
+            <Text></Text>
+            <Line>-1</Line>
+            <RingType>Type 1</RingType>
+        </alertInfo>
+        <alertInfo index="5">
+            <Text></Text>
+            <Line>-1</Line>
+            <RingType>Type 1</RingType>
+        </alertInfo>
+        <alertInfo index="6">
+            <Text></Text>
+            <Line>-1</Line>
+            <RingType>Type 1</RingType>
+        </alertInfo>
+        <alertInfo index="7">
+            <Text></Text>
+            <Line>-1</Line>
+            <RingType>Type 1</RingType>
+        </alertInfo>
+        <alertInfo index="8">
+            <Text></Text>
+            <Line>-1</Line>
+            <RingType>Type 1</RingType>
+        </alertInfo>
+        <alertInfo index="9">
+            <Text></Text>
+            <Line>-1</Line>
+            <RingType>Type 1</RingType>
+        </alertInfo>
+        <alertInfo index="10">
+            <Text></Text>
+            <Line>-1</Line>
+            <RingType>Type 1</RingType>
+        </alertInfo>
+    </call>
+    <phone>
+        <MenuPassword>admin</MenuPassword>
+        <KeyLockPassword>admin</KeyLockPassword>
+        <FastKeylockCode></FastKeylockCode>
+        <EnableKeyLock>0</EnableKeyLock>
+        <KeyLockTimeout>0</KeyLockTimeout>
+        <KeyLockStatus>0</KeyLockStatus>
+        <EmergencyCall>110</EmergencyCall>
+        <PushXMLIP></PushXMLIP>
+        <SIPNumberPlan>0</SIPNumberPlan>
+        <LDAPSearch>0</LDAPSearch>
+        <SearchPath>0</SearchPath>
+        <CallerDisplayT>5</CallerDisplayT>
+        <CallLogDisplayType>0</CallLogDisplayType>
+        <EnableRecvSMS>1</EnableRecvSMS>
+        <EnableCallHistory>1</EnableCallHistory>
+        <LineDisplayFormat>$name</LineDisplayFormat>
+        <EnableMWITone>0</EnableMWITone>
+        <SIPNotifyXML>1</SIPNotifyXML>
+        <BlockXMLWhenCall>1</BlockXMLWhenCall>
+        <XMLUpdateInterval>30</XMLUpdateInterval>
+        <VqmDisplayOrder></VqmDisplayOrder>
+        <EnablePushXMLAuth>0</EnablePushXMLAuth>
+        <PickupVisualAlert>0</PickupVisualAlert>
+        <PickupAudioAlert>0</PickupAudioAlert>
+        <PickupRingType></PickupRingType>
+        <display>
+            <LCDTitle>{$fanvil_greeting}</LCDTitle>
+            <LCDConstrast>5</LCDConstrast>
+            <EnableEnergysaving>{if isset($fanvil_display_brightness_inactive)}{$fanvil_display_brightness_inactive}{else}4{/if}</EnableEnergysaving>
+            <LCDLuminanceLevel>{if isset($fanvil_display_brightness_active)}{$fanvil_display_brightness_active}{else}12{/if}</LCDLuminanceLevel>
+            <BacklightOffTime>{if isset($fanvil_display_inactivity_time)}{$fanvil_display_inactivity_time}{else}45{/if}</BacklightOffTime>
+            <DisableCHNIME>0</DisableCHNIME>
+            <PhoneModel></PhoneModel>
+            <HostName>localhost</HostName>
+            <DefaultLanguage>en</DefaultLanguage>
+            <EnableGreetings>0</EnableGreetings>
+        </display>
+        <powerLed>
+            <Power>0</Power>
+            <MWIOrSMS>3</MWIOrSMS>
+            <InUsing>0</InUsing>
+            <Ring>2</Ring>
+            <Hold>0</Hold>
+            <Mute>0</Mute>
+            <MissedCall>3</MissedCall>
+            <StandbyLampEffect>0</StandbyLampEffect>
+            <LampEffectPlayTime>1</LampEffectPlayTime>
+            <CustomLampEffectTime>1200</CustomLampEffectTime>
+            <StandbyLampEffectType>0</StandbyLampEffectType>
+            <OffhookLampEffect>1</OffhookLampEffect>
+            <OffhookLampEffectColor>0</OffhookLampEffectColor>
+            <RingingLampEffect>0</RingingLampEffect>
+            <RingingLampEffectType>0</RingingLampEffectType>
+            <TalkingLampEffect>0</TalkingLampEffect>
+            <TalkingLampEffectType>0</TalkingLampEffectType>
+            <CallingLampEffect>0</CallingLampEffect>
+            <CallingLampEffectType>0</CallingLampEffectType>
+        </powerLed>
+        <lineLed>
+            <LineIdleColor>0</LineIdleColor>
+            <LineIdleCtl>1</LineIdleCtl>
+        </lineLed>
+        <blfLed>
+            <BLFIdleColor>0</BLFIdleColor>
+            <BLFIdleCtl>1</BLFIdleCtl>
+            <BLFIdleText>terminated</BLFIdleText>
+            <BLFRingColor>1</BLFRingColor>
+            <BLFRingCtl>2</BLFRingCtl>
+            <BLFRingText>early</BLFRingText>
+            <BLFDialingColor>1</BLFDialingColor>
+            <BLFDialingCtl>0</BLFDialingCtl>
+            <BLFDialingText></BLFDialingText>
+            <BLFTalkingColor>1</BLFTalkingColor>
+            <BLFTalkingCtl>1</BLFTalkingCtl>
+            <BLFTalkingText>confirmed</BLFTalkingText>
+            <BLFHoldColor>1</BLFHoldColor>
+            <BLFHoldCtl>0</BLFHoldCtl>
+            <BLFHoldText></BLFHoldText>
+            <BLFFailedColor>0</BLFFailedColor>
+            <BLFFailedCtl>0</BLFFailedCtl>
+            <BLFFailedText>failed</BLFFailedText>
+            <BLFParkedColor>1</BLFParkedColor>
+            <BLFParkedCtl>3</BLFParkedCtl>
+            <BLFParkedText>parked</BLFParkedText>
+        </blfLed>
+        <volume>
+            <HandsetVol>6</HandsetVol>
+            <HandsetMicVol>3</HandsetMicVol>
+            <HeadsetVol>6</HeadsetVol>
+            <HeadsetMicVol>3</HeadsetMicVol>
+            <HeadsetRingVol>3</HeadsetRingVol>
+            <HandFreeVol>6</HandFreeVol>
+            <HandFreeMicVol>3</HandFreeMicVol>
+            <HandFreeRingVol>6</HandFreeRingVol>
+            <RingType>{if isset($fanvil_default_ringtone)}{$fanvil_default_ringtone}{else}Happy_Technology_Logo.ogg{/if}</RingType>
+        </volume>
+        <date>
+            <EnableSNTP>{if isset($fanvil_enable_sntp)}{$fanvil_enable_sntp}{else}1{/if}</EnableSNTP>
+            <SNTPServer>{$ntp_server_primary}</SNTPServer>
+            <SecondSNTPServer>{$ntp_server_secondary}</SecondSNTPServer>
+            <TimeZone>{$fanvil_time_zone}</TimeZone>
+            <TimeZoneName>{$fanvil_time_zone_name}</TimeZoneName>
+            <SNTPTimeout>60</SNTPTimeout>
+            <Enable_DST>{$fanvil_enable_dst}</Enable_DST>
+            <DST_Fixed_Type>{if isset($fanvil_dst_fixed_type)}{$fanvil_dst_fixed_type}{else}0{/if}</DST_Fixed_Type>
+            <SNTPTimeout>60</SNTPTimeout>
+            <DSTType>1</DSTType>
+            <DSTLocation>{if isset($fanvil_location)}{$fanvil_location}{else}4{/if}</DSTLocation>
+            <DSTRuleMode>0</DSTRuleMode>
+            <DSTMinOffset>{if isset($fanvil_dst_minute_offset)}{$fanvil_dst_minute_offset}{else}60{/if}</DSTMinOffset>
+            <DSTStartMon>3</DSTStartMon>
+            <DSTStartWeek>5</DSTStartWeek>
+            <DSTStartWday>0</DSTStartWday>
+            <DSTStartHour>2</DSTStartHour>
+            <DSTEndMon>10</DSTEndMon>
+            <DSTEndWeek>5</DSTEndWeek>
+            <DSTEndWday>0</DSTEndWday>
+            <DSTEndHour>2</DSTEndHour>
+        </date>
+        <timeDisplay>
+            <EnableTimeDisplay>0</EnableTimeDisplay>
+            <TimeDisplayStyle>{if isset($fanvil_time_display)}{$fanvil_time_display}{else}0{/if}</TimeDisplayStyle>
+            <DateDisplayStyle>{if isset($fanvil_date_display)}{$fanvil_date_display}{else}6{/if}</DateDisplayStyle>
+            <DateSeparator>{if isset($fanvil_date_separator)}{$fanvil_date_separator}{else}0{/if}</DateSeparator>
+        </timeDisplay>
+        <softKeyConfig>
+            <SoftkeyMode>0</SoftkeyMode>
+            <SoftKeyExitStyle>{if isset($fanvil_softkey_exit)}{$fanvil_softkey_exit}{else}2{/if}</SoftKeyExitStyle>
+            <DesktopSoftkey>{if isset($fanvil_softkey_desktopsoftkey)}{$fanvil_softkey_desktopsoftkey}{else}history;contact;dnd;menu;{/if}</DesktopSoftkey>
+            <TalkingSoftkey>{if isset($fanvil_softkey_talkingsoftkey)}{$fanvil_softkey_talkingsoftkey}{else}video;xfer;end;conf;hold;new;mute;record;dialpad;{/if}</TalkingSoftkey>
+            <RingingSoftkey>{if isset($fanvil_softkey_ringingsoftkey)}{$fanvil_softkey_ringingsoftkey}{else}forward;audio;video;reject;{/if}</RingingSoftkey>
+            <AlertingSoftkey>dialpad;xfer;cancel;</AlertingSoftkey>
+            <XAlertingSoftkey>dialpad;xfer;cancel;</XAlertingSoftkey>
+            <ConferenceSoftkey>conf;dialpad;end;split;hold;mute;exit;</ConferenceSoftkey>
+            <WaitingSoftkey>hold;xfer;conf;end;</WaitingSoftkey>
+            <EndingSoftkey>complete;autoRedial;end;redial;</EndingSoftkey>
+            <DialerPreSoftkey>audio;video;redial;</DialerPreSoftkey>
+            <DialerCallSoftkey>audio;video;redial;</DialerCallSoftkey>
+            <DialerXferSoftkey>audio;video;xfer;contact;history;cancel;</DialerXferSoftkey>
+            <DialerCfwdSoftkey>contact;history;forward;cancel;</DialerCfwdSoftkey>
+            <DesktopClick>{if isset($fanvil_softkey_desktopclick)}{$fanvil_softkey_desktopclick}{else}history;status;none;none;none;{/if}</DesktopClick>
+            <DailerClick>pline;nline;none;none;none;</DailerClick>
+            <RingingClick>none;none;none;none;none;</RingingClick>
+            <CallClick>pcall;ncall;voldown;volup;none;</CallClick>
+            <DesktopLongPress>status;none;none;mwi;none;reset;</DesktopLongPress>
+            <DialerConfSoftkey>audio;video;cancel;contact;history;redial;</DialerConfSoftkey>
+        </softKeyConfig>
+        <agent>
+            <AgentUsername></AgentUsername>
+            <AgentPassword></AgentPassword>
+            <AgentNumber></AgentNumber>
+            <AgentSipline>0</AgentSipline>
+            <AgentStatus>0</AgentStatus>
+            <AgentStatusReason></AgentStatusReason>
+            <AgentClearCallLog>0</AgentClearCallLog>
+        </agent>
+        <bwDir index="1">
+            <Title></Title>
+            <URL></URL>
+            <Username></Username>
+            <Password></Password>
+            <SipLine>0</SipLine>
+        </bwDir>
+        <bwDir index="2">
+            <Title></Title>
+            <URL></URL>
+            <Username></Username>
+            <Password></Password>
+            <SipLine>0</SipLine>
+        </bwDir>
+        <bwDir index="3">
+            <Title></Title>
+            <URL></URL>
+            <Username></Username>
+            <Password></Password>
+            <SipLine>0</SipLine>
+        </bwDir>
+        <bwDir index="4">
+            <Title></Title>
+            <URL></URL>
+            <Username></Username>
+            <Password></Password>
+            <SipLine>0</SipLine>
+        </bwDir>
+        <bwDir index="5">
+            <Title></Title>
+            <URL></URL>
+            <Username></Username>
+            <Password></Password>
+            <SipLine>0</SipLine>
+        </bwDir>
+        <bwDir index="6">
+            <Title></Title>
+            <URL></URL>
+            <Username></Username>
+            <Password></Password>
+            <SipLine>0</SipLine>
+        </bwDir>
+        <bwCallLog index="1">
+            <Title></Title>
+            <URL></URL>
+            <Username></Username>
+            <Password></Password>
+            <SipLine>0</SipLine>
+        </bwCallLog>
+        <bwCallLog index="2">
+            <Title></Title>
+            <URL></URL>
+            <Username></Username>
+            <Password></Password>
+            <SipLine>0</SipLine>
+        </bwCallLog>
+        <bwCallLog index="3">
+            <Title></Title>
+            <URL></URL>
+            <Username></Username>
+            <Password></Password>
+            <SipLine>0</SipLine>
+        </bwCallLog>
+        <ldap index="1">
+            <Title></Title>
+            <Server></Server>
+            <port>389</port>
+            <Base></Base>
+            <UseSSL>0</UseSSL>
+            <Version>3</Version>
+            <CallingLine>-1</CallingLine>
+            <BindLine>-1</BindLine>
+            <InCallSearch>0</InCallSearch>
+            <OutCallSearch>0</OutCallSearch>
+            <Authenticate>3</Authenticate>
+            <Username></Username>
+            <Password></Password>
+            <TelAttr>telephoneNumber</TelAttr>
+            <MobileAttr>mobile</MobileAttr>
+            <OtherAttr>other</OtherAttr>
+            <NameAttr>cn sn ou</NameAttr>
+            <SortAttr>cn</SortAttr>
+            <Displayname>cn</Displayname>
+            <NumberFilter>(|(telephoneNumber=%)(mobile=%)(other=%))</NumberFilter>
+            <NameFilter>(|(cn=%)(sn=%))</NameFilter>
+            <MaxHits>50</MaxHits>
+            <DisplayType>0</DisplayType>
+        </ldap>
+        <ldap index="2">
+            <Title></Title>
+            <Server></Server>
+            <port>389</port>
+            <Base></Base>
+            <UseSSL>0</UseSSL>
+            <Version>3</Version>
+            <CallingLine>-1</CallingLine>
+            <BindLine>-1</BindLine>
+            <InCallSearch>0</InCallSearch>
+            <OutCallSearch>0</OutCallSearch>
+            <Authenticate>3</Authenticate>
+            <Username></Username>
+            <Password></Password>
+            <TelAttr>telephoneNumber</TelAttr>
+            <MobileAttr>mobile</MobileAttr>
+            <OtherAttr>other</OtherAttr>
+            <NameAttr>cn sn ou</NameAttr>
+            <SortAttr>cn</SortAttr>
+            <Displayname>cn</Displayname>
+            <NumberFilter>(|(telephoneNumber=%)(mobile=%)(other=%))</NumberFilter>
+            <NameFilter>(|(cn=%)(sn=%))</NameFilter>
+            <MaxHits>50</MaxHits>
+            <DisplayType>0</DisplayType>
+        </ldap>
+        <ldap index="3">
+            <Title></Title>
+            <Server></Server>
+            <port>389</port>
+            <Base></Base>
+            <UseSSL>0</UseSSL>
+            <Version>3</Version>
+            <CallingLine>-1</CallingLine>
+            <BindLine>-1</BindLine>
+            <InCallSearch>0</InCallSearch>
+            <OutCallSearch>0</OutCallSearch>
+            <Authenticate>3</Authenticate>
+            <Username></Username>
+            <Password></Password>
+            <TelAttr>telephoneNumber</TelAttr>
+            <MobileAttr>mobile</MobileAttr>
+            <OtherAttr>other</OtherAttr>
+            <NameAttr>cn sn ou</NameAttr>
+            <SortAttr>cn</SortAttr>
+            <Displayname>cn</Displayname>
+            <NumberFilter>(|(telephoneNumber=%)(mobile=%)(other=%))</NumberFilter>
+            <NameFilter>(|(cn=%)(sn=%))</NameFilter>
+            <MaxHits>50</MaxHits>
+            <DisplayType>0</DisplayType>
+        </ldap>
+        <ldap index="4">
+            <Title></Title>
+            <Server></Server>
+            <port>389</port>
+            <Base></Base>
+            <UseSSL>0</UseSSL>
+            <Version>3</Version>
+            <CallingLine>-1</CallingLine>
+            <BindLine>-1</BindLine>
+            <InCallSearch>0</InCallSearch>
+            <OutCallSearch>0</OutCallSearch>
+            <Authenticate>3</Authenticate>
+            <Username></Username>
+            <Password></Password>
+            <TelAttr>telephoneNumber</TelAttr>
+            <MobileAttr>mobile</MobileAttr>
+            <OtherAttr>other</OtherAttr>
+            <NameAttr>cn sn ou</NameAttr>
+            <SortAttr>cn</SortAttr>
+            <Displayname>cn</Displayname>
+            <NumberFilter>(|(telephoneNumber=%)(mobile=%)(other=%))</NumberFilter>
+            <NameFilter>(|(cn=%)(sn=%))</NameFilter>
+            <MaxHits>50</MaxHits>
+            <DisplayType>0</DisplayType>
+        </ldap>
+        <ldap index="5">
+            <Title></Title>
+            <Server></Server>
+            <port>389</port>
+            <Base></Base>
+            <UseSSL>0</UseSSL>
+            <Version>3</Version>
+            <CallingLine>-1</CallingLine>
+            <BindLine>-1</BindLine>
+            <InCallSearch>0</InCallSearch>
+            <OutCallSearch>0</OutCallSearch>
+            <Authenticate>3</Authenticate>
+            <Username></Username>
+            <Password></Password>
+            <TelAttr>telephoneNumber</TelAttr>
+            <MobileAttr>mobile</MobileAttr>
+            <OtherAttr>other</OtherAttr>
+            <NameAttr>cn sn ou</NameAttr>
+            <SortAttr>cn</SortAttr>
+            <Displayname>cn</Displayname>
+            <NumberFilter>(|(telephoneNumber=%)(mobile=%)(other=%))</NumberFilter>
+            <NameFilter>(|(cn=%)(sn=%))</NameFilter>
+            <MaxHits>50</MaxHits>
+            <DisplayType>0</DisplayType>
+        </ldap>
+        <xmlContact index="1">
+            <Name></Name>
+            <Addr></Addr>
+            <UserName></UserName>
+            <PassWd></PassWd>
+            <Sipline>-1</Sipline>
+            <BindLine>-1</BindLine>
+        </xmlContact>
+        <xmlContact index="2">
+            <Name></Name>
+            <Addr></Addr>
+            <UserName></UserName>
+            <PassWd></PassWd>
+            <Sipline>-1</Sipline>
+            <BindLine>-1</BindLine>
+        </xmlContact>
+        <xmlContact index="3">
+            <Name></Name>
+            <Addr></Addr>
+            <UserName></UserName>
+            <PassWd></PassWd>
+            <Sipline>-1</Sipline>
+            <BindLine>-1</BindLine>
+        </xmlContact>
+        <xmlContact index="4">
+            <Name></Name>
+            <Addr></Addr>
+            <UserName></UserName>
+            <PassWd></PassWd>
+            <Sipline>-1</Sipline>
+            <BindLine>-1</BindLine>
+        </xmlContact>
+        <xmlContact index="5">
+            <Name></Name>
+            <Addr></Addr>
+            <UserName></UserName>
+            <PassWd></PassWd>
+            <Sipline>-1</Sipline>
+            <BindLine>-1</BindLine>
+        </xmlContact>
+    </phone>
+    <dm>
+        <OnhookTime>200</OnhookTime>
+        <EnableHookflash>0</EnableHookflash>
+        <KeyLongPressTime>2</KeyLongPressTime>
+        <KeyLongLongPressTime>6</KeyLongLongPressTime>
+    </dm>
+    <vqm>
+        <SessionReport>1</SessionReport>
+        <IntervalReport>1</IntervalReport>
+        <IntervalPeriod>60</IntervalPeriod>
+        <MOS-LQWarning>40</MOS-LQWarning>
+        <MOS-LQCritical>25</MOS-LQCritical>
+        <DelayWarning>150</DelayWarning>
+        <DelayCritical>200</DelayCritical>
+        <PhoneReport>1</PhoneReport>
+        <WEBReport>1</WEBReport>
+    </vqm>
+    <cti>
+        <EnabledActiveUri>1</EnabledActiveUri>
+        <EnabledActionUrl>1</EnabledActionUrl>
+        <ActiveUriIP></ActiveUriIP>
+        <StartRebootUrl></StartRebootUrl>
+        <BootCompletedUrl></BootCompletedUrl>
+        <IPChangeUrl></IPChangeUrl>
+        <RegOnUrl></RegOnUrl>
+        <RegOffUrl></RegOffUrl>
+        <RegFailedUrl></RegFailedUrl>
+        <PhoneStateIdleUrl></PhoneStateIdleUrl>
+        <PhoneStateTalking></PhoneStateTalking>
+        <PhoneStateRinging></PhoneStateRinging>
+        <DNDOnUrl></DNDOnUrl>
+        <DNDOffUrl></DNDOffUrl>
+        <AlwaysFWDOnUrl></AlwaysFWDOnUrl>
+        <AlwaysFWDOffUrl></AlwaysFWDOffUrl>
+        <BusyFWDOnUrl></BusyFWDOnUrl>
+        <BusyFWDOffUrl></BusyFWDOffUrl>
+        <NoAnsFWDOnUrl></NoAnsFWDOnUrl>
+        <NoAnsFWDOffUrl></NoAnsFWDOffUrl>
+        <MuteOnUrl></MuteOnUrl>
+        <MuteOffUrl></MuteOffUrl>
+        <IncomingCallUrl></IncomingCallUrl>
+        <OutgoingCallUrl></OutgoingCallUrl>
+        <CallActiveUrl></CallActiveUrl>
+        <CallStopUrl></CallStopUrl>
+        <TransferUrl></TransferUrl>
+        <HoldOnUrl></HoldOnUrl>
+        <HoldOffUrl></HoldOffUrl>
+        <HeldOnUrl></HeldOnUrl>
+        <HeldOffUrl></HeldOffUrl>
+        <MuteOnCallUrl></MuteOnCallUrl>
+        <MuteOffCallUrl></MuteOffCallUrl>
+        <NewMissedcallUrl></NewMissedcallUrl>
+        <NewMWIUrl></NewMWIUrl>
+        <NewSMSUrl></NewSMSUrl>
+        <WebAuthChangedUrl></WebAuthChangedUrl>
+        <at>
+            <AtEnabled>0</AtEnabled>
+            <AtServer></AtServer>
+        </at>
+    </cti>
+    <mcast>
+        <Priority>0</Priority>
+        <EnablePriority>0</EnablePriority>
+        <EnablePrioChan>0</EnablePrioChan>
+        <EnableEmerChan>0</EnableEmerChan>
+        <MulticastTone>1</MulticastTone>
+        <McastListeningRenewTime>0</McastListeningRenewTime>
+        <addr index="1">
+            <Name></Name>
+            <Host></Host>
+            <Port>0</Port>
+            <Channel>0</Channel>
+        </addr>
+        <addr index="2">
+            <Name></Name>
+            <Host></Host>
+            <Port>0</Port>
+            <Channel>0</Channel>
+        </addr>
+        <addr index="3">
+            <Name></Name>
+            <Host></Host>
+            <Port>0</Port>
+            <Channel>0</Channel>
+        </addr>
+        <addr index="4">
+            <Name></Name>
+            <Host></Host>
+            <Port>0</Port>
+            <Channel>0</Channel>
+        </addr>
+        <addr index="5">
+            <Name></Name>
+            <Host></Host>
+            <Port>0</Port>
+            <Channel>0</Channel>
+        </addr>
+        <addr index="6">
+            <Name></Name>
+            <Host></Host>
+            <Port>0</Port>
+            <Channel>0</Channel>
+        </addr>
+        <addr index="7">
+            <Name></Name>
+            <Host></Host>
+            <Port>0</Port>
+            <Channel>0</Channel>
+        </addr>
+        <addr index="8">
+            <Name></Name>
+            <Host></Host>
+            <Port>0</Port>
+            <Channel>0</Channel>
+        </addr>
+        <addr index="9">
+            <Name></Name>
+            <Host></Host>
+            <Port>0</Port>
+            <Channel>0</Channel>
+        </addr>
+        <addr index="10">
+            <Name></Name>
+            <Host></Host>
+            <Port>0</Port>
+            <Channel>0</Channel>
+        </addr>
+        <dynamic>
+            <AutoExitExpires>60</AutoExitExpires>
+        </dynamic>
+    </mcast>
+    <dsskey>
+        <SelectDsskeyAction>0</SelectDsskeyAction>
+        <MemoryKeytoBXfer>0</MemoryKeytoBXfer>
+        <FuncKeyPageNum>4</FuncKeyPageNum>
+        <SideKeyPageNum>1</SideKeyPageNum>
+        <DSSHomePage>0</DSSHomePage>
+        <DisplayParkedInfo>0</DisplayParkedInfo>
+        <DSSDIALSwitchMode>0</DSSDIALSwitchMode>
+        <FirstCallWaitTime>16</FirstCallWaitTime>
+        <FirstNumStartTime>360</FirstNumStartTime>
+        <FirstNumEndTime>1080</FirstNumEndTime>
+        <DSSLongPressAction>1</DSSLongPressAction>
+        <Extern1PageBelong>0</Extern1PageBelong>
+        <Extern2PageBelong>0</Extern2PageBelong>
+        <Extern3PageBelong>0</Extern3PageBelong>
+        <Extern4PageBelong>0</Extern4PageBelong>
+        <Extern5PageBelong>0</Extern5PageBelong>
+        <DSSExtend1MAC></DSSExtend1MAC>
+        <DSSExtend1IP></DSSExtend1IP>
+        <DSSExtend2MAC></DSSExtend2MAC>
+        <DSSExtend2IP></DSSExtend2IP>
+        <DSSExtend3MAC></DSSExtend3MAC>
+        <DSSExtend3IP></DSSExtend3IP>
+        <DSSExtend4MAC></DSSExtend4MAC>
+        <DSSExtend4IP></DSSExtend4IP>
+        <DSSExtend5MAC></DSSExtend5MAC>
+        <DSSExtend5IP></DSSExtend5IP>
+
+        {strip}{*-- Each Internal Index contains 32 keys --*}{/strip}
+        <internal index="1">
+            <Fkey index="1">
+                <Type>2</Type>
+                <Value>SIP1</Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="2">
+                <Type>2</Type>
+                <Value>SIP2</Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="3">
+                <Type>2</Type>
+                <Value>SIP3</Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="4">
+                <Type>2</Type>
+                <Value>SIP4</Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="5">
+                <Type>2</Type>
+                <Value>SIP5</Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="6">
+                <Type>3</Type>
+                <Value>F_HEADSET</Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="7">
+                <Type>3</Type>
+                <Value>F_REDIAL</Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="8">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="9">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="10">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="11">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="12">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="13">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="14">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="15">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="16">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="17">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="18">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="19">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="20">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="21">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="22">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="23">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="24">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="25">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="26">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="27">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="28">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="29">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+        </internal>
+        <internal index="2">
+            <Fkey index="1">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="2">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="3">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="4">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="5">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="6">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="7">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="8">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="9">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="10">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="11">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="12">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="13">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="14">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="15">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="16">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="17">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="18">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="19">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="20">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="21">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="22">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="23">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="24">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="25">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="26">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="27">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="28">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="29">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+        </internal>
+        <internal index="3">
+            <Fkey index="1">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="2">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="3">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="4">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="5">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="6">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="7">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="8">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="9">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="10">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="11">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="12">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="13">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="14">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="15">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="16">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="17">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="18">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="19">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="20">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="21">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="22">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="23">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="24">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="25">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="26">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="27">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="28">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="29">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+        </internal>
+        <internal index="4">
+            <Fkey index="1">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="2">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="3">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="4">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="5">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="6">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="7">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="8">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="9">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="10">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="11">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="12">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="13">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="14">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="15">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="16">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="17">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="18">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="19">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="20">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="21">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="22">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="23">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="24">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="25">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="26">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="27">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="28">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="29">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+        </internal>
+        <dssSoft index="1">
+            <Type>0</Type>
+            <Value></Value>
+            <Title></Title>
+            <ICON>Green</ICON>
+        </dssSoft>
+        <dssSoft index="2">
+            <Type>0</Type>
+            <Value></Value>
+            <Title></Title>
+            <ICON>Green</ICON>
+        </dssSoft>
+        <dssSoft index="3">
+            <Type>0</Type>
+            <Value></Value>
+            <Title></Title>
+            <ICON>Green</ICON>
+        </dssSoft>
+        <dssSoft index="4">
+            <Type>0</Type>
+            <Value></Value>
+            <Title></Title>
+            <ICON>Green</ICON>
+        </dssSoft>
+        <dssSoft index="5">
+            <Type>0</Type>
+            <Value></Value>
+            <Title></Title>
+            <ICON>Green</ICON>
+        </dssSoft>
+        <dssSoft index="6">
+            <Type>0</Type>
+            <Value></Value>
+            <Title></Title>
+            <ICON>Green</ICON>
+        </dssSoft>
+        <dssSoft index="7">
+            <Type>0</Type>
+            <Value></Value>
+            <Title></Title>
+            <ICON>Green</ICON>
+        </dssSoft>
+        <dssSoft index="8">
+            <Type>0</Type>
+            <Value></Value>
+            <Title></Title>
+            <ICON>Green</ICON>
+        </dssSoft>
+        <dssSoft index="9">
+            <Type>0</Type>
+            <Value></Value>
+            <Title></Title>
+            <ICON>Green</ICON>
+        </dssSoft>
+        <dssSoft index="10">
+            <Type>0</Type>
+            <Value></Value>
+            <Title></Title>
+            <ICON>Green</ICON>
+        </dssSoft>
+    </dsskey>
+    <web>
+        <WebServerType>0</WebServerType>
+        <WebPort>80</WebPort>
+        <HttpsWebPort>443</HttpsWebPort>
+        <RemoteControl>1</RemoteControl>
+        <EnableMMIFilter>0</EnableMMIFilter>
+        <WebAuthentication>0</WebAuthentication>
+        <EnableTelnet>0</EnableTelnet>
+        <TelnetPort>23</TelnetPort>
+        <TelnetPrompt></TelnetPrompt>
+        <LogonTimeout>15</LogonTimeout>
+        <account index="1">
+            <Name>{if isset($admin_name)}{$admin_name}{else}admin{/if}</Name>
+            <Password>{if isset($admin_password)}{$admin_password}{else}admin{/if}</Password>
+            <Level>10</Level>
+        </account>
+        <account index="2">
+            <Name>guest</Name>
+            <Password>guest</Password>
+            <Level>5</Level>
+        </account>
+    </web>
+    <log>
+        <Level>INFO</Level>
+        <Style>level,tag</Style>
+        {if $fanvil_syslog_enable == '1'}<OutputDevice>syslog</OutputDevice>
+        {elseif $fanvil_output_device == ''}<OutputDevice></OutputDevice>
+        {elseif $fanvil_output_device == 'syslog'}<OutputDevice>syslog</OutputDevice>
+        {elseif $fanvil_output_device == 'stdout'}<OutputDevice>stdout</OutputDevice>
+        {elseif $fanvil_output_device == 'syslog,stdout'}<OutputDevice>syslog,stdout</OutputDevice>
+        {elseif $fanvil_output_device == 'stdout,syslog'}<OutputDevice>syslog,stdout</OutputDevice>
+        {/if}
+        <FileName>platform.log</FileName>
+        <FileSize>512KB</FileSize>
+        <SyslogTag>platform</SyslogTag>
+        <SyslogServer>{if isset($fanvil_syslog_server)}{$fanvil_syslog_server}{else}0.0.0.0{/if}</SyslogServer>
+        <SyslogServerPort>{if isset($fanvil_syslog_server_port)}{$fanvil_syslog_server_port}{else}514{/if}</SyslogServerPort>
+    </log>
+    <tr069>
+        <TR069Tone>1</TR069Tone>
+        <CPESerialNumber></CPESerialNumber>
+        <ACSServerType>1</ACSServerType>
+        <EnableTR069>0</EnableTR069>
+        <ACSURL>0.0.0.0</ACSURL>
+        <ACSUserName>admin</ACSUserName>
+        <ACSPassword></ACSPassword>
+        <ACSBackupURL>0.0.0.0</ACSBackupURL>
+        <ACSBackupUserName></ACSBackupUserName>
+        <ACSBackupPassword></ACSBackupPassword>
+        <CPEUserName>dps</CPEUserName>
+        <CPEPassword>dps</CPEPassword>
+        <PeriodixInterval>3600</PeriodixInterval>
+        <TLSVersion>2</TLSVersion>
+        <AreaCode></AreaCode>
+        <STUNEnable>0</STUNEnable>
+        <STUNServerAddr>{$fanvil_stun_server}</STUNServerAddr>
+        <STUNServerPort>{$fanvil_stun_port}</STUNServerPort>
+        <STUNLocalPort>30000</STUNLocalPort>
+    </tr069>
+    <hotspot>
+        <EnableHotspot>0</EnableHotspot>
+        <Mode>1</Mode>
+        <ListenType>0</ListenType>
+        <ListenIP>224.0.2.0</ListenIP>
+        <ListenPort>16360</ListenPort>
+        <OwnName>SIP Hotspot</OwnName>
+        <RingMode>0</RingMode>
+        <GroupCallMode>0</GroupCallMode>
+        <EnableManageMode>0</EnableManageMode>
+        <EnableConfigMode>0</EnableConfigMode>
+        <hs index="1">
+            <Enable>1</Enable>
+            <ExtPrefix></ExtPrefix>
+        </hs>
+        <hs index="2">
+            <Enable>1</Enable>
+            <ExtPrefix></ExtPrefix>
+        </hs>
+        <hs index="3">
+            <Enable>1</Enable>
+            <ExtPrefix></ExtPrefix>
+        </hs>
+        <hs index="4">
+            <Enable>1</Enable>
+            <ExtPrefix></ExtPrefix>
+        </hs>
+        <hs index="5">
+            <Enable>1</Enable>
+            <ExtPrefix></ExtPrefix>
+        </hs>
+        <hs index="6">
+            <Enable>1</Enable>
+            <ExtPrefix></ExtPrefix>
+        </hs>
+        <hs index="7">
+            <Enable>1</Enable>
+            <ExtPrefix></ExtPrefix>
+        </hs>
+        <hs index="8">
+            <Enable>1</Enable>
+            <ExtPrefix></ExtPrefix>
+        </hs>
+        <hs index="9">
+            <Enable>1</Enable>
+            <ExtPrefix></ExtPrefix>
+        </hs>
+        <hs index="10">
+            <Enable>1</Enable>
+            <ExtPrefix></ExtPrefix>
+        </hs>
+        <hs index="11">
+            <Enable>1</Enable>
+            <ExtPrefix></ExtPrefix>
+        </hs>
+        <hs index="12">
+            <Enable>1</Enable>
+            <ExtPrefix></ExtPrefix>
+        </hs>
+        <hs index="13">
+            <Enable>1</Enable>
+            <ExtPrefix></ExtPrefix>
+        </hs>
+        <hs index="14">
+            <Enable>1</Enable>
+            <ExtPrefix></ExtPrefix>
+        </hs>
+        <hs index="15">
+            <Enable>1</Enable>
+            <ExtPrefix></ExtPrefix>
+        </hs>
+        <hs index="16">
+            <Enable>1</Enable>
+            <ExtPrefix></ExtPrefix>
+        </hs>
+        <hs index="17">
+            <Enable>1</Enable>
+            <ExtPrefix></ExtPrefix>
+        </hs>
+        <hs index="18">
+            <Enable>1</Enable>
+            <ExtPrefix></ExtPrefix>
+        </hs>
+        <hs index="19">
+            <Enable>1</Enable>
+            <ExtPrefix></ExtPrefix>
+        </hs>
+        <hs index="20">
+            <Enable>1</Enable>
+            <ExtPrefix></ExtPrefix>
+        </hs>
+    </hotspot>
+    <mt>
+        <ContactUpdateMode>0</ContactUpdateMode>
+        <AutoServerDigest>0</AutoServerDigest>
+    </mt>
+    <ap>
+        <DefaultUsername>{$http_auth_username}</DefaultUsername>
+        <DefaultPassword>{$http_auth_password}</DefaultPassword>
+        <InputCfgFileName></InputCfgFileName>
+        <DeviceCfgFileKey></DeviceCfgFileKey>
+        <CommonCfgFileKey></CommonCfgFileKey>
+        <DownloadCommonConf>1</DownloadCommonConf>
+        <SaveProvisionInfo>1</SaveProvisionInfo>
+        <CheckFailTimes>5</CheckFailTimes>
+        <FlashServerIP>{if isset($fanvil_provision_url)}{$fanvil_provision_url}{else}{$domain_name}/app/provision{/if}</FlashServerIP>
+        <FlashFileName>{$fanvil_firmware_config}</FlashFileName>
+        <FlashProtocol>5</FlashProtocol>
+        <FlashMode>1</FlashMode>
+        <FlashInterval>1</FlashInterval>
+        <updatePBInterval>720</updatePBInterval>
+        <pnp>
+            <PNPEnable>1</PNPEnable>
+            <PNPIP>224.0.1.75</PNPIP>
+            <PNPPort>5060</PNPPort>
+            <PNPTransport>0</PNPTransport>
+            <PNPInterval>1</PNPInterval>
+        </pnp>
+        <opt>
+            <DHCPOption>66</DHCPOption>
+            <DhcpOption120>0</DhcpOption120>
+            <DHCPv6Option>0</DHCPv6Option>
+        </opt>
+    </ap>
+    <qos>
+        <EnableVLAN>{if isset($fanvil_enable_vlan)}{$fanvil_enable_vlan}{else}0{/if}</EnableVLAN>
+        <VLANID>{if isset($fanvil_lan_port_vlan)}{$fanvil_lan_port_vlan}{else}256{/if}</VLANID>
+        <EnablePVID>{if isset($fanvil_pc_port_vlan)}2{else}0{/if}</EnablePVID>
+        <PVIDValue>{if isset($fanvil_pc_port_vlan)}{$fanvil_pc_port_vlan}{else}254{/if}</PVIDValue>
+        <SignallingPriority>{if isset($fanvil_qos_sip)}{$fanvil_qos_sip}{else}0{/if}</SignallingPriority>
+        <VoicePriority>{if isset($fanvil_qos_rtp_voice)}{$fanvil_qos_rtp_voice}{else}0{/if}</VoicePriority>
+        <VideoPriority>{if isset($fanvil_qos_rtp_video)}{$fanvil_qos_rtp_video}{else}0{/if}</VideoPriority>
+        <LANPortPriority>0</LANPortPriority>
+        <EnablediffServ>{if isset($fanvil_enable_diffserv)}{$fanvil_enable_diffserv}{else}0{/if}</EnablediffServ>
+        <SingallingDSCP>{if isset($fanvil_dscp_sip)}{$fanvil_dscp_sip}{else}46{/if}</SingallingDSCP>
+        <VoiceDSCP>{if isset($fanvil_dscp_rtp_voice)}{$fanvil_dscp_rtp_voice}{else}46{/if}</VoiceDSCP>
+        <VideoDSCP>{if isset($fanvil_dscp_rtp_video)}{$fanvil_dscp_rtp_video}{else}34{/if}</VideoDSCP>
+        <LLDPTransmit>{if isset($fanvil_lldp_tx_enable)}{$fanvil_lldp_tx_enable}{else}0{/if}</LLDPTransmit>
+        <LLDPRefreshTime>{if isset($fanvil_lldp_refresh)}{$fanvil_lldp_refresh}{else}60{/if}</LLDPRefreshTime>
+        <LLDPLearnPolicy>{if isset($fanvil_lldp_learn)}{$fanvil_lldp_learn}{else}0{/if}</LLDPLearnPolicy>
+        <LLDPSaveLearnData>1</LLDPSaveLearnData>
+        <CDPEnable>0</CDPEnable>
+        <CDPRefreshTime>60</CDPRefreshTime>
+        <DHCPOptionVlan>132</DHCPOptionVlan>
+    </qos>
+    <dot1x>
+        <XsupMode>0</XsupMode>
+        <XsupUser>admin</XsupUser>
+        <XsupPassword>admin</XsupPassword>
+        <sslMode>
+            <PermissionCTF>0</PermissionCTF>
+            <CommonName>0</CommonName>
+            <CTFmode>0</CTFmode>
+            <DeviceCertMode>0</DeviceCertMode>
+        </sslMode>
+    </dot1x>
+    <rtsp>
+        <RtspClientWorkMode>0</RtspClientWorkMode>
+    </rtsp>
+    <pubApp>
+        <WatchDogEnabled>1</WatchDogEnabled>
+        <EnableInAccess>0</EnableInAccess>
+        <EnableOutAccess>0</EnableOutAccess>
+    </pubApp>
+    <android>
+        <displayConfig>
+            <OperatorMode>0</OperatorMode>
+            <EnableShortcuts>1</EnableShortcuts>
+            <EnableLCDPassword>1</EnableLCDPassword>
+        </displayConfig>
+        <softKeyConfig>
+            <DIdleSoftkey>dialpad;mwi;contact;history;cfwd;redial;capse;</DIdleSoftkey>
+            <DTalkingSoftkey>dialpad;new;conf;hold;xfer;end;capse;</DTalkingSoftkey>
+            <DRingSoftkey>dialpad;forward;audio;video;mute;reject;capse;</DRingSoftkey>
+            <DAlertingSoftkey>dialpad;none;none;none;xfer;cancel;capse;</DAlertingSoftkey>
+            <DXAlertingSoftkey>dialpad;none;none;none;xfer;none;capse;</DXAlertingSoftkey>
+            <DConferenceSoftkey>dialpad;exit;split;hold;xfer;end;capse;</DConferenceSoftkey>
+            <DEndingSoftkey>contact;history;new;complete;autoRedial;end;capse;</DEndingSoftkey>
+            <DPredialSoftkey>dialpad;mwi;contact;history;redial;cancel;capse;</DPredialSoftkey>
+            <DDialingSoftkey>dialpad;mwi;contact;history;redial;cancel;capse;</DDialingSoftkey>
+            <DDialerCfwdSoftkey>dialpad;new;contact;history;forward;cancel;capse;</DDialerCfwdSoftkey>
+            <DDialerXferSoftkey>dialpad;new;contact;history;xfer;cancel;capse;</DDialerXferSoftkey>
+            <DSlectionSoftkey>new;cancel;ok;conf;hold;xfer;capse;</DSlectionSoftkey>
+        </softKeyConfig>
+        <dspConfig>
+            <VideoDisplayMosaic>1</VideoDisplayMosaic>
+        </dspConfig>
+        <teleConfig>
+            <EnableRecord>1</EnableRecord>
+            <EnableIMApp>0</EnableIMApp>
+            <OffhooktoOpenApp>0</OffhooktoOpenApp>
+            <IMAppPackageInfo></IMAppPackageInfo>
+            <SupportedIMSet></SupportedIMSet>
+            <HideLocalCode>0</HideLocalCode>
+            <UpdateDialCall>0</UpdateDialCall>
+            <CountryCode></CountryCode>
+        </teleConfig>
+    </android>
+    <uiMainTainConfig>
+        <EHSHeadsettype>0</EHSHeadsettype>
+        <TimeoutToScreensaver>7200</TimeoutToScreensaver>
+        <DisplayProvisionprompt>0</DisplayProvisionprompt>
+    </uiMainTainConfig>
+    <fwCheck>
+        <EnableAutoUpgrade>0</EnableAutoUpgrade>
+        <UpgradeServer1></UpgradeServer1>
+        <UpgradeServer2></UpgradeServer2>
+        <AutoUpgradeInterval>24</AutoUpgradeInterval>
+    </fwCheck>
+    <record>
+        <Enabled>1</Enabled>
+        <VoiceCodec>PCMU</VoiceCodec>
+        <RecordType>0</RecordType>
+        <FileSizeLimit>0</FileSizeLimit>
+        <ServerAddr>0.0.0.0</ServerAddr>
+        <ServerPort>10000</ServerPort>
+    </record>
+    <IO>
+        <RingtoneDuration>5</RingtoneDuration>
+        <AlarmServerAddr></AlarmServerAddr>
+        <DTMFTriggerRing>NONE</DTMFTriggerRing>
+        <URITriggerRing>NONE</URITriggerRing>
+        <SMSTriggerRing>NONE</SMSTriggerRing>
+        <DsskeyTriggerRing>NONE</DsskeyTriggerRing>
+    </IO>
+</sysConf>

--- a/resources/templates/provision/fanvil/v62/{$mac}.cfg
+++ b/resources/templates/provision/fanvil/v62/{$mac}.cfg
@@ -1,0 +1,2013 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sysConf>
+    <Version>2.0000000000</Version>
+    <net>
+        <WANTYPE>0</WANTYPE>
+        <WANIP></WANIP>
+        <WANSubnetMask>255.255.255.0</WANSubnetMask>
+        <WANGateway></WANGateway>
+        <DomainName></DomainName>
+        <PrimaryDNS>{if isset($dns_server_primary)}{$dns_server_primary}{else}9.9.9.9{/if}</PrimaryDNS>
+        <SecondaryDNS>{if isset($dns_server_secondary)}{$dns_server_secondary}{else}1.1.1.1{/if}</SecondaryDNS>
+        <EnableDHCP>1</EnableDHCP>
+        <DHCPAutoDNS>1</DHCPAutoDNS>
+        <DHCPAutoTime>1</DHCPAutoTime>
+        <DHCPOption100-101>1</DHCPOption100-101>
+        <UseVendorClassID>0</UseVendorClassID>
+        <VendorClassID>Fanvil</VendorClassID>
+        <EnablePPPoE>0</EnablePPPoE>
+        <PPPoEUser>user123</PPPoEUser>
+        <PPPoEPassword>password</PPPoEPassword>
+        <ARPCacheLife>2</ARPCacheLife>
+        <MTU>1500</MTU>
+        <PPPoEAutoConnect>0</PPPoEAutoConnect>
+        <PPPoEAutoRecnct>0</PPPoEAutoRecnct>
+        <WAN6IP></WAN6IP>
+        <WAN6IPPREFIX></WAN6IPPREFIX>
+        <WAN6Gateway></WAN6Gateway>
+        <Domain6Name></Domain6Name>
+        <PrimaryDNS6></PrimaryDNS6>
+        <SecondaryDNS6></SecondaryDNS6>
+        <EnableDHCP6>1</EnableDHCP6>
+        <DHCP6AutoDNS>1</DHCP6AutoDNS>
+        <DHCP6AutoTime>0</DHCP6AutoTime>
+        <UseVendor6ClassID>0</UseVendor6ClassID>
+        <Vendor6ClassID></Vendor6ClassID>
+    </net>
+    <mm>
+        <G723BitRate>1</G723BitRate>
+        <ILBCPayloadType>97</ILBCPayloadType>
+        <ILBCPayloadLen>20</ILBCPayloadLen>
+        <AMRPayloadType>108</AMRPayloadType>
+        <AMRWBPayloadType>109</AMRWBPayloadType>
+        <G726-16PayloadType>103</G726-16PayloadType>
+        <G726-24PayloadType>104</G726-24PayloadType>
+        <G726-32PayloadType>102</G726-32PayloadType>
+        <G726-40PayloadType>105</G726-40PayloadType>
+        <DtmfPayloadType>101</DtmfPayloadType>
+        <OpusPayloadType>107</OpusPayloadType>
+        <OpusSampleRate>0</OpusSampleRate>
+        <VAD>0</VAD>
+        <H264PayloadType>117</H264PayloadType>
+        <H264PacketMode>0</H264PacketMode>
+        <H264Profile>0</H264Profile>
+        <ResvAudioBand>0</ResvAudioBand>
+        <H265PayloadType>98</H265PayloadType>
+        <RTPInitialPort>16384</RTPInitialPort>
+        <RTPPortQuantity>16384</RTPPortQuantity>
+        <RTPKeepAlive>0</RTPKeepAlive>
+        <RTPRelay>0</RTPRelay>
+        <RTCPCNAMEUser></RTCPCNAMEUser>
+        <RTCPCNAMEHost></RTCPCNAMEHost>
+        <SelectYourTone>{if isset($fanvil_country_toneset)}{$fanvil_country_toneset}{else}11{/if}</SelectYourTone>
+        <SidetoneGAIN>1</SidetoneGAIN>
+        <PlayEgressDTMF>0</PlayEgressDTMF>
+        <DialTone>350+440/0</DialTone>
+        <RingbackTone>440+480/2000,0/4000</RingbackTone>
+        <BusyTone>480+620/500,0/500</BusyTone>
+        <CongestionTone></CongestionTone>
+        <CallwaitingTone>440/300,0/10000,440/300,0/10000,0/0</CallwaitingTone>
+        <HoldingTone></HoldingTone>
+        <ErrorTone></ErrorTone>
+        <StutterTone></StutterTone>
+        <InformationTone></InformationTone>
+        <DialRecallTone>350+440/100,0/100,350+440/100,0/100,350+440/100,0/100,350+440/0</DialRecallTone>
+        <MessageTone></MessageTone>
+        <HowlerTone></HowlerTone>
+        <NumberUnobtainable>400/500,0/6000</NumberUnobtainable>
+        <WarningTone>1400/500,0/0</WarningTone>
+        <RecordTone>440/500,0/5000</RecordTone>
+        <AutoAnswerTone></AutoAnswerTone>
+        <capability>
+            <AudioCodecSets>G722,PCMU,PCMA,OPUS</AudioCodecSets>
+            <VideoCodecSets>{if isset($fanvil_video_codec)}{$fanvil_video_codec}{else}H264{/if}</VideoCodecSets>
+            <VideoFrameRate>30</VideoFrameRate>
+            <VideoBitRate>2000000</VideoBitRate>
+            <VideoResolution>7</VideoResolution>
+            <VideoNegotiateDir>0</VideoNegotiateDir>
+        </capability>
+    </mm>
+    <sip>
+        <SIPPort>{$sip_port}</SIPPort>
+        <STUNServer>{$fanvil_stun_server}</STUNServer>
+        <STUNPort>{$fanvil_stun_port}</STUNPort>
+        <STUNRefreshTime>50</STUNRefreshTime>
+        <SIPWaitStunTime>800</SIPWaitStunTime>
+        <ExternNATAddrs></ExternNATAddrs>
+        <RegFailInterval>32</RegFailInterval>
+        <StrictBranchPrefix>0</StrictBranchPrefix>
+        <VideoMuteAttr>0</VideoMuteAttr>
+        <EnableGroupBackup>0</EnableGroupBackup>
+        <EnableRFC4475>1</EnableRFC4475>
+        <StrictUAMatch>1</StrictUAMatch>
+        <CSTAEnable>0</CSTAEnable>
+        <NotifyReboot>1</NotifyReboot>
+	{foreach $lines as $row}
+        <line index="{$row.device_key_id}">
+            <PhoneNumber>{$row.user_id}</PhoneNumber>
+            <DisplayName>{$row.display_name}</DisplayName>
+            <SipName></SipName>
+            <RegisterAddr>{$row.server_address}</RegisterAddr>
+            <RegisterPort>{$row.sip_port}</RegisterPort>
+            <RegisterUser>{$row.auth_id}</RegisterUser>
+            <RegisterPswd>{$row.password}</RegisterPswd>
+            <RegisterTTL>{$row.register_expires}</RegisterTTL>
+            <BackupAddr></BackupAddr>
+            <BackupPort>5060</BackupPort>
+            <BackupTransport>0</BackupTransport>
+            <BackupTTL>3600</BackupTTL>
+            <EnableReg>0</EnableReg>
+            <EnableReg>{if isset($row.password)}1{else}0{/if}</EnableReg>
+            <ProxyAddr>{$row.outbound_proxy_primary}</ProxyAddr>
+            <ProxyPort>{$row.sip_port}</ProxyPort>
+            <ProxyUser>{$row.auth_id}</ProxyUser>
+            <ProxyPswd>{$row.password}</ProxyPswd>
+            <ProxyNeedRegOn>0</ProxyNeedRegOn>
+            <BakProxyAddr>{$row.outbound_proxy_secondary}</BakProxyAddr>
+            <BakProxyPort>{$row.sip_port}</BakProxyPort>
+            <BakProxyNeedRegOn>0</BakProxyNeedRegOn>
+            <EnableFailback>{if isset($row.outbound_proxy_secondary)}1{else}0{/if}</EnableFailback>
+            <FailbackInterval>1800</FailbackInterval>
+            <SignalFailback>0</SignalFailback>
+            <SignalRetryCounts>3</SignalRetryCounts>
+            <SigCryptoKey></SigCryptoKey>
+            <EnableOSRTP>0</EnableOSRTP>
+            <MediaCrypto>0</MediaCrypto>
+            <MedCryptoKey></MedCryptoKey>
+            <SRTPAuth-Tag>0</SRTPAuth-Tag>
+            <EnableRFC5939>0</EnableRFC5939>
+            <LocalDomain></LocalDomain>
+            <AlwaysFWD>0</AlwaysFWD>
+            <BusyFWD>0</BusyFWD>
+            <NoAnswerFWD>0</NoAnswerFWD>
+            <AlwaysFWDNum></AlwaysFWDNum>
+            <BusyFWDNum></BusyFWDNum>
+            <NoAnswerFWDNum></NoAnswerFWDNum>
+            <FWDTimer>5</FWDTimer>
+            <HotlineNum></HotlineNum>
+            <EnableHotline>0</EnableHotline>
+            <WarmLineTime>0</WarmLineTime>
+            <PickupNum></PickupNum>
+            <JoinNum></JoinNum>
+            <IntercomNum></IntercomNum>
+            <RingType>{if isset($fanvil_ringtone_line1)}{$fanvil_ringtone_line1}{else}default{/if}</RingType>
+            <NATUDPUpdate>2</NATUDPUpdate>
+            <UDPUpdateTTL>30</UDPUpdateTTL>
+            <ServerType>0</ServerType>
+            <UserAgent></UserAgent>
+            <PRACK>0</PRACK>
+            <KeepAUTH>0</KeepAUTH>
+            <SessionTimer>0</SessionTimer>
+            <STimerExpires>0</STimerExpires>
+            <EnableGRUU>0</EnableGRUU>
+            <DTMFMode>3</DTMFMode>
+            <DTMFInfoMode>0</DTMFInfoMode>
+            <NATType>0</NATType>
+            <EnableRport>1</EnableRport>
+            <Subscribe>{if isset($row.user_id)}1{else}{/if}</Subscribe>
+            <SubExpire>{$row.register_expires}</SubExpire>
+            <SingleCodec>0</SingleCodec>
+            <CLIR>0</CLIR>
+            <StrictProxy>1</StrictProxy>
+            <DirectContact>0</DirectContact>
+            <HistoryInfo>0</HistoryInfo>
+            {if $row.sip_transport == 'dns srv'}<DNSSRV>1</DNSSRV>{/if}
+            {if $row.sip_transport == 'dns srv'}<DNSMode>1</DNSMode>{/if}
+            <XFERExpire>0</XFERExpire>
+            <BanAnonymous>0</BanAnonymous>
+            <DialOffLine>0</DialOffLine>
+            <QuotaName>0</QuotaName>
+            <PresenceMode>0</PresenceMode>
+            <RFCVer>1</RFCVer>
+            <PhonePort>0</PhonePort>
+            <SignalPort>5060</SignalPort>
+            {if $row.sip_transport == 'udp'}<Transport>0</Transport>{/if}
+            {if $row.sip_transport == 'tcp'}<Transport>1</Transport>{/if}
+            {if $row.sip_transport == 'tls'}<Transport>3</Transport>{/if}
+            <UseSRVMixer>0</UseSRVMixer>
+            <SRVMixerUri></SRVMixerUri>
+            <LongContact>0</LongContact>
+            <AutoTCP>1</AutoTCP>
+            <UriEscaped>1</UriEscaped>
+            <ClicktoTalk>0</ClicktoTalk>
+            <MwiNo></MwiNo>
+            <MWINum>{if isset($row.user_id)}{$voicemail_number}{else}{/if}</MWINum>
+            <ParkNo></ParkNo>
+            <CallParkNum></CallParkNum>
+            <RetrieveNum></RetrieveNum>
+            <HelpNo></HelpNo>
+            <MSRPHelpNum></MSRPHelpNum>
+            <UserIsPhone>0</UserIsPhone>
+            <AutoAnswer>0</AutoAnswer>
+            <NoAnswerTime>5</NoAnswerTime>
+            <MissedCallLog>1</MissedCallLog>
+            <ParkMode></ParkMode>
+            <SvcCodeMode>0</SvcCodeMode>
+            <DNDOnSvcCode></DNDOnSvcCode>
+            <DNDOffSvcCode></DNDOffSvcCode>
+            <CFUOnSvcCode></CFUOnSvcCode>
+            <CFUOffSvcCode></CFUOffSvcCode>
+            <CFBOnSvcCode></CFBOnSvcCode>
+            <CFBOffSvcCode></CFBOffSvcCode>
+            <CFNOnSvcCode></CFNOnSvcCode>
+            <CFNOffSvcCode></CFNOffSvcCode>
+            <ANCOnSvcCode></ANCOnSvcCode>
+            <ANCOffSvcCode></ANCOffSvcCode>
+            <SendANOnCode></SendANOnCode>
+            <SendANOffCode></SendANOffCode>
+            <CWOnCode></CWOnCode>
+            <CWOffCode></CWOffCode>
+            <VoiceCodecMap>OPUS,G722,PCMU,PCMA</VoiceCodecMap>
+            <VideoCodecMap>{if isset($fanvil_video_codec)}{$fanvil_video_codec}{else}{/if}</VideoCodecMap>
+            <BLFListUri></BLFListUri>
+            <BLFServer></BLFServer>
+            <Respond182>0</Respond182>
+            <EnableBLFList>0</EnableBLFList>
+            <CallerIdType>4</CallerIdType>
+            <SynClockTime>0</SynClockTime>
+            <MohServer></MohServer>
+            <UseVPN>1</UseVPN>
+            <EnableDND>0</EnableDND>
+            <InactiveHold>0</InactiveHold>
+            <ReqWithPort>1</ReqWithPort>
+            <UpdateRegExpire>1</UpdateRegExpire>
+            <EnableSCA>0</EnableSCA>
+            <SubCallPark>0</SubCallPark>
+            <SubCCStatus>0</SubCCStatus>
+            <FeatureSync>0</FeatureSync>
+            <EnableXferBack>1</EnableXferBack>
+            <XferBackTime>35</XferBackTime>
+            <UseTelCall>0</UseTelCall>
+            <EnablePreview>0</EnablePreview>
+            <PreviewMode>1</PreviewMode>
+            <TLSVersion>2</TLSVersion>
+            <CSTANumber></CSTANumber>
+            <EnableChgPort>0</EnableChgPort>
+            <VQName></VQName>
+            <VQServer></VQServer>
+            <VQServerPort>5060</VQServerPort>
+            <VQHTTPServer></VQHTTPServer>
+            <FlashMode>0</FlashMode>
+            <ContentType></ContentType>
+            <ContentBody></ContentBody>
+            <UnregisterOnBoot>0</UnregisterOnBoot>
+            <EnableMACHeader>0</EnableMACHeader>
+            <EnableRegisterMAC>0</EnableRegisterMAC>
+            <RecordStart>Record:on</RecordStart>
+            <RecordStop>Record:off</RecordStop>
+            <BLFDialogMatch>1</BLFDialogMatch>
+            <Ptime>0</Ptime>
+            <EnableDeal180>1</EnableDeal180>
+            <KeepSingleContact>0</KeepSingleContact>
+            <SessionTimerT1>500</SessionTimerT1>
+            <SessionTimerT2>4000</SessionTimerT2>
+            <SessionTimerT4>5000</SessionTimerT4>
+            <UnavailableMode>0</UnavailableMode>
+            <TCPUseRetryTimer>0</TCPUseRetryTimer>
+        </line>
+	{/foreach}
+        <p2p>
+            <SIPP2PEnableAutoAnswer>0</SIPP2PEnableAutoAnswer>
+            <SIPP2PAutoAnswerDelay>30</SIPP2PAutoAnswerDelay>
+            <SIPP2PDtmfMode>1</SIPP2PDtmfMode>
+            <SIPP2PSipInfoDtmfMode>0</SIPP2PSipInfoDtmfMode>
+            <SIPP2PEnablePreview>0</SIPP2PEnablePreview>
+            <SIPP2PPreviewMode>0</SIPP2PPreviewMode>
+            <SIPP2PUseVPN>1</SIPP2PUseVPN>
+        </p2p>
+    </sip>
+    <call>
+        <port index="1">
+            <EnableXferDPlan>1</EnableXferDPlan>
+            <EnableFwdDPlan>1</EnableFwdDPlan>
+            <EnablePreDPlan>0</EnablePreDPlan>
+            <IPDialPrefix>.</IPDialPrefix>
+            <EnableDND>1</EnableDND>
+            <DNDMode>0</DNDMode>
+            <EnableSpaceDND>0</EnableSpaceDND>
+            <DNDStartTime>1500</DNDStartTime>
+            <DNDEndTime>1730</DNDEndTime>
+            <EnableWhiteList>0</EnableWhiteList>
+            <EnableBlackList>0</EnableBlackList>
+            <EnableCallBar>0</EnableCallBar>
+            <MuteRinging>0</MuteRinging>
+            <BanDialOut>0</BanDialOut>
+            <BanEmptyCID>0</BanEmptyCID>
+            <EnableCLIP>1</EnableCLIP>
+            <CallWaiting>1</CallWaiting>
+            <CallTransfer>1</CallTransfer>
+            <CallSemiXfer>1</CallSemiXfer>
+            <CallConference>1</CallConference>
+            <AutoPickupNext>0</AutoPickupNext>
+            <BusyNoLine>1</BusyNoLine>
+            <AutoOnhook>1</AutoOnhook>
+            <AutoOnhookTime>3</AutoOnhookTime>
+            <EnableIntercom>1</EnableIntercom>
+            <IntercomMute>0</IntercomMute>
+            <IntercomTone>1</IntercomTone>
+            <IntercomBarge>0</IntercomBarge>
+            <UseAutoRedial>0</UseAutoRedial>
+            <RedialEnterCallLog>0</RedialEnterCallLog>
+            <AutoRedialDelay>30</AutoRedialDelay>
+            <AutoRedialTimes>5</AutoRedialTimes>
+            <CallComplete>0</CallComplete>
+            <CHoldingTone>1</CHoldingTone>
+            <CWaitingTone>1</CWaitingTone>
+            <HideDTMFType>0</HideDTMFType>
+            <TalkDTMFTone>1</TalkDTMFTone>
+            <DialDTMFTone>1</DialDTMFTone>
+            <PswDialMode>0</PswDialMode>
+            <PswDialLength>0</PswDialLength>
+            <PswDialPrefix></PswDialPrefix>
+            <EnableMultiLine>1</EnableMultiLine>
+            <AllowIPCall>1</AllowIPCall>
+            <CallerNameType>0</CallerNameType>
+            <MuteForRing>0</MuteForRing>
+            <AutoHandleVideo>0</AutoHandleVideo>
+            <DefaultAnsMode>{$fanvil_default_answer_mode}</DefaultAnsMode>
+            <DefaultDialMode>{$fanvil_default_dial_mode}</DefaultDialMode>
+            <HoldToTransfer>0</HoldToTransfer>
+            <EnablePreDial>1</EnablePreDial>
+            <DefaultExtLine>1</DefaultExtLine>
+            <EnableDefLine>1</EnableDefLine>
+            <EnableSelLine>1</EnableSelLine>
+            <RinginHeadset>0</RinginHeadset>
+            <AutoHeadset>0</AutoHeadset>
+            <DNDReturnCode>480</DNDReturnCode>
+            <BusyReturnCode>486</BusyReturnCode>
+            <RejectReturnCode>603</RejectReturnCode>
+            <ContactType>0</ContactType>
+            <EnableCountryCode>0</EnableCountryCode>
+            <CountryCode></CountryCode>
+            <CallAreaCode></CallAreaCode>
+            <NumberPrivacy>0</NumberPrivacy>
+            <PrivacyRule></PrivacyRule>
+            <TransfDTMFCode></TransfDTMFCode>
+            <HoldDTMFCode></HoldDTMFCode>
+            <ConfDTMFCode></ConfDTMFCode>
+            <DisableDialSearch>0</DisableDialSearch>
+            <CallNumberFilter></CallNumberFilter>
+            <AutoResumeCurrent>0</AutoResumeCurrent>
+            <CallTimeout>120</CallTimeout>
+            <RingTimeout>120</RingTimeout>
+            <RingPriority>1</RingPriority>
+        </port>
+        <basic>
+            <DialbyPound>1</DialbyPound>
+            <BTransferbyPound>0</BTransferbyPound>
+            <OnhooktoBXfer>0</OnhooktoBXfer>
+            <OnhooktoAXfer>0</OnhooktoAXfer>
+            <ConfOnhooktoXfer>0</ConfOnhooktoXfer>
+            <DialFixedLength>0</DialFixedLength>
+            <FixedLengthNums>11</FixedLengthNums>
+            <DialbyTimeout>1</DialbyTimeout>
+            <DialTimeoutvalue>10</DialTimeoutvalue>
+            <EnableEOneSixFour>0</EnableEOneSixFour>
+        </basic>
+        <alertInfo index="1">
+            <Text></Text>
+            <Line>-1</Line>
+            <RingType>Type 1</RingType>
+        </alertInfo>
+        <alertInfo index="2">
+            <Text></Text>
+            <Line>-1</Line>
+            <RingType>Type 1</RingType>
+        </alertInfo>
+        <alertInfo index="3">
+            <Text></Text>
+            <Line>-1</Line>
+            <RingType>Type 1</RingType>
+        </alertInfo>
+        <alertInfo index="4">
+            <Text></Text>
+            <Line>-1</Line>
+            <RingType>Type 1</RingType>
+        </alertInfo>
+        <alertInfo index="5">
+            <Text></Text>
+            <Line>-1</Line>
+            <RingType>Type 1</RingType>
+        </alertInfo>
+        <alertInfo index="6">
+            <Text></Text>
+            <Line>-1</Line>
+            <RingType>Type 1</RingType>
+        </alertInfo>
+        <alertInfo index="7">
+            <Text></Text>
+            <Line>-1</Line>
+            <RingType>Type 1</RingType>
+        </alertInfo>
+        <alertInfo index="8">
+            <Text></Text>
+            <Line>-1</Line>
+            <RingType>Type 1</RingType>
+        </alertInfo>
+        <alertInfo index="9">
+            <Text></Text>
+            <Line>-1</Line>
+            <RingType>Type 1</RingType>
+        </alertInfo>
+        <alertInfo index="10">
+            <Text></Text>
+            <Line>-1</Line>
+            <RingType>Type 1</RingType>
+        </alertInfo>
+    </call>
+    <phone>
+        <MenuPassword>admin</MenuPassword>
+        <KeyLockPassword>admin</KeyLockPassword>
+        <FastKeylockCode></FastKeylockCode>
+        <EnableKeyLock>0</EnableKeyLock>
+        <KeyLockTimeout>0</KeyLockTimeout>
+        <KeyLockStatus>0</KeyLockStatus>
+        <EmergencyCall>110</EmergencyCall>
+        <PushXMLIP></PushXMLIP>
+        <SIPNumberPlan>0</SIPNumberPlan>
+        <LDAPSearch>0</LDAPSearch>
+        <SearchPath>0</SearchPath>
+        <CallerDisplayT>5</CallerDisplayT>
+        <CallLogDisplayType>0</CallLogDisplayType>
+        <EnableRecvSMS>1</EnableRecvSMS>
+        <EnableCallHistory>1</EnableCallHistory>
+        <LineDisplayFormat>$name</LineDisplayFormat>
+        <EnableMWITone>0</EnableMWITone>
+        <SIPNotifyXML>1</SIPNotifyXML>
+        <BlockXMLWhenCall>1</BlockXMLWhenCall>
+        <XMLUpdateInterval>30</XMLUpdateInterval>
+        <VqmDisplayOrder></VqmDisplayOrder>
+        <EnablePushXMLAuth>0</EnablePushXMLAuth>
+        <PickupVisualAlert>0</PickupVisualAlert>
+        <PickupAudioAlert>0</PickupAudioAlert>
+        <PickupRingType></PickupRingType>
+        <display>
+            <LCDTitle>{$fanvil_greeting}</LCDTitle>
+            <LCDConstrast>5</LCDConstrast>
+            <EnableEnergysaving>{if isset($fanvil_display_brightness_inactive)}{$fanvil_display_brightness_inactive}{else}4{/if}</EnableEnergysaving>
+            <LCDLuminanceLevel>{if isset($fanvil_display_brightness_active)}{$fanvil_display_brightness_active}{else}12{/if}</LCDLuminanceLevel>
+            <BacklightOffTime>{if isset($fanvil_display_inactivity_time)}{$fanvil_display_inactivity_time}{else}45{/if}</BacklightOffTime>
+            <DisableCHNIME>0</DisableCHNIME>
+            <PhoneModel></PhoneModel>
+            <HostName>localhost</HostName>
+            <DefaultLanguage>en</DefaultLanguage>
+            <EnableGreetings>0</EnableGreetings>
+        </display>
+        <powerLed>
+            <Power>0</Power>
+            <MWIOrSMS>3</MWIOrSMS>
+            <InUsing>0</InUsing>
+            <Ring>2</Ring>
+            <Hold>0</Hold>
+            <Mute>0</Mute>
+            <MissedCall>3</MissedCall>
+            <StandbyLampEffect>0</StandbyLampEffect>
+            <LampEffectPlayTime>1</LampEffectPlayTime>
+            <CustomLampEffectTime>1200</CustomLampEffectTime>
+            <StandbyLampEffectType>0</StandbyLampEffectType>
+            <OffhookLampEffect>1</OffhookLampEffect>
+            <OffhookLampEffectColor>0</OffhookLampEffectColor>
+            <RingingLampEffect>0</RingingLampEffect>
+            <RingingLampEffectType>0</RingingLampEffectType>
+            <TalkingLampEffect>0</TalkingLampEffect>
+            <TalkingLampEffectType>0</TalkingLampEffectType>
+            <CallingLampEffect>0</CallingLampEffect>
+            <CallingLampEffectType>0</CallingLampEffectType>
+        </powerLed>
+        <lineLed>
+            <LineIdleColor>0</LineIdleColor>
+            <LineIdleCtl>1</LineIdleCtl>
+        </lineLed>
+        <blfLed>
+            <BLFIdleColor>0</BLFIdleColor>
+            <BLFIdleCtl>1</BLFIdleCtl>
+            <BLFIdleText>terminated</BLFIdleText>
+            <BLFRingColor>1</BLFRingColor>
+            <BLFRingCtl>2</BLFRingCtl>
+            <BLFRingText>early</BLFRingText>
+            <BLFDialingColor>1</BLFDialingColor>
+            <BLFDialingCtl>0</BLFDialingCtl>
+            <BLFDialingText></BLFDialingText>
+            <BLFTalkingColor>1</BLFTalkingColor>
+            <BLFTalkingCtl>1</BLFTalkingCtl>
+            <BLFTalkingText>confirmed</BLFTalkingText>
+            <BLFHoldColor>1</BLFHoldColor>
+            <BLFHoldCtl>0</BLFHoldCtl>
+            <BLFHoldText></BLFHoldText>
+            <BLFFailedColor>0</BLFFailedColor>
+            <BLFFailedCtl>0</BLFFailedCtl>
+            <BLFFailedText>failed</BLFFailedText>
+            <BLFParkedColor>1</BLFParkedColor>
+            <BLFParkedCtl>3</BLFParkedCtl>
+            <BLFParkedText>parked</BLFParkedText>
+        </blfLed>
+        <volume>
+            <HandsetVol>6</HandsetVol>
+            <HandsetMicVol>3</HandsetMicVol>
+            <HeadsetVol>6</HeadsetVol>
+            <HeadsetMicVol>3</HeadsetMicVol>
+            <HeadsetRingVol>3</HeadsetRingVol>
+            <HandFreeVol>6</HandFreeVol>
+            <HandFreeMicVol>3</HandFreeMicVol>
+            <HandFreeRingVol>6</HandFreeRingVol>
+            <RingType>{if isset($fanvil_default_ringtone)}{$fanvil_default_ringtone}{else}Happy_Technology_Logo.ogg{/if}</RingType>
+        </volume>
+        <date>
+            <EnableSNTP>{if isset($fanvil_enable_sntp)}{$fanvil_enable_sntp}{else}1{/if}</EnableSNTP>
+            <SNTPServer>{$ntp_server_primary}</SNTPServer>
+            <SecondSNTPServer>{$ntp_server_secondary}</SecondSNTPServer>
+            <TimeZone>{$fanvil_time_zone}</TimeZone>
+            <TimeZoneName>{$fanvil_time_zone_name}</TimeZoneName>
+            <SNTPTimeout>60</SNTPTimeout>
+            <Enable_DST>{$fanvil_enable_dst}</Enable_DST>
+            <DST_Fixed_Type>{if isset($fanvil_dst_fixed_type)}{$fanvil_dst_fixed_type}{else}0{/if}</DST_Fixed_Type>
+            <SNTPTimeout>60</SNTPTimeout>
+            <DSTType>1</DSTType>
+            <DSTLocation>{if isset($fanvil_location)}{$fanvil_location}{else}4{/if}</DSTLocation>
+            <DSTRuleMode>0</DSTRuleMode>
+            <DSTMinOffset>{if isset($fanvil_dst_minute_offset)}{$fanvil_dst_minute_offset}{else}60{/if}</DSTMinOffset>
+            <DSTStartMon>3</DSTStartMon>
+            <DSTStartWeek>5</DSTStartWeek>
+            <DSTStartWday>0</DSTStartWday>
+            <DSTStartHour>2</DSTStartHour>
+            <DSTEndMon>10</DSTEndMon>
+            <DSTEndWeek>5</DSTEndWeek>
+            <DSTEndWday>0</DSTEndWday>
+            <DSTEndHour>2</DSTEndHour>
+        </date>
+        <timeDisplay>
+            <EnableTimeDisplay>0</EnableTimeDisplay>
+            <TimeDisplayStyle>{if isset($fanvil_time_display)}{$fanvil_time_display}{else}0{/if}</TimeDisplayStyle>
+            <DateDisplayStyle>{if isset($fanvil_date_display)}{$fanvil_date_display}{else}6{/if}</DateDisplayStyle>
+            <DateSeparator>{if isset($fanvil_date_separator)}{$fanvil_date_separator}{else}0{/if}</DateSeparator>
+        </timeDisplay>
+        <softKeyConfig>
+            <SoftkeyMode>0</SoftkeyMode>
+            <SoftKeyExitStyle>{if isset($fanvil_softkey_exit)}{$fanvil_softkey_exit}{else}2{/if}</SoftKeyExitStyle>
+            <DesktopSoftkey>{if isset($fanvil_softkey_desktopsoftkey)}{$fanvil_softkey_desktopsoftkey}{else}history;contact;dnd;menu;{/if}</DesktopSoftkey>
+            <TalkingSoftkey>{if isset($fanvil_softkey_talkingsoftkey)}{$fanvil_softkey_talkingsoftkey}{else}video;xfer;end;conf;hold;new;mute;record;dialpad;{/if}</TalkingSoftkey>
+            <RingingSoftkey>{if isset($fanvil_softkey_ringingsoftkey)}{$fanvil_softkey_ringingsoftkey}{else}forward;audio;video;reject;{/if}</RingingSoftkey>
+            <AlertingSoftkey>dialpad;xfer;cancel;</AlertingSoftkey>
+            <XAlertingSoftkey>dialpad;xfer;cancel;</XAlertingSoftkey>
+            <ConferenceSoftkey>conf;dialpad;end;split;hold;mute;exit;</ConferenceSoftkey>
+            <WaitingSoftkey>hold;xfer;conf;end;</WaitingSoftkey>
+            <EndingSoftkey>complete;autoRedial;end;redial;</EndingSoftkey>
+            <DialerPreSoftkey>audio;video;redial;</DialerPreSoftkey>
+            <DialerCallSoftkey>audio;video;redial;</DialerCallSoftkey>
+            <DialerXferSoftkey>audio;video;xfer;contact;history;cancel;</DialerXferSoftkey>
+            <DialerCfwdSoftkey>contact;history;forward;cancel;</DialerCfwdSoftkey>
+            <DesktopClick>{if isset($fanvil_softkey_desktopclick)}{$fanvil_softkey_desktopclick}{else}history;status;none;none;none;{/if}</DesktopClick>
+            <DailerClick>pline;nline;none;none;none;</DailerClick>
+            <RingingClick>none;none;none;none;none;</RingingClick>
+            <CallClick>pcall;ncall;voldown;volup;none;</CallClick>
+            <DesktopLongPress>status;none;none;mwi;none;reset;</DesktopLongPress>
+            <DialerConfSoftkey>audio;video;cancel;contact;history;redial;</DialerConfSoftkey>
+        </softKeyConfig>
+        <agent>
+            <AgentUsername></AgentUsername>
+            <AgentPassword></AgentPassword>
+            <AgentNumber></AgentNumber>
+            <AgentSipline>0</AgentSipline>
+            <AgentStatus>0</AgentStatus>
+            <AgentStatusReason></AgentStatusReason>
+            <AgentClearCallLog>0</AgentClearCallLog>
+        </agent>
+        <bwDir index="1">
+            <Title></Title>
+            <URL></URL>
+            <Username></Username>
+            <Password></Password>
+            <SipLine>0</SipLine>
+        </bwDir>
+        <bwDir index="2">
+            <Title></Title>
+            <URL></URL>
+            <Username></Username>
+            <Password></Password>
+            <SipLine>0</SipLine>
+        </bwDir>
+        <bwDir index="3">
+            <Title></Title>
+            <URL></URL>
+            <Username></Username>
+            <Password></Password>
+            <SipLine>0</SipLine>
+        </bwDir>
+        <bwDir index="4">
+            <Title></Title>
+            <URL></URL>
+            <Username></Username>
+            <Password></Password>
+            <SipLine>0</SipLine>
+        </bwDir>
+        <bwDir index="5">
+            <Title></Title>
+            <URL></URL>
+            <Username></Username>
+            <Password></Password>
+            <SipLine>0</SipLine>
+        </bwDir>
+        <bwDir index="6">
+            <Title></Title>
+            <URL></URL>
+            <Username></Username>
+            <Password></Password>
+            <SipLine>0</SipLine>
+        </bwDir>
+        <bwCallLog index="1">
+            <Title></Title>
+            <URL></URL>
+            <Username></Username>
+            <Password></Password>
+            <SipLine>0</SipLine>
+        </bwCallLog>
+        <bwCallLog index="2">
+            <Title></Title>
+            <URL></URL>
+            <Username></Username>
+            <Password></Password>
+            <SipLine>0</SipLine>
+        </bwCallLog>
+        <bwCallLog index="3">
+            <Title></Title>
+            <URL></URL>
+            <Username></Username>
+            <Password></Password>
+            <SipLine>0</SipLine>
+        </bwCallLog>
+        <ldap index="1">
+            <Title></Title>
+            <Server></Server>
+            <port>389</port>
+            <Base></Base>
+            <UseSSL>0</UseSSL>
+            <Version>3</Version>
+            <CallingLine>-1</CallingLine>
+            <BindLine>-1</BindLine>
+            <InCallSearch>0</InCallSearch>
+            <OutCallSearch>0</OutCallSearch>
+            <Authenticate>3</Authenticate>
+            <Username></Username>
+            <Password></Password>
+            <TelAttr>telephoneNumber</TelAttr>
+            <MobileAttr>mobile</MobileAttr>
+            <OtherAttr>other</OtherAttr>
+            <NameAttr>cn sn ou</NameAttr>
+            <SortAttr>cn</SortAttr>
+            <Displayname>cn</Displayname>
+            <NumberFilter>(|(telephoneNumber=%)(mobile=%)(other=%))</NumberFilter>
+            <NameFilter>(|(cn=%)(sn=%))</NameFilter>
+            <MaxHits>50</MaxHits>
+            <DisplayType>0</DisplayType>
+        </ldap>
+        <ldap index="2">
+            <Title></Title>
+            <Server></Server>
+            <port>389</port>
+            <Base></Base>
+            <UseSSL>0</UseSSL>
+            <Version>3</Version>
+            <CallingLine>-1</CallingLine>
+            <BindLine>-1</BindLine>
+            <InCallSearch>0</InCallSearch>
+            <OutCallSearch>0</OutCallSearch>
+            <Authenticate>3</Authenticate>
+            <Username></Username>
+            <Password></Password>
+            <TelAttr>telephoneNumber</TelAttr>
+            <MobileAttr>mobile</MobileAttr>
+            <OtherAttr>other</OtherAttr>
+            <NameAttr>cn sn ou</NameAttr>
+            <SortAttr>cn</SortAttr>
+            <Displayname>cn</Displayname>
+            <NumberFilter>(|(telephoneNumber=%)(mobile=%)(other=%))</NumberFilter>
+            <NameFilter>(|(cn=%)(sn=%))</NameFilter>
+            <MaxHits>50</MaxHits>
+            <DisplayType>0</DisplayType>
+        </ldap>
+        <ldap index="3">
+            <Title></Title>
+            <Server></Server>
+            <port>389</port>
+            <Base></Base>
+            <UseSSL>0</UseSSL>
+            <Version>3</Version>
+            <CallingLine>-1</CallingLine>
+            <BindLine>-1</BindLine>
+            <InCallSearch>0</InCallSearch>
+            <OutCallSearch>0</OutCallSearch>
+            <Authenticate>3</Authenticate>
+            <Username></Username>
+            <Password></Password>
+            <TelAttr>telephoneNumber</TelAttr>
+            <MobileAttr>mobile</MobileAttr>
+            <OtherAttr>other</OtherAttr>
+            <NameAttr>cn sn ou</NameAttr>
+            <SortAttr>cn</SortAttr>
+            <Displayname>cn</Displayname>
+            <NumberFilter>(|(telephoneNumber=%)(mobile=%)(other=%))</NumberFilter>
+            <NameFilter>(|(cn=%)(sn=%))</NameFilter>
+            <MaxHits>50</MaxHits>
+            <DisplayType>0</DisplayType>
+        </ldap>
+        <ldap index="4">
+            <Title></Title>
+            <Server></Server>
+            <port>389</port>
+            <Base></Base>
+            <UseSSL>0</UseSSL>
+            <Version>3</Version>
+            <CallingLine>-1</CallingLine>
+            <BindLine>-1</BindLine>
+            <InCallSearch>0</InCallSearch>
+            <OutCallSearch>0</OutCallSearch>
+            <Authenticate>3</Authenticate>
+            <Username></Username>
+            <Password></Password>
+            <TelAttr>telephoneNumber</TelAttr>
+            <MobileAttr>mobile</MobileAttr>
+            <OtherAttr>other</OtherAttr>
+            <NameAttr>cn sn ou</NameAttr>
+            <SortAttr>cn</SortAttr>
+            <Displayname>cn</Displayname>
+            <NumberFilter>(|(telephoneNumber=%)(mobile=%)(other=%))</NumberFilter>
+            <NameFilter>(|(cn=%)(sn=%))</NameFilter>
+            <MaxHits>50</MaxHits>
+            <DisplayType>0</DisplayType>
+        </ldap>
+        <ldap index="5">
+            <Title></Title>
+            <Server></Server>
+            <port>389</port>
+            <Base></Base>
+            <UseSSL>0</UseSSL>
+            <Version>3</Version>
+            <CallingLine>-1</CallingLine>
+            <BindLine>-1</BindLine>
+            <InCallSearch>0</InCallSearch>
+            <OutCallSearch>0</OutCallSearch>
+            <Authenticate>3</Authenticate>
+            <Username></Username>
+            <Password></Password>
+            <TelAttr>telephoneNumber</TelAttr>
+            <MobileAttr>mobile</MobileAttr>
+            <OtherAttr>other</OtherAttr>
+            <NameAttr>cn sn ou</NameAttr>
+            <SortAttr>cn</SortAttr>
+            <Displayname>cn</Displayname>
+            <NumberFilter>(|(telephoneNumber=%)(mobile=%)(other=%))</NumberFilter>
+            <NameFilter>(|(cn=%)(sn=%))</NameFilter>
+            <MaxHits>50</MaxHits>
+            <DisplayType>0</DisplayType>
+        </ldap>
+        <xmlContact index="1">
+            <Name></Name>
+            <Addr></Addr>
+            <UserName></UserName>
+            <PassWd></PassWd>
+            <Sipline>-1</Sipline>
+            <BindLine>-1</BindLine>
+        </xmlContact>
+        <xmlContact index="2">
+            <Name></Name>
+            <Addr></Addr>
+            <UserName></UserName>
+            <PassWd></PassWd>
+            <Sipline>-1</Sipline>
+            <BindLine>-1</BindLine>
+        </xmlContact>
+        <xmlContact index="3">
+            <Name></Name>
+            <Addr></Addr>
+            <UserName></UserName>
+            <PassWd></PassWd>
+            <Sipline>-1</Sipline>
+            <BindLine>-1</BindLine>
+        </xmlContact>
+        <xmlContact index="4">
+            <Name></Name>
+            <Addr></Addr>
+            <UserName></UserName>
+            <PassWd></PassWd>
+            <Sipline>-1</Sipline>
+            <BindLine>-1</BindLine>
+        </xmlContact>
+        <xmlContact index="5">
+            <Name></Name>
+            <Addr></Addr>
+            <UserName></UserName>
+            <PassWd></PassWd>
+            <Sipline>-1</Sipline>
+            <BindLine>-1</BindLine>
+        </xmlContact>
+    </phone>
+    <dm>
+        <OnhookTime>200</OnhookTime>
+        <EnableHookflash>0</EnableHookflash>
+        <KeyLongPressTime>2</KeyLongPressTime>
+        <KeyLongLongPressTime>6</KeyLongLongPressTime>
+    </dm>
+    <vqm>
+        <SessionReport>1</SessionReport>
+        <IntervalReport>1</IntervalReport>
+        <IntervalPeriod>60</IntervalPeriod>
+        <MOS-LQWarning>40</MOS-LQWarning>
+        <MOS-LQCritical>25</MOS-LQCritical>
+        <DelayWarning>150</DelayWarning>
+        <DelayCritical>200</DelayCritical>
+        <PhoneReport>1</PhoneReport>
+        <WEBReport>1</WEBReport>
+    </vqm>
+    <cti>
+        <EnabledActiveUri>1</EnabledActiveUri>
+        <EnabledActionUrl>1</EnabledActionUrl>
+        <ActiveUriIP></ActiveUriIP>
+        <StartRebootUrl></StartRebootUrl>
+        <BootCompletedUrl></BootCompletedUrl>
+        <IPChangeUrl></IPChangeUrl>
+        <RegOnUrl></RegOnUrl>
+        <RegOffUrl></RegOffUrl>
+        <RegFailedUrl></RegFailedUrl>
+        <PhoneStateIdleUrl></PhoneStateIdleUrl>
+        <PhoneStateTalking></PhoneStateTalking>
+        <PhoneStateRinging></PhoneStateRinging>
+        <DNDOnUrl></DNDOnUrl>
+        <DNDOffUrl></DNDOffUrl>
+        <AlwaysFWDOnUrl></AlwaysFWDOnUrl>
+        <AlwaysFWDOffUrl></AlwaysFWDOffUrl>
+        <BusyFWDOnUrl></BusyFWDOnUrl>
+        <BusyFWDOffUrl></BusyFWDOffUrl>
+        <NoAnsFWDOnUrl></NoAnsFWDOnUrl>
+        <NoAnsFWDOffUrl></NoAnsFWDOffUrl>
+        <MuteOnUrl></MuteOnUrl>
+        <MuteOffUrl></MuteOffUrl>
+        <IncomingCallUrl></IncomingCallUrl>
+        <OutgoingCallUrl></OutgoingCallUrl>
+        <CallActiveUrl></CallActiveUrl>
+        <CallStopUrl></CallStopUrl>
+        <TransferUrl></TransferUrl>
+        <HoldOnUrl></HoldOnUrl>
+        <HoldOffUrl></HoldOffUrl>
+        <HeldOnUrl></HeldOnUrl>
+        <HeldOffUrl></HeldOffUrl>
+        <MuteOnCallUrl></MuteOnCallUrl>
+        <MuteOffCallUrl></MuteOffCallUrl>
+        <NewMissedcallUrl></NewMissedcallUrl>
+        <NewMWIUrl></NewMWIUrl>
+        <NewSMSUrl></NewSMSUrl>
+        <WebAuthChangedUrl></WebAuthChangedUrl>
+        <at>
+            <AtEnabled>0</AtEnabled>
+            <AtServer></AtServer>
+        </at>
+    </cti>
+    <mcast>
+        <Priority>0</Priority>
+        <EnablePriority>0</EnablePriority>
+        <EnablePrioChan>0</EnablePrioChan>
+        <EnableEmerChan>0</EnableEmerChan>
+        <MulticastTone>1</MulticastTone>
+        <McastListeningRenewTime>0</McastListeningRenewTime>
+        <addr index="1">
+            <Name></Name>
+            <Host></Host>
+            <Port>0</Port>
+            <Channel>0</Channel>
+        </addr>
+        <addr index="2">
+            <Name></Name>
+            <Host></Host>
+            <Port>0</Port>
+            <Channel>0</Channel>
+        </addr>
+        <addr index="3">
+            <Name></Name>
+            <Host></Host>
+            <Port>0</Port>
+            <Channel>0</Channel>
+        </addr>
+        <addr index="4">
+            <Name></Name>
+            <Host></Host>
+            <Port>0</Port>
+            <Channel>0</Channel>
+        </addr>
+        <addr index="5">
+            <Name></Name>
+            <Host></Host>
+            <Port>0</Port>
+            <Channel>0</Channel>
+        </addr>
+        <addr index="6">
+            <Name></Name>
+            <Host></Host>
+            <Port>0</Port>
+            <Channel>0</Channel>
+        </addr>
+        <addr index="7">
+            <Name></Name>
+            <Host></Host>
+            <Port>0</Port>
+            <Channel>0</Channel>
+        </addr>
+        <addr index="8">
+            <Name></Name>
+            <Host></Host>
+            <Port>0</Port>
+            <Channel>0</Channel>
+        </addr>
+        <addr index="9">
+            <Name></Name>
+            <Host></Host>
+            <Port>0</Port>
+            <Channel>0</Channel>
+        </addr>
+        <addr index="10">
+            <Name></Name>
+            <Host></Host>
+            <Port>0</Port>
+            <Channel>0</Channel>
+        </addr>
+        <dynamic>
+            <AutoExitExpires>60</AutoExitExpires>
+        </dynamic>
+    </mcast>
+    <dsskey>
+        <SelectDsskeyAction>0</SelectDsskeyAction>
+        <MemoryKeytoBXfer>0</MemoryKeytoBXfer>
+        <FuncKeyPageNum>4</FuncKeyPageNum>
+        <SideKeyPageNum>1</SideKeyPageNum>
+        <DSSHomePage>0</DSSHomePage>
+        <DisplayParkedInfo>0</DisplayParkedInfo>
+        <DSSDIALSwitchMode>0</DSSDIALSwitchMode>
+        <FirstCallWaitTime>16</FirstCallWaitTime>
+        <FirstNumStartTime>360</FirstNumStartTime>
+        <FirstNumEndTime>1080</FirstNumEndTime>
+        <DSSLongPressAction>1</DSSLongPressAction>
+        <Extern1PageBelong>0</Extern1PageBelong>
+        <Extern2PageBelong>0</Extern2PageBelong>
+        <Extern3PageBelong>0</Extern3PageBelong>
+        <Extern4PageBelong>0</Extern4PageBelong>
+        <Extern5PageBelong>0</Extern5PageBelong>
+        <DSSExtend1MAC></DSSExtend1MAC>
+        <DSSExtend1IP></DSSExtend1IP>
+        <DSSExtend2MAC></DSSExtend2MAC>
+        <DSSExtend2IP></DSSExtend2IP>
+        <DSSExtend3MAC></DSSExtend3MAC>
+        <DSSExtend3IP></DSSExtend3IP>
+        <DSSExtend4MAC></DSSExtend4MAC>
+        <DSSExtend4IP></DSSExtend4IP>
+        <DSSExtend5MAC></DSSExtend5MAC>
+        <DSSExtend5IP></DSSExtend5IP>
+
+        {strip}{*-- Each Internal Index contains 32 keys --*}{/strip}
+        <internal index="1">
+            <Fkey index="1">
+                <Type>2</Type>
+                <Value>SIP1</Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="2">
+                <Type>2</Type>
+                <Value>SIP2</Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="3">
+                <Type>2</Type>
+                <Value>SIP3</Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="4">
+                <Type>2</Type>
+                <Value>SIP4</Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="5">
+                <Type>2</Type>
+                <Value>SIP5</Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="6">
+                <Type>3</Type>
+                <Value>F_HEADSET</Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="7">
+                <Type>3</Type>
+                <Value>F_REDIAL</Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="8">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="9">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="10">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="11">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="12">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="13">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="14">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="15">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="16">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="17">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="18">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="19">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="20">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="21">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="22">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="23">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="24">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="25">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="26">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="27">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="28">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="29">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+        </internal>
+        <internal index="2">
+            <Fkey index="1">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="2">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="3">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="4">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="5">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="6">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="7">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="8">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="9">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="10">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="11">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="12">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="13">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="14">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="15">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="16">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="17">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="18">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="19">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="20">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="21">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="22">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="23">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="24">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="25">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="26">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="27">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="28">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="29">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+        </internal>
+        <internal index="3">
+            <Fkey index="1">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="2">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="3">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="4">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="5">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="6">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="7">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="8">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="9">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="10">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="11">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="12">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="13">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="14">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="15">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="16">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="17">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="18">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="19">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="20">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="21">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="22">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="23">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="24">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="25">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="26">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="27">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="28">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="29">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+        </internal>
+        <internal index="4">
+            <Fkey index="1">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="2">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="3">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="4">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="5">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="6">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="7">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="8">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="9">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="10">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="11">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="12">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="13">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="14">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="15">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="16">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="17">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="18">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="19">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="20">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="21">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="22">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="23">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="24">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="25">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="26">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="27">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="28">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="29">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+        </internal>
+        <dssSoft index="1">
+            <Type>0</Type>
+            <Value></Value>
+            <Title></Title>
+            <ICON>Green</ICON>
+        </dssSoft>
+        <dssSoft index="2">
+            <Type>0</Type>
+            <Value></Value>
+            <Title></Title>
+            <ICON>Green</ICON>
+        </dssSoft>
+        <dssSoft index="3">
+            <Type>0</Type>
+            <Value></Value>
+            <Title></Title>
+            <ICON>Green</ICON>
+        </dssSoft>
+        <dssSoft index="4">
+            <Type>0</Type>
+            <Value></Value>
+            <Title></Title>
+            <ICON>Green</ICON>
+        </dssSoft>
+        <dssSoft index="5">
+            <Type>0</Type>
+            <Value></Value>
+            <Title></Title>
+            <ICON>Green</ICON>
+        </dssSoft>
+        <dssSoft index="6">
+            <Type>0</Type>
+            <Value></Value>
+            <Title></Title>
+            <ICON>Green</ICON>
+        </dssSoft>
+        <dssSoft index="7">
+            <Type>0</Type>
+            <Value></Value>
+            <Title></Title>
+            <ICON>Green</ICON>
+        </dssSoft>
+        <dssSoft index="8">
+            <Type>0</Type>
+            <Value></Value>
+            <Title></Title>
+            <ICON>Green</ICON>
+        </dssSoft>
+        <dssSoft index="9">
+            <Type>0</Type>
+            <Value></Value>
+            <Title></Title>
+            <ICON>Green</ICON>
+        </dssSoft>
+        <dssSoft index="10">
+            <Type>0</Type>
+            <Value></Value>
+            <Title></Title>
+            <ICON>Green</ICON>
+        </dssSoft>
+    </dsskey>
+    <web>
+        <WebServerType>0</WebServerType>
+        <WebPort>80</WebPort>
+        <HttpsWebPort>443</HttpsWebPort>
+        <RemoteControl>1</RemoteControl>
+        <EnableMMIFilter>0</EnableMMIFilter>
+        <WebAuthentication>0</WebAuthentication>
+        <EnableTelnet>0</EnableTelnet>
+        <TelnetPort>23</TelnetPort>
+        <TelnetPrompt></TelnetPrompt>
+        <LogonTimeout>15</LogonTimeout>
+        <account index="1">
+            <Name>{if isset($admin_name)}{$admin_name}{else}admin{/if}</Name>
+            <Password>{if isset($admin_password)}{$admin_password}{else}admin{/if}</Password>
+            <Level>10</Level>
+        </account>
+        <account index="2">
+            <Name>guest</Name>
+            <Password>guest</Password>
+            <Level>5</Level>
+        </account>
+    </web>
+    <log>
+        <Level>INFO</Level>
+        <Style>level,tag</Style>
+        {if $fanvil_syslog_enable == '1'}<OutputDevice>syslog</OutputDevice>
+        {elseif $fanvil_output_device == ''}<OutputDevice></OutputDevice>
+        {elseif $fanvil_output_device == 'syslog'}<OutputDevice>syslog</OutputDevice>
+        {elseif $fanvil_output_device == 'stdout'}<OutputDevice>stdout</OutputDevice>
+        {elseif $fanvil_output_device == 'syslog,stdout'}<OutputDevice>syslog,stdout</OutputDevice>
+        {elseif $fanvil_output_device == 'stdout,syslog'}<OutputDevice>syslog,stdout</OutputDevice>
+        {/if}
+        <FileName>platform.log</FileName>
+        <FileSize>512KB</FileSize>
+        <SyslogTag>platform</SyslogTag>
+        <SyslogServer>{if isset($fanvil_syslog_server)}{$fanvil_syslog_server}{else}0.0.0.0{/if}</SyslogServer>
+        <SyslogServerPort>{if isset($fanvil_syslog_server_port)}{$fanvil_syslog_server_port}{else}514{/if}</SyslogServerPort>
+    </log>
+    <tr069>
+        <TR069Tone>1</TR069Tone>
+        <CPESerialNumber></CPESerialNumber>
+        <ACSServerType>1</ACSServerType>
+        <EnableTR069>0</EnableTR069>
+        <ACSURL>0.0.0.0</ACSURL>
+        <ACSUserName>admin</ACSUserName>
+        <ACSPassword></ACSPassword>
+        <ACSBackupURL>0.0.0.0</ACSBackupURL>
+        <ACSBackupUserName></ACSBackupUserName>
+        <ACSBackupPassword></ACSBackupPassword>
+        <CPEUserName>dps</CPEUserName>
+        <CPEPassword>dps</CPEPassword>
+        <PeriodixInterval>3600</PeriodixInterval>
+        <TLSVersion>2</TLSVersion>
+        <AreaCode></AreaCode>
+        <STUNEnable>0</STUNEnable>
+        <STUNServerAddr>{$fanvil_stun_server}</STUNServerAddr>
+        <STUNServerPort>{$fanvil_stun_port}</STUNServerPort>
+        <STUNLocalPort>30000</STUNLocalPort>
+    </tr069>
+    <hotspot>
+        <EnableHotspot>0</EnableHotspot>
+        <Mode>1</Mode>
+        <ListenType>0</ListenType>
+        <ListenIP>224.0.2.0</ListenIP>
+        <ListenPort>16360</ListenPort>
+        <OwnName>SIP Hotspot</OwnName>
+        <RingMode>0</RingMode>
+        <GroupCallMode>0</GroupCallMode>
+        <EnableManageMode>0</EnableManageMode>
+        <EnableConfigMode>0</EnableConfigMode>
+        <hs index="1">
+            <Enable>1</Enable>
+            <ExtPrefix></ExtPrefix>
+        </hs>
+        <hs index="2">
+            <Enable>1</Enable>
+            <ExtPrefix></ExtPrefix>
+        </hs>
+        <hs index="3">
+            <Enable>1</Enable>
+            <ExtPrefix></ExtPrefix>
+        </hs>
+        <hs index="4">
+            <Enable>1</Enable>
+            <ExtPrefix></ExtPrefix>
+        </hs>
+        <hs index="5">
+            <Enable>1</Enable>
+            <ExtPrefix></ExtPrefix>
+        </hs>
+        <hs index="6">
+            <Enable>1</Enable>
+            <ExtPrefix></ExtPrefix>
+        </hs>
+        <hs index="7">
+            <Enable>1</Enable>
+            <ExtPrefix></ExtPrefix>
+        </hs>
+        <hs index="8">
+            <Enable>1</Enable>
+            <ExtPrefix></ExtPrefix>
+        </hs>
+        <hs index="9">
+            <Enable>1</Enable>
+            <ExtPrefix></ExtPrefix>
+        </hs>
+        <hs index="10">
+            <Enable>1</Enable>
+            <ExtPrefix></ExtPrefix>
+        </hs>
+        <hs index="11">
+            <Enable>1</Enable>
+            <ExtPrefix></ExtPrefix>
+        </hs>
+        <hs index="12">
+            <Enable>1</Enable>
+            <ExtPrefix></ExtPrefix>
+        </hs>
+        <hs index="13">
+            <Enable>1</Enable>
+            <ExtPrefix></ExtPrefix>
+        </hs>
+        <hs index="14">
+            <Enable>1</Enable>
+            <ExtPrefix></ExtPrefix>
+        </hs>
+        <hs index="15">
+            <Enable>1</Enable>
+            <ExtPrefix></ExtPrefix>
+        </hs>
+        <hs index="16">
+            <Enable>1</Enable>
+            <ExtPrefix></ExtPrefix>
+        </hs>
+        <hs index="17">
+            <Enable>1</Enable>
+            <ExtPrefix></ExtPrefix>
+        </hs>
+        <hs index="18">
+            <Enable>1</Enable>
+            <ExtPrefix></ExtPrefix>
+        </hs>
+        <hs index="19">
+            <Enable>1</Enable>
+            <ExtPrefix></ExtPrefix>
+        </hs>
+        <hs index="20">
+            <Enable>1</Enable>
+            <ExtPrefix></ExtPrefix>
+        </hs>
+    </hotspot>
+    <mt>
+        <ContactUpdateMode>0</ContactUpdateMode>
+        <AutoServerDigest>0</AutoServerDigest>
+    </mt>
+    <ap>
+        <DefaultUsername>{$http_auth_username}</DefaultUsername>
+        <DefaultPassword>{$http_auth_password}</DefaultPassword>
+        <InputCfgFileName></InputCfgFileName>
+        <DeviceCfgFileKey></DeviceCfgFileKey>
+        <CommonCfgFileKey></CommonCfgFileKey>
+        <DownloadCommonConf>1</DownloadCommonConf>
+        <SaveProvisionInfo>1</SaveProvisionInfo>
+        <CheckFailTimes>5</CheckFailTimes>
+        <FlashServerIP>{if isset($fanvil_provision_url)}{$fanvil_provision_url}{else}{$domain_name}/app/provision{/if}</FlashServerIP>
+        <FlashFileName>{$fanvil_firmware_config}</FlashFileName>
+        <FlashProtocol>5</FlashProtocol>
+        <FlashMode>1</FlashMode>
+        <FlashInterval>1</FlashInterval>
+        <updatePBInterval>720</updatePBInterval>
+        <pnp>
+            <PNPEnable>1</PNPEnable>
+            <PNPIP>224.0.1.75</PNPIP>
+            <PNPPort>5060</PNPPort>
+            <PNPTransport>0</PNPTransport>
+            <PNPInterval>1</PNPInterval>
+        </pnp>
+        <opt>
+            <DHCPOption>66</DHCPOption>
+            <DhcpOption120>0</DhcpOption120>
+            <DHCPv6Option>0</DHCPv6Option>
+        </opt>
+    </ap>
+    <qos>
+        <EnableVLAN>{if isset($fanvil_enable_vlan)}{$fanvil_enable_vlan}{else}0{/if}</EnableVLAN>
+        <VLANID>{if isset($fanvil_lan_port_vlan)}{$fanvil_lan_port_vlan}{else}256{/if}</VLANID>
+        <EnablePVID>{if isset($fanvil_pc_port_vlan)}2{else}0{/if}</EnablePVID>
+        <PVIDValue>{if isset($fanvil_pc_port_vlan)}{$fanvil_pc_port_vlan}{else}254{/if}</PVIDValue>
+        <SignallingPriority>{if isset($fanvil_qos_sip)}{$fanvil_qos_sip}{else}0{/if}</SignallingPriority>
+        <VoicePriority>{if isset($fanvil_qos_rtp_voice)}{$fanvil_qos_rtp_voice}{else}0{/if}</VoicePriority>
+        <VideoPriority>{if isset($fanvil_qos_rtp_video)}{$fanvil_qos_rtp_video}{else}0{/if}</VideoPriority>
+        <LANPortPriority>0</LANPortPriority>
+        <EnablediffServ>{if isset($fanvil_enable_diffserv)}{$fanvil_enable_diffserv}{else}0{/if}</EnablediffServ>
+        <SingallingDSCP>{if isset($fanvil_dscp_sip)}{$fanvil_dscp_sip}{else}46{/if}</SingallingDSCP>
+        <VoiceDSCP>{if isset($fanvil_dscp_rtp_voice)}{$fanvil_dscp_rtp_voice}{else}46{/if}</VoiceDSCP>
+        <VideoDSCP>{if isset($fanvil_dscp_rtp_video)}{$fanvil_dscp_rtp_video}{else}34{/if}</VideoDSCP>
+        <LLDPTransmit>{if isset($fanvil_lldp_tx_enable)}{$fanvil_lldp_tx_enable}{else}0{/if}</LLDPTransmit>
+        <LLDPRefreshTime>{if isset($fanvil_lldp_refresh)}{$fanvil_lldp_refresh}{else}60{/if}</LLDPRefreshTime>
+        <LLDPLearnPolicy>{if isset($fanvil_lldp_learn)}{$fanvil_lldp_learn}{else}0{/if}</LLDPLearnPolicy>
+        <LLDPSaveLearnData>1</LLDPSaveLearnData>
+        <CDPEnable>0</CDPEnable>
+        <CDPRefreshTime>60</CDPRefreshTime>
+        <DHCPOptionVlan>132</DHCPOptionVlan>
+    </qos>
+    <dot1x>
+        <XsupMode>0</XsupMode>
+        <XsupUser>admin</XsupUser>
+        <XsupPassword>admin</XsupPassword>
+        <sslMode>
+            <PermissionCTF>0</PermissionCTF>
+            <CommonName>0</CommonName>
+            <CTFmode>0</CTFmode>
+            <DeviceCertMode>0</DeviceCertMode>
+        </sslMode>
+    </dot1x>
+    <rtsp>
+        <RtspClientWorkMode>0</RtspClientWorkMode>
+    </rtsp>
+    <pubApp>
+        <WatchDogEnabled>1</WatchDogEnabled>
+        <EnableInAccess>0</EnableInAccess>
+        <EnableOutAccess>0</EnableOutAccess>
+    </pubApp>
+    <android>
+        <displayConfig>
+            <OperatorMode>0</OperatorMode>
+            <EnableShortcuts>1</EnableShortcuts>
+            <EnableLCDPassword>1</EnableLCDPassword>
+        </displayConfig>
+        <softKeyConfig>
+            <DIdleSoftkey>dialpad;mwi;contact;history;cfwd;redial;capse;</DIdleSoftkey>
+            <DTalkingSoftkey>dialpad;new;conf;hold;xfer;end;capse;</DTalkingSoftkey>
+            <DRingSoftkey>dialpad;forward;audio;video;mute;reject;capse;</DRingSoftkey>
+            <DAlertingSoftkey>dialpad;none;none;none;xfer;cancel;capse;</DAlertingSoftkey>
+            <DXAlertingSoftkey>dialpad;none;none;none;xfer;none;capse;</DXAlertingSoftkey>
+            <DConferenceSoftkey>dialpad;exit;split;hold;xfer;end;capse;</DConferenceSoftkey>
+            <DEndingSoftkey>contact;history;new;complete;autoRedial;end;capse;</DEndingSoftkey>
+            <DPredialSoftkey>dialpad;mwi;contact;history;redial;cancel;capse;</DPredialSoftkey>
+            <DDialingSoftkey>dialpad;mwi;contact;history;redial;cancel;capse;</DDialingSoftkey>
+            <DDialerCfwdSoftkey>dialpad;new;contact;history;forward;cancel;capse;</DDialerCfwdSoftkey>
+            <DDialerXferSoftkey>dialpad;new;contact;history;xfer;cancel;capse;</DDialerXferSoftkey>
+            <DSlectionSoftkey>new;cancel;ok;conf;hold;xfer;capse;</DSlectionSoftkey>
+        </softKeyConfig>
+        <dspConfig>
+            <VideoDisplayMosaic>1</VideoDisplayMosaic>
+        </dspConfig>
+        <teleConfig>
+            <EnableRecord>1</EnableRecord>
+            <EnableIMApp>0</EnableIMApp>
+            <OffhooktoOpenApp>0</OffhooktoOpenApp>
+            <IMAppPackageInfo></IMAppPackageInfo>
+            <SupportedIMSet></SupportedIMSet>
+            <HideLocalCode>0</HideLocalCode>
+            <UpdateDialCall>0</UpdateDialCall>
+            <CountryCode></CountryCode>
+        </teleConfig>
+    </android>
+    <uiMainTainConfig>
+        <EHSHeadsettype>0</EHSHeadsettype>
+        <TimeoutToScreensaver>7200</TimeoutToScreensaver>
+        <DisplayProvisionprompt>0</DisplayProvisionprompt>
+    </uiMainTainConfig>
+    <fwCheck>
+        <EnableAutoUpgrade>0</EnableAutoUpgrade>
+        <UpgradeServer1></UpgradeServer1>
+        <UpgradeServer2></UpgradeServer2>
+        <AutoUpgradeInterval>24</AutoUpgradeInterval>
+    </fwCheck>
+    <record>
+        <Enabled>1</Enabled>
+        <VoiceCodec>PCMU</VoiceCodec>
+        <RecordType>0</RecordType>
+        <FileSizeLimit>0</FileSizeLimit>
+        <ServerAddr>0.0.0.0</ServerAddr>
+        <ServerPort>10000</ServerPort>
+    </record>
+    <IO>
+        <RingtoneDuration>5</RingtoneDuration>
+        <AlarmServerAddr></AlarmServerAddr>
+        <DTMFTriggerRing>NONE</DTMFTriggerRing>
+        <URITriggerRing>NONE</URITriggerRing>
+        <SMSTriggerRing>NONE</SMSTriggerRing>
+        <DsskeyTriggerRing>NONE</DsskeyTriggerRing>
+    </IO>
+</sysConf>

--- a/resources/templates/provision/fanvil/v63/{$mac}.cfg
+++ b/resources/templates/provision/fanvil/v63/{$mac}.cfg
@@ -1,0 +1,2013 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sysConf>
+    <Version>2.0000000000</Version>
+    <net>
+        <WANTYPE>0</WANTYPE>
+        <WANIP></WANIP>
+        <WANSubnetMask>255.255.255.0</WANSubnetMask>
+        <WANGateway></WANGateway>
+        <DomainName></DomainName>
+        <PrimaryDNS>{if isset($dns_server_primary)}{$dns_server_primary}{else}9.9.9.9{/if}</PrimaryDNS>
+        <SecondaryDNS>{if isset($dns_server_secondary)}{$dns_server_secondary}{else}1.1.1.1{/if}</SecondaryDNS>
+        <EnableDHCP>1</EnableDHCP>
+        <DHCPAutoDNS>1</DHCPAutoDNS>
+        <DHCPAutoTime>1</DHCPAutoTime>
+        <DHCPOption100-101>1</DHCPOption100-101>
+        <UseVendorClassID>0</UseVendorClassID>
+        <VendorClassID>Fanvil</VendorClassID>
+        <EnablePPPoE>0</EnablePPPoE>
+        <PPPoEUser>user123</PPPoEUser>
+        <PPPoEPassword>password</PPPoEPassword>
+        <ARPCacheLife>2</ARPCacheLife>
+        <MTU>1500</MTU>
+        <PPPoEAutoConnect>0</PPPoEAutoConnect>
+        <PPPoEAutoRecnct>0</PPPoEAutoRecnct>
+        <WAN6IP></WAN6IP>
+        <WAN6IPPREFIX></WAN6IPPREFIX>
+        <WAN6Gateway></WAN6Gateway>
+        <Domain6Name></Domain6Name>
+        <PrimaryDNS6></PrimaryDNS6>
+        <SecondaryDNS6></SecondaryDNS6>
+        <EnableDHCP6>1</EnableDHCP6>
+        <DHCP6AutoDNS>1</DHCP6AutoDNS>
+        <DHCP6AutoTime>0</DHCP6AutoTime>
+        <UseVendor6ClassID>0</UseVendor6ClassID>
+        <Vendor6ClassID></Vendor6ClassID>
+    </net>
+    <mm>
+        <G723BitRate>1</G723BitRate>
+        <ILBCPayloadType>97</ILBCPayloadType>
+        <ILBCPayloadLen>20</ILBCPayloadLen>
+        <AMRPayloadType>108</AMRPayloadType>
+        <AMRWBPayloadType>109</AMRWBPayloadType>
+        <G726-16PayloadType>103</G726-16PayloadType>
+        <G726-24PayloadType>104</G726-24PayloadType>
+        <G726-32PayloadType>102</G726-32PayloadType>
+        <G726-40PayloadType>105</G726-40PayloadType>
+        <DtmfPayloadType>101</DtmfPayloadType>
+        <OpusPayloadType>107</OpusPayloadType>
+        <OpusSampleRate>0</OpusSampleRate>
+        <VAD>0</VAD>
+        <H264PayloadType>117</H264PayloadType>
+        <H264PacketMode>0</H264PacketMode>
+        <H264Profile>0</H264Profile>
+        <ResvAudioBand>0</ResvAudioBand>
+        <H265PayloadType>98</H265PayloadType>
+        <RTPInitialPort>16384</RTPInitialPort>
+        <RTPPortQuantity>16384</RTPPortQuantity>
+        <RTPKeepAlive>0</RTPKeepAlive>
+        <RTPRelay>0</RTPRelay>
+        <RTCPCNAMEUser></RTCPCNAMEUser>
+        <RTCPCNAMEHost></RTCPCNAMEHost>
+        <SelectYourTone>{if isset($fanvil_country_toneset)}{$fanvil_country_toneset}{else}11{/if}</SelectYourTone>
+        <SidetoneGAIN>1</SidetoneGAIN>
+        <PlayEgressDTMF>0</PlayEgressDTMF>
+        <DialTone>350+440/0</DialTone>
+        <RingbackTone>440+480/2000,0/4000</RingbackTone>
+        <BusyTone>480+620/500,0/500</BusyTone>
+        <CongestionTone></CongestionTone>
+        <CallwaitingTone>440/300,0/10000,440/300,0/10000,0/0</CallwaitingTone>
+        <HoldingTone></HoldingTone>
+        <ErrorTone></ErrorTone>
+        <StutterTone></StutterTone>
+        <InformationTone></InformationTone>
+        <DialRecallTone>350+440/100,0/100,350+440/100,0/100,350+440/100,0/100,350+440/0</DialRecallTone>
+        <MessageTone></MessageTone>
+        <HowlerTone></HowlerTone>
+        <NumberUnobtainable>400/500,0/6000</NumberUnobtainable>
+        <WarningTone>1400/500,0/0</WarningTone>
+        <RecordTone>440/500,0/5000</RecordTone>
+        <AutoAnswerTone></AutoAnswerTone>
+        <capability>
+            <AudioCodecSets>G722,PCMU,PCMA,OPUS</AudioCodecSets>
+            <VideoCodecSets>{if isset($fanvil_video_codec)}{$fanvil_video_codec}{else}H264{/if}</VideoCodecSets>
+            <VideoFrameRate>30</VideoFrameRate>
+            <VideoBitRate>2000000</VideoBitRate>
+            <VideoResolution>7</VideoResolution>
+            <VideoNegotiateDir>0</VideoNegotiateDir>
+        </capability>
+    </mm>
+    <sip>
+        <SIPPort>{$sip_port}</SIPPort>
+        <STUNServer>{$fanvil_stun_server}</STUNServer>
+        <STUNPort>{$fanvil_stun_port}</STUNPort>
+        <STUNRefreshTime>50</STUNRefreshTime>
+        <SIPWaitStunTime>800</SIPWaitStunTime>
+        <ExternNATAddrs></ExternNATAddrs>
+        <RegFailInterval>32</RegFailInterval>
+        <StrictBranchPrefix>0</StrictBranchPrefix>
+        <VideoMuteAttr>0</VideoMuteAttr>
+        <EnableGroupBackup>0</EnableGroupBackup>
+        <EnableRFC4475>1</EnableRFC4475>
+        <StrictUAMatch>1</StrictUAMatch>
+        <CSTAEnable>0</CSTAEnable>
+        <NotifyReboot>1</NotifyReboot>
+	{foreach $lines as $row}
+        <line index="{$row.device_key_id}">
+            <PhoneNumber>{$row.user_id}</PhoneNumber>
+            <DisplayName>{$row.display_name}</DisplayName>
+            <SipName></SipName>
+            <RegisterAddr>{$row.server_address}</RegisterAddr>
+            <RegisterPort>{$row.sip_port}</RegisterPort>
+            <RegisterUser>{$row.auth_id}</RegisterUser>
+            <RegisterPswd>{$row.password}</RegisterPswd>
+            <RegisterTTL>{$row.register_expires}</RegisterTTL>
+            <BackupAddr></BackupAddr>
+            <BackupPort>5060</BackupPort>
+            <BackupTransport>0</BackupTransport>
+            <BackupTTL>3600</BackupTTL>
+            <EnableReg>0</EnableReg>
+            <EnableReg>{if isset($row.password)}1{else}0{/if}</EnableReg>
+            <ProxyAddr>{$row.outbound_proxy_primary}</ProxyAddr>
+            <ProxyPort>{$row.sip_port}</ProxyPort>
+            <ProxyUser>{$row.auth_id}</ProxyUser>
+            <ProxyPswd>{$row.password}</ProxyPswd>
+            <ProxyNeedRegOn>0</ProxyNeedRegOn>
+            <BakProxyAddr>{$row.outbound_proxy_secondary}</BakProxyAddr>
+            <BakProxyPort>{$row.sip_port}</BakProxyPort>
+            <BakProxyNeedRegOn>0</BakProxyNeedRegOn>
+            <EnableFailback>{if isset($row.outbound_proxy_secondary)}1{else}0{/if}</EnableFailback>
+            <FailbackInterval>1800</FailbackInterval>
+            <SignalFailback>0</SignalFailback>
+            <SignalRetryCounts>3</SignalRetryCounts>
+            <SigCryptoKey></SigCryptoKey>
+            <EnableOSRTP>0</EnableOSRTP>
+            <MediaCrypto>0</MediaCrypto>
+            <MedCryptoKey></MedCryptoKey>
+            <SRTPAuth-Tag>0</SRTPAuth-Tag>
+            <EnableRFC5939>0</EnableRFC5939>
+            <LocalDomain></LocalDomain>
+            <AlwaysFWD>0</AlwaysFWD>
+            <BusyFWD>0</BusyFWD>
+            <NoAnswerFWD>0</NoAnswerFWD>
+            <AlwaysFWDNum></AlwaysFWDNum>
+            <BusyFWDNum></BusyFWDNum>
+            <NoAnswerFWDNum></NoAnswerFWDNum>
+            <FWDTimer>5</FWDTimer>
+            <HotlineNum></HotlineNum>
+            <EnableHotline>0</EnableHotline>
+            <WarmLineTime>0</WarmLineTime>
+            <PickupNum></PickupNum>
+            <JoinNum></JoinNum>
+            <IntercomNum></IntercomNum>
+            <RingType>{if isset($fanvil_ringtone_line1)}{$fanvil_ringtone_line1}{else}default{/if}</RingType>
+            <NATUDPUpdate>2</NATUDPUpdate>
+            <UDPUpdateTTL>30</UDPUpdateTTL>
+            <ServerType>0</ServerType>
+            <UserAgent></UserAgent>
+            <PRACK>0</PRACK>
+            <KeepAUTH>0</KeepAUTH>
+            <SessionTimer>0</SessionTimer>
+            <STimerExpires>0</STimerExpires>
+            <EnableGRUU>0</EnableGRUU>
+            <DTMFMode>3</DTMFMode>
+            <DTMFInfoMode>0</DTMFInfoMode>
+            <NATType>0</NATType>
+            <EnableRport>1</EnableRport>
+            <Subscribe>{if isset($row.user_id)}1{else}{/if}</Subscribe>
+            <SubExpire>{$row.register_expires}</SubExpire>
+            <SingleCodec>0</SingleCodec>
+            <CLIR>0</CLIR>
+            <StrictProxy>1</StrictProxy>
+            <DirectContact>0</DirectContact>
+            <HistoryInfo>0</HistoryInfo>
+            {if $row.sip_transport == 'dns srv'}<DNSSRV>1</DNSSRV>{/if}
+            {if $row.sip_transport == 'dns srv'}<DNSMode>1</DNSMode>{/if}
+            <XFERExpire>0</XFERExpire>
+            <BanAnonymous>0</BanAnonymous>
+            <DialOffLine>0</DialOffLine>
+            <QuotaName>0</QuotaName>
+            <PresenceMode>0</PresenceMode>
+            <RFCVer>1</RFCVer>
+            <PhonePort>0</PhonePort>
+            <SignalPort>5060</SignalPort>
+            {if $row.sip_transport == 'udp'}<Transport>0</Transport>{/if}
+            {if $row.sip_transport == 'tcp'}<Transport>1</Transport>{/if}
+            {if $row.sip_transport == 'tls'}<Transport>3</Transport>{/if}
+            <UseSRVMixer>0</UseSRVMixer>
+            <SRVMixerUri></SRVMixerUri>
+            <LongContact>0</LongContact>
+            <AutoTCP>1</AutoTCP>
+            <UriEscaped>1</UriEscaped>
+            <ClicktoTalk>0</ClicktoTalk>
+            <MwiNo></MwiNo>
+            <MWINum>{if isset($row.user_id)}{$voicemail_number}{else}{/if}</MWINum>
+            <ParkNo></ParkNo>
+            <CallParkNum></CallParkNum>
+            <RetrieveNum></RetrieveNum>
+            <HelpNo></HelpNo>
+            <MSRPHelpNum></MSRPHelpNum>
+            <UserIsPhone>0</UserIsPhone>
+            <AutoAnswer>0</AutoAnswer>
+            <NoAnswerTime>5</NoAnswerTime>
+            <MissedCallLog>1</MissedCallLog>
+            <ParkMode></ParkMode>
+            <SvcCodeMode>0</SvcCodeMode>
+            <DNDOnSvcCode></DNDOnSvcCode>
+            <DNDOffSvcCode></DNDOffSvcCode>
+            <CFUOnSvcCode></CFUOnSvcCode>
+            <CFUOffSvcCode></CFUOffSvcCode>
+            <CFBOnSvcCode></CFBOnSvcCode>
+            <CFBOffSvcCode></CFBOffSvcCode>
+            <CFNOnSvcCode></CFNOnSvcCode>
+            <CFNOffSvcCode></CFNOffSvcCode>
+            <ANCOnSvcCode></ANCOnSvcCode>
+            <ANCOffSvcCode></ANCOffSvcCode>
+            <SendANOnCode></SendANOnCode>
+            <SendANOffCode></SendANOffCode>
+            <CWOnCode></CWOnCode>
+            <CWOffCode></CWOffCode>
+            <VoiceCodecMap>OPUS,G722,PCMU,PCMA</VoiceCodecMap>
+            <VideoCodecMap>{if isset($fanvil_video_codec)}{$fanvil_video_codec}{else}{/if}</VideoCodecMap>
+            <BLFListUri></BLFListUri>
+            <BLFServer></BLFServer>
+            <Respond182>0</Respond182>
+            <EnableBLFList>0</EnableBLFList>
+            <CallerIdType>4</CallerIdType>
+            <SynClockTime>0</SynClockTime>
+            <MohServer></MohServer>
+            <UseVPN>1</UseVPN>
+            <EnableDND>0</EnableDND>
+            <InactiveHold>0</InactiveHold>
+            <ReqWithPort>1</ReqWithPort>
+            <UpdateRegExpire>1</UpdateRegExpire>
+            <EnableSCA>0</EnableSCA>
+            <SubCallPark>0</SubCallPark>
+            <SubCCStatus>0</SubCCStatus>
+            <FeatureSync>0</FeatureSync>
+            <EnableXferBack>1</EnableXferBack>
+            <XferBackTime>35</XferBackTime>
+            <UseTelCall>0</UseTelCall>
+            <EnablePreview>0</EnablePreview>
+            <PreviewMode>1</PreviewMode>
+            <TLSVersion>2</TLSVersion>
+            <CSTANumber></CSTANumber>
+            <EnableChgPort>0</EnableChgPort>
+            <VQName></VQName>
+            <VQServer></VQServer>
+            <VQServerPort>5060</VQServerPort>
+            <VQHTTPServer></VQHTTPServer>
+            <FlashMode>0</FlashMode>
+            <ContentType></ContentType>
+            <ContentBody></ContentBody>
+            <UnregisterOnBoot>0</UnregisterOnBoot>
+            <EnableMACHeader>0</EnableMACHeader>
+            <EnableRegisterMAC>0</EnableRegisterMAC>
+            <RecordStart>Record:on</RecordStart>
+            <RecordStop>Record:off</RecordStop>
+            <BLFDialogMatch>1</BLFDialogMatch>
+            <Ptime>0</Ptime>
+            <EnableDeal180>1</EnableDeal180>
+            <KeepSingleContact>0</KeepSingleContact>
+            <SessionTimerT1>500</SessionTimerT1>
+            <SessionTimerT2>4000</SessionTimerT2>
+            <SessionTimerT4>5000</SessionTimerT4>
+            <UnavailableMode>0</UnavailableMode>
+            <TCPUseRetryTimer>0</TCPUseRetryTimer>
+        </line>
+	{/foreach}
+        <p2p>
+            <SIPP2PEnableAutoAnswer>0</SIPP2PEnableAutoAnswer>
+            <SIPP2PAutoAnswerDelay>30</SIPP2PAutoAnswerDelay>
+            <SIPP2PDtmfMode>1</SIPP2PDtmfMode>
+            <SIPP2PSipInfoDtmfMode>0</SIPP2PSipInfoDtmfMode>
+            <SIPP2PEnablePreview>0</SIPP2PEnablePreview>
+            <SIPP2PPreviewMode>0</SIPP2PPreviewMode>
+            <SIPP2PUseVPN>1</SIPP2PUseVPN>
+        </p2p>
+    </sip>
+    <call>
+        <port index="1">
+            <EnableXferDPlan>1</EnableXferDPlan>
+            <EnableFwdDPlan>1</EnableFwdDPlan>
+            <EnablePreDPlan>0</EnablePreDPlan>
+            <IPDialPrefix>.</IPDialPrefix>
+            <EnableDND>1</EnableDND>
+            <DNDMode>0</DNDMode>
+            <EnableSpaceDND>0</EnableSpaceDND>
+            <DNDStartTime>1500</DNDStartTime>
+            <DNDEndTime>1730</DNDEndTime>
+            <EnableWhiteList>0</EnableWhiteList>
+            <EnableBlackList>0</EnableBlackList>
+            <EnableCallBar>0</EnableCallBar>
+            <MuteRinging>0</MuteRinging>
+            <BanDialOut>0</BanDialOut>
+            <BanEmptyCID>0</BanEmptyCID>
+            <EnableCLIP>1</EnableCLIP>
+            <CallWaiting>1</CallWaiting>
+            <CallTransfer>1</CallTransfer>
+            <CallSemiXfer>1</CallSemiXfer>
+            <CallConference>1</CallConference>
+            <AutoPickupNext>0</AutoPickupNext>
+            <BusyNoLine>1</BusyNoLine>
+            <AutoOnhook>1</AutoOnhook>
+            <AutoOnhookTime>3</AutoOnhookTime>
+            <EnableIntercom>1</EnableIntercom>
+            <IntercomMute>0</IntercomMute>
+            <IntercomTone>1</IntercomTone>
+            <IntercomBarge>0</IntercomBarge>
+            <UseAutoRedial>0</UseAutoRedial>
+            <RedialEnterCallLog>0</RedialEnterCallLog>
+            <AutoRedialDelay>30</AutoRedialDelay>
+            <AutoRedialTimes>5</AutoRedialTimes>
+            <CallComplete>0</CallComplete>
+            <CHoldingTone>1</CHoldingTone>
+            <CWaitingTone>1</CWaitingTone>
+            <HideDTMFType>0</HideDTMFType>
+            <TalkDTMFTone>1</TalkDTMFTone>
+            <DialDTMFTone>1</DialDTMFTone>
+            <PswDialMode>0</PswDialMode>
+            <PswDialLength>0</PswDialLength>
+            <PswDialPrefix></PswDialPrefix>
+            <EnableMultiLine>1</EnableMultiLine>
+            <AllowIPCall>1</AllowIPCall>
+            <CallerNameType>0</CallerNameType>
+            <MuteForRing>0</MuteForRing>
+            <AutoHandleVideo>0</AutoHandleVideo>
+            <DefaultAnsMode>{$fanvil_default_answer_mode}</DefaultAnsMode>
+            <DefaultDialMode>{$fanvil_default_dial_mode}</DefaultDialMode>
+            <HoldToTransfer>0</HoldToTransfer>
+            <EnablePreDial>1</EnablePreDial>
+            <DefaultExtLine>1</DefaultExtLine>
+            <EnableDefLine>1</EnableDefLine>
+            <EnableSelLine>1</EnableSelLine>
+            <RinginHeadset>0</RinginHeadset>
+            <AutoHeadset>0</AutoHeadset>
+            <DNDReturnCode>480</DNDReturnCode>
+            <BusyReturnCode>486</BusyReturnCode>
+            <RejectReturnCode>603</RejectReturnCode>
+            <ContactType>0</ContactType>
+            <EnableCountryCode>0</EnableCountryCode>
+            <CountryCode></CountryCode>
+            <CallAreaCode></CallAreaCode>
+            <NumberPrivacy>0</NumberPrivacy>
+            <PrivacyRule></PrivacyRule>
+            <TransfDTMFCode></TransfDTMFCode>
+            <HoldDTMFCode></HoldDTMFCode>
+            <ConfDTMFCode></ConfDTMFCode>
+            <DisableDialSearch>0</DisableDialSearch>
+            <CallNumberFilter></CallNumberFilter>
+            <AutoResumeCurrent>0</AutoResumeCurrent>
+            <CallTimeout>120</CallTimeout>
+            <RingTimeout>120</RingTimeout>
+            <RingPriority>1</RingPriority>
+        </port>
+        <basic>
+            <DialbyPound>1</DialbyPound>
+            <BTransferbyPound>0</BTransferbyPound>
+            <OnhooktoBXfer>0</OnhooktoBXfer>
+            <OnhooktoAXfer>0</OnhooktoAXfer>
+            <ConfOnhooktoXfer>0</ConfOnhooktoXfer>
+            <DialFixedLength>0</DialFixedLength>
+            <FixedLengthNums>11</FixedLengthNums>
+            <DialbyTimeout>1</DialbyTimeout>
+            <DialTimeoutvalue>10</DialTimeoutvalue>
+            <EnableEOneSixFour>0</EnableEOneSixFour>
+        </basic>
+        <alertInfo index="1">
+            <Text></Text>
+            <Line>-1</Line>
+            <RingType>Type 1</RingType>
+        </alertInfo>
+        <alertInfo index="2">
+            <Text></Text>
+            <Line>-1</Line>
+            <RingType>Type 1</RingType>
+        </alertInfo>
+        <alertInfo index="3">
+            <Text></Text>
+            <Line>-1</Line>
+            <RingType>Type 1</RingType>
+        </alertInfo>
+        <alertInfo index="4">
+            <Text></Text>
+            <Line>-1</Line>
+            <RingType>Type 1</RingType>
+        </alertInfo>
+        <alertInfo index="5">
+            <Text></Text>
+            <Line>-1</Line>
+            <RingType>Type 1</RingType>
+        </alertInfo>
+        <alertInfo index="6">
+            <Text></Text>
+            <Line>-1</Line>
+            <RingType>Type 1</RingType>
+        </alertInfo>
+        <alertInfo index="7">
+            <Text></Text>
+            <Line>-1</Line>
+            <RingType>Type 1</RingType>
+        </alertInfo>
+        <alertInfo index="8">
+            <Text></Text>
+            <Line>-1</Line>
+            <RingType>Type 1</RingType>
+        </alertInfo>
+        <alertInfo index="9">
+            <Text></Text>
+            <Line>-1</Line>
+            <RingType>Type 1</RingType>
+        </alertInfo>
+        <alertInfo index="10">
+            <Text></Text>
+            <Line>-1</Line>
+            <RingType>Type 1</RingType>
+        </alertInfo>
+    </call>
+    <phone>
+        <MenuPassword>admin</MenuPassword>
+        <KeyLockPassword>admin</KeyLockPassword>
+        <FastKeylockCode></FastKeylockCode>
+        <EnableKeyLock>0</EnableKeyLock>
+        <KeyLockTimeout>0</KeyLockTimeout>
+        <KeyLockStatus>0</KeyLockStatus>
+        <EmergencyCall>110</EmergencyCall>
+        <PushXMLIP></PushXMLIP>
+        <SIPNumberPlan>0</SIPNumberPlan>
+        <LDAPSearch>0</LDAPSearch>
+        <SearchPath>0</SearchPath>
+        <CallerDisplayT>5</CallerDisplayT>
+        <CallLogDisplayType>0</CallLogDisplayType>
+        <EnableRecvSMS>1</EnableRecvSMS>
+        <EnableCallHistory>1</EnableCallHistory>
+        <LineDisplayFormat>$name</LineDisplayFormat>
+        <EnableMWITone>0</EnableMWITone>
+        <SIPNotifyXML>1</SIPNotifyXML>
+        <BlockXMLWhenCall>1</BlockXMLWhenCall>
+        <XMLUpdateInterval>30</XMLUpdateInterval>
+        <VqmDisplayOrder></VqmDisplayOrder>
+        <EnablePushXMLAuth>0</EnablePushXMLAuth>
+        <PickupVisualAlert>0</PickupVisualAlert>
+        <PickupAudioAlert>0</PickupAudioAlert>
+        <PickupRingType></PickupRingType>
+        <display>
+            <LCDTitle>{$fanvil_greeting}</LCDTitle>
+            <LCDConstrast>5</LCDConstrast>
+            <EnableEnergysaving>{if isset($fanvil_display_brightness_inactive)}{$fanvil_display_brightness_inactive}{else}4{/if}</EnableEnergysaving>
+            <LCDLuminanceLevel>{if isset($fanvil_display_brightness_active)}{$fanvil_display_brightness_active}{else}12{/if}</LCDLuminanceLevel>
+            <BacklightOffTime>{if isset($fanvil_display_inactivity_time)}{$fanvil_display_inactivity_time}{else}45{/if}</BacklightOffTime>
+            <DisableCHNIME>0</DisableCHNIME>
+            <PhoneModel></PhoneModel>
+            <HostName>localhost</HostName>
+            <DefaultLanguage>en</DefaultLanguage>
+            <EnableGreetings>0</EnableGreetings>
+        </display>
+        <powerLed>
+            <Power>0</Power>
+            <MWIOrSMS>3</MWIOrSMS>
+            <InUsing>0</InUsing>
+            <Ring>2</Ring>
+            <Hold>0</Hold>
+            <Mute>0</Mute>
+            <MissedCall>3</MissedCall>
+            <StandbyLampEffect>0</StandbyLampEffect>
+            <LampEffectPlayTime>1</LampEffectPlayTime>
+            <CustomLampEffectTime>1200</CustomLampEffectTime>
+            <StandbyLampEffectType>0</StandbyLampEffectType>
+            <OffhookLampEffect>1</OffhookLampEffect>
+            <OffhookLampEffectColor>0</OffhookLampEffectColor>
+            <RingingLampEffect>0</RingingLampEffect>
+            <RingingLampEffectType>0</RingingLampEffectType>
+            <TalkingLampEffect>0</TalkingLampEffect>
+            <TalkingLampEffectType>0</TalkingLampEffectType>
+            <CallingLampEffect>0</CallingLampEffect>
+            <CallingLampEffectType>0</CallingLampEffectType>
+        </powerLed>
+        <lineLed>
+            <LineIdleColor>0</LineIdleColor>
+            <LineIdleCtl>1</LineIdleCtl>
+        </lineLed>
+        <blfLed>
+            <BLFIdleColor>0</BLFIdleColor>
+            <BLFIdleCtl>1</BLFIdleCtl>
+            <BLFIdleText>terminated</BLFIdleText>
+            <BLFRingColor>1</BLFRingColor>
+            <BLFRingCtl>2</BLFRingCtl>
+            <BLFRingText>early</BLFRingText>
+            <BLFDialingColor>1</BLFDialingColor>
+            <BLFDialingCtl>0</BLFDialingCtl>
+            <BLFDialingText></BLFDialingText>
+            <BLFTalkingColor>1</BLFTalkingColor>
+            <BLFTalkingCtl>1</BLFTalkingCtl>
+            <BLFTalkingText>confirmed</BLFTalkingText>
+            <BLFHoldColor>1</BLFHoldColor>
+            <BLFHoldCtl>0</BLFHoldCtl>
+            <BLFHoldText></BLFHoldText>
+            <BLFFailedColor>0</BLFFailedColor>
+            <BLFFailedCtl>0</BLFFailedCtl>
+            <BLFFailedText>failed</BLFFailedText>
+            <BLFParkedColor>1</BLFParkedColor>
+            <BLFParkedCtl>3</BLFParkedCtl>
+            <BLFParkedText>parked</BLFParkedText>
+        </blfLed>
+        <volume>
+            <HandsetVol>6</HandsetVol>
+            <HandsetMicVol>3</HandsetMicVol>
+            <HeadsetVol>6</HeadsetVol>
+            <HeadsetMicVol>3</HeadsetMicVol>
+            <HeadsetRingVol>3</HeadsetRingVol>
+            <HandFreeVol>6</HandFreeVol>
+            <HandFreeMicVol>3</HandFreeMicVol>
+            <HandFreeRingVol>6</HandFreeRingVol>
+            <RingType>{if isset($fanvil_default_ringtone)}{$fanvil_default_ringtone}{else}Happy_Technology_Logo.ogg{/if}</RingType>
+        </volume>
+        <date>
+            <EnableSNTP>{if isset($fanvil_enable_sntp)}{$fanvil_enable_sntp}{else}1{/if}</EnableSNTP>
+            <SNTPServer>{$ntp_server_primary}</SNTPServer>
+            <SecondSNTPServer>{$ntp_server_secondary}</SecondSNTPServer>
+            <TimeZone>{$fanvil_time_zone}</TimeZone>
+            <TimeZoneName>{$fanvil_time_zone_name}</TimeZoneName>
+            <SNTPTimeout>60</SNTPTimeout>
+            <Enable_DST>{$fanvil_enable_dst}</Enable_DST>
+            <DST_Fixed_Type>{if isset($fanvil_dst_fixed_type)}{$fanvil_dst_fixed_type}{else}0{/if}</DST_Fixed_Type>
+            <SNTPTimeout>60</SNTPTimeout>
+            <DSTType>1</DSTType>
+            <DSTLocation>{if isset($fanvil_location)}{$fanvil_location}{else}4{/if}</DSTLocation>
+            <DSTRuleMode>0</DSTRuleMode>
+            <DSTMinOffset>{if isset($fanvil_dst_minute_offset)}{$fanvil_dst_minute_offset}{else}60{/if}</DSTMinOffset>
+            <DSTStartMon>3</DSTStartMon>
+            <DSTStartWeek>5</DSTStartWeek>
+            <DSTStartWday>0</DSTStartWday>
+            <DSTStartHour>2</DSTStartHour>
+            <DSTEndMon>10</DSTEndMon>
+            <DSTEndWeek>5</DSTEndWeek>
+            <DSTEndWday>0</DSTEndWday>
+            <DSTEndHour>2</DSTEndHour>
+        </date>
+        <timeDisplay>
+            <EnableTimeDisplay>0</EnableTimeDisplay>
+            <TimeDisplayStyle>{if isset($fanvil_time_display)}{$fanvil_time_display}{else}0{/if}</TimeDisplayStyle>
+            <DateDisplayStyle>{if isset($fanvil_date_display)}{$fanvil_date_display}{else}6{/if}</DateDisplayStyle>
+            <DateSeparator>{if isset($fanvil_date_separator)}{$fanvil_date_separator}{else}0{/if}</DateSeparator>
+        </timeDisplay>
+        <softKeyConfig>
+            <SoftkeyMode>0</SoftkeyMode>
+            <SoftKeyExitStyle>{if isset($fanvil_softkey_exit)}{$fanvil_softkey_exit}{else}2{/if}</SoftKeyExitStyle>
+            <DesktopSoftkey>{if isset($fanvil_softkey_desktopsoftkey)}{$fanvil_softkey_desktopsoftkey}{else}history;contact;dnd;menu;{/if}</DesktopSoftkey>
+            <TalkingSoftkey>{if isset($fanvil_softkey_talkingsoftkey)}{$fanvil_softkey_talkingsoftkey}{else}video;xfer;end;conf;hold;new;mute;record;dialpad;{/if}</TalkingSoftkey>
+            <RingingSoftkey>{if isset($fanvil_softkey_ringingsoftkey)}{$fanvil_softkey_ringingsoftkey}{else}forward;audio;video;reject;{/if}</RingingSoftkey>
+            <AlertingSoftkey>dialpad;xfer;cancel;</AlertingSoftkey>
+            <XAlertingSoftkey>dialpad;xfer;cancel;</XAlertingSoftkey>
+            <ConferenceSoftkey>conf;dialpad;end;split;hold;mute;exit;</ConferenceSoftkey>
+            <WaitingSoftkey>hold;xfer;conf;end;</WaitingSoftkey>
+            <EndingSoftkey>complete;autoRedial;end;redial;</EndingSoftkey>
+            <DialerPreSoftkey>audio;video;redial;</DialerPreSoftkey>
+            <DialerCallSoftkey>audio;video;redial;</DialerCallSoftkey>
+            <DialerXferSoftkey>audio;video;xfer;contact;history;cancel;</DialerXferSoftkey>
+            <DialerCfwdSoftkey>contact;history;forward;cancel;</DialerCfwdSoftkey>
+            <DesktopClick>{if isset($fanvil_softkey_desktopclick)}{$fanvil_softkey_desktopclick}{else}history;status;none;none;none;{/if}</DesktopClick>
+            <DailerClick>pline;nline;none;none;none;</DailerClick>
+            <RingingClick>none;none;none;none;none;</RingingClick>
+            <CallClick>pcall;ncall;voldown;volup;none;</CallClick>
+            <DesktopLongPress>status;none;none;mwi;none;reset;</DesktopLongPress>
+            <DialerConfSoftkey>audio;video;cancel;contact;history;redial;</DialerConfSoftkey>
+        </softKeyConfig>
+        <agent>
+            <AgentUsername></AgentUsername>
+            <AgentPassword></AgentPassword>
+            <AgentNumber></AgentNumber>
+            <AgentSipline>0</AgentSipline>
+            <AgentStatus>0</AgentStatus>
+            <AgentStatusReason></AgentStatusReason>
+            <AgentClearCallLog>0</AgentClearCallLog>
+        </agent>
+        <bwDir index="1">
+            <Title></Title>
+            <URL></URL>
+            <Username></Username>
+            <Password></Password>
+            <SipLine>0</SipLine>
+        </bwDir>
+        <bwDir index="2">
+            <Title></Title>
+            <URL></URL>
+            <Username></Username>
+            <Password></Password>
+            <SipLine>0</SipLine>
+        </bwDir>
+        <bwDir index="3">
+            <Title></Title>
+            <URL></URL>
+            <Username></Username>
+            <Password></Password>
+            <SipLine>0</SipLine>
+        </bwDir>
+        <bwDir index="4">
+            <Title></Title>
+            <URL></URL>
+            <Username></Username>
+            <Password></Password>
+            <SipLine>0</SipLine>
+        </bwDir>
+        <bwDir index="5">
+            <Title></Title>
+            <URL></URL>
+            <Username></Username>
+            <Password></Password>
+            <SipLine>0</SipLine>
+        </bwDir>
+        <bwDir index="6">
+            <Title></Title>
+            <URL></URL>
+            <Username></Username>
+            <Password></Password>
+            <SipLine>0</SipLine>
+        </bwDir>
+        <bwCallLog index="1">
+            <Title></Title>
+            <URL></URL>
+            <Username></Username>
+            <Password></Password>
+            <SipLine>0</SipLine>
+        </bwCallLog>
+        <bwCallLog index="2">
+            <Title></Title>
+            <URL></URL>
+            <Username></Username>
+            <Password></Password>
+            <SipLine>0</SipLine>
+        </bwCallLog>
+        <bwCallLog index="3">
+            <Title></Title>
+            <URL></URL>
+            <Username></Username>
+            <Password></Password>
+            <SipLine>0</SipLine>
+        </bwCallLog>
+        <ldap index="1">
+            <Title></Title>
+            <Server></Server>
+            <port>389</port>
+            <Base></Base>
+            <UseSSL>0</UseSSL>
+            <Version>3</Version>
+            <CallingLine>-1</CallingLine>
+            <BindLine>-1</BindLine>
+            <InCallSearch>0</InCallSearch>
+            <OutCallSearch>0</OutCallSearch>
+            <Authenticate>3</Authenticate>
+            <Username></Username>
+            <Password></Password>
+            <TelAttr>telephoneNumber</TelAttr>
+            <MobileAttr>mobile</MobileAttr>
+            <OtherAttr>other</OtherAttr>
+            <NameAttr>cn sn ou</NameAttr>
+            <SortAttr>cn</SortAttr>
+            <Displayname>cn</Displayname>
+            <NumberFilter>(|(telephoneNumber=%)(mobile=%)(other=%))</NumberFilter>
+            <NameFilter>(|(cn=%)(sn=%))</NameFilter>
+            <MaxHits>50</MaxHits>
+            <DisplayType>0</DisplayType>
+        </ldap>
+        <ldap index="2">
+            <Title></Title>
+            <Server></Server>
+            <port>389</port>
+            <Base></Base>
+            <UseSSL>0</UseSSL>
+            <Version>3</Version>
+            <CallingLine>-1</CallingLine>
+            <BindLine>-1</BindLine>
+            <InCallSearch>0</InCallSearch>
+            <OutCallSearch>0</OutCallSearch>
+            <Authenticate>3</Authenticate>
+            <Username></Username>
+            <Password></Password>
+            <TelAttr>telephoneNumber</TelAttr>
+            <MobileAttr>mobile</MobileAttr>
+            <OtherAttr>other</OtherAttr>
+            <NameAttr>cn sn ou</NameAttr>
+            <SortAttr>cn</SortAttr>
+            <Displayname>cn</Displayname>
+            <NumberFilter>(|(telephoneNumber=%)(mobile=%)(other=%))</NumberFilter>
+            <NameFilter>(|(cn=%)(sn=%))</NameFilter>
+            <MaxHits>50</MaxHits>
+            <DisplayType>0</DisplayType>
+        </ldap>
+        <ldap index="3">
+            <Title></Title>
+            <Server></Server>
+            <port>389</port>
+            <Base></Base>
+            <UseSSL>0</UseSSL>
+            <Version>3</Version>
+            <CallingLine>-1</CallingLine>
+            <BindLine>-1</BindLine>
+            <InCallSearch>0</InCallSearch>
+            <OutCallSearch>0</OutCallSearch>
+            <Authenticate>3</Authenticate>
+            <Username></Username>
+            <Password></Password>
+            <TelAttr>telephoneNumber</TelAttr>
+            <MobileAttr>mobile</MobileAttr>
+            <OtherAttr>other</OtherAttr>
+            <NameAttr>cn sn ou</NameAttr>
+            <SortAttr>cn</SortAttr>
+            <Displayname>cn</Displayname>
+            <NumberFilter>(|(telephoneNumber=%)(mobile=%)(other=%))</NumberFilter>
+            <NameFilter>(|(cn=%)(sn=%))</NameFilter>
+            <MaxHits>50</MaxHits>
+            <DisplayType>0</DisplayType>
+        </ldap>
+        <ldap index="4">
+            <Title></Title>
+            <Server></Server>
+            <port>389</port>
+            <Base></Base>
+            <UseSSL>0</UseSSL>
+            <Version>3</Version>
+            <CallingLine>-1</CallingLine>
+            <BindLine>-1</BindLine>
+            <InCallSearch>0</InCallSearch>
+            <OutCallSearch>0</OutCallSearch>
+            <Authenticate>3</Authenticate>
+            <Username></Username>
+            <Password></Password>
+            <TelAttr>telephoneNumber</TelAttr>
+            <MobileAttr>mobile</MobileAttr>
+            <OtherAttr>other</OtherAttr>
+            <NameAttr>cn sn ou</NameAttr>
+            <SortAttr>cn</SortAttr>
+            <Displayname>cn</Displayname>
+            <NumberFilter>(|(telephoneNumber=%)(mobile=%)(other=%))</NumberFilter>
+            <NameFilter>(|(cn=%)(sn=%))</NameFilter>
+            <MaxHits>50</MaxHits>
+            <DisplayType>0</DisplayType>
+        </ldap>
+        <ldap index="5">
+            <Title></Title>
+            <Server></Server>
+            <port>389</port>
+            <Base></Base>
+            <UseSSL>0</UseSSL>
+            <Version>3</Version>
+            <CallingLine>-1</CallingLine>
+            <BindLine>-1</BindLine>
+            <InCallSearch>0</InCallSearch>
+            <OutCallSearch>0</OutCallSearch>
+            <Authenticate>3</Authenticate>
+            <Username></Username>
+            <Password></Password>
+            <TelAttr>telephoneNumber</TelAttr>
+            <MobileAttr>mobile</MobileAttr>
+            <OtherAttr>other</OtherAttr>
+            <NameAttr>cn sn ou</NameAttr>
+            <SortAttr>cn</SortAttr>
+            <Displayname>cn</Displayname>
+            <NumberFilter>(|(telephoneNumber=%)(mobile=%)(other=%))</NumberFilter>
+            <NameFilter>(|(cn=%)(sn=%))</NameFilter>
+            <MaxHits>50</MaxHits>
+            <DisplayType>0</DisplayType>
+        </ldap>
+        <xmlContact index="1">
+            <Name></Name>
+            <Addr></Addr>
+            <UserName></UserName>
+            <PassWd></PassWd>
+            <Sipline>-1</Sipline>
+            <BindLine>-1</BindLine>
+        </xmlContact>
+        <xmlContact index="2">
+            <Name></Name>
+            <Addr></Addr>
+            <UserName></UserName>
+            <PassWd></PassWd>
+            <Sipline>-1</Sipline>
+            <BindLine>-1</BindLine>
+        </xmlContact>
+        <xmlContact index="3">
+            <Name></Name>
+            <Addr></Addr>
+            <UserName></UserName>
+            <PassWd></PassWd>
+            <Sipline>-1</Sipline>
+            <BindLine>-1</BindLine>
+        </xmlContact>
+        <xmlContact index="4">
+            <Name></Name>
+            <Addr></Addr>
+            <UserName></UserName>
+            <PassWd></PassWd>
+            <Sipline>-1</Sipline>
+            <BindLine>-1</BindLine>
+        </xmlContact>
+        <xmlContact index="5">
+            <Name></Name>
+            <Addr></Addr>
+            <UserName></UserName>
+            <PassWd></PassWd>
+            <Sipline>-1</Sipline>
+            <BindLine>-1</BindLine>
+        </xmlContact>
+    </phone>
+    <dm>
+        <OnhookTime>200</OnhookTime>
+        <EnableHookflash>0</EnableHookflash>
+        <KeyLongPressTime>2</KeyLongPressTime>
+        <KeyLongLongPressTime>6</KeyLongLongPressTime>
+    </dm>
+    <vqm>
+        <SessionReport>1</SessionReport>
+        <IntervalReport>1</IntervalReport>
+        <IntervalPeriod>60</IntervalPeriod>
+        <MOS-LQWarning>40</MOS-LQWarning>
+        <MOS-LQCritical>25</MOS-LQCritical>
+        <DelayWarning>150</DelayWarning>
+        <DelayCritical>200</DelayCritical>
+        <PhoneReport>1</PhoneReport>
+        <WEBReport>1</WEBReport>
+    </vqm>
+    <cti>
+        <EnabledActiveUri>1</EnabledActiveUri>
+        <EnabledActionUrl>1</EnabledActionUrl>
+        <ActiveUriIP></ActiveUriIP>
+        <StartRebootUrl></StartRebootUrl>
+        <BootCompletedUrl></BootCompletedUrl>
+        <IPChangeUrl></IPChangeUrl>
+        <RegOnUrl></RegOnUrl>
+        <RegOffUrl></RegOffUrl>
+        <RegFailedUrl></RegFailedUrl>
+        <PhoneStateIdleUrl></PhoneStateIdleUrl>
+        <PhoneStateTalking></PhoneStateTalking>
+        <PhoneStateRinging></PhoneStateRinging>
+        <DNDOnUrl></DNDOnUrl>
+        <DNDOffUrl></DNDOffUrl>
+        <AlwaysFWDOnUrl></AlwaysFWDOnUrl>
+        <AlwaysFWDOffUrl></AlwaysFWDOffUrl>
+        <BusyFWDOnUrl></BusyFWDOnUrl>
+        <BusyFWDOffUrl></BusyFWDOffUrl>
+        <NoAnsFWDOnUrl></NoAnsFWDOnUrl>
+        <NoAnsFWDOffUrl></NoAnsFWDOffUrl>
+        <MuteOnUrl></MuteOnUrl>
+        <MuteOffUrl></MuteOffUrl>
+        <IncomingCallUrl></IncomingCallUrl>
+        <OutgoingCallUrl></OutgoingCallUrl>
+        <CallActiveUrl></CallActiveUrl>
+        <CallStopUrl></CallStopUrl>
+        <TransferUrl></TransferUrl>
+        <HoldOnUrl></HoldOnUrl>
+        <HoldOffUrl></HoldOffUrl>
+        <HeldOnUrl></HeldOnUrl>
+        <HeldOffUrl></HeldOffUrl>
+        <MuteOnCallUrl></MuteOnCallUrl>
+        <MuteOffCallUrl></MuteOffCallUrl>
+        <NewMissedcallUrl></NewMissedcallUrl>
+        <NewMWIUrl></NewMWIUrl>
+        <NewSMSUrl></NewSMSUrl>
+        <WebAuthChangedUrl></WebAuthChangedUrl>
+        <at>
+            <AtEnabled>0</AtEnabled>
+            <AtServer></AtServer>
+        </at>
+    </cti>
+    <mcast>
+        <Priority>0</Priority>
+        <EnablePriority>0</EnablePriority>
+        <EnablePrioChan>0</EnablePrioChan>
+        <EnableEmerChan>0</EnableEmerChan>
+        <MulticastTone>1</MulticastTone>
+        <McastListeningRenewTime>0</McastListeningRenewTime>
+        <addr index="1">
+            <Name></Name>
+            <Host></Host>
+            <Port>0</Port>
+            <Channel>0</Channel>
+        </addr>
+        <addr index="2">
+            <Name></Name>
+            <Host></Host>
+            <Port>0</Port>
+            <Channel>0</Channel>
+        </addr>
+        <addr index="3">
+            <Name></Name>
+            <Host></Host>
+            <Port>0</Port>
+            <Channel>0</Channel>
+        </addr>
+        <addr index="4">
+            <Name></Name>
+            <Host></Host>
+            <Port>0</Port>
+            <Channel>0</Channel>
+        </addr>
+        <addr index="5">
+            <Name></Name>
+            <Host></Host>
+            <Port>0</Port>
+            <Channel>0</Channel>
+        </addr>
+        <addr index="6">
+            <Name></Name>
+            <Host></Host>
+            <Port>0</Port>
+            <Channel>0</Channel>
+        </addr>
+        <addr index="7">
+            <Name></Name>
+            <Host></Host>
+            <Port>0</Port>
+            <Channel>0</Channel>
+        </addr>
+        <addr index="8">
+            <Name></Name>
+            <Host></Host>
+            <Port>0</Port>
+            <Channel>0</Channel>
+        </addr>
+        <addr index="9">
+            <Name></Name>
+            <Host></Host>
+            <Port>0</Port>
+            <Channel>0</Channel>
+        </addr>
+        <addr index="10">
+            <Name></Name>
+            <Host></Host>
+            <Port>0</Port>
+            <Channel>0</Channel>
+        </addr>
+        <dynamic>
+            <AutoExitExpires>60</AutoExitExpires>
+        </dynamic>
+    </mcast>
+    <dsskey>
+        <SelectDsskeyAction>0</SelectDsskeyAction>
+        <MemoryKeytoBXfer>0</MemoryKeytoBXfer>
+        <FuncKeyPageNum>4</FuncKeyPageNum>
+        <SideKeyPageNum>1</SideKeyPageNum>
+        <DSSHomePage>0</DSSHomePage>
+        <DisplayParkedInfo>0</DisplayParkedInfo>
+        <DSSDIALSwitchMode>0</DSSDIALSwitchMode>
+        <FirstCallWaitTime>16</FirstCallWaitTime>
+        <FirstNumStartTime>360</FirstNumStartTime>
+        <FirstNumEndTime>1080</FirstNumEndTime>
+        <DSSLongPressAction>1</DSSLongPressAction>
+        <Extern1PageBelong>0</Extern1PageBelong>
+        <Extern2PageBelong>0</Extern2PageBelong>
+        <Extern3PageBelong>0</Extern3PageBelong>
+        <Extern4PageBelong>0</Extern4PageBelong>
+        <Extern5PageBelong>0</Extern5PageBelong>
+        <DSSExtend1MAC></DSSExtend1MAC>
+        <DSSExtend1IP></DSSExtend1IP>
+        <DSSExtend2MAC></DSSExtend2MAC>
+        <DSSExtend2IP></DSSExtend2IP>
+        <DSSExtend3MAC></DSSExtend3MAC>
+        <DSSExtend3IP></DSSExtend3IP>
+        <DSSExtend4MAC></DSSExtend4MAC>
+        <DSSExtend4IP></DSSExtend4IP>
+        <DSSExtend5MAC></DSSExtend5MAC>
+        <DSSExtend5IP></DSSExtend5IP>
+
+        {strip}{*-- Each Internal Index contains 32 keys --*}{/strip}
+        <internal index="1">
+            <Fkey index="1">
+                <Type>2</Type>
+                <Value>SIP1</Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="2">
+                <Type>2</Type>
+                <Value>SIP2</Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="3">
+                <Type>2</Type>
+                <Value>SIP3</Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="4">
+                <Type>2</Type>
+                <Value>SIP4</Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="5">
+                <Type>2</Type>
+                <Value>SIP5</Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="6">
+                <Type>3</Type>
+                <Value>F_HEADSET</Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="7">
+                <Type>3</Type>
+                <Value>F_REDIAL</Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="8">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="9">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="10">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="11">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="12">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="13">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="14">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="15">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="16">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="17">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="18">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="19">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="20">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="21">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="22">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="23">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="24">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="25">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="26">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="27">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="28">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="29">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+        </internal>
+        <internal index="2">
+            <Fkey index="1">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="2">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="3">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="4">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="5">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="6">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="7">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="8">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="9">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="10">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="11">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="12">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="13">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="14">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="15">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="16">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="17">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="18">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="19">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="20">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="21">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="22">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="23">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="24">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="25">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="26">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="27">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="28">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="29">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+        </internal>
+        <internal index="3">
+            <Fkey index="1">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="2">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="3">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="4">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="5">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="6">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="7">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="8">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="9">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="10">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="11">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="12">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="13">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="14">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="15">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="16">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="17">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="18">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="19">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="20">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="21">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="22">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="23">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="24">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="25">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="26">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="27">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="28">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="29">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+        </internal>
+        <internal index="4">
+            <Fkey index="1">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="2">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="3">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="4">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="5">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="6">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="7">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="8">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="9">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="10">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="11">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="12">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="13">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="14">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="15">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="16">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="17">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="18">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="19">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="20">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="21">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="22">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="23">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="24">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="25">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="26">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="27">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="28">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="29">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+        </internal>
+        <dssSoft index="1">
+            <Type>0</Type>
+            <Value></Value>
+            <Title></Title>
+            <ICON>Green</ICON>
+        </dssSoft>
+        <dssSoft index="2">
+            <Type>0</Type>
+            <Value></Value>
+            <Title></Title>
+            <ICON>Green</ICON>
+        </dssSoft>
+        <dssSoft index="3">
+            <Type>0</Type>
+            <Value></Value>
+            <Title></Title>
+            <ICON>Green</ICON>
+        </dssSoft>
+        <dssSoft index="4">
+            <Type>0</Type>
+            <Value></Value>
+            <Title></Title>
+            <ICON>Green</ICON>
+        </dssSoft>
+        <dssSoft index="5">
+            <Type>0</Type>
+            <Value></Value>
+            <Title></Title>
+            <ICON>Green</ICON>
+        </dssSoft>
+        <dssSoft index="6">
+            <Type>0</Type>
+            <Value></Value>
+            <Title></Title>
+            <ICON>Green</ICON>
+        </dssSoft>
+        <dssSoft index="7">
+            <Type>0</Type>
+            <Value></Value>
+            <Title></Title>
+            <ICON>Green</ICON>
+        </dssSoft>
+        <dssSoft index="8">
+            <Type>0</Type>
+            <Value></Value>
+            <Title></Title>
+            <ICON>Green</ICON>
+        </dssSoft>
+        <dssSoft index="9">
+            <Type>0</Type>
+            <Value></Value>
+            <Title></Title>
+            <ICON>Green</ICON>
+        </dssSoft>
+        <dssSoft index="10">
+            <Type>0</Type>
+            <Value></Value>
+            <Title></Title>
+            <ICON>Green</ICON>
+        </dssSoft>
+    </dsskey>
+    <web>
+        <WebServerType>0</WebServerType>
+        <WebPort>80</WebPort>
+        <HttpsWebPort>443</HttpsWebPort>
+        <RemoteControl>1</RemoteControl>
+        <EnableMMIFilter>0</EnableMMIFilter>
+        <WebAuthentication>0</WebAuthentication>
+        <EnableTelnet>0</EnableTelnet>
+        <TelnetPort>23</TelnetPort>
+        <TelnetPrompt></TelnetPrompt>
+        <LogonTimeout>15</LogonTimeout>
+        <account index="1">
+            <Name>{if isset($admin_name)}{$admin_name}{else}admin{/if}</Name>
+            <Password>{if isset($admin_password)}{$admin_password}{else}admin{/if}</Password>
+            <Level>10</Level>
+        </account>
+        <account index="2">
+            <Name>guest</Name>
+            <Password>guest</Password>
+            <Level>5</Level>
+        </account>
+    </web>
+    <log>
+        <Level>INFO</Level>
+        <Style>level,tag</Style>
+        {if $fanvil_syslog_enable == '1'}<OutputDevice>syslog</OutputDevice>
+        {elseif $fanvil_output_device == ''}<OutputDevice></OutputDevice>
+        {elseif $fanvil_output_device == 'syslog'}<OutputDevice>syslog</OutputDevice>
+        {elseif $fanvil_output_device == 'stdout'}<OutputDevice>stdout</OutputDevice>
+        {elseif $fanvil_output_device == 'syslog,stdout'}<OutputDevice>syslog,stdout</OutputDevice>
+        {elseif $fanvil_output_device == 'stdout,syslog'}<OutputDevice>syslog,stdout</OutputDevice>
+        {/if}
+        <FileName>platform.log</FileName>
+        <FileSize>512KB</FileSize>
+        <SyslogTag>platform</SyslogTag>
+        <SyslogServer>{if isset($fanvil_syslog_server)}{$fanvil_syslog_server}{else}0.0.0.0{/if}</SyslogServer>
+        <SyslogServerPort>{if isset($fanvil_syslog_server_port)}{$fanvil_syslog_server_port}{else}514{/if}</SyslogServerPort>
+    </log>
+    <tr069>
+        <TR069Tone>1</TR069Tone>
+        <CPESerialNumber></CPESerialNumber>
+        <ACSServerType>1</ACSServerType>
+        <EnableTR069>0</EnableTR069>
+        <ACSURL>0.0.0.0</ACSURL>
+        <ACSUserName>admin</ACSUserName>
+        <ACSPassword></ACSPassword>
+        <ACSBackupURL>0.0.0.0</ACSBackupURL>
+        <ACSBackupUserName></ACSBackupUserName>
+        <ACSBackupPassword></ACSBackupPassword>
+        <CPEUserName>dps</CPEUserName>
+        <CPEPassword>dps</CPEPassword>
+        <PeriodixInterval>3600</PeriodixInterval>
+        <TLSVersion>2</TLSVersion>
+        <AreaCode></AreaCode>
+        <STUNEnable>0</STUNEnable>
+        <STUNServerAddr>{$fanvil_stun_server}</STUNServerAddr>
+        <STUNServerPort>{$fanvil_stun_port}</STUNServerPort>
+        <STUNLocalPort>30000</STUNLocalPort>
+    </tr069>
+    <hotspot>
+        <EnableHotspot>0</EnableHotspot>
+        <Mode>1</Mode>
+        <ListenType>0</ListenType>
+        <ListenIP>224.0.2.0</ListenIP>
+        <ListenPort>16360</ListenPort>
+        <OwnName>SIP Hotspot</OwnName>
+        <RingMode>0</RingMode>
+        <GroupCallMode>0</GroupCallMode>
+        <EnableManageMode>0</EnableManageMode>
+        <EnableConfigMode>0</EnableConfigMode>
+        <hs index="1">
+            <Enable>1</Enable>
+            <ExtPrefix></ExtPrefix>
+        </hs>
+        <hs index="2">
+            <Enable>1</Enable>
+            <ExtPrefix></ExtPrefix>
+        </hs>
+        <hs index="3">
+            <Enable>1</Enable>
+            <ExtPrefix></ExtPrefix>
+        </hs>
+        <hs index="4">
+            <Enable>1</Enable>
+            <ExtPrefix></ExtPrefix>
+        </hs>
+        <hs index="5">
+            <Enable>1</Enable>
+            <ExtPrefix></ExtPrefix>
+        </hs>
+        <hs index="6">
+            <Enable>1</Enable>
+            <ExtPrefix></ExtPrefix>
+        </hs>
+        <hs index="7">
+            <Enable>1</Enable>
+            <ExtPrefix></ExtPrefix>
+        </hs>
+        <hs index="8">
+            <Enable>1</Enable>
+            <ExtPrefix></ExtPrefix>
+        </hs>
+        <hs index="9">
+            <Enable>1</Enable>
+            <ExtPrefix></ExtPrefix>
+        </hs>
+        <hs index="10">
+            <Enable>1</Enable>
+            <ExtPrefix></ExtPrefix>
+        </hs>
+        <hs index="11">
+            <Enable>1</Enable>
+            <ExtPrefix></ExtPrefix>
+        </hs>
+        <hs index="12">
+            <Enable>1</Enable>
+            <ExtPrefix></ExtPrefix>
+        </hs>
+        <hs index="13">
+            <Enable>1</Enable>
+            <ExtPrefix></ExtPrefix>
+        </hs>
+        <hs index="14">
+            <Enable>1</Enable>
+            <ExtPrefix></ExtPrefix>
+        </hs>
+        <hs index="15">
+            <Enable>1</Enable>
+            <ExtPrefix></ExtPrefix>
+        </hs>
+        <hs index="16">
+            <Enable>1</Enable>
+            <ExtPrefix></ExtPrefix>
+        </hs>
+        <hs index="17">
+            <Enable>1</Enable>
+            <ExtPrefix></ExtPrefix>
+        </hs>
+        <hs index="18">
+            <Enable>1</Enable>
+            <ExtPrefix></ExtPrefix>
+        </hs>
+        <hs index="19">
+            <Enable>1</Enable>
+            <ExtPrefix></ExtPrefix>
+        </hs>
+        <hs index="20">
+            <Enable>1</Enable>
+            <ExtPrefix></ExtPrefix>
+        </hs>
+    </hotspot>
+    <mt>
+        <ContactUpdateMode>0</ContactUpdateMode>
+        <AutoServerDigest>0</AutoServerDigest>
+    </mt>
+    <ap>
+        <DefaultUsername>{$http_auth_username}</DefaultUsername>
+        <DefaultPassword>{$http_auth_password}</DefaultPassword>
+        <InputCfgFileName></InputCfgFileName>
+        <DeviceCfgFileKey></DeviceCfgFileKey>
+        <CommonCfgFileKey></CommonCfgFileKey>
+        <DownloadCommonConf>1</DownloadCommonConf>
+        <SaveProvisionInfo>1</SaveProvisionInfo>
+        <CheckFailTimes>5</CheckFailTimes>
+        <FlashServerIP>{if isset($fanvil_provision_url)}{$fanvil_provision_url}{else}{$domain_name}/app/provision{/if}</FlashServerIP>
+        <FlashFileName>{$fanvil_firmware_config}</FlashFileName>
+        <FlashProtocol>5</FlashProtocol>
+        <FlashMode>1</FlashMode>
+        <FlashInterval>1</FlashInterval>
+        <updatePBInterval>720</updatePBInterval>
+        <pnp>
+            <PNPEnable>1</PNPEnable>
+            <PNPIP>224.0.1.75</PNPIP>
+            <PNPPort>5060</PNPPort>
+            <PNPTransport>0</PNPTransport>
+            <PNPInterval>1</PNPInterval>
+        </pnp>
+        <opt>
+            <DHCPOption>66</DHCPOption>
+            <DhcpOption120>0</DhcpOption120>
+            <DHCPv6Option>0</DHCPv6Option>
+        </opt>
+    </ap>
+    <qos>
+        <EnableVLAN>{if isset($fanvil_enable_vlan)}{$fanvil_enable_vlan}{else}0{/if}</EnableVLAN>
+        <VLANID>{if isset($fanvil_lan_port_vlan)}{$fanvil_lan_port_vlan}{else}256{/if}</VLANID>
+        <EnablePVID>{if isset($fanvil_pc_port_vlan)}2{else}0{/if}</EnablePVID>
+        <PVIDValue>{if isset($fanvil_pc_port_vlan)}{$fanvil_pc_port_vlan}{else}254{/if}</PVIDValue>
+        <SignallingPriority>{if isset($fanvil_qos_sip)}{$fanvil_qos_sip}{else}0{/if}</SignallingPriority>
+        <VoicePriority>{if isset($fanvil_qos_rtp_voice)}{$fanvil_qos_rtp_voice}{else}0{/if}</VoicePriority>
+        <VideoPriority>{if isset($fanvil_qos_rtp_video)}{$fanvil_qos_rtp_video}{else}0{/if}</VideoPriority>
+        <LANPortPriority>0</LANPortPriority>
+        <EnablediffServ>{if isset($fanvil_enable_diffserv)}{$fanvil_enable_diffserv}{else}0{/if}</EnablediffServ>
+        <SingallingDSCP>{if isset($fanvil_dscp_sip)}{$fanvil_dscp_sip}{else}46{/if}</SingallingDSCP>
+        <VoiceDSCP>{if isset($fanvil_dscp_rtp_voice)}{$fanvil_dscp_rtp_voice}{else}46{/if}</VoiceDSCP>
+        <VideoDSCP>{if isset($fanvil_dscp_rtp_video)}{$fanvil_dscp_rtp_video}{else}34{/if}</VideoDSCP>
+        <LLDPTransmit>{if isset($fanvil_lldp_tx_enable)}{$fanvil_lldp_tx_enable}{else}0{/if}</LLDPTransmit>
+        <LLDPRefreshTime>{if isset($fanvil_lldp_refresh)}{$fanvil_lldp_refresh}{else}60{/if}</LLDPRefreshTime>
+        <LLDPLearnPolicy>{if isset($fanvil_lldp_learn)}{$fanvil_lldp_learn}{else}0{/if}</LLDPLearnPolicy>
+        <LLDPSaveLearnData>1</LLDPSaveLearnData>
+        <CDPEnable>0</CDPEnable>
+        <CDPRefreshTime>60</CDPRefreshTime>
+        <DHCPOptionVlan>132</DHCPOptionVlan>
+    </qos>
+    <dot1x>
+        <XsupMode>0</XsupMode>
+        <XsupUser>admin</XsupUser>
+        <XsupPassword>admin</XsupPassword>
+        <sslMode>
+            <PermissionCTF>0</PermissionCTF>
+            <CommonName>0</CommonName>
+            <CTFmode>0</CTFmode>
+            <DeviceCertMode>0</DeviceCertMode>
+        </sslMode>
+    </dot1x>
+    <rtsp>
+        <RtspClientWorkMode>0</RtspClientWorkMode>
+    </rtsp>
+    <pubApp>
+        <WatchDogEnabled>1</WatchDogEnabled>
+        <EnableInAccess>0</EnableInAccess>
+        <EnableOutAccess>0</EnableOutAccess>
+    </pubApp>
+    <android>
+        <displayConfig>
+            <OperatorMode>0</OperatorMode>
+            <EnableShortcuts>1</EnableShortcuts>
+            <EnableLCDPassword>1</EnableLCDPassword>
+        </displayConfig>
+        <softKeyConfig>
+            <DIdleSoftkey>dialpad;mwi;contact;history;cfwd;redial;capse;</DIdleSoftkey>
+            <DTalkingSoftkey>dialpad;new;conf;hold;xfer;end;capse;</DTalkingSoftkey>
+            <DRingSoftkey>dialpad;forward;audio;video;mute;reject;capse;</DRingSoftkey>
+            <DAlertingSoftkey>dialpad;none;none;none;xfer;cancel;capse;</DAlertingSoftkey>
+            <DXAlertingSoftkey>dialpad;none;none;none;xfer;none;capse;</DXAlertingSoftkey>
+            <DConferenceSoftkey>dialpad;exit;split;hold;xfer;end;capse;</DConferenceSoftkey>
+            <DEndingSoftkey>contact;history;new;complete;autoRedial;end;capse;</DEndingSoftkey>
+            <DPredialSoftkey>dialpad;mwi;contact;history;redial;cancel;capse;</DPredialSoftkey>
+            <DDialingSoftkey>dialpad;mwi;contact;history;redial;cancel;capse;</DDialingSoftkey>
+            <DDialerCfwdSoftkey>dialpad;new;contact;history;forward;cancel;capse;</DDialerCfwdSoftkey>
+            <DDialerXferSoftkey>dialpad;new;contact;history;xfer;cancel;capse;</DDialerXferSoftkey>
+            <DSlectionSoftkey>new;cancel;ok;conf;hold;xfer;capse;</DSlectionSoftkey>
+        </softKeyConfig>
+        <dspConfig>
+            <VideoDisplayMosaic>1</VideoDisplayMosaic>
+        </dspConfig>
+        <teleConfig>
+            <EnableRecord>1</EnableRecord>
+            <EnableIMApp>0</EnableIMApp>
+            <OffhooktoOpenApp>0</OffhooktoOpenApp>
+            <IMAppPackageInfo></IMAppPackageInfo>
+            <SupportedIMSet></SupportedIMSet>
+            <HideLocalCode>0</HideLocalCode>
+            <UpdateDialCall>0</UpdateDialCall>
+            <CountryCode></CountryCode>
+        </teleConfig>
+    </android>
+    <uiMainTainConfig>
+        <EHSHeadsettype>0</EHSHeadsettype>
+        <TimeoutToScreensaver>7200</TimeoutToScreensaver>
+        <DisplayProvisionprompt>0</DisplayProvisionprompt>
+    </uiMainTainConfig>
+    <fwCheck>
+        <EnableAutoUpgrade>0</EnableAutoUpgrade>
+        <UpgradeServer1></UpgradeServer1>
+        <UpgradeServer2></UpgradeServer2>
+        <AutoUpgradeInterval>24</AutoUpgradeInterval>
+    </fwCheck>
+    <record>
+        <Enabled>1</Enabled>
+        <VoiceCodec>PCMU</VoiceCodec>
+        <RecordType>0</RecordType>
+        <FileSizeLimit>0</FileSizeLimit>
+        <ServerAddr>0.0.0.0</ServerAddr>
+        <ServerPort>10000</ServerPort>
+    </record>
+    <IO>
+        <RingtoneDuration>5</RingtoneDuration>
+        <AlarmServerAddr></AlarmServerAddr>
+        <DTMFTriggerRing>NONE</DTMFTriggerRing>
+        <URITriggerRing>NONE</URITriggerRing>
+        <SMSTriggerRing>NONE</SMSTriggerRing>
+        <DsskeyTriggerRing>NONE</DsskeyTriggerRing>
+    </IO>
+</sysConf>

--- a/resources/templates/provision/fanvil/v64/{$mac}.cfg
+++ b/resources/templates/provision/fanvil/v64/{$mac}.cfg
@@ -1,0 +1,2013 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sysConf>
+    <Version>2.0000000000</Version>
+    <net>
+        <WANTYPE>0</WANTYPE>
+        <WANIP></WANIP>
+        <WANSubnetMask>255.255.255.0</WANSubnetMask>
+        <WANGateway></WANGateway>
+        <DomainName></DomainName>
+        <PrimaryDNS>{if isset($dns_server_primary)}{$dns_server_primary}{else}9.9.9.9{/if}</PrimaryDNS>
+        <SecondaryDNS>{if isset($dns_server_secondary)}{$dns_server_secondary}{else}1.1.1.1{/if}</SecondaryDNS>
+        <EnableDHCP>1</EnableDHCP>
+        <DHCPAutoDNS>1</DHCPAutoDNS>
+        <DHCPAutoTime>1</DHCPAutoTime>
+        <DHCPOption100-101>1</DHCPOption100-101>
+        <UseVendorClassID>0</UseVendorClassID>
+        <VendorClassID>Fanvil</VendorClassID>
+        <EnablePPPoE>0</EnablePPPoE>
+        <PPPoEUser>user123</PPPoEUser>
+        <PPPoEPassword>password</PPPoEPassword>
+        <ARPCacheLife>2</ARPCacheLife>
+        <MTU>1500</MTU>
+        <PPPoEAutoConnect>0</PPPoEAutoConnect>
+        <PPPoEAutoRecnct>0</PPPoEAutoRecnct>
+        <WAN6IP></WAN6IP>
+        <WAN6IPPREFIX></WAN6IPPREFIX>
+        <WAN6Gateway></WAN6Gateway>
+        <Domain6Name></Domain6Name>
+        <PrimaryDNS6></PrimaryDNS6>
+        <SecondaryDNS6></SecondaryDNS6>
+        <EnableDHCP6>1</EnableDHCP6>
+        <DHCP6AutoDNS>1</DHCP6AutoDNS>
+        <DHCP6AutoTime>0</DHCP6AutoTime>
+        <UseVendor6ClassID>0</UseVendor6ClassID>
+        <Vendor6ClassID></Vendor6ClassID>
+    </net>
+    <mm>
+        <G723BitRate>1</G723BitRate>
+        <ILBCPayloadType>97</ILBCPayloadType>
+        <ILBCPayloadLen>20</ILBCPayloadLen>
+        <AMRPayloadType>108</AMRPayloadType>
+        <AMRWBPayloadType>109</AMRWBPayloadType>
+        <G726-16PayloadType>103</G726-16PayloadType>
+        <G726-24PayloadType>104</G726-24PayloadType>
+        <G726-32PayloadType>102</G726-32PayloadType>
+        <G726-40PayloadType>105</G726-40PayloadType>
+        <DtmfPayloadType>101</DtmfPayloadType>
+        <OpusPayloadType>107</OpusPayloadType>
+        <OpusSampleRate>0</OpusSampleRate>
+        <VAD>0</VAD>
+        <H264PayloadType>117</H264PayloadType>
+        <H264PacketMode>0</H264PacketMode>
+        <H264Profile>0</H264Profile>
+        <ResvAudioBand>0</ResvAudioBand>
+        <H265PayloadType>98</H265PayloadType>
+        <RTPInitialPort>16384</RTPInitialPort>
+        <RTPPortQuantity>16384</RTPPortQuantity>
+        <RTPKeepAlive>0</RTPKeepAlive>
+        <RTPRelay>0</RTPRelay>
+        <RTCPCNAMEUser></RTCPCNAMEUser>
+        <RTCPCNAMEHost></RTCPCNAMEHost>
+        <SelectYourTone>{if isset($fanvil_country_toneset)}{$fanvil_country_toneset}{else}11{/if}</SelectYourTone>
+        <SidetoneGAIN>1</SidetoneGAIN>
+        <PlayEgressDTMF>0</PlayEgressDTMF>
+        <DialTone>350+440/0</DialTone>
+        <RingbackTone>440+480/2000,0/4000</RingbackTone>
+        <BusyTone>480+620/500,0/500</BusyTone>
+        <CongestionTone></CongestionTone>
+        <CallwaitingTone>440/300,0/10000,440/300,0/10000,0/0</CallwaitingTone>
+        <HoldingTone></HoldingTone>
+        <ErrorTone></ErrorTone>
+        <StutterTone></StutterTone>
+        <InformationTone></InformationTone>
+        <DialRecallTone>350+440/100,0/100,350+440/100,0/100,350+440/100,0/100,350+440/0</DialRecallTone>
+        <MessageTone></MessageTone>
+        <HowlerTone></HowlerTone>
+        <NumberUnobtainable>400/500,0/6000</NumberUnobtainable>
+        <WarningTone>1400/500,0/0</WarningTone>
+        <RecordTone>440/500,0/5000</RecordTone>
+        <AutoAnswerTone></AutoAnswerTone>
+        <capability>
+            <AudioCodecSets>G722,PCMU,PCMA,OPUS</AudioCodecSets>
+            <VideoCodecSets>{if isset($fanvil_video_codec)}{$fanvil_video_codec}{else}H264{/if}</VideoCodecSets>
+            <VideoFrameRate>30</VideoFrameRate>
+            <VideoBitRate>2000000</VideoBitRate>
+            <VideoResolution>7</VideoResolution>
+            <VideoNegotiateDir>0</VideoNegotiateDir>
+        </capability>
+    </mm>
+    <sip>
+        <SIPPort>{$sip_port}</SIPPort>
+        <STUNServer>{$fanvil_stun_server}</STUNServer>
+        <STUNPort>{$fanvil_stun_port}</STUNPort>
+        <STUNRefreshTime>50</STUNRefreshTime>
+        <SIPWaitStunTime>800</SIPWaitStunTime>
+        <ExternNATAddrs></ExternNATAddrs>
+        <RegFailInterval>32</RegFailInterval>
+        <StrictBranchPrefix>0</StrictBranchPrefix>
+        <VideoMuteAttr>0</VideoMuteAttr>
+        <EnableGroupBackup>0</EnableGroupBackup>
+        <EnableRFC4475>1</EnableRFC4475>
+        <StrictUAMatch>1</StrictUAMatch>
+        <CSTAEnable>0</CSTAEnable>
+        <NotifyReboot>1</NotifyReboot>
+	{foreach $lines as $row}
+        <line index="{$row.device_key_id}">
+            <PhoneNumber>{$row.user_id}</PhoneNumber>
+            <DisplayName>{$row.display_name}</DisplayName>
+            <SipName></SipName>
+            <RegisterAddr>{$row.server_address}</RegisterAddr>
+            <RegisterPort>{$row.sip_port}</RegisterPort>
+            <RegisterUser>{$row.auth_id}</RegisterUser>
+            <RegisterPswd>{$row.password}</RegisterPswd>
+            <RegisterTTL>{$row.register_expires}</RegisterTTL>
+            <BackupAddr></BackupAddr>
+            <BackupPort>5060</BackupPort>
+            <BackupTransport>0</BackupTransport>
+            <BackupTTL>3600</BackupTTL>
+            <EnableReg>0</EnableReg>
+            <EnableReg>{if isset($row.password)}1{else}0{/if}</EnableReg>
+            <ProxyAddr>{$row.outbound_proxy_primary}</ProxyAddr>
+            <ProxyPort>{$row.sip_port}</ProxyPort>
+            <ProxyUser>{$row.auth_id}</ProxyUser>
+            <ProxyPswd>{$row.password}</ProxyPswd>
+            <ProxyNeedRegOn>0</ProxyNeedRegOn>
+            <BakProxyAddr>{$row.outbound_proxy_secondary}</BakProxyAddr>
+            <BakProxyPort>{$row.sip_port}</BakProxyPort>
+            <BakProxyNeedRegOn>0</BakProxyNeedRegOn>
+            <EnableFailback>{if isset($row.outbound_proxy_secondary)}1{else}0{/if}</EnableFailback>
+            <FailbackInterval>1800</FailbackInterval>
+            <SignalFailback>0</SignalFailback>
+            <SignalRetryCounts>3</SignalRetryCounts>
+            <SigCryptoKey></SigCryptoKey>
+            <EnableOSRTP>0</EnableOSRTP>
+            <MediaCrypto>0</MediaCrypto>
+            <MedCryptoKey></MedCryptoKey>
+            <SRTPAuth-Tag>0</SRTPAuth-Tag>
+            <EnableRFC5939>0</EnableRFC5939>
+            <LocalDomain></LocalDomain>
+            <AlwaysFWD>0</AlwaysFWD>
+            <BusyFWD>0</BusyFWD>
+            <NoAnswerFWD>0</NoAnswerFWD>
+            <AlwaysFWDNum></AlwaysFWDNum>
+            <BusyFWDNum></BusyFWDNum>
+            <NoAnswerFWDNum></NoAnswerFWDNum>
+            <FWDTimer>5</FWDTimer>
+            <HotlineNum></HotlineNum>
+            <EnableHotline>0</EnableHotline>
+            <WarmLineTime>0</WarmLineTime>
+            <PickupNum></PickupNum>
+            <JoinNum></JoinNum>
+            <IntercomNum></IntercomNum>
+            <RingType>{if isset($fanvil_ringtone_line1)}{$fanvil_ringtone_line1}{else}default{/if}</RingType>
+            <NATUDPUpdate>2</NATUDPUpdate>
+            <UDPUpdateTTL>30</UDPUpdateTTL>
+            <ServerType>0</ServerType>
+            <UserAgent></UserAgent>
+            <PRACK>0</PRACK>
+            <KeepAUTH>0</KeepAUTH>
+            <SessionTimer>0</SessionTimer>
+            <STimerExpires>0</STimerExpires>
+            <EnableGRUU>0</EnableGRUU>
+            <DTMFMode>3</DTMFMode>
+            <DTMFInfoMode>0</DTMFInfoMode>
+            <NATType>0</NATType>
+            <EnableRport>1</EnableRport>
+            <Subscribe>{if isset($row.user_id)}1{else}{/if}</Subscribe>
+            <SubExpire>{$row.register_expires}</SubExpire>
+            <SingleCodec>0</SingleCodec>
+            <CLIR>0</CLIR>
+            <StrictProxy>1</StrictProxy>
+            <DirectContact>0</DirectContact>
+            <HistoryInfo>0</HistoryInfo>
+            {if $row.sip_transport == 'dns srv'}<DNSSRV>1</DNSSRV>{/if}
+            {if $row.sip_transport == 'dns srv'}<DNSMode>1</DNSMode>{/if}
+            <XFERExpire>0</XFERExpire>
+            <BanAnonymous>0</BanAnonymous>
+            <DialOffLine>0</DialOffLine>
+            <QuotaName>0</QuotaName>
+            <PresenceMode>0</PresenceMode>
+            <RFCVer>1</RFCVer>
+            <PhonePort>0</PhonePort>
+            <SignalPort>5060</SignalPort>
+            {if $row.sip_transport == 'udp'}<Transport>0</Transport>{/if}
+            {if $row.sip_transport == 'tcp'}<Transport>1</Transport>{/if}
+            {if $row.sip_transport == 'tls'}<Transport>3</Transport>{/if}
+            <UseSRVMixer>0</UseSRVMixer>
+            <SRVMixerUri></SRVMixerUri>
+            <LongContact>0</LongContact>
+            <AutoTCP>1</AutoTCP>
+            <UriEscaped>1</UriEscaped>
+            <ClicktoTalk>0</ClicktoTalk>
+            <MwiNo></MwiNo>
+            <MWINum>{if isset($row.user_id)}{$voicemail_number}{else}{/if}</MWINum>
+            <ParkNo></ParkNo>
+            <CallParkNum></CallParkNum>
+            <RetrieveNum></RetrieveNum>
+            <HelpNo></HelpNo>
+            <MSRPHelpNum></MSRPHelpNum>
+            <UserIsPhone>0</UserIsPhone>
+            <AutoAnswer>0</AutoAnswer>
+            <NoAnswerTime>5</NoAnswerTime>
+            <MissedCallLog>1</MissedCallLog>
+            <ParkMode></ParkMode>
+            <SvcCodeMode>0</SvcCodeMode>
+            <DNDOnSvcCode></DNDOnSvcCode>
+            <DNDOffSvcCode></DNDOffSvcCode>
+            <CFUOnSvcCode></CFUOnSvcCode>
+            <CFUOffSvcCode></CFUOffSvcCode>
+            <CFBOnSvcCode></CFBOnSvcCode>
+            <CFBOffSvcCode></CFBOffSvcCode>
+            <CFNOnSvcCode></CFNOnSvcCode>
+            <CFNOffSvcCode></CFNOffSvcCode>
+            <ANCOnSvcCode></ANCOnSvcCode>
+            <ANCOffSvcCode></ANCOffSvcCode>
+            <SendANOnCode></SendANOnCode>
+            <SendANOffCode></SendANOffCode>
+            <CWOnCode></CWOnCode>
+            <CWOffCode></CWOffCode>
+            <VoiceCodecMap>OPUS,G722,PCMU,PCMA</VoiceCodecMap>
+            <VideoCodecMap>{if isset($fanvil_video_codec)}{$fanvil_video_codec}{else}{/if}</VideoCodecMap>
+            <BLFListUri></BLFListUri>
+            <BLFServer></BLFServer>
+            <Respond182>0</Respond182>
+            <EnableBLFList>0</EnableBLFList>
+            <CallerIdType>4</CallerIdType>
+            <SynClockTime>0</SynClockTime>
+            <MohServer></MohServer>
+            <UseVPN>1</UseVPN>
+            <EnableDND>0</EnableDND>
+            <InactiveHold>0</InactiveHold>
+            <ReqWithPort>1</ReqWithPort>
+            <UpdateRegExpire>1</UpdateRegExpire>
+            <EnableSCA>0</EnableSCA>
+            <SubCallPark>0</SubCallPark>
+            <SubCCStatus>0</SubCCStatus>
+            <FeatureSync>0</FeatureSync>
+            <EnableXferBack>1</EnableXferBack>
+            <XferBackTime>35</XferBackTime>
+            <UseTelCall>0</UseTelCall>
+            <EnablePreview>0</EnablePreview>
+            <PreviewMode>1</PreviewMode>
+            <TLSVersion>2</TLSVersion>
+            <CSTANumber></CSTANumber>
+            <EnableChgPort>0</EnableChgPort>
+            <VQName></VQName>
+            <VQServer></VQServer>
+            <VQServerPort>5060</VQServerPort>
+            <VQHTTPServer></VQHTTPServer>
+            <FlashMode>0</FlashMode>
+            <ContentType></ContentType>
+            <ContentBody></ContentBody>
+            <UnregisterOnBoot>0</UnregisterOnBoot>
+            <EnableMACHeader>0</EnableMACHeader>
+            <EnableRegisterMAC>0</EnableRegisterMAC>
+            <RecordStart>Record:on</RecordStart>
+            <RecordStop>Record:off</RecordStop>
+            <BLFDialogMatch>1</BLFDialogMatch>
+            <Ptime>0</Ptime>
+            <EnableDeal180>1</EnableDeal180>
+            <KeepSingleContact>0</KeepSingleContact>
+            <SessionTimerT1>500</SessionTimerT1>
+            <SessionTimerT2>4000</SessionTimerT2>
+            <SessionTimerT4>5000</SessionTimerT4>
+            <UnavailableMode>0</UnavailableMode>
+            <TCPUseRetryTimer>0</TCPUseRetryTimer>
+        </line>
+	{/foreach}
+        <p2p>
+            <SIPP2PEnableAutoAnswer>0</SIPP2PEnableAutoAnswer>
+            <SIPP2PAutoAnswerDelay>30</SIPP2PAutoAnswerDelay>
+            <SIPP2PDtmfMode>1</SIPP2PDtmfMode>
+            <SIPP2PSipInfoDtmfMode>0</SIPP2PSipInfoDtmfMode>
+            <SIPP2PEnablePreview>0</SIPP2PEnablePreview>
+            <SIPP2PPreviewMode>0</SIPP2PPreviewMode>
+            <SIPP2PUseVPN>1</SIPP2PUseVPN>
+        </p2p>
+    </sip>
+    <call>
+        <port index="1">
+            <EnableXferDPlan>1</EnableXferDPlan>
+            <EnableFwdDPlan>1</EnableFwdDPlan>
+            <EnablePreDPlan>0</EnablePreDPlan>
+            <IPDialPrefix>.</IPDialPrefix>
+            <EnableDND>1</EnableDND>
+            <DNDMode>0</DNDMode>
+            <EnableSpaceDND>0</EnableSpaceDND>
+            <DNDStartTime>1500</DNDStartTime>
+            <DNDEndTime>1730</DNDEndTime>
+            <EnableWhiteList>0</EnableWhiteList>
+            <EnableBlackList>0</EnableBlackList>
+            <EnableCallBar>0</EnableCallBar>
+            <MuteRinging>0</MuteRinging>
+            <BanDialOut>0</BanDialOut>
+            <BanEmptyCID>0</BanEmptyCID>
+            <EnableCLIP>1</EnableCLIP>
+            <CallWaiting>1</CallWaiting>
+            <CallTransfer>1</CallTransfer>
+            <CallSemiXfer>1</CallSemiXfer>
+            <CallConference>1</CallConference>
+            <AutoPickupNext>0</AutoPickupNext>
+            <BusyNoLine>1</BusyNoLine>
+            <AutoOnhook>1</AutoOnhook>
+            <AutoOnhookTime>3</AutoOnhookTime>
+            <EnableIntercom>1</EnableIntercom>
+            <IntercomMute>0</IntercomMute>
+            <IntercomTone>1</IntercomTone>
+            <IntercomBarge>0</IntercomBarge>
+            <UseAutoRedial>0</UseAutoRedial>
+            <RedialEnterCallLog>0</RedialEnterCallLog>
+            <AutoRedialDelay>30</AutoRedialDelay>
+            <AutoRedialTimes>5</AutoRedialTimes>
+            <CallComplete>0</CallComplete>
+            <CHoldingTone>1</CHoldingTone>
+            <CWaitingTone>1</CWaitingTone>
+            <HideDTMFType>0</HideDTMFType>
+            <TalkDTMFTone>1</TalkDTMFTone>
+            <DialDTMFTone>1</DialDTMFTone>
+            <PswDialMode>0</PswDialMode>
+            <PswDialLength>0</PswDialLength>
+            <PswDialPrefix></PswDialPrefix>
+            <EnableMultiLine>1</EnableMultiLine>
+            <AllowIPCall>1</AllowIPCall>
+            <CallerNameType>0</CallerNameType>
+            <MuteForRing>0</MuteForRing>
+            <AutoHandleVideo>0</AutoHandleVideo>
+            <DefaultAnsMode>{$fanvil_default_answer_mode}</DefaultAnsMode>
+            <DefaultDialMode>{$fanvil_default_dial_mode}</DefaultDialMode>
+            <HoldToTransfer>0</HoldToTransfer>
+            <EnablePreDial>1</EnablePreDial>
+            <DefaultExtLine>1</DefaultExtLine>
+            <EnableDefLine>1</EnableDefLine>
+            <EnableSelLine>1</EnableSelLine>
+            <RinginHeadset>0</RinginHeadset>
+            <AutoHeadset>0</AutoHeadset>
+            <DNDReturnCode>480</DNDReturnCode>
+            <BusyReturnCode>486</BusyReturnCode>
+            <RejectReturnCode>603</RejectReturnCode>
+            <ContactType>0</ContactType>
+            <EnableCountryCode>0</EnableCountryCode>
+            <CountryCode></CountryCode>
+            <CallAreaCode></CallAreaCode>
+            <NumberPrivacy>0</NumberPrivacy>
+            <PrivacyRule></PrivacyRule>
+            <TransfDTMFCode></TransfDTMFCode>
+            <HoldDTMFCode></HoldDTMFCode>
+            <ConfDTMFCode></ConfDTMFCode>
+            <DisableDialSearch>0</DisableDialSearch>
+            <CallNumberFilter></CallNumberFilter>
+            <AutoResumeCurrent>0</AutoResumeCurrent>
+            <CallTimeout>120</CallTimeout>
+            <RingTimeout>120</RingTimeout>
+            <RingPriority>1</RingPriority>
+        </port>
+        <basic>
+            <DialbyPound>1</DialbyPound>
+            <BTransferbyPound>0</BTransferbyPound>
+            <OnhooktoBXfer>0</OnhooktoBXfer>
+            <OnhooktoAXfer>0</OnhooktoAXfer>
+            <ConfOnhooktoXfer>0</ConfOnhooktoXfer>
+            <DialFixedLength>0</DialFixedLength>
+            <FixedLengthNums>11</FixedLengthNums>
+            <DialbyTimeout>1</DialbyTimeout>
+            <DialTimeoutvalue>10</DialTimeoutvalue>
+            <EnableEOneSixFour>0</EnableEOneSixFour>
+        </basic>
+        <alertInfo index="1">
+            <Text></Text>
+            <Line>-1</Line>
+            <RingType>Type 1</RingType>
+        </alertInfo>
+        <alertInfo index="2">
+            <Text></Text>
+            <Line>-1</Line>
+            <RingType>Type 1</RingType>
+        </alertInfo>
+        <alertInfo index="3">
+            <Text></Text>
+            <Line>-1</Line>
+            <RingType>Type 1</RingType>
+        </alertInfo>
+        <alertInfo index="4">
+            <Text></Text>
+            <Line>-1</Line>
+            <RingType>Type 1</RingType>
+        </alertInfo>
+        <alertInfo index="5">
+            <Text></Text>
+            <Line>-1</Line>
+            <RingType>Type 1</RingType>
+        </alertInfo>
+        <alertInfo index="6">
+            <Text></Text>
+            <Line>-1</Line>
+            <RingType>Type 1</RingType>
+        </alertInfo>
+        <alertInfo index="7">
+            <Text></Text>
+            <Line>-1</Line>
+            <RingType>Type 1</RingType>
+        </alertInfo>
+        <alertInfo index="8">
+            <Text></Text>
+            <Line>-1</Line>
+            <RingType>Type 1</RingType>
+        </alertInfo>
+        <alertInfo index="9">
+            <Text></Text>
+            <Line>-1</Line>
+            <RingType>Type 1</RingType>
+        </alertInfo>
+        <alertInfo index="10">
+            <Text></Text>
+            <Line>-1</Line>
+            <RingType>Type 1</RingType>
+        </alertInfo>
+    </call>
+    <phone>
+        <MenuPassword>admin</MenuPassword>
+        <KeyLockPassword>admin</KeyLockPassword>
+        <FastKeylockCode></FastKeylockCode>
+        <EnableKeyLock>0</EnableKeyLock>
+        <KeyLockTimeout>0</KeyLockTimeout>
+        <KeyLockStatus>0</KeyLockStatus>
+        <EmergencyCall>110</EmergencyCall>
+        <PushXMLIP></PushXMLIP>
+        <SIPNumberPlan>0</SIPNumberPlan>
+        <LDAPSearch>0</LDAPSearch>
+        <SearchPath>0</SearchPath>
+        <CallerDisplayT>5</CallerDisplayT>
+        <CallLogDisplayType>0</CallLogDisplayType>
+        <EnableRecvSMS>1</EnableRecvSMS>
+        <EnableCallHistory>1</EnableCallHistory>
+        <LineDisplayFormat>$name</LineDisplayFormat>
+        <EnableMWITone>0</EnableMWITone>
+        <SIPNotifyXML>1</SIPNotifyXML>
+        <BlockXMLWhenCall>1</BlockXMLWhenCall>
+        <XMLUpdateInterval>30</XMLUpdateInterval>
+        <VqmDisplayOrder></VqmDisplayOrder>
+        <EnablePushXMLAuth>0</EnablePushXMLAuth>
+        <PickupVisualAlert>0</PickupVisualAlert>
+        <PickupAudioAlert>0</PickupAudioAlert>
+        <PickupRingType></PickupRingType>
+        <display>
+            <LCDTitle>{$fanvil_greeting}</LCDTitle>
+            <LCDConstrast>5</LCDConstrast>
+            <EnableEnergysaving>{if isset($fanvil_display_brightness_inactive)}{$fanvil_display_brightness_inactive}{else}4{/if}</EnableEnergysaving>
+            <LCDLuminanceLevel>{if isset($fanvil_display_brightness_active)}{$fanvil_display_brightness_active}{else}12{/if}</LCDLuminanceLevel>
+            <BacklightOffTime>{if isset($fanvil_display_inactivity_time)}{$fanvil_display_inactivity_time}{else}45{/if}</BacklightOffTime>
+            <DisableCHNIME>0</DisableCHNIME>
+            <PhoneModel></PhoneModel>
+            <HostName>localhost</HostName>
+            <DefaultLanguage>en</DefaultLanguage>
+            <EnableGreetings>0</EnableGreetings>
+        </display>
+        <powerLed>
+            <Power>0</Power>
+            <MWIOrSMS>3</MWIOrSMS>
+            <InUsing>0</InUsing>
+            <Ring>2</Ring>
+            <Hold>0</Hold>
+            <Mute>0</Mute>
+            <MissedCall>3</MissedCall>
+            <StandbyLampEffect>0</StandbyLampEffect>
+            <LampEffectPlayTime>1</LampEffectPlayTime>
+            <CustomLampEffectTime>1200</CustomLampEffectTime>
+            <StandbyLampEffectType>0</StandbyLampEffectType>
+            <OffhookLampEffect>1</OffhookLampEffect>
+            <OffhookLampEffectColor>0</OffhookLampEffectColor>
+            <RingingLampEffect>0</RingingLampEffect>
+            <RingingLampEffectType>0</RingingLampEffectType>
+            <TalkingLampEffect>0</TalkingLampEffect>
+            <TalkingLampEffectType>0</TalkingLampEffectType>
+            <CallingLampEffect>0</CallingLampEffect>
+            <CallingLampEffectType>0</CallingLampEffectType>
+        </powerLed>
+        <lineLed>
+            <LineIdleColor>0</LineIdleColor>
+            <LineIdleCtl>1</LineIdleCtl>
+        </lineLed>
+        <blfLed>
+            <BLFIdleColor>0</BLFIdleColor>
+            <BLFIdleCtl>1</BLFIdleCtl>
+            <BLFIdleText>terminated</BLFIdleText>
+            <BLFRingColor>1</BLFRingColor>
+            <BLFRingCtl>2</BLFRingCtl>
+            <BLFRingText>early</BLFRingText>
+            <BLFDialingColor>1</BLFDialingColor>
+            <BLFDialingCtl>0</BLFDialingCtl>
+            <BLFDialingText></BLFDialingText>
+            <BLFTalkingColor>1</BLFTalkingColor>
+            <BLFTalkingCtl>1</BLFTalkingCtl>
+            <BLFTalkingText>confirmed</BLFTalkingText>
+            <BLFHoldColor>1</BLFHoldColor>
+            <BLFHoldCtl>0</BLFHoldCtl>
+            <BLFHoldText></BLFHoldText>
+            <BLFFailedColor>0</BLFFailedColor>
+            <BLFFailedCtl>0</BLFFailedCtl>
+            <BLFFailedText>failed</BLFFailedText>
+            <BLFParkedColor>1</BLFParkedColor>
+            <BLFParkedCtl>3</BLFParkedCtl>
+            <BLFParkedText>parked</BLFParkedText>
+        </blfLed>
+        <volume>
+            <HandsetVol>6</HandsetVol>
+            <HandsetMicVol>3</HandsetMicVol>
+            <HeadsetVol>6</HeadsetVol>
+            <HeadsetMicVol>3</HeadsetMicVol>
+            <HeadsetRingVol>3</HeadsetRingVol>
+            <HandFreeVol>6</HandFreeVol>
+            <HandFreeMicVol>3</HandFreeMicVol>
+            <HandFreeRingVol>6</HandFreeRingVol>
+            <RingType>{if isset($fanvil_default_ringtone)}{$fanvil_default_ringtone}{else}Happy_Technology_Logo.ogg{/if}</RingType>
+        </volume>
+        <date>
+            <EnableSNTP>{if isset($fanvil_enable_sntp)}{$fanvil_enable_sntp}{else}1{/if}</EnableSNTP>
+            <SNTPServer>{$ntp_server_primary}</SNTPServer>
+            <SecondSNTPServer>{$ntp_server_secondary}</SecondSNTPServer>
+            <TimeZone>{$fanvil_time_zone}</TimeZone>
+            <TimeZoneName>{$fanvil_time_zone_name}</TimeZoneName>
+            <SNTPTimeout>60</SNTPTimeout>
+            <Enable_DST>{$fanvil_enable_dst}</Enable_DST>
+            <DST_Fixed_Type>{if isset($fanvil_dst_fixed_type)}{$fanvil_dst_fixed_type}{else}0{/if}</DST_Fixed_Type>
+            <SNTPTimeout>60</SNTPTimeout>
+            <DSTType>1</DSTType>
+            <DSTLocation>{if isset($fanvil_location)}{$fanvil_location}{else}4{/if}</DSTLocation>
+            <DSTRuleMode>0</DSTRuleMode>
+            <DSTMinOffset>{if isset($fanvil_dst_minute_offset)}{$fanvil_dst_minute_offset}{else}60{/if}</DSTMinOffset>
+            <DSTStartMon>3</DSTStartMon>
+            <DSTStartWeek>5</DSTStartWeek>
+            <DSTStartWday>0</DSTStartWday>
+            <DSTStartHour>2</DSTStartHour>
+            <DSTEndMon>10</DSTEndMon>
+            <DSTEndWeek>5</DSTEndWeek>
+            <DSTEndWday>0</DSTEndWday>
+            <DSTEndHour>2</DSTEndHour>
+        </date>
+        <timeDisplay>
+            <EnableTimeDisplay>0</EnableTimeDisplay>
+            <TimeDisplayStyle>{if isset($fanvil_time_display)}{$fanvil_time_display}{else}0{/if}</TimeDisplayStyle>
+            <DateDisplayStyle>{if isset($fanvil_date_display)}{$fanvil_date_display}{else}6{/if}</DateDisplayStyle>
+            <DateSeparator>{if isset($fanvil_date_separator)}{$fanvil_date_separator}{else}0{/if}</DateSeparator>
+        </timeDisplay>
+        <softKeyConfig>
+            <SoftkeyMode>0</SoftkeyMode>
+            <SoftKeyExitStyle>{if isset($fanvil_softkey_exit)}{$fanvil_softkey_exit}{else}2{/if}</SoftKeyExitStyle>
+            <DesktopSoftkey>{if isset($fanvil_softkey_desktopsoftkey)}{$fanvil_softkey_desktopsoftkey}{else}history;contact;dnd;menu;{/if}</DesktopSoftkey>
+            <TalkingSoftkey>{if isset($fanvil_softkey_talkingsoftkey)}{$fanvil_softkey_talkingsoftkey}{else}video;xfer;end;conf;hold;new;mute;record;dialpad;{/if}</TalkingSoftkey>
+            <RingingSoftkey>{if isset($fanvil_softkey_ringingsoftkey)}{$fanvil_softkey_ringingsoftkey}{else}forward;audio;video;reject;{/if}</RingingSoftkey>
+            <AlertingSoftkey>dialpad;xfer;cancel;</AlertingSoftkey>
+            <XAlertingSoftkey>dialpad;xfer;cancel;</XAlertingSoftkey>
+            <ConferenceSoftkey>conf;dialpad;end;split;hold;mute;exit;</ConferenceSoftkey>
+            <WaitingSoftkey>hold;xfer;conf;end;</WaitingSoftkey>
+            <EndingSoftkey>complete;autoRedial;end;redial;</EndingSoftkey>
+            <DialerPreSoftkey>audio;video;redial;</DialerPreSoftkey>
+            <DialerCallSoftkey>audio;video;redial;</DialerCallSoftkey>
+            <DialerXferSoftkey>audio;video;xfer;contact;history;cancel;</DialerXferSoftkey>
+            <DialerCfwdSoftkey>contact;history;forward;cancel;</DialerCfwdSoftkey>
+            <DesktopClick>{if isset($fanvil_softkey_desktopclick)}{$fanvil_softkey_desktopclick}{else}history;status;none;none;none;{/if}</DesktopClick>
+            <DailerClick>pline;nline;none;none;none;</DailerClick>
+            <RingingClick>none;none;none;none;none;</RingingClick>
+            <CallClick>pcall;ncall;voldown;volup;none;</CallClick>
+            <DesktopLongPress>status;none;none;mwi;none;reset;</DesktopLongPress>
+            <DialerConfSoftkey>audio;video;cancel;contact;history;redial;</DialerConfSoftkey>
+        </softKeyConfig>
+        <agent>
+            <AgentUsername></AgentUsername>
+            <AgentPassword></AgentPassword>
+            <AgentNumber></AgentNumber>
+            <AgentSipline>0</AgentSipline>
+            <AgentStatus>0</AgentStatus>
+            <AgentStatusReason></AgentStatusReason>
+            <AgentClearCallLog>0</AgentClearCallLog>
+        </agent>
+        <bwDir index="1">
+            <Title></Title>
+            <URL></URL>
+            <Username></Username>
+            <Password></Password>
+            <SipLine>0</SipLine>
+        </bwDir>
+        <bwDir index="2">
+            <Title></Title>
+            <URL></URL>
+            <Username></Username>
+            <Password></Password>
+            <SipLine>0</SipLine>
+        </bwDir>
+        <bwDir index="3">
+            <Title></Title>
+            <URL></URL>
+            <Username></Username>
+            <Password></Password>
+            <SipLine>0</SipLine>
+        </bwDir>
+        <bwDir index="4">
+            <Title></Title>
+            <URL></URL>
+            <Username></Username>
+            <Password></Password>
+            <SipLine>0</SipLine>
+        </bwDir>
+        <bwDir index="5">
+            <Title></Title>
+            <URL></URL>
+            <Username></Username>
+            <Password></Password>
+            <SipLine>0</SipLine>
+        </bwDir>
+        <bwDir index="6">
+            <Title></Title>
+            <URL></URL>
+            <Username></Username>
+            <Password></Password>
+            <SipLine>0</SipLine>
+        </bwDir>
+        <bwCallLog index="1">
+            <Title></Title>
+            <URL></URL>
+            <Username></Username>
+            <Password></Password>
+            <SipLine>0</SipLine>
+        </bwCallLog>
+        <bwCallLog index="2">
+            <Title></Title>
+            <URL></URL>
+            <Username></Username>
+            <Password></Password>
+            <SipLine>0</SipLine>
+        </bwCallLog>
+        <bwCallLog index="3">
+            <Title></Title>
+            <URL></URL>
+            <Username></Username>
+            <Password></Password>
+            <SipLine>0</SipLine>
+        </bwCallLog>
+        <ldap index="1">
+            <Title></Title>
+            <Server></Server>
+            <port>389</port>
+            <Base></Base>
+            <UseSSL>0</UseSSL>
+            <Version>3</Version>
+            <CallingLine>-1</CallingLine>
+            <BindLine>-1</BindLine>
+            <InCallSearch>0</InCallSearch>
+            <OutCallSearch>0</OutCallSearch>
+            <Authenticate>3</Authenticate>
+            <Username></Username>
+            <Password></Password>
+            <TelAttr>telephoneNumber</TelAttr>
+            <MobileAttr>mobile</MobileAttr>
+            <OtherAttr>other</OtherAttr>
+            <NameAttr>cn sn ou</NameAttr>
+            <SortAttr>cn</SortAttr>
+            <Displayname>cn</Displayname>
+            <NumberFilter>(|(telephoneNumber=%)(mobile=%)(other=%))</NumberFilter>
+            <NameFilter>(|(cn=%)(sn=%))</NameFilter>
+            <MaxHits>50</MaxHits>
+            <DisplayType>0</DisplayType>
+        </ldap>
+        <ldap index="2">
+            <Title></Title>
+            <Server></Server>
+            <port>389</port>
+            <Base></Base>
+            <UseSSL>0</UseSSL>
+            <Version>3</Version>
+            <CallingLine>-1</CallingLine>
+            <BindLine>-1</BindLine>
+            <InCallSearch>0</InCallSearch>
+            <OutCallSearch>0</OutCallSearch>
+            <Authenticate>3</Authenticate>
+            <Username></Username>
+            <Password></Password>
+            <TelAttr>telephoneNumber</TelAttr>
+            <MobileAttr>mobile</MobileAttr>
+            <OtherAttr>other</OtherAttr>
+            <NameAttr>cn sn ou</NameAttr>
+            <SortAttr>cn</SortAttr>
+            <Displayname>cn</Displayname>
+            <NumberFilter>(|(telephoneNumber=%)(mobile=%)(other=%))</NumberFilter>
+            <NameFilter>(|(cn=%)(sn=%))</NameFilter>
+            <MaxHits>50</MaxHits>
+            <DisplayType>0</DisplayType>
+        </ldap>
+        <ldap index="3">
+            <Title></Title>
+            <Server></Server>
+            <port>389</port>
+            <Base></Base>
+            <UseSSL>0</UseSSL>
+            <Version>3</Version>
+            <CallingLine>-1</CallingLine>
+            <BindLine>-1</BindLine>
+            <InCallSearch>0</InCallSearch>
+            <OutCallSearch>0</OutCallSearch>
+            <Authenticate>3</Authenticate>
+            <Username></Username>
+            <Password></Password>
+            <TelAttr>telephoneNumber</TelAttr>
+            <MobileAttr>mobile</MobileAttr>
+            <OtherAttr>other</OtherAttr>
+            <NameAttr>cn sn ou</NameAttr>
+            <SortAttr>cn</SortAttr>
+            <Displayname>cn</Displayname>
+            <NumberFilter>(|(telephoneNumber=%)(mobile=%)(other=%))</NumberFilter>
+            <NameFilter>(|(cn=%)(sn=%))</NameFilter>
+            <MaxHits>50</MaxHits>
+            <DisplayType>0</DisplayType>
+        </ldap>
+        <ldap index="4">
+            <Title></Title>
+            <Server></Server>
+            <port>389</port>
+            <Base></Base>
+            <UseSSL>0</UseSSL>
+            <Version>3</Version>
+            <CallingLine>-1</CallingLine>
+            <BindLine>-1</BindLine>
+            <InCallSearch>0</InCallSearch>
+            <OutCallSearch>0</OutCallSearch>
+            <Authenticate>3</Authenticate>
+            <Username></Username>
+            <Password></Password>
+            <TelAttr>telephoneNumber</TelAttr>
+            <MobileAttr>mobile</MobileAttr>
+            <OtherAttr>other</OtherAttr>
+            <NameAttr>cn sn ou</NameAttr>
+            <SortAttr>cn</SortAttr>
+            <Displayname>cn</Displayname>
+            <NumberFilter>(|(telephoneNumber=%)(mobile=%)(other=%))</NumberFilter>
+            <NameFilter>(|(cn=%)(sn=%))</NameFilter>
+            <MaxHits>50</MaxHits>
+            <DisplayType>0</DisplayType>
+        </ldap>
+        <ldap index="5">
+            <Title></Title>
+            <Server></Server>
+            <port>389</port>
+            <Base></Base>
+            <UseSSL>0</UseSSL>
+            <Version>3</Version>
+            <CallingLine>-1</CallingLine>
+            <BindLine>-1</BindLine>
+            <InCallSearch>0</InCallSearch>
+            <OutCallSearch>0</OutCallSearch>
+            <Authenticate>3</Authenticate>
+            <Username></Username>
+            <Password></Password>
+            <TelAttr>telephoneNumber</TelAttr>
+            <MobileAttr>mobile</MobileAttr>
+            <OtherAttr>other</OtherAttr>
+            <NameAttr>cn sn ou</NameAttr>
+            <SortAttr>cn</SortAttr>
+            <Displayname>cn</Displayname>
+            <NumberFilter>(|(telephoneNumber=%)(mobile=%)(other=%))</NumberFilter>
+            <NameFilter>(|(cn=%)(sn=%))</NameFilter>
+            <MaxHits>50</MaxHits>
+            <DisplayType>0</DisplayType>
+        </ldap>
+        <xmlContact index="1">
+            <Name></Name>
+            <Addr></Addr>
+            <UserName></UserName>
+            <PassWd></PassWd>
+            <Sipline>-1</Sipline>
+            <BindLine>-1</BindLine>
+        </xmlContact>
+        <xmlContact index="2">
+            <Name></Name>
+            <Addr></Addr>
+            <UserName></UserName>
+            <PassWd></PassWd>
+            <Sipline>-1</Sipline>
+            <BindLine>-1</BindLine>
+        </xmlContact>
+        <xmlContact index="3">
+            <Name></Name>
+            <Addr></Addr>
+            <UserName></UserName>
+            <PassWd></PassWd>
+            <Sipline>-1</Sipline>
+            <BindLine>-1</BindLine>
+        </xmlContact>
+        <xmlContact index="4">
+            <Name></Name>
+            <Addr></Addr>
+            <UserName></UserName>
+            <PassWd></PassWd>
+            <Sipline>-1</Sipline>
+            <BindLine>-1</BindLine>
+        </xmlContact>
+        <xmlContact index="5">
+            <Name></Name>
+            <Addr></Addr>
+            <UserName></UserName>
+            <PassWd></PassWd>
+            <Sipline>-1</Sipline>
+            <BindLine>-1</BindLine>
+        </xmlContact>
+    </phone>
+    <dm>
+        <OnhookTime>200</OnhookTime>
+        <EnableHookflash>0</EnableHookflash>
+        <KeyLongPressTime>2</KeyLongPressTime>
+        <KeyLongLongPressTime>6</KeyLongLongPressTime>
+    </dm>
+    <vqm>
+        <SessionReport>1</SessionReport>
+        <IntervalReport>1</IntervalReport>
+        <IntervalPeriod>60</IntervalPeriod>
+        <MOS-LQWarning>40</MOS-LQWarning>
+        <MOS-LQCritical>25</MOS-LQCritical>
+        <DelayWarning>150</DelayWarning>
+        <DelayCritical>200</DelayCritical>
+        <PhoneReport>1</PhoneReport>
+        <WEBReport>1</WEBReport>
+    </vqm>
+    <cti>
+        <EnabledActiveUri>1</EnabledActiveUri>
+        <EnabledActionUrl>1</EnabledActionUrl>
+        <ActiveUriIP></ActiveUriIP>
+        <StartRebootUrl></StartRebootUrl>
+        <BootCompletedUrl></BootCompletedUrl>
+        <IPChangeUrl></IPChangeUrl>
+        <RegOnUrl></RegOnUrl>
+        <RegOffUrl></RegOffUrl>
+        <RegFailedUrl></RegFailedUrl>
+        <PhoneStateIdleUrl></PhoneStateIdleUrl>
+        <PhoneStateTalking></PhoneStateTalking>
+        <PhoneStateRinging></PhoneStateRinging>
+        <DNDOnUrl></DNDOnUrl>
+        <DNDOffUrl></DNDOffUrl>
+        <AlwaysFWDOnUrl></AlwaysFWDOnUrl>
+        <AlwaysFWDOffUrl></AlwaysFWDOffUrl>
+        <BusyFWDOnUrl></BusyFWDOnUrl>
+        <BusyFWDOffUrl></BusyFWDOffUrl>
+        <NoAnsFWDOnUrl></NoAnsFWDOnUrl>
+        <NoAnsFWDOffUrl></NoAnsFWDOffUrl>
+        <MuteOnUrl></MuteOnUrl>
+        <MuteOffUrl></MuteOffUrl>
+        <IncomingCallUrl></IncomingCallUrl>
+        <OutgoingCallUrl></OutgoingCallUrl>
+        <CallActiveUrl></CallActiveUrl>
+        <CallStopUrl></CallStopUrl>
+        <TransferUrl></TransferUrl>
+        <HoldOnUrl></HoldOnUrl>
+        <HoldOffUrl></HoldOffUrl>
+        <HeldOnUrl></HeldOnUrl>
+        <HeldOffUrl></HeldOffUrl>
+        <MuteOnCallUrl></MuteOnCallUrl>
+        <MuteOffCallUrl></MuteOffCallUrl>
+        <NewMissedcallUrl></NewMissedcallUrl>
+        <NewMWIUrl></NewMWIUrl>
+        <NewSMSUrl></NewSMSUrl>
+        <WebAuthChangedUrl></WebAuthChangedUrl>
+        <at>
+            <AtEnabled>0</AtEnabled>
+            <AtServer></AtServer>
+        </at>
+    </cti>
+    <mcast>
+        <Priority>0</Priority>
+        <EnablePriority>0</EnablePriority>
+        <EnablePrioChan>0</EnablePrioChan>
+        <EnableEmerChan>0</EnableEmerChan>
+        <MulticastTone>1</MulticastTone>
+        <McastListeningRenewTime>0</McastListeningRenewTime>
+        <addr index="1">
+            <Name></Name>
+            <Host></Host>
+            <Port>0</Port>
+            <Channel>0</Channel>
+        </addr>
+        <addr index="2">
+            <Name></Name>
+            <Host></Host>
+            <Port>0</Port>
+            <Channel>0</Channel>
+        </addr>
+        <addr index="3">
+            <Name></Name>
+            <Host></Host>
+            <Port>0</Port>
+            <Channel>0</Channel>
+        </addr>
+        <addr index="4">
+            <Name></Name>
+            <Host></Host>
+            <Port>0</Port>
+            <Channel>0</Channel>
+        </addr>
+        <addr index="5">
+            <Name></Name>
+            <Host></Host>
+            <Port>0</Port>
+            <Channel>0</Channel>
+        </addr>
+        <addr index="6">
+            <Name></Name>
+            <Host></Host>
+            <Port>0</Port>
+            <Channel>0</Channel>
+        </addr>
+        <addr index="7">
+            <Name></Name>
+            <Host></Host>
+            <Port>0</Port>
+            <Channel>0</Channel>
+        </addr>
+        <addr index="8">
+            <Name></Name>
+            <Host></Host>
+            <Port>0</Port>
+            <Channel>0</Channel>
+        </addr>
+        <addr index="9">
+            <Name></Name>
+            <Host></Host>
+            <Port>0</Port>
+            <Channel>0</Channel>
+        </addr>
+        <addr index="10">
+            <Name></Name>
+            <Host></Host>
+            <Port>0</Port>
+            <Channel>0</Channel>
+        </addr>
+        <dynamic>
+            <AutoExitExpires>60</AutoExitExpires>
+        </dynamic>
+    </mcast>
+    <dsskey>
+        <SelectDsskeyAction>0</SelectDsskeyAction>
+        <MemoryKeytoBXfer>0</MemoryKeytoBXfer>
+        <FuncKeyPageNum>4</FuncKeyPageNum>
+        <SideKeyPageNum>1</SideKeyPageNum>
+        <DSSHomePage>0</DSSHomePage>
+        <DisplayParkedInfo>0</DisplayParkedInfo>
+        <DSSDIALSwitchMode>0</DSSDIALSwitchMode>
+        <FirstCallWaitTime>16</FirstCallWaitTime>
+        <FirstNumStartTime>360</FirstNumStartTime>
+        <FirstNumEndTime>1080</FirstNumEndTime>
+        <DSSLongPressAction>1</DSSLongPressAction>
+        <Extern1PageBelong>0</Extern1PageBelong>
+        <Extern2PageBelong>0</Extern2PageBelong>
+        <Extern3PageBelong>0</Extern3PageBelong>
+        <Extern4PageBelong>0</Extern4PageBelong>
+        <Extern5PageBelong>0</Extern5PageBelong>
+        <DSSExtend1MAC></DSSExtend1MAC>
+        <DSSExtend1IP></DSSExtend1IP>
+        <DSSExtend2MAC></DSSExtend2MAC>
+        <DSSExtend2IP></DSSExtend2IP>
+        <DSSExtend3MAC></DSSExtend3MAC>
+        <DSSExtend3IP></DSSExtend3IP>
+        <DSSExtend4MAC></DSSExtend4MAC>
+        <DSSExtend4IP></DSSExtend4IP>
+        <DSSExtend5MAC></DSSExtend5MAC>
+        <DSSExtend5IP></DSSExtend5IP>
+
+        {strip}{*-- Each Internal Index contains 32 keys --*}{/strip}
+        <internal index="1">
+            <Fkey index="1">
+                <Type>2</Type>
+                <Value>SIP1</Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="2">
+                <Type>2</Type>
+                <Value>SIP2</Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="3">
+                <Type>2</Type>
+                <Value>SIP3</Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="4">
+                <Type>2</Type>
+                <Value>SIP4</Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="5">
+                <Type>2</Type>
+                <Value>SIP5</Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="6">
+                <Type>3</Type>
+                <Value>F_HEADSET</Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="7">
+                <Type>3</Type>
+                <Value>F_REDIAL</Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="8">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="9">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="10">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="11">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="12">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="13">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="14">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="15">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="16">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="17">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="18">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="19">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="20">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="21">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="22">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="23">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="24">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="25">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="26">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="27">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="28">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="29">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+        </internal>
+        <internal index="2">
+            <Fkey index="1">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="2">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="3">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="4">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="5">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="6">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="7">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="8">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="9">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="10">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="11">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="12">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="13">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="14">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="15">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="16">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="17">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="18">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="19">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="20">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="21">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="22">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="23">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="24">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="25">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="26">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="27">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="28">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="29">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+        </internal>
+        <internal index="3">
+            <Fkey index="1">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="2">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="3">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="4">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="5">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="6">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="7">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="8">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="9">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="10">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="11">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="12">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="13">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="14">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="15">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="16">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="17">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="18">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="19">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="20">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="21">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="22">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="23">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="24">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="25">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="26">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="27">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="28">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="29">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+        </internal>
+        <internal index="4">
+            <Fkey index="1">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="2">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="3">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="4">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="5">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="6">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="7">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="8">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="9">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="10">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="11">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="12">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="13">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="14">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="15">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="16">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="17">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="18">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="19">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="20">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="21">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="22">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="23">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="24">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="25">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="26">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="27">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="28">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="29">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+        </internal>
+        <dssSoft index="1">
+            <Type>0</Type>
+            <Value></Value>
+            <Title></Title>
+            <ICON>Green</ICON>
+        </dssSoft>
+        <dssSoft index="2">
+            <Type>0</Type>
+            <Value></Value>
+            <Title></Title>
+            <ICON>Green</ICON>
+        </dssSoft>
+        <dssSoft index="3">
+            <Type>0</Type>
+            <Value></Value>
+            <Title></Title>
+            <ICON>Green</ICON>
+        </dssSoft>
+        <dssSoft index="4">
+            <Type>0</Type>
+            <Value></Value>
+            <Title></Title>
+            <ICON>Green</ICON>
+        </dssSoft>
+        <dssSoft index="5">
+            <Type>0</Type>
+            <Value></Value>
+            <Title></Title>
+            <ICON>Green</ICON>
+        </dssSoft>
+        <dssSoft index="6">
+            <Type>0</Type>
+            <Value></Value>
+            <Title></Title>
+            <ICON>Green</ICON>
+        </dssSoft>
+        <dssSoft index="7">
+            <Type>0</Type>
+            <Value></Value>
+            <Title></Title>
+            <ICON>Green</ICON>
+        </dssSoft>
+        <dssSoft index="8">
+            <Type>0</Type>
+            <Value></Value>
+            <Title></Title>
+            <ICON>Green</ICON>
+        </dssSoft>
+        <dssSoft index="9">
+            <Type>0</Type>
+            <Value></Value>
+            <Title></Title>
+            <ICON>Green</ICON>
+        </dssSoft>
+        <dssSoft index="10">
+            <Type>0</Type>
+            <Value></Value>
+            <Title></Title>
+            <ICON>Green</ICON>
+        </dssSoft>
+    </dsskey>
+    <web>
+        <WebServerType>0</WebServerType>
+        <WebPort>80</WebPort>
+        <HttpsWebPort>443</HttpsWebPort>
+        <RemoteControl>1</RemoteControl>
+        <EnableMMIFilter>0</EnableMMIFilter>
+        <WebAuthentication>0</WebAuthentication>
+        <EnableTelnet>0</EnableTelnet>
+        <TelnetPort>23</TelnetPort>
+        <TelnetPrompt></TelnetPrompt>
+        <LogonTimeout>15</LogonTimeout>
+        <account index="1">
+            <Name>{if isset($admin_name)}{$admin_name}{else}admin{/if}</Name>
+            <Password>{if isset($admin_password)}{$admin_password}{else}admin{/if}</Password>
+            <Level>10</Level>
+        </account>
+        <account index="2">
+            <Name>guest</Name>
+            <Password>guest</Password>
+            <Level>5</Level>
+        </account>
+    </web>
+    <log>
+        <Level>INFO</Level>
+        <Style>level,tag</Style>
+        {if $fanvil_syslog_enable == '1'}<OutputDevice>syslog</OutputDevice>
+        {elseif $fanvil_output_device == ''}<OutputDevice></OutputDevice>
+        {elseif $fanvil_output_device == 'syslog'}<OutputDevice>syslog</OutputDevice>
+        {elseif $fanvil_output_device == 'stdout'}<OutputDevice>stdout</OutputDevice>
+        {elseif $fanvil_output_device == 'syslog,stdout'}<OutputDevice>syslog,stdout</OutputDevice>
+        {elseif $fanvil_output_device == 'stdout,syslog'}<OutputDevice>syslog,stdout</OutputDevice>
+        {/if}
+        <FileName>platform.log</FileName>
+        <FileSize>512KB</FileSize>
+        <SyslogTag>platform</SyslogTag>
+        <SyslogServer>{if isset($fanvil_syslog_server)}{$fanvil_syslog_server}{else}0.0.0.0{/if}</SyslogServer>
+        <SyslogServerPort>{if isset($fanvil_syslog_server_port)}{$fanvil_syslog_server_port}{else}514{/if}</SyslogServerPort>
+    </log>
+    <tr069>
+        <TR069Tone>1</TR069Tone>
+        <CPESerialNumber></CPESerialNumber>
+        <ACSServerType>1</ACSServerType>
+        <EnableTR069>0</EnableTR069>
+        <ACSURL>0.0.0.0</ACSURL>
+        <ACSUserName>admin</ACSUserName>
+        <ACSPassword></ACSPassword>
+        <ACSBackupURL>0.0.0.0</ACSBackupURL>
+        <ACSBackupUserName></ACSBackupUserName>
+        <ACSBackupPassword></ACSBackupPassword>
+        <CPEUserName>dps</CPEUserName>
+        <CPEPassword>dps</CPEPassword>
+        <PeriodixInterval>3600</PeriodixInterval>
+        <TLSVersion>2</TLSVersion>
+        <AreaCode></AreaCode>
+        <STUNEnable>0</STUNEnable>
+        <STUNServerAddr>{$fanvil_stun_server}</STUNServerAddr>
+        <STUNServerPort>{$fanvil_stun_port}</STUNServerPort>
+        <STUNLocalPort>30000</STUNLocalPort>
+    </tr069>
+    <hotspot>
+        <EnableHotspot>0</EnableHotspot>
+        <Mode>1</Mode>
+        <ListenType>0</ListenType>
+        <ListenIP>224.0.2.0</ListenIP>
+        <ListenPort>16360</ListenPort>
+        <OwnName>SIP Hotspot</OwnName>
+        <RingMode>0</RingMode>
+        <GroupCallMode>0</GroupCallMode>
+        <EnableManageMode>0</EnableManageMode>
+        <EnableConfigMode>0</EnableConfigMode>
+        <hs index="1">
+            <Enable>1</Enable>
+            <ExtPrefix></ExtPrefix>
+        </hs>
+        <hs index="2">
+            <Enable>1</Enable>
+            <ExtPrefix></ExtPrefix>
+        </hs>
+        <hs index="3">
+            <Enable>1</Enable>
+            <ExtPrefix></ExtPrefix>
+        </hs>
+        <hs index="4">
+            <Enable>1</Enable>
+            <ExtPrefix></ExtPrefix>
+        </hs>
+        <hs index="5">
+            <Enable>1</Enable>
+            <ExtPrefix></ExtPrefix>
+        </hs>
+        <hs index="6">
+            <Enable>1</Enable>
+            <ExtPrefix></ExtPrefix>
+        </hs>
+        <hs index="7">
+            <Enable>1</Enable>
+            <ExtPrefix></ExtPrefix>
+        </hs>
+        <hs index="8">
+            <Enable>1</Enable>
+            <ExtPrefix></ExtPrefix>
+        </hs>
+        <hs index="9">
+            <Enable>1</Enable>
+            <ExtPrefix></ExtPrefix>
+        </hs>
+        <hs index="10">
+            <Enable>1</Enable>
+            <ExtPrefix></ExtPrefix>
+        </hs>
+        <hs index="11">
+            <Enable>1</Enable>
+            <ExtPrefix></ExtPrefix>
+        </hs>
+        <hs index="12">
+            <Enable>1</Enable>
+            <ExtPrefix></ExtPrefix>
+        </hs>
+        <hs index="13">
+            <Enable>1</Enable>
+            <ExtPrefix></ExtPrefix>
+        </hs>
+        <hs index="14">
+            <Enable>1</Enable>
+            <ExtPrefix></ExtPrefix>
+        </hs>
+        <hs index="15">
+            <Enable>1</Enable>
+            <ExtPrefix></ExtPrefix>
+        </hs>
+        <hs index="16">
+            <Enable>1</Enable>
+            <ExtPrefix></ExtPrefix>
+        </hs>
+        <hs index="17">
+            <Enable>1</Enable>
+            <ExtPrefix></ExtPrefix>
+        </hs>
+        <hs index="18">
+            <Enable>1</Enable>
+            <ExtPrefix></ExtPrefix>
+        </hs>
+        <hs index="19">
+            <Enable>1</Enable>
+            <ExtPrefix></ExtPrefix>
+        </hs>
+        <hs index="20">
+            <Enable>1</Enable>
+            <ExtPrefix></ExtPrefix>
+        </hs>
+    </hotspot>
+    <mt>
+        <ContactUpdateMode>0</ContactUpdateMode>
+        <AutoServerDigest>0</AutoServerDigest>
+    </mt>
+    <ap>
+        <DefaultUsername>{$http_auth_username}</DefaultUsername>
+        <DefaultPassword>{$http_auth_password}</DefaultPassword>
+        <InputCfgFileName></InputCfgFileName>
+        <DeviceCfgFileKey></DeviceCfgFileKey>
+        <CommonCfgFileKey></CommonCfgFileKey>
+        <DownloadCommonConf>1</DownloadCommonConf>
+        <SaveProvisionInfo>1</SaveProvisionInfo>
+        <CheckFailTimes>5</CheckFailTimes>
+        <FlashServerIP>{if isset($fanvil_provision_url)}{$fanvil_provision_url}{else}{$domain_name}/app/provision{/if}</FlashServerIP>
+        <FlashFileName>{$fanvil_firmware_config}</FlashFileName>
+        <FlashProtocol>5</FlashProtocol>
+        <FlashMode>1</FlashMode>
+        <FlashInterval>1</FlashInterval>
+        <updatePBInterval>720</updatePBInterval>
+        <pnp>
+            <PNPEnable>1</PNPEnable>
+            <PNPIP>224.0.1.75</PNPIP>
+            <PNPPort>5060</PNPPort>
+            <PNPTransport>0</PNPTransport>
+            <PNPInterval>1</PNPInterval>
+        </pnp>
+        <opt>
+            <DHCPOption>66</DHCPOption>
+            <DhcpOption120>0</DhcpOption120>
+            <DHCPv6Option>0</DHCPv6Option>
+        </opt>
+    </ap>
+    <qos>
+        <EnableVLAN>{if isset($fanvil_enable_vlan)}{$fanvil_enable_vlan}{else}0{/if}</EnableVLAN>
+        <VLANID>{if isset($fanvil_lan_port_vlan)}{$fanvil_lan_port_vlan}{else}256{/if}</VLANID>
+        <EnablePVID>{if isset($fanvil_pc_port_vlan)}2{else}0{/if}</EnablePVID>
+        <PVIDValue>{if isset($fanvil_pc_port_vlan)}{$fanvil_pc_port_vlan}{else}254{/if}</PVIDValue>
+        <SignallingPriority>{if isset($fanvil_qos_sip)}{$fanvil_qos_sip}{else}0{/if}</SignallingPriority>
+        <VoicePriority>{if isset($fanvil_qos_rtp_voice)}{$fanvil_qos_rtp_voice}{else}0{/if}</VoicePriority>
+        <VideoPriority>{if isset($fanvil_qos_rtp_video)}{$fanvil_qos_rtp_video}{else}0{/if}</VideoPriority>
+        <LANPortPriority>0</LANPortPriority>
+        <EnablediffServ>{if isset($fanvil_enable_diffserv)}{$fanvil_enable_diffserv}{else}0{/if}</EnablediffServ>
+        <SingallingDSCP>{if isset($fanvil_dscp_sip)}{$fanvil_dscp_sip}{else}46{/if}</SingallingDSCP>
+        <VoiceDSCP>{if isset($fanvil_dscp_rtp_voice)}{$fanvil_dscp_rtp_voice}{else}46{/if}</VoiceDSCP>
+        <VideoDSCP>{if isset($fanvil_dscp_rtp_video)}{$fanvil_dscp_rtp_video}{else}34{/if}</VideoDSCP>
+        <LLDPTransmit>{if isset($fanvil_lldp_tx_enable)}{$fanvil_lldp_tx_enable}{else}0{/if}</LLDPTransmit>
+        <LLDPRefreshTime>{if isset($fanvil_lldp_refresh)}{$fanvil_lldp_refresh}{else}60{/if}</LLDPRefreshTime>
+        <LLDPLearnPolicy>{if isset($fanvil_lldp_learn)}{$fanvil_lldp_learn}{else}0{/if}</LLDPLearnPolicy>
+        <LLDPSaveLearnData>1</LLDPSaveLearnData>
+        <CDPEnable>0</CDPEnable>
+        <CDPRefreshTime>60</CDPRefreshTime>
+        <DHCPOptionVlan>132</DHCPOptionVlan>
+    </qos>
+    <dot1x>
+        <XsupMode>0</XsupMode>
+        <XsupUser>admin</XsupUser>
+        <XsupPassword>admin</XsupPassword>
+        <sslMode>
+            <PermissionCTF>0</PermissionCTF>
+            <CommonName>0</CommonName>
+            <CTFmode>0</CTFmode>
+            <DeviceCertMode>0</DeviceCertMode>
+        </sslMode>
+    </dot1x>
+    <rtsp>
+        <RtspClientWorkMode>0</RtspClientWorkMode>
+    </rtsp>
+    <pubApp>
+        <WatchDogEnabled>1</WatchDogEnabled>
+        <EnableInAccess>0</EnableInAccess>
+        <EnableOutAccess>0</EnableOutAccess>
+    </pubApp>
+    <android>
+        <displayConfig>
+            <OperatorMode>0</OperatorMode>
+            <EnableShortcuts>1</EnableShortcuts>
+            <EnableLCDPassword>1</EnableLCDPassword>
+        </displayConfig>
+        <softKeyConfig>
+            <DIdleSoftkey>dialpad;mwi;contact;history;cfwd;redial;capse;</DIdleSoftkey>
+            <DTalkingSoftkey>dialpad;new;conf;hold;xfer;end;capse;</DTalkingSoftkey>
+            <DRingSoftkey>dialpad;forward;audio;video;mute;reject;capse;</DRingSoftkey>
+            <DAlertingSoftkey>dialpad;none;none;none;xfer;cancel;capse;</DAlertingSoftkey>
+            <DXAlertingSoftkey>dialpad;none;none;none;xfer;none;capse;</DXAlertingSoftkey>
+            <DConferenceSoftkey>dialpad;exit;split;hold;xfer;end;capse;</DConferenceSoftkey>
+            <DEndingSoftkey>contact;history;new;complete;autoRedial;end;capse;</DEndingSoftkey>
+            <DPredialSoftkey>dialpad;mwi;contact;history;redial;cancel;capse;</DPredialSoftkey>
+            <DDialingSoftkey>dialpad;mwi;contact;history;redial;cancel;capse;</DDialingSoftkey>
+            <DDialerCfwdSoftkey>dialpad;new;contact;history;forward;cancel;capse;</DDialerCfwdSoftkey>
+            <DDialerXferSoftkey>dialpad;new;contact;history;xfer;cancel;capse;</DDialerXferSoftkey>
+            <DSlectionSoftkey>new;cancel;ok;conf;hold;xfer;capse;</DSlectionSoftkey>
+        </softKeyConfig>
+        <dspConfig>
+            <VideoDisplayMosaic>1</VideoDisplayMosaic>
+        </dspConfig>
+        <teleConfig>
+            <EnableRecord>1</EnableRecord>
+            <EnableIMApp>0</EnableIMApp>
+            <OffhooktoOpenApp>0</OffhooktoOpenApp>
+            <IMAppPackageInfo></IMAppPackageInfo>
+            <SupportedIMSet></SupportedIMSet>
+            <HideLocalCode>0</HideLocalCode>
+            <UpdateDialCall>0</UpdateDialCall>
+            <CountryCode></CountryCode>
+        </teleConfig>
+    </android>
+    <uiMainTainConfig>
+        <EHSHeadsettype>0</EHSHeadsettype>
+        <TimeoutToScreensaver>7200</TimeoutToScreensaver>
+        <DisplayProvisionprompt>0</DisplayProvisionprompt>
+    </uiMainTainConfig>
+    <fwCheck>
+        <EnableAutoUpgrade>0</EnableAutoUpgrade>
+        <UpgradeServer1></UpgradeServer1>
+        <UpgradeServer2></UpgradeServer2>
+        <AutoUpgradeInterval>24</AutoUpgradeInterval>
+    </fwCheck>
+    <record>
+        <Enabled>1</Enabled>
+        <VoiceCodec>PCMU</VoiceCodec>
+        <RecordType>0</RecordType>
+        <FileSizeLimit>0</FileSizeLimit>
+        <ServerAddr>0.0.0.0</ServerAddr>
+        <ServerPort>10000</ServerPort>
+    </record>
+    <IO>
+        <RingtoneDuration>5</RingtoneDuration>
+        <AlarmServerAddr></AlarmServerAddr>
+        <DTMFTriggerRing>NONE</DTMFTriggerRing>
+        <URITriggerRing>NONE</URITriggerRing>
+        <SMSTriggerRing>NONE</SMSTriggerRing>
+        <DsskeyTriggerRing>NONE</DsskeyTriggerRing>
+    </IO>
+</sysConf>

--- a/resources/templates/provision/fanvil/v65/{$mac}.cfg
+++ b/resources/templates/provision/fanvil/v65/{$mac}.cfg
@@ -1,0 +1,2013 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sysConf>
+    <Version>2.0000000000</Version>
+    <net>
+        <WANTYPE>0</WANTYPE>
+        <WANIP></WANIP>
+        <WANSubnetMask>255.255.255.0</WANSubnetMask>
+        <WANGateway></WANGateway>
+        <DomainName></DomainName>
+        <PrimaryDNS>{if isset($dns_server_primary)}{$dns_server_primary}{else}9.9.9.9{/if}</PrimaryDNS>
+        <SecondaryDNS>{if isset($dns_server_secondary)}{$dns_server_secondary}{else}1.1.1.1{/if}</SecondaryDNS>
+        <EnableDHCP>1</EnableDHCP>
+        <DHCPAutoDNS>1</DHCPAutoDNS>
+        <DHCPAutoTime>1</DHCPAutoTime>
+        <DHCPOption100-101>1</DHCPOption100-101>
+        <UseVendorClassID>0</UseVendorClassID>
+        <VendorClassID>Fanvil</VendorClassID>
+        <EnablePPPoE>0</EnablePPPoE>
+        <PPPoEUser>user123</PPPoEUser>
+        <PPPoEPassword>password</PPPoEPassword>
+        <ARPCacheLife>2</ARPCacheLife>
+        <MTU>1500</MTU>
+        <PPPoEAutoConnect>0</PPPoEAutoConnect>
+        <PPPoEAutoRecnct>0</PPPoEAutoRecnct>
+        <WAN6IP></WAN6IP>
+        <WAN6IPPREFIX></WAN6IPPREFIX>
+        <WAN6Gateway></WAN6Gateway>
+        <Domain6Name></Domain6Name>
+        <PrimaryDNS6></PrimaryDNS6>
+        <SecondaryDNS6></SecondaryDNS6>
+        <EnableDHCP6>1</EnableDHCP6>
+        <DHCP6AutoDNS>1</DHCP6AutoDNS>
+        <DHCP6AutoTime>0</DHCP6AutoTime>
+        <UseVendor6ClassID>0</UseVendor6ClassID>
+        <Vendor6ClassID></Vendor6ClassID>
+    </net>
+    <mm>
+        <G723BitRate>1</G723BitRate>
+        <ILBCPayloadType>97</ILBCPayloadType>
+        <ILBCPayloadLen>20</ILBCPayloadLen>
+        <AMRPayloadType>108</AMRPayloadType>
+        <AMRWBPayloadType>109</AMRWBPayloadType>
+        <G726-16PayloadType>103</G726-16PayloadType>
+        <G726-24PayloadType>104</G726-24PayloadType>
+        <G726-32PayloadType>102</G726-32PayloadType>
+        <G726-40PayloadType>105</G726-40PayloadType>
+        <DtmfPayloadType>101</DtmfPayloadType>
+        <OpusPayloadType>107</OpusPayloadType>
+        <OpusSampleRate>0</OpusSampleRate>
+        <VAD>0</VAD>
+        <H264PayloadType>117</H264PayloadType>
+        <H264PacketMode>0</H264PacketMode>
+        <H264Profile>0</H264Profile>
+        <ResvAudioBand>0</ResvAudioBand>
+        <H265PayloadType>98</H265PayloadType>
+        <RTPInitialPort>16384</RTPInitialPort>
+        <RTPPortQuantity>16384</RTPPortQuantity>
+        <RTPKeepAlive>0</RTPKeepAlive>
+        <RTPRelay>0</RTPRelay>
+        <RTCPCNAMEUser></RTCPCNAMEUser>
+        <RTCPCNAMEHost></RTCPCNAMEHost>
+        <SelectYourTone>{if isset($fanvil_country_toneset)}{$fanvil_country_toneset}{else}11{/if}</SelectYourTone>
+        <SidetoneGAIN>1</SidetoneGAIN>
+        <PlayEgressDTMF>0</PlayEgressDTMF>
+        <DialTone>350+440/0</DialTone>
+        <RingbackTone>440+480/2000,0/4000</RingbackTone>
+        <BusyTone>480+620/500,0/500</BusyTone>
+        <CongestionTone></CongestionTone>
+        <CallwaitingTone>440/300,0/10000,440/300,0/10000,0/0</CallwaitingTone>
+        <HoldingTone></HoldingTone>
+        <ErrorTone></ErrorTone>
+        <StutterTone></StutterTone>
+        <InformationTone></InformationTone>
+        <DialRecallTone>350+440/100,0/100,350+440/100,0/100,350+440/100,0/100,350+440/0</DialRecallTone>
+        <MessageTone></MessageTone>
+        <HowlerTone></HowlerTone>
+        <NumberUnobtainable>400/500,0/6000</NumberUnobtainable>
+        <WarningTone>1400/500,0/0</WarningTone>
+        <RecordTone>440/500,0/5000</RecordTone>
+        <AutoAnswerTone></AutoAnswerTone>
+        <capability>
+            <AudioCodecSets>G722,PCMU,PCMA,OPUS</AudioCodecSets>
+            <VideoCodecSets>{if isset($fanvil_video_codec)}{$fanvil_video_codec}{else}H264{/if}</VideoCodecSets>
+            <VideoFrameRate>30</VideoFrameRate>
+            <VideoBitRate>2000000</VideoBitRate>
+            <VideoResolution>7</VideoResolution>
+            <VideoNegotiateDir>0</VideoNegotiateDir>
+        </capability>
+    </mm>
+    <sip>
+        <SIPPort>{$sip_port}</SIPPort>
+        <STUNServer>{$fanvil_stun_server}</STUNServer>
+        <STUNPort>{$fanvil_stun_port}</STUNPort>
+        <STUNRefreshTime>50</STUNRefreshTime>
+        <SIPWaitStunTime>800</SIPWaitStunTime>
+        <ExternNATAddrs></ExternNATAddrs>
+        <RegFailInterval>32</RegFailInterval>
+        <StrictBranchPrefix>0</StrictBranchPrefix>
+        <VideoMuteAttr>0</VideoMuteAttr>
+        <EnableGroupBackup>0</EnableGroupBackup>
+        <EnableRFC4475>1</EnableRFC4475>
+        <StrictUAMatch>1</StrictUAMatch>
+        <CSTAEnable>0</CSTAEnable>
+        <NotifyReboot>1</NotifyReboot>
+	{foreach $lines as $row}
+        <line index="{$row.device_key_id}">
+            <PhoneNumber>{$row.user_id}</PhoneNumber>
+            <DisplayName>{$row.display_name}</DisplayName>
+            <SipName></SipName>
+            <RegisterAddr>{$row.server_address}</RegisterAddr>
+            <RegisterPort>{$row.sip_port}</RegisterPort>
+            <RegisterUser>{$row.auth_id}</RegisterUser>
+            <RegisterPswd>{$row.password}</RegisterPswd>
+            <RegisterTTL>{$row.register_expires}</RegisterTTL>
+            <BackupAddr></BackupAddr>
+            <BackupPort>5060</BackupPort>
+            <BackupTransport>0</BackupTransport>
+            <BackupTTL>3600</BackupTTL>
+            <EnableReg>0</EnableReg>
+            <EnableReg>{if isset($row.password)}1{else}0{/if}</EnableReg>
+            <ProxyAddr>{$row.outbound_proxy_primary}</ProxyAddr>
+            <ProxyPort>{$row.sip_port}</ProxyPort>
+            <ProxyUser>{$row.auth_id}</ProxyUser>
+            <ProxyPswd>{$row.password}</ProxyPswd>
+            <ProxyNeedRegOn>0</ProxyNeedRegOn>
+            <BakProxyAddr>{$row.outbound_proxy_secondary}</BakProxyAddr>
+            <BakProxyPort>{$row.sip_port}</BakProxyPort>
+            <BakProxyNeedRegOn>0</BakProxyNeedRegOn>
+            <EnableFailback>{if isset($row.outbound_proxy_secondary)}1{else}0{/if}</EnableFailback>
+            <FailbackInterval>1800</FailbackInterval>
+            <SignalFailback>0</SignalFailback>
+            <SignalRetryCounts>3</SignalRetryCounts>
+            <SigCryptoKey></SigCryptoKey>
+            <EnableOSRTP>0</EnableOSRTP>
+            <MediaCrypto>0</MediaCrypto>
+            <MedCryptoKey></MedCryptoKey>
+            <SRTPAuth-Tag>0</SRTPAuth-Tag>
+            <EnableRFC5939>0</EnableRFC5939>
+            <LocalDomain></LocalDomain>
+            <AlwaysFWD>0</AlwaysFWD>
+            <BusyFWD>0</BusyFWD>
+            <NoAnswerFWD>0</NoAnswerFWD>
+            <AlwaysFWDNum></AlwaysFWDNum>
+            <BusyFWDNum></BusyFWDNum>
+            <NoAnswerFWDNum></NoAnswerFWDNum>
+            <FWDTimer>5</FWDTimer>
+            <HotlineNum></HotlineNum>
+            <EnableHotline>0</EnableHotline>
+            <WarmLineTime>0</WarmLineTime>
+            <PickupNum></PickupNum>
+            <JoinNum></JoinNum>
+            <IntercomNum></IntercomNum>
+            <RingType>{if isset($fanvil_ringtone_line1)}{$fanvil_ringtone_line1}{else}default{/if}</RingType>
+            <NATUDPUpdate>2</NATUDPUpdate>
+            <UDPUpdateTTL>30</UDPUpdateTTL>
+            <ServerType>0</ServerType>
+            <UserAgent></UserAgent>
+            <PRACK>0</PRACK>
+            <KeepAUTH>0</KeepAUTH>
+            <SessionTimer>0</SessionTimer>
+            <STimerExpires>0</STimerExpires>
+            <EnableGRUU>0</EnableGRUU>
+            <DTMFMode>3</DTMFMode>
+            <DTMFInfoMode>0</DTMFInfoMode>
+            <NATType>0</NATType>
+            <EnableRport>1</EnableRport>
+            <Subscribe>{if isset($row.user_id)}1{else}{/if}</Subscribe>
+            <SubExpire>{$row.register_expires}</SubExpire>
+            <SingleCodec>0</SingleCodec>
+            <CLIR>0</CLIR>
+            <StrictProxy>1</StrictProxy>
+            <DirectContact>0</DirectContact>
+            <HistoryInfo>0</HistoryInfo>
+            {if $row.sip_transport == 'dns srv'}<DNSSRV>1</DNSSRV>{/if}
+            {if $row.sip_transport == 'dns srv'}<DNSMode>1</DNSMode>{/if}
+            <XFERExpire>0</XFERExpire>
+            <BanAnonymous>0</BanAnonymous>
+            <DialOffLine>0</DialOffLine>
+            <QuotaName>0</QuotaName>
+            <PresenceMode>0</PresenceMode>
+            <RFCVer>1</RFCVer>
+            <PhonePort>0</PhonePort>
+            <SignalPort>5060</SignalPort>
+            {if $row.sip_transport == 'udp'}<Transport>0</Transport>{/if}
+            {if $row.sip_transport == 'tcp'}<Transport>1</Transport>{/if}
+            {if $row.sip_transport == 'tls'}<Transport>3</Transport>{/if}
+            <UseSRVMixer>0</UseSRVMixer>
+            <SRVMixerUri></SRVMixerUri>
+            <LongContact>0</LongContact>
+            <AutoTCP>1</AutoTCP>
+            <UriEscaped>1</UriEscaped>
+            <ClicktoTalk>0</ClicktoTalk>
+            <MwiNo></MwiNo>
+            <MWINum>{if isset($row.user_id)}{$voicemail_number}{else}{/if}</MWINum>
+            <ParkNo></ParkNo>
+            <CallParkNum></CallParkNum>
+            <RetrieveNum></RetrieveNum>
+            <HelpNo></HelpNo>
+            <MSRPHelpNum></MSRPHelpNum>
+            <UserIsPhone>0</UserIsPhone>
+            <AutoAnswer>0</AutoAnswer>
+            <NoAnswerTime>5</NoAnswerTime>
+            <MissedCallLog>1</MissedCallLog>
+            <ParkMode></ParkMode>
+            <SvcCodeMode>0</SvcCodeMode>
+            <DNDOnSvcCode></DNDOnSvcCode>
+            <DNDOffSvcCode></DNDOffSvcCode>
+            <CFUOnSvcCode></CFUOnSvcCode>
+            <CFUOffSvcCode></CFUOffSvcCode>
+            <CFBOnSvcCode></CFBOnSvcCode>
+            <CFBOffSvcCode></CFBOffSvcCode>
+            <CFNOnSvcCode></CFNOnSvcCode>
+            <CFNOffSvcCode></CFNOffSvcCode>
+            <ANCOnSvcCode></ANCOnSvcCode>
+            <ANCOffSvcCode></ANCOffSvcCode>
+            <SendANOnCode></SendANOnCode>
+            <SendANOffCode></SendANOffCode>
+            <CWOnCode></CWOnCode>
+            <CWOffCode></CWOffCode>
+            <VoiceCodecMap>OPUS,G722,PCMU,PCMA</VoiceCodecMap>
+            <VideoCodecMap>{if isset($fanvil_video_codec)}{$fanvil_video_codec}{else}{/if}</VideoCodecMap>
+            <BLFListUri></BLFListUri>
+            <BLFServer></BLFServer>
+            <Respond182>0</Respond182>
+            <EnableBLFList>0</EnableBLFList>
+            <CallerIdType>4</CallerIdType>
+            <SynClockTime>0</SynClockTime>
+            <MohServer></MohServer>
+            <UseVPN>1</UseVPN>
+            <EnableDND>0</EnableDND>
+            <InactiveHold>0</InactiveHold>
+            <ReqWithPort>1</ReqWithPort>
+            <UpdateRegExpire>1</UpdateRegExpire>
+            <EnableSCA>0</EnableSCA>
+            <SubCallPark>0</SubCallPark>
+            <SubCCStatus>0</SubCCStatus>
+            <FeatureSync>0</FeatureSync>
+            <EnableXferBack>1</EnableXferBack>
+            <XferBackTime>35</XferBackTime>
+            <UseTelCall>0</UseTelCall>
+            <EnablePreview>0</EnablePreview>
+            <PreviewMode>1</PreviewMode>
+            <TLSVersion>2</TLSVersion>
+            <CSTANumber></CSTANumber>
+            <EnableChgPort>0</EnableChgPort>
+            <VQName></VQName>
+            <VQServer></VQServer>
+            <VQServerPort>5060</VQServerPort>
+            <VQHTTPServer></VQHTTPServer>
+            <FlashMode>0</FlashMode>
+            <ContentType></ContentType>
+            <ContentBody></ContentBody>
+            <UnregisterOnBoot>0</UnregisterOnBoot>
+            <EnableMACHeader>0</EnableMACHeader>
+            <EnableRegisterMAC>0</EnableRegisterMAC>
+            <RecordStart>Record:on</RecordStart>
+            <RecordStop>Record:off</RecordStop>
+            <BLFDialogMatch>1</BLFDialogMatch>
+            <Ptime>0</Ptime>
+            <EnableDeal180>1</EnableDeal180>
+            <KeepSingleContact>0</KeepSingleContact>
+            <SessionTimerT1>500</SessionTimerT1>
+            <SessionTimerT2>4000</SessionTimerT2>
+            <SessionTimerT4>5000</SessionTimerT4>
+            <UnavailableMode>0</UnavailableMode>
+            <TCPUseRetryTimer>0</TCPUseRetryTimer>
+        </line>
+	{/foreach}
+        <p2p>
+            <SIPP2PEnableAutoAnswer>0</SIPP2PEnableAutoAnswer>
+            <SIPP2PAutoAnswerDelay>30</SIPP2PAutoAnswerDelay>
+            <SIPP2PDtmfMode>1</SIPP2PDtmfMode>
+            <SIPP2PSipInfoDtmfMode>0</SIPP2PSipInfoDtmfMode>
+            <SIPP2PEnablePreview>0</SIPP2PEnablePreview>
+            <SIPP2PPreviewMode>0</SIPP2PPreviewMode>
+            <SIPP2PUseVPN>1</SIPP2PUseVPN>
+        </p2p>
+    </sip>
+    <call>
+        <port index="1">
+            <EnableXferDPlan>1</EnableXferDPlan>
+            <EnableFwdDPlan>1</EnableFwdDPlan>
+            <EnablePreDPlan>0</EnablePreDPlan>
+            <IPDialPrefix>.</IPDialPrefix>
+            <EnableDND>1</EnableDND>
+            <DNDMode>0</DNDMode>
+            <EnableSpaceDND>0</EnableSpaceDND>
+            <DNDStartTime>1500</DNDStartTime>
+            <DNDEndTime>1730</DNDEndTime>
+            <EnableWhiteList>0</EnableWhiteList>
+            <EnableBlackList>0</EnableBlackList>
+            <EnableCallBar>0</EnableCallBar>
+            <MuteRinging>0</MuteRinging>
+            <BanDialOut>0</BanDialOut>
+            <BanEmptyCID>0</BanEmptyCID>
+            <EnableCLIP>1</EnableCLIP>
+            <CallWaiting>1</CallWaiting>
+            <CallTransfer>1</CallTransfer>
+            <CallSemiXfer>1</CallSemiXfer>
+            <CallConference>1</CallConference>
+            <AutoPickupNext>0</AutoPickupNext>
+            <BusyNoLine>1</BusyNoLine>
+            <AutoOnhook>1</AutoOnhook>
+            <AutoOnhookTime>3</AutoOnhookTime>
+            <EnableIntercom>1</EnableIntercom>
+            <IntercomMute>0</IntercomMute>
+            <IntercomTone>1</IntercomTone>
+            <IntercomBarge>0</IntercomBarge>
+            <UseAutoRedial>0</UseAutoRedial>
+            <RedialEnterCallLog>0</RedialEnterCallLog>
+            <AutoRedialDelay>30</AutoRedialDelay>
+            <AutoRedialTimes>5</AutoRedialTimes>
+            <CallComplete>0</CallComplete>
+            <CHoldingTone>1</CHoldingTone>
+            <CWaitingTone>1</CWaitingTone>
+            <HideDTMFType>0</HideDTMFType>
+            <TalkDTMFTone>1</TalkDTMFTone>
+            <DialDTMFTone>1</DialDTMFTone>
+            <PswDialMode>0</PswDialMode>
+            <PswDialLength>0</PswDialLength>
+            <PswDialPrefix></PswDialPrefix>
+            <EnableMultiLine>1</EnableMultiLine>
+            <AllowIPCall>1</AllowIPCall>
+            <CallerNameType>0</CallerNameType>
+            <MuteForRing>0</MuteForRing>
+            <AutoHandleVideo>0</AutoHandleVideo>
+            <DefaultAnsMode>{$fanvil_default_answer_mode}</DefaultAnsMode>
+            <DefaultDialMode>{$fanvil_default_dial_mode}</DefaultDialMode>
+            <HoldToTransfer>0</HoldToTransfer>
+            <EnablePreDial>1</EnablePreDial>
+            <DefaultExtLine>1</DefaultExtLine>
+            <EnableDefLine>1</EnableDefLine>
+            <EnableSelLine>1</EnableSelLine>
+            <RinginHeadset>0</RinginHeadset>
+            <AutoHeadset>0</AutoHeadset>
+            <DNDReturnCode>480</DNDReturnCode>
+            <BusyReturnCode>486</BusyReturnCode>
+            <RejectReturnCode>603</RejectReturnCode>
+            <ContactType>0</ContactType>
+            <EnableCountryCode>0</EnableCountryCode>
+            <CountryCode></CountryCode>
+            <CallAreaCode></CallAreaCode>
+            <NumberPrivacy>0</NumberPrivacy>
+            <PrivacyRule></PrivacyRule>
+            <TransfDTMFCode></TransfDTMFCode>
+            <HoldDTMFCode></HoldDTMFCode>
+            <ConfDTMFCode></ConfDTMFCode>
+            <DisableDialSearch>0</DisableDialSearch>
+            <CallNumberFilter></CallNumberFilter>
+            <AutoResumeCurrent>0</AutoResumeCurrent>
+            <CallTimeout>120</CallTimeout>
+            <RingTimeout>120</RingTimeout>
+            <RingPriority>1</RingPriority>
+        </port>
+        <basic>
+            <DialbyPound>1</DialbyPound>
+            <BTransferbyPound>0</BTransferbyPound>
+            <OnhooktoBXfer>0</OnhooktoBXfer>
+            <OnhooktoAXfer>0</OnhooktoAXfer>
+            <ConfOnhooktoXfer>0</ConfOnhooktoXfer>
+            <DialFixedLength>0</DialFixedLength>
+            <FixedLengthNums>11</FixedLengthNums>
+            <DialbyTimeout>1</DialbyTimeout>
+            <DialTimeoutvalue>10</DialTimeoutvalue>
+            <EnableEOneSixFour>0</EnableEOneSixFour>
+        </basic>
+        <alertInfo index="1">
+            <Text></Text>
+            <Line>-1</Line>
+            <RingType>Type 1</RingType>
+        </alertInfo>
+        <alertInfo index="2">
+            <Text></Text>
+            <Line>-1</Line>
+            <RingType>Type 1</RingType>
+        </alertInfo>
+        <alertInfo index="3">
+            <Text></Text>
+            <Line>-1</Line>
+            <RingType>Type 1</RingType>
+        </alertInfo>
+        <alertInfo index="4">
+            <Text></Text>
+            <Line>-1</Line>
+            <RingType>Type 1</RingType>
+        </alertInfo>
+        <alertInfo index="5">
+            <Text></Text>
+            <Line>-1</Line>
+            <RingType>Type 1</RingType>
+        </alertInfo>
+        <alertInfo index="6">
+            <Text></Text>
+            <Line>-1</Line>
+            <RingType>Type 1</RingType>
+        </alertInfo>
+        <alertInfo index="7">
+            <Text></Text>
+            <Line>-1</Line>
+            <RingType>Type 1</RingType>
+        </alertInfo>
+        <alertInfo index="8">
+            <Text></Text>
+            <Line>-1</Line>
+            <RingType>Type 1</RingType>
+        </alertInfo>
+        <alertInfo index="9">
+            <Text></Text>
+            <Line>-1</Line>
+            <RingType>Type 1</RingType>
+        </alertInfo>
+        <alertInfo index="10">
+            <Text></Text>
+            <Line>-1</Line>
+            <RingType>Type 1</RingType>
+        </alertInfo>
+    </call>
+    <phone>
+        <MenuPassword>admin</MenuPassword>
+        <KeyLockPassword>admin</KeyLockPassword>
+        <FastKeylockCode></FastKeylockCode>
+        <EnableKeyLock>0</EnableKeyLock>
+        <KeyLockTimeout>0</KeyLockTimeout>
+        <KeyLockStatus>0</KeyLockStatus>
+        <EmergencyCall>110</EmergencyCall>
+        <PushXMLIP></PushXMLIP>
+        <SIPNumberPlan>0</SIPNumberPlan>
+        <LDAPSearch>0</LDAPSearch>
+        <SearchPath>0</SearchPath>
+        <CallerDisplayT>5</CallerDisplayT>
+        <CallLogDisplayType>0</CallLogDisplayType>
+        <EnableRecvSMS>1</EnableRecvSMS>
+        <EnableCallHistory>1</EnableCallHistory>
+        <LineDisplayFormat>$name</LineDisplayFormat>
+        <EnableMWITone>0</EnableMWITone>
+        <SIPNotifyXML>1</SIPNotifyXML>
+        <BlockXMLWhenCall>1</BlockXMLWhenCall>
+        <XMLUpdateInterval>30</XMLUpdateInterval>
+        <VqmDisplayOrder></VqmDisplayOrder>
+        <EnablePushXMLAuth>0</EnablePushXMLAuth>
+        <PickupVisualAlert>0</PickupVisualAlert>
+        <PickupAudioAlert>0</PickupAudioAlert>
+        <PickupRingType></PickupRingType>
+        <display>
+            <LCDTitle>{$fanvil_greeting}</LCDTitle>
+            <LCDConstrast>5</LCDConstrast>
+            <EnableEnergysaving>{if isset($fanvil_display_brightness_inactive)}{$fanvil_display_brightness_inactive}{else}4{/if}</EnableEnergysaving>
+            <LCDLuminanceLevel>{if isset($fanvil_display_brightness_active)}{$fanvil_display_brightness_active}{else}12{/if}</LCDLuminanceLevel>
+            <BacklightOffTime>{if isset($fanvil_display_inactivity_time)}{$fanvil_display_inactivity_time}{else}45{/if}</BacklightOffTime>
+            <DisableCHNIME>0</DisableCHNIME>
+            <PhoneModel></PhoneModel>
+            <HostName>localhost</HostName>
+            <DefaultLanguage>en</DefaultLanguage>
+            <EnableGreetings>0</EnableGreetings>
+        </display>
+        <powerLed>
+            <Power>0</Power>
+            <MWIOrSMS>3</MWIOrSMS>
+            <InUsing>0</InUsing>
+            <Ring>2</Ring>
+            <Hold>0</Hold>
+            <Mute>0</Mute>
+            <MissedCall>3</MissedCall>
+            <StandbyLampEffect>0</StandbyLampEffect>
+            <LampEffectPlayTime>1</LampEffectPlayTime>
+            <CustomLampEffectTime>1200</CustomLampEffectTime>
+            <StandbyLampEffectType>0</StandbyLampEffectType>
+            <OffhookLampEffect>1</OffhookLampEffect>
+            <OffhookLampEffectColor>0</OffhookLampEffectColor>
+            <RingingLampEffect>0</RingingLampEffect>
+            <RingingLampEffectType>0</RingingLampEffectType>
+            <TalkingLampEffect>0</TalkingLampEffect>
+            <TalkingLampEffectType>0</TalkingLampEffectType>
+            <CallingLampEffect>0</CallingLampEffect>
+            <CallingLampEffectType>0</CallingLampEffectType>
+        </powerLed>
+        <lineLed>
+            <LineIdleColor>0</LineIdleColor>
+            <LineIdleCtl>1</LineIdleCtl>
+        </lineLed>
+        <blfLed>
+            <BLFIdleColor>0</BLFIdleColor>
+            <BLFIdleCtl>1</BLFIdleCtl>
+            <BLFIdleText>terminated</BLFIdleText>
+            <BLFRingColor>1</BLFRingColor>
+            <BLFRingCtl>2</BLFRingCtl>
+            <BLFRingText>early</BLFRingText>
+            <BLFDialingColor>1</BLFDialingColor>
+            <BLFDialingCtl>0</BLFDialingCtl>
+            <BLFDialingText></BLFDialingText>
+            <BLFTalkingColor>1</BLFTalkingColor>
+            <BLFTalkingCtl>1</BLFTalkingCtl>
+            <BLFTalkingText>confirmed</BLFTalkingText>
+            <BLFHoldColor>1</BLFHoldColor>
+            <BLFHoldCtl>0</BLFHoldCtl>
+            <BLFHoldText></BLFHoldText>
+            <BLFFailedColor>0</BLFFailedColor>
+            <BLFFailedCtl>0</BLFFailedCtl>
+            <BLFFailedText>failed</BLFFailedText>
+            <BLFParkedColor>1</BLFParkedColor>
+            <BLFParkedCtl>3</BLFParkedCtl>
+            <BLFParkedText>parked</BLFParkedText>
+        </blfLed>
+        <volume>
+            <HandsetVol>6</HandsetVol>
+            <HandsetMicVol>3</HandsetMicVol>
+            <HeadsetVol>6</HeadsetVol>
+            <HeadsetMicVol>3</HeadsetMicVol>
+            <HeadsetRingVol>3</HeadsetRingVol>
+            <HandFreeVol>6</HandFreeVol>
+            <HandFreeMicVol>3</HandFreeMicVol>
+            <HandFreeRingVol>6</HandFreeRingVol>
+            <RingType>{if isset($fanvil_default_ringtone)}{$fanvil_default_ringtone}{else}Happy_Technology_Logo.ogg{/if}</RingType>
+        </volume>
+        <date>
+            <EnableSNTP>{if isset($fanvil_enable_sntp)}{$fanvil_enable_sntp}{else}1{/if}</EnableSNTP>
+            <SNTPServer>{$ntp_server_primary}</SNTPServer>
+            <SecondSNTPServer>{$ntp_server_secondary}</SecondSNTPServer>
+            <TimeZone>{$fanvil_time_zone}</TimeZone>
+            <TimeZoneName>{$fanvil_time_zone_name}</TimeZoneName>
+            <SNTPTimeout>60</SNTPTimeout>
+            <Enable_DST>{$fanvil_enable_dst}</Enable_DST>
+            <DST_Fixed_Type>{if isset($fanvil_dst_fixed_type)}{$fanvil_dst_fixed_type}{else}0{/if}</DST_Fixed_Type>
+            <SNTPTimeout>60</SNTPTimeout>
+            <DSTType>1</DSTType>
+            <DSTLocation>{if isset($fanvil_location)}{$fanvil_location}{else}4{/if}</DSTLocation>
+            <DSTRuleMode>0</DSTRuleMode>
+            <DSTMinOffset>{if isset($fanvil_dst_minute_offset)}{$fanvil_dst_minute_offset}{else}60{/if}</DSTMinOffset>
+            <DSTStartMon>3</DSTStartMon>
+            <DSTStartWeek>5</DSTStartWeek>
+            <DSTStartWday>0</DSTStartWday>
+            <DSTStartHour>2</DSTStartHour>
+            <DSTEndMon>10</DSTEndMon>
+            <DSTEndWeek>5</DSTEndWeek>
+            <DSTEndWday>0</DSTEndWday>
+            <DSTEndHour>2</DSTEndHour>
+        </date>
+        <timeDisplay>
+            <EnableTimeDisplay>0</EnableTimeDisplay>
+            <TimeDisplayStyle>{if isset($fanvil_time_display)}{$fanvil_time_display}{else}0{/if}</TimeDisplayStyle>
+            <DateDisplayStyle>{if isset($fanvil_date_display)}{$fanvil_date_display}{else}6{/if}</DateDisplayStyle>
+            <DateSeparator>{if isset($fanvil_date_separator)}{$fanvil_date_separator}{else}0{/if}</DateSeparator>
+        </timeDisplay>
+        <softKeyConfig>
+            <SoftkeyMode>0</SoftkeyMode>
+            <SoftKeyExitStyle>{if isset($fanvil_softkey_exit)}{$fanvil_softkey_exit}{else}2{/if}</SoftKeyExitStyle>
+            <DesktopSoftkey>{if isset($fanvil_softkey_desktopsoftkey)}{$fanvil_softkey_desktopsoftkey}{else}history;contact;dnd;menu;{/if}</DesktopSoftkey>
+            <TalkingSoftkey>{if isset($fanvil_softkey_talkingsoftkey)}{$fanvil_softkey_talkingsoftkey}{else}video;xfer;end;conf;hold;new;mute;record;dialpad;{/if}</TalkingSoftkey>
+            <RingingSoftkey>{if isset($fanvil_softkey_ringingsoftkey)}{$fanvil_softkey_ringingsoftkey}{else}forward;audio;video;reject;{/if}</RingingSoftkey>
+            <AlertingSoftkey>dialpad;xfer;cancel;</AlertingSoftkey>
+            <XAlertingSoftkey>dialpad;xfer;cancel;</XAlertingSoftkey>
+            <ConferenceSoftkey>conf;dialpad;end;split;hold;mute;exit;</ConferenceSoftkey>
+            <WaitingSoftkey>hold;xfer;conf;end;</WaitingSoftkey>
+            <EndingSoftkey>complete;autoRedial;end;redial;</EndingSoftkey>
+            <DialerPreSoftkey>audio;video;redial;</DialerPreSoftkey>
+            <DialerCallSoftkey>audio;video;redial;</DialerCallSoftkey>
+            <DialerXferSoftkey>audio;video;xfer;contact;history;cancel;</DialerXferSoftkey>
+            <DialerCfwdSoftkey>contact;history;forward;cancel;</DialerCfwdSoftkey>
+            <DesktopClick>{if isset($fanvil_softkey_desktopclick)}{$fanvil_softkey_desktopclick}{else}history;status;none;none;none;{/if}</DesktopClick>
+            <DailerClick>pline;nline;none;none;none;</DailerClick>
+            <RingingClick>none;none;none;none;none;</RingingClick>
+            <CallClick>pcall;ncall;voldown;volup;none;</CallClick>
+            <DesktopLongPress>status;none;none;mwi;none;reset;</DesktopLongPress>
+            <DialerConfSoftkey>audio;video;cancel;contact;history;redial;</DialerConfSoftkey>
+        </softKeyConfig>
+        <agent>
+            <AgentUsername></AgentUsername>
+            <AgentPassword></AgentPassword>
+            <AgentNumber></AgentNumber>
+            <AgentSipline>0</AgentSipline>
+            <AgentStatus>0</AgentStatus>
+            <AgentStatusReason></AgentStatusReason>
+            <AgentClearCallLog>0</AgentClearCallLog>
+        </agent>
+        <bwDir index="1">
+            <Title></Title>
+            <URL></URL>
+            <Username></Username>
+            <Password></Password>
+            <SipLine>0</SipLine>
+        </bwDir>
+        <bwDir index="2">
+            <Title></Title>
+            <URL></URL>
+            <Username></Username>
+            <Password></Password>
+            <SipLine>0</SipLine>
+        </bwDir>
+        <bwDir index="3">
+            <Title></Title>
+            <URL></URL>
+            <Username></Username>
+            <Password></Password>
+            <SipLine>0</SipLine>
+        </bwDir>
+        <bwDir index="4">
+            <Title></Title>
+            <URL></URL>
+            <Username></Username>
+            <Password></Password>
+            <SipLine>0</SipLine>
+        </bwDir>
+        <bwDir index="5">
+            <Title></Title>
+            <URL></URL>
+            <Username></Username>
+            <Password></Password>
+            <SipLine>0</SipLine>
+        </bwDir>
+        <bwDir index="6">
+            <Title></Title>
+            <URL></URL>
+            <Username></Username>
+            <Password></Password>
+            <SipLine>0</SipLine>
+        </bwDir>
+        <bwCallLog index="1">
+            <Title></Title>
+            <URL></URL>
+            <Username></Username>
+            <Password></Password>
+            <SipLine>0</SipLine>
+        </bwCallLog>
+        <bwCallLog index="2">
+            <Title></Title>
+            <URL></URL>
+            <Username></Username>
+            <Password></Password>
+            <SipLine>0</SipLine>
+        </bwCallLog>
+        <bwCallLog index="3">
+            <Title></Title>
+            <URL></URL>
+            <Username></Username>
+            <Password></Password>
+            <SipLine>0</SipLine>
+        </bwCallLog>
+        <ldap index="1">
+            <Title></Title>
+            <Server></Server>
+            <port>389</port>
+            <Base></Base>
+            <UseSSL>0</UseSSL>
+            <Version>3</Version>
+            <CallingLine>-1</CallingLine>
+            <BindLine>-1</BindLine>
+            <InCallSearch>0</InCallSearch>
+            <OutCallSearch>0</OutCallSearch>
+            <Authenticate>3</Authenticate>
+            <Username></Username>
+            <Password></Password>
+            <TelAttr>telephoneNumber</TelAttr>
+            <MobileAttr>mobile</MobileAttr>
+            <OtherAttr>other</OtherAttr>
+            <NameAttr>cn sn ou</NameAttr>
+            <SortAttr>cn</SortAttr>
+            <Displayname>cn</Displayname>
+            <NumberFilter>(|(telephoneNumber=%)(mobile=%)(other=%))</NumberFilter>
+            <NameFilter>(|(cn=%)(sn=%))</NameFilter>
+            <MaxHits>50</MaxHits>
+            <DisplayType>0</DisplayType>
+        </ldap>
+        <ldap index="2">
+            <Title></Title>
+            <Server></Server>
+            <port>389</port>
+            <Base></Base>
+            <UseSSL>0</UseSSL>
+            <Version>3</Version>
+            <CallingLine>-1</CallingLine>
+            <BindLine>-1</BindLine>
+            <InCallSearch>0</InCallSearch>
+            <OutCallSearch>0</OutCallSearch>
+            <Authenticate>3</Authenticate>
+            <Username></Username>
+            <Password></Password>
+            <TelAttr>telephoneNumber</TelAttr>
+            <MobileAttr>mobile</MobileAttr>
+            <OtherAttr>other</OtherAttr>
+            <NameAttr>cn sn ou</NameAttr>
+            <SortAttr>cn</SortAttr>
+            <Displayname>cn</Displayname>
+            <NumberFilter>(|(telephoneNumber=%)(mobile=%)(other=%))</NumberFilter>
+            <NameFilter>(|(cn=%)(sn=%))</NameFilter>
+            <MaxHits>50</MaxHits>
+            <DisplayType>0</DisplayType>
+        </ldap>
+        <ldap index="3">
+            <Title></Title>
+            <Server></Server>
+            <port>389</port>
+            <Base></Base>
+            <UseSSL>0</UseSSL>
+            <Version>3</Version>
+            <CallingLine>-1</CallingLine>
+            <BindLine>-1</BindLine>
+            <InCallSearch>0</InCallSearch>
+            <OutCallSearch>0</OutCallSearch>
+            <Authenticate>3</Authenticate>
+            <Username></Username>
+            <Password></Password>
+            <TelAttr>telephoneNumber</TelAttr>
+            <MobileAttr>mobile</MobileAttr>
+            <OtherAttr>other</OtherAttr>
+            <NameAttr>cn sn ou</NameAttr>
+            <SortAttr>cn</SortAttr>
+            <Displayname>cn</Displayname>
+            <NumberFilter>(|(telephoneNumber=%)(mobile=%)(other=%))</NumberFilter>
+            <NameFilter>(|(cn=%)(sn=%))</NameFilter>
+            <MaxHits>50</MaxHits>
+            <DisplayType>0</DisplayType>
+        </ldap>
+        <ldap index="4">
+            <Title></Title>
+            <Server></Server>
+            <port>389</port>
+            <Base></Base>
+            <UseSSL>0</UseSSL>
+            <Version>3</Version>
+            <CallingLine>-1</CallingLine>
+            <BindLine>-1</BindLine>
+            <InCallSearch>0</InCallSearch>
+            <OutCallSearch>0</OutCallSearch>
+            <Authenticate>3</Authenticate>
+            <Username></Username>
+            <Password></Password>
+            <TelAttr>telephoneNumber</TelAttr>
+            <MobileAttr>mobile</MobileAttr>
+            <OtherAttr>other</OtherAttr>
+            <NameAttr>cn sn ou</NameAttr>
+            <SortAttr>cn</SortAttr>
+            <Displayname>cn</Displayname>
+            <NumberFilter>(|(telephoneNumber=%)(mobile=%)(other=%))</NumberFilter>
+            <NameFilter>(|(cn=%)(sn=%))</NameFilter>
+            <MaxHits>50</MaxHits>
+            <DisplayType>0</DisplayType>
+        </ldap>
+        <ldap index="5">
+            <Title></Title>
+            <Server></Server>
+            <port>389</port>
+            <Base></Base>
+            <UseSSL>0</UseSSL>
+            <Version>3</Version>
+            <CallingLine>-1</CallingLine>
+            <BindLine>-1</BindLine>
+            <InCallSearch>0</InCallSearch>
+            <OutCallSearch>0</OutCallSearch>
+            <Authenticate>3</Authenticate>
+            <Username></Username>
+            <Password></Password>
+            <TelAttr>telephoneNumber</TelAttr>
+            <MobileAttr>mobile</MobileAttr>
+            <OtherAttr>other</OtherAttr>
+            <NameAttr>cn sn ou</NameAttr>
+            <SortAttr>cn</SortAttr>
+            <Displayname>cn</Displayname>
+            <NumberFilter>(|(telephoneNumber=%)(mobile=%)(other=%))</NumberFilter>
+            <NameFilter>(|(cn=%)(sn=%))</NameFilter>
+            <MaxHits>50</MaxHits>
+            <DisplayType>0</DisplayType>
+        </ldap>
+        <xmlContact index="1">
+            <Name></Name>
+            <Addr></Addr>
+            <UserName></UserName>
+            <PassWd></PassWd>
+            <Sipline>-1</Sipline>
+            <BindLine>-1</BindLine>
+        </xmlContact>
+        <xmlContact index="2">
+            <Name></Name>
+            <Addr></Addr>
+            <UserName></UserName>
+            <PassWd></PassWd>
+            <Sipline>-1</Sipline>
+            <BindLine>-1</BindLine>
+        </xmlContact>
+        <xmlContact index="3">
+            <Name></Name>
+            <Addr></Addr>
+            <UserName></UserName>
+            <PassWd></PassWd>
+            <Sipline>-1</Sipline>
+            <BindLine>-1</BindLine>
+        </xmlContact>
+        <xmlContact index="4">
+            <Name></Name>
+            <Addr></Addr>
+            <UserName></UserName>
+            <PassWd></PassWd>
+            <Sipline>-1</Sipline>
+            <BindLine>-1</BindLine>
+        </xmlContact>
+        <xmlContact index="5">
+            <Name></Name>
+            <Addr></Addr>
+            <UserName></UserName>
+            <PassWd></PassWd>
+            <Sipline>-1</Sipline>
+            <BindLine>-1</BindLine>
+        </xmlContact>
+    </phone>
+    <dm>
+        <OnhookTime>200</OnhookTime>
+        <EnableHookflash>0</EnableHookflash>
+        <KeyLongPressTime>2</KeyLongPressTime>
+        <KeyLongLongPressTime>6</KeyLongLongPressTime>
+    </dm>
+    <vqm>
+        <SessionReport>1</SessionReport>
+        <IntervalReport>1</IntervalReport>
+        <IntervalPeriod>60</IntervalPeriod>
+        <MOS-LQWarning>40</MOS-LQWarning>
+        <MOS-LQCritical>25</MOS-LQCritical>
+        <DelayWarning>150</DelayWarning>
+        <DelayCritical>200</DelayCritical>
+        <PhoneReport>1</PhoneReport>
+        <WEBReport>1</WEBReport>
+    </vqm>
+    <cti>
+        <EnabledActiveUri>1</EnabledActiveUri>
+        <EnabledActionUrl>1</EnabledActionUrl>
+        <ActiveUriIP></ActiveUriIP>
+        <StartRebootUrl></StartRebootUrl>
+        <BootCompletedUrl></BootCompletedUrl>
+        <IPChangeUrl></IPChangeUrl>
+        <RegOnUrl></RegOnUrl>
+        <RegOffUrl></RegOffUrl>
+        <RegFailedUrl></RegFailedUrl>
+        <PhoneStateIdleUrl></PhoneStateIdleUrl>
+        <PhoneStateTalking></PhoneStateTalking>
+        <PhoneStateRinging></PhoneStateRinging>
+        <DNDOnUrl></DNDOnUrl>
+        <DNDOffUrl></DNDOffUrl>
+        <AlwaysFWDOnUrl></AlwaysFWDOnUrl>
+        <AlwaysFWDOffUrl></AlwaysFWDOffUrl>
+        <BusyFWDOnUrl></BusyFWDOnUrl>
+        <BusyFWDOffUrl></BusyFWDOffUrl>
+        <NoAnsFWDOnUrl></NoAnsFWDOnUrl>
+        <NoAnsFWDOffUrl></NoAnsFWDOffUrl>
+        <MuteOnUrl></MuteOnUrl>
+        <MuteOffUrl></MuteOffUrl>
+        <IncomingCallUrl></IncomingCallUrl>
+        <OutgoingCallUrl></OutgoingCallUrl>
+        <CallActiveUrl></CallActiveUrl>
+        <CallStopUrl></CallStopUrl>
+        <TransferUrl></TransferUrl>
+        <HoldOnUrl></HoldOnUrl>
+        <HoldOffUrl></HoldOffUrl>
+        <HeldOnUrl></HeldOnUrl>
+        <HeldOffUrl></HeldOffUrl>
+        <MuteOnCallUrl></MuteOnCallUrl>
+        <MuteOffCallUrl></MuteOffCallUrl>
+        <NewMissedcallUrl></NewMissedcallUrl>
+        <NewMWIUrl></NewMWIUrl>
+        <NewSMSUrl></NewSMSUrl>
+        <WebAuthChangedUrl></WebAuthChangedUrl>
+        <at>
+            <AtEnabled>0</AtEnabled>
+            <AtServer></AtServer>
+        </at>
+    </cti>
+    <mcast>
+        <Priority>0</Priority>
+        <EnablePriority>0</EnablePriority>
+        <EnablePrioChan>0</EnablePrioChan>
+        <EnableEmerChan>0</EnableEmerChan>
+        <MulticastTone>1</MulticastTone>
+        <McastListeningRenewTime>0</McastListeningRenewTime>
+        <addr index="1">
+            <Name></Name>
+            <Host></Host>
+            <Port>0</Port>
+            <Channel>0</Channel>
+        </addr>
+        <addr index="2">
+            <Name></Name>
+            <Host></Host>
+            <Port>0</Port>
+            <Channel>0</Channel>
+        </addr>
+        <addr index="3">
+            <Name></Name>
+            <Host></Host>
+            <Port>0</Port>
+            <Channel>0</Channel>
+        </addr>
+        <addr index="4">
+            <Name></Name>
+            <Host></Host>
+            <Port>0</Port>
+            <Channel>0</Channel>
+        </addr>
+        <addr index="5">
+            <Name></Name>
+            <Host></Host>
+            <Port>0</Port>
+            <Channel>0</Channel>
+        </addr>
+        <addr index="6">
+            <Name></Name>
+            <Host></Host>
+            <Port>0</Port>
+            <Channel>0</Channel>
+        </addr>
+        <addr index="7">
+            <Name></Name>
+            <Host></Host>
+            <Port>0</Port>
+            <Channel>0</Channel>
+        </addr>
+        <addr index="8">
+            <Name></Name>
+            <Host></Host>
+            <Port>0</Port>
+            <Channel>0</Channel>
+        </addr>
+        <addr index="9">
+            <Name></Name>
+            <Host></Host>
+            <Port>0</Port>
+            <Channel>0</Channel>
+        </addr>
+        <addr index="10">
+            <Name></Name>
+            <Host></Host>
+            <Port>0</Port>
+            <Channel>0</Channel>
+        </addr>
+        <dynamic>
+            <AutoExitExpires>60</AutoExitExpires>
+        </dynamic>
+    </mcast>
+    <dsskey>
+        <SelectDsskeyAction>0</SelectDsskeyAction>
+        <MemoryKeytoBXfer>0</MemoryKeytoBXfer>
+        <FuncKeyPageNum>4</FuncKeyPageNum>
+        <SideKeyPageNum>1</SideKeyPageNum>
+        <DSSHomePage>0</DSSHomePage>
+        <DisplayParkedInfo>0</DisplayParkedInfo>
+        <DSSDIALSwitchMode>0</DSSDIALSwitchMode>
+        <FirstCallWaitTime>16</FirstCallWaitTime>
+        <FirstNumStartTime>360</FirstNumStartTime>
+        <FirstNumEndTime>1080</FirstNumEndTime>
+        <DSSLongPressAction>1</DSSLongPressAction>
+        <Extern1PageBelong>0</Extern1PageBelong>
+        <Extern2PageBelong>0</Extern2PageBelong>
+        <Extern3PageBelong>0</Extern3PageBelong>
+        <Extern4PageBelong>0</Extern4PageBelong>
+        <Extern5PageBelong>0</Extern5PageBelong>
+        <DSSExtend1MAC></DSSExtend1MAC>
+        <DSSExtend1IP></DSSExtend1IP>
+        <DSSExtend2MAC></DSSExtend2MAC>
+        <DSSExtend2IP></DSSExtend2IP>
+        <DSSExtend3MAC></DSSExtend3MAC>
+        <DSSExtend3IP></DSSExtend3IP>
+        <DSSExtend4MAC></DSSExtend4MAC>
+        <DSSExtend4IP></DSSExtend4IP>
+        <DSSExtend5MAC></DSSExtend5MAC>
+        <DSSExtend5IP></DSSExtend5IP>
+
+        {strip}{*-- Each Internal Index contains 32 keys --*}{/strip}
+        <internal index="1">
+            <Fkey index="1">
+                <Type>2</Type>
+                <Value>SIP1</Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="2">
+                <Type>2</Type>
+                <Value>SIP2</Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="3">
+                <Type>2</Type>
+                <Value>SIP3</Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="4">
+                <Type>2</Type>
+                <Value>SIP4</Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="5">
+                <Type>2</Type>
+                <Value>SIP5</Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="6">
+                <Type>3</Type>
+                <Value>F_HEADSET</Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="7">
+                <Type>3</Type>
+                <Value>F_REDIAL</Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="8">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="9">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="10">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="11">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="12">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="13">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="14">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="15">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="16">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="17">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="18">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="19">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="20">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="21">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="22">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="23">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="24">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="25">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="26">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="27">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="28">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="29">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+        </internal>
+        <internal index="2">
+            <Fkey index="1">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="2">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="3">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="4">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="5">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="6">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="7">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="8">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="9">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="10">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="11">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="12">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="13">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="14">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="15">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="16">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="17">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="18">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="19">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="20">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="21">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="22">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="23">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="24">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="25">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="26">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="27">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="28">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="29">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+        </internal>
+        <internal index="3">
+            <Fkey index="1">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="2">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="3">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="4">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="5">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="6">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="7">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="8">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="9">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="10">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="11">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="12">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="13">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="14">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="15">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="16">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="17">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="18">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="19">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="20">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="21">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="22">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="23">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="24">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="25">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="26">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="27">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="28">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="29">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+        </internal>
+        <internal index="4">
+            <Fkey index="1">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="2">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="3">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="4">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="5">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="6">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="7">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="8">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="9">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="10">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="11">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="12">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="13">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="14">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="15">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="16">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="17">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="18">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="19">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="20">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="21">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="22">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="23">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="24">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="25">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="26">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="27">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="28">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+            <Fkey index="29">
+                <Type>0</Type>
+                <Value></Value>
+                <Title></Title>
+                <ICON>Green</ICON>
+            </Fkey>
+        </internal>
+        <dssSoft index="1">
+            <Type>0</Type>
+            <Value></Value>
+            <Title></Title>
+            <ICON>Green</ICON>
+        </dssSoft>
+        <dssSoft index="2">
+            <Type>0</Type>
+            <Value></Value>
+            <Title></Title>
+            <ICON>Green</ICON>
+        </dssSoft>
+        <dssSoft index="3">
+            <Type>0</Type>
+            <Value></Value>
+            <Title></Title>
+            <ICON>Green</ICON>
+        </dssSoft>
+        <dssSoft index="4">
+            <Type>0</Type>
+            <Value></Value>
+            <Title></Title>
+            <ICON>Green</ICON>
+        </dssSoft>
+        <dssSoft index="5">
+            <Type>0</Type>
+            <Value></Value>
+            <Title></Title>
+            <ICON>Green</ICON>
+        </dssSoft>
+        <dssSoft index="6">
+            <Type>0</Type>
+            <Value></Value>
+            <Title></Title>
+            <ICON>Green</ICON>
+        </dssSoft>
+        <dssSoft index="7">
+            <Type>0</Type>
+            <Value></Value>
+            <Title></Title>
+            <ICON>Green</ICON>
+        </dssSoft>
+        <dssSoft index="8">
+            <Type>0</Type>
+            <Value></Value>
+            <Title></Title>
+            <ICON>Green</ICON>
+        </dssSoft>
+        <dssSoft index="9">
+            <Type>0</Type>
+            <Value></Value>
+            <Title></Title>
+            <ICON>Green</ICON>
+        </dssSoft>
+        <dssSoft index="10">
+            <Type>0</Type>
+            <Value></Value>
+            <Title></Title>
+            <ICON>Green</ICON>
+        </dssSoft>
+    </dsskey>
+    <web>
+        <WebServerType>0</WebServerType>
+        <WebPort>80</WebPort>
+        <HttpsWebPort>443</HttpsWebPort>
+        <RemoteControl>1</RemoteControl>
+        <EnableMMIFilter>0</EnableMMIFilter>
+        <WebAuthentication>0</WebAuthentication>
+        <EnableTelnet>0</EnableTelnet>
+        <TelnetPort>23</TelnetPort>
+        <TelnetPrompt></TelnetPrompt>
+        <LogonTimeout>15</LogonTimeout>
+        <account index="1">
+            <Name>{if isset($admin_name)}{$admin_name}{else}admin{/if}</Name>
+            <Password>{if isset($admin_password)}{$admin_password}{else}admin{/if}</Password>
+            <Level>10</Level>
+        </account>
+        <account index="2">
+            <Name>guest</Name>
+            <Password>guest</Password>
+            <Level>5</Level>
+        </account>
+    </web>
+    <log>
+        <Level>INFO</Level>
+        <Style>level,tag</Style>
+        {if $fanvil_syslog_enable == '1'}<OutputDevice>syslog</OutputDevice>
+        {elseif $fanvil_output_device == ''}<OutputDevice></OutputDevice>
+        {elseif $fanvil_output_device == 'syslog'}<OutputDevice>syslog</OutputDevice>
+        {elseif $fanvil_output_device == 'stdout'}<OutputDevice>stdout</OutputDevice>
+        {elseif $fanvil_output_device == 'syslog,stdout'}<OutputDevice>syslog,stdout</OutputDevice>
+        {elseif $fanvil_output_device == 'stdout,syslog'}<OutputDevice>syslog,stdout</OutputDevice>
+        {/if}
+        <FileName>platform.log</FileName>
+        <FileSize>512KB</FileSize>
+        <SyslogTag>platform</SyslogTag>
+        <SyslogServer>{if isset($fanvil_syslog_server)}{$fanvil_syslog_server}{else}0.0.0.0{/if}</SyslogServer>
+        <SyslogServerPort>{if isset($fanvil_syslog_server_port)}{$fanvil_syslog_server_port}{else}514{/if}</SyslogServerPort>
+    </log>
+    <tr069>
+        <TR069Tone>1</TR069Tone>
+        <CPESerialNumber></CPESerialNumber>
+        <ACSServerType>1</ACSServerType>
+        <EnableTR069>0</EnableTR069>
+        <ACSURL>0.0.0.0</ACSURL>
+        <ACSUserName>admin</ACSUserName>
+        <ACSPassword></ACSPassword>
+        <ACSBackupURL>0.0.0.0</ACSBackupURL>
+        <ACSBackupUserName></ACSBackupUserName>
+        <ACSBackupPassword></ACSBackupPassword>
+        <CPEUserName>dps</CPEUserName>
+        <CPEPassword>dps</CPEPassword>
+        <PeriodixInterval>3600</PeriodixInterval>
+        <TLSVersion>2</TLSVersion>
+        <AreaCode></AreaCode>
+        <STUNEnable>0</STUNEnable>
+        <STUNServerAddr>{$fanvil_stun_server}</STUNServerAddr>
+        <STUNServerPort>{$fanvil_stun_port}</STUNServerPort>
+        <STUNLocalPort>30000</STUNLocalPort>
+    </tr069>
+    <hotspot>
+        <EnableHotspot>0</EnableHotspot>
+        <Mode>1</Mode>
+        <ListenType>0</ListenType>
+        <ListenIP>224.0.2.0</ListenIP>
+        <ListenPort>16360</ListenPort>
+        <OwnName>SIP Hotspot</OwnName>
+        <RingMode>0</RingMode>
+        <GroupCallMode>0</GroupCallMode>
+        <EnableManageMode>0</EnableManageMode>
+        <EnableConfigMode>0</EnableConfigMode>
+        <hs index="1">
+            <Enable>1</Enable>
+            <ExtPrefix></ExtPrefix>
+        </hs>
+        <hs index="2">
+            <Enable>1</Enable>
+            <ExtPrefix></ExtPrefix>
+        </hs>
+        <hs index="3">
+            <Enable>1</Enable>
+            <ExtPrefix></ExtPrefix>
+        </hs>
+        <hs index="4">
+            <Enable>1</Enable>
+            <ExtPrefix></ExtPrefix>
+        </hs>
+        <hs index="5">
+            <Enable>1</Enable>
+            <ExtPrefix></ExtPrefix>
+        </hs>
+        <hs index="6">
+            <Enable>1</Enable>
+            <ExtPrefix></ExtPrefix>
+        </hs>
+        <hs index="7">
+            <Enable>1</Enable>
+            <ExtPrefix></ExtPrefix>
+        </hs>
+        <hs index="8">
+            <Enable>1</Enable>
+            <ExtPrefix></ExtPrefix>
+        </hs>
+        <hs index="9">
+            <Enable>1</Enable>
+            <ExtPrefix></ExtPrefix>
+        </hs>
+        <hs index="10">
+            <Enable>1</Enable>
+            <ExtPrefix></ExtPrefix>
+        </hs>
+        <hs index="11">
+            <Enable>1</Enable>
+            <ExtPrefix></ExtPrefix>
+        </hs>
+        <hs index="12">
+            <Enable>1</Enable>
+            <ExtPrefix></ExtPrefix>
+        </hs>
+        <hs index="13">
+            <Enable>1</Enable>
+            <ExtPrefix></ExtPrefix>
+        </hs>
+        <hs index="14">
+            <Enable>1</Enable>
+            <ExtPrefix></ExtPrefix>
+        </hs>
+        <hs index="15">
+            <Enable>1</Enable>
+            <ExtPrefix></ExtPrefix>
+        </hs>
+        <hs index="16">
+            <Enable>1</Enable>
+            <ExtPrefix></ExtPrefix>
+        </hs>
+        <hs index="17">
+            <Enable>1</Enable>
+            <ExtPrefix></ExtPrefix>
+        </hs>
+        <hs index="18">
+            <Enable>1</Enable>
+            <ExtPrefix></ExtPrefix>
+        </hs>
+        <hs index="19">
+            <Enable>1</Enable>
+            <ExtPrefix></ExtPrefix>
+        </hs>
+        <hs index="20">
+            <Enable>1</Enable>
+            <ExtPrefix></ExtPrefix>
+        </hs>
+    </hotspot>
+    <mt>
+        <ContactUpdateMode>0</ContactUpdateMode>
+        <AutoServerDigest>0</AutoServerDigest>
+    </mt>
+    <ap>
+        <DefaultUsername>{$http_auth_username}</DefaultUsername>
+        <DefaultPassword>{$http_auth_password}</DefaultPassword>
+        <InputCfgFileName></InputCfgFileName>
+        <DeviceCfgFileKey></DeviceCfgFileKey>
+        <CommonCfgFileKey></CommonCfgFileKey>
+        <DownloadCommonConf>1</DownloadCommonConf>
+        <SaveProvisionInfo>1</SaveProvisionInfo>
+        <CheckFailTimes>5</CheckFailTimes>
+        <FlashServerIP>{if isset($fanvil_provision_url)}{$fanvil_provision_url}{else}{$domain_name}/app/provision{/if}</FlashServerIP>
+        <FlashFileName>{$fanvil_firmware_config}</FlashFileName>
+        <FlashProtocol>5</FlashProtocol>
+        <FlashMode>1</FlashMode>
+        <FlashInterval>1</FlashInterval>
+        <updatePBInterval>720</updatePBInterval>
+        <pnp>
+            <PNPEnable>1</PNPEnable>
+            <PNPIP>224.0.1.75</PNPIP>
+            <PNPPort>5060</PNPPort>
+            <PNPTransport>0</PNPTransport>
+            <PNPInterval>1</PNPInterval>
+        </pnp>
+        <opt>
+            <DHCPOption>66</DHCPOption>
+            <DhcpOption120>0</DhcpOption120>
+            <DHCPv6Option>0</DHCPv6Option>
+        </opt>
+    </ap>
+    <qos>
+        <EnableVLAN>{if isset($fanvil_enable_vlan)}{$fanvil_enable_vlan}{else}0{/if}</EnableVLAN>
+        <VLANID>{if isset($fanvil_lan_port_vlan)}{$fanvil_lan_port_vlan}{else}256{/if}</VLANID>
+        <EnablePVID>{if isset($fanvil_pc_port_vlan)}2{else}0{/if}</EnablePVID>
+        <PVIDValue>{if isset($fanvil_pc_port_vlan)}{$fanvil_pc_port_vlan}{else}254{/if}</PVIDValue>
+        <SignallingPriority>{if isset($fanvil_qos_sip)}{$fanvil_qos_sip}{else}0{/if}</SignallingPriority>
+        <VoicePriority>{if isset($fanvil_qos_rtp_voice)}{$fanvil_qos_rtp_voice}{else}0{/if}</VoicePriority>
+        <VideoPriority>{if isset($fanvil_qos_rtp_video)}{$fanvil_qos_rtp_video}{else}0{/if}</VideoPriority>
+        <LANPortPriority>0</LANPortPriority>
+        <EnablediffServ>{if isset($fanvil_enable_diffserv)}{$fanvil_enable_diffserv}{else}0{/if}</EnablediffServ>
+        <SingallingDSCP>{if isset($fanvil_dscp_sip)}{$fanvil_dscp_sip}{else}46{/if}</SingallingDSCP>
+        <VoiceDSCP>{if isset($fanvil_dscp_rtp_voice)}{$fanvil_dscp_rtp_voice}{else}46{/if}</VoiceDSCP>
+        <VideoDSCP>{if isset($fanvil_dscp_rtp_video)}{$fanvil_dscp_rtp_video}{else}34{/if}</VideoDSCP>
+        <LLDPTransmit>{if isset($fanvil_lldp_tx_enable)}{$fanvil_lldp_tx_enable}{else}0{/if}</LLDPTransmit>
+        <LLDPRefreshTime>{if isset($fanvil_lldp_refresh)}{$fanvil_lldp_refresh}{else}60{/if}</LLDPRefreshTime>
+        <LLDPLearnPolicy>{if isset($fanvil_lldp_learn)}{$fanvil_lldp_learn}{else}0{/if}</LLDPLearnPolicy>
+        <LLDPSaveLearnData>1</LLDPSaveLearnData>
+        <CDPEnable>0</CDPEnable>
+        <CDPRefreshTime>60</CDPRefreshTime>
+        <DHCPOptionVlan>132</DHCPOptionVlan>
+    </qos>
+    <dot1x>
+        <XsupMode>0</XsupMode>
+        <XsupUser>admin</XsupUser>
+        <XsupPassword>admin</XsupPassword>
+        <sslMode>
+            <PermissionCTF>0</PermissionCTF>
+            <CommonName>0</CommonName>
+            <CTFmode>0</CTFmode>
+            <DeviceCertMode>0</DeviceCertMode>
+        </sslMode>
+    </dot1x>
+    <rtsp>
+        <RtspClientWorkMode>0</RtspClientWorkMode>
+    </rtsp>
+    <pubApp>
+        <WatchDogEnabled>1</WatchDogEnabled>
+        <EnableInAccess>0</EnableInAccess>
+        <EnableOutAccess>0</EnableOutAccess>
+    </pubApp>
+    <android>
+        <displayConfig>
+            <OperatorMode>0</OperatorMode>
+            <EnableShortcuts>1</EnableShortcuts>
+            <EnableLCDPassword>1</EnableLCDPassword>
+        </displayConfig>
+        <softKeyConfig>
+            <DIdleSoftkey>dialpad;mwi;contact;history;cfwd;redial;capse;</DIdleSoftkey>
+            <DTalkingSoftkey>dialpad;new;conf;hold;xfer;end;capse;</DTalkingSoftkey>
+            <DRingSoftkey>dialpad;forward;audio;video;mute;reject;capse;</DRingSoftkey>
+            <DAlertingSoftkey>dialpad;none;none;none;xfer;cancel;capse;</DAlertingSoftkey>
+            <DXAlertingSoftkey>dialpad;none;none;none;xfer;none;capse;</DXAlertingSoftkey>
+            <DConferenceSoftkey>dialpad;exit;split;hold;xfer;end;capse;</DConferenceSoftkey>
+            <DEndingSoftkey>contact;history;new;complete;autoRedial;end;capse;</DEndingSoftkey>
+            <DPredialSoftkey>dialpad;mwi;contact;history;redial;cancel;capse;</DPredialSoftkey>
+            <DDialingSoftkey>dialpad;mwi;contact;history;redial;cancel;capse;</DDialingSoftkey>
+            <DDialerCfwdSoftkey>dialpad;new;contact;history;forward;cancel;capse;</DDialerCfwdSoftkey>
+            <DDialerXferSoftkey>dialpad;new;contact;history;xfer;cancel;capse;</DDialerXferSoftkey>
+            <DSlectionSoftkey>new;cancel;ok;conf;hold;xfer;capse;</DSlectionSoftkey>
+        </softKeyConfig>
+        <dspConfig>
+            <VideoDisplayMosaic>1</VideoDisplayMosaic>
+        </dspConfig>
+        <teleConfig>
+            <EnableRecord>1</EnableRecord>
+            <EnableIMApp>0</EnableIMApp>
+            <OffhooktoOpenApp>0</OffhooktoOpenApp>
+            <IMAppPackageInfo></IMAppPackageInfo>
+            <SupportedIMSet></SupportedIMSet>
+            <HideLocalCode>0</HideLocalCode>
+            <UpdateDialCall>0</UpdateDialCall>
+            <CountryCode></CountryCode>
+        </teleConfig>
+    </android>
+    <uiMainTainConfig>
+        <EHSHeadsettype>0</EHSHeadsettype>
+        <TimeoutToScreensaver>7200</TimeoutToScreensaver>
+        <DisplayProvisionprompt>0</DisplayProvisionprompt>
+    </uiMainTainConfig>
+    <fwCheck>
+        <EnableAutoUpgrade>0</EnableAutoUpgrade>
+        <UpgradeServer1></UpgradeServer1>
+        <UpgradeServer2></UpgradeServer2>
+        <AutoUpgradeInterval>24</AutoUpgradeInterval>
+    </fwCheck>
+    <record>
+        <Enabled>1</Enabled>
+        <VoiceCodec>PCMU</VoiceCodec>
+        <RecordType>0</RecordType>
+        <FileSizeLimit>0</FileSizeLimit>
+        <ServerAddr>0.0.0.0</ServerAddr>
+        <ServerPort>10000</ServerPort>
+    </record>
+    <IO>
+        <RingtoneDuration>5</RingtoneDuration>
+        <AlarmServerAddr></AlarmServerAddr>
+        <DTMFTriggerRing>NONE</DTMFTriggerRing>
+        <URITriggerRing>NONE</URITriggerRing>
+        <SMSTriggerRing>NONE</SMSTriggerRing>
+        <DsskeyTriggerRing>NONE</DsskeyTriggerRing>
+    </IO>
+</sysConf>


### PR DESCRIPTION
All Fanvil V6x phones share the same <sysConf> XML provisioning schema and {$mac}.cfg filename convention, so each of the new templates is a copy of the existing v67 template with <UseVendorClassID> set to 0 and <VendorClassID> set to a generic "Fanvil" string. This avoids coupling the templates to a single model's DHCP Option 60 identifier while letting operators pick the matching device type in the provisioning UI.