### PR TITLE
Add browser-based WebRTC using mod_verto eavesdrop for active calls

### DIFF
--- a/app/active_calls/.user.ini
+++ b/app/active_calls/.user.ini
@@ -1,0 +1,1 @@
+auto_prepend_file = /var/www/fusionpbx/app/active_calls/eavesdrop_web_intercept.php

--- a/app/active_calls/eavesdrop_web_intercept.php
+++ b/app/active_calls/eavesdrop_web_intercept.php
@@ -1,0 +1,247 @@
+<?php
+/*
+ * eavesdrop_web_intercept.php  (active_calls/ — new WebSocket-based page)
+ *
+ * Loaded via .user.ini auto_prepend_file. Runs before every PHP script in
+ * app/active_calls/.
+ *
+ * Behaviour depends entirely on the call_active_eavesdrop_web permission:
+ *
+ *   PERMISSION OFF — this file does nothing. The page behaves exactly as
+ *                    FusionPBX shipped it (click eavesdrop button → original
+ *                    websocket request → phone originate).
+ *
+ *   PERMISSION ON  — only active_calls.php is patched: appends a <script>
+ *                    that captures clicks on every btn_eavesdrop_* button
+ *                    (before the page's own listener runs) and shows a
+ *                    Web / Phone / Cancel modal.
+ *
+ *                    Web   → opens /app/calls_active/eavesdrop_listen.php
+ *                            (the existing WebRTC listener from the old page)
+ *                            inside a floating iframe in the bottom-right.
+ *                    Phone → re-issues the same websocket request the page
+ *                            would have sent: client.request('active.calls',
+ *                            'eavesdrop', {...}) — resulting in the normal
+ *                            FreeSWITCH phone originate.
+ *
+ * NO existing FusionPBX files are modified.  The WebRTC iframe, the
+ * eavesdrop_web_<uuid> → three_way() dialplan, and the permission row in
+ * v_permissions are all shared with the old calls_active page.
+ */
+
+$_script = basename($_SERVER['SCRIPT_FILENAME']);
+
+// Only patch active_calls.php — everything else in this directory runs untouched.
+if ($_script !== 'active_calls.php') return;
+
+// Bootstrap FusionPBX so we can check the permission. require.php is idempotent.
+if (!class_exists('database')) {
+    require_once dirname(__DIR__, 2) . '/resources/require.php';
+}
+
+// Without the web eavesdrop permission, do nothing — page behaves as shipped.
+if (!permission_exists('call_active_eavesdrop_web')) return;
+
+// Pull the translated "Eavesdrop" label so our Phone fallback uses the same
+// caller_id_name the page would have — otherwise the eavesdrop leg would
+// show up in the active calls list (line 846 of active_calls.php filters
+// rows by this exact string).
+$eav_label = 'Eavesdrop';
+if (class_exists('text')) {
+    $_t = (new text())->get();
+    if (!empty($_t['label-eavesdrop'])) {
+        $eav_label = $_t['label-eavesdrop'];
+    }
+}
+$js_eav_label = json_encode($eav_label, JSON_UNESCAPED_UNICODE);
+
+$js_override = <<<JSOVERRIDE
+<script>
+(function() {
+  'use strict';
+
+  const EAV_LABEL = $js_eav_label;
+
+  function ensureModal() {
+    if (document.getElementById('eav_overlay')) return;
+
+    const s = document.createElement('style');
+    s.textContent =
+      '#eav_overlay{display:none;position:fixed;inset:0;background:rgba(0,0,0,.5);z-index:10000;align-items:center;justify-content:center;}' +
+      '#eav_overlay.show{display:flex;}' +
+      '#eav_box{background:#1e1e2e;border-radius:10px;padding:22px 26px;color:#cdd6f4;font-family:"Segoe UI",sans-serif;font-size:14px;min-width:290px;box-shadow:0 4px 24px rgba(0,0,0,.7);}' +
+      '#eav_box h3{margin:0 0 4px;font-size:15px;}' +
+      '#eav_box p{margin:0 0 18px;font-size:12px;color:#a6adc8;}' +
+      '#eav_btns{display:flex;gap:10px;}' +
+      '#eav_btns button{flex:1;padding:8px 0;border:none;border-radius:6px;cursor:pointer;font-size:13px;font-weight:600;}' +
+      '#btn_eav_web{background:#89b4fa;color:#1e1e2e;}' +
+      '#btn_eav_web:hover{background:#74c7ec;}' +
+      '#btn_eav_phone{background:#313244;color:#cdd6f4;}' +
+      '#btn_eav_phone:hover,#btn_eav_cancel:hover{background:#45475a;}' +
+      '#btn_eav_cancel{background:#313244;color:#a6adc8;}' +
+      '#cmd_response{position:fixed;bottom:20px;right:20px;z-index:9999;width:360px;background:#1e1e2e;padding:0;border-radius:8px;box-shadow:0 2px 12px rgba(0,0,0,.4);overflow:hidden;}' +
+      '#eav_drag_handle{cursor:move;user-select:none;padding:6px 10px;background:#11111b;color:#a6adc8;font:11px/1.3 "Segoe UI",sans-serif;display:flex;align-items:center;gap:6px;border-top-left-radius:8px;border-top-right-radius:8px;}' +
+      '#eav_drag_handle .grip{color:#585b70;letter-spacing:-1px;}' +
+      '#eav_drag_handle.dragging{cursor:grabbing;}';
+    document.head.appendChild(s);
+
+    const m = document.createElement('div');
+    m.id = 'eav_overlay';
+    m.innerHTML =
+      '<div id="eav_box">' +
+        '<h3>Eavesdrop on this call?</h3>' +
+        '<p>Choose how you want to listen in.</p>' +
+        '<div id="eav_btns">' +
+          '<button id="btn_eav_web" type="button">Web</button>' +
+          '<button id="btn_eav_phone" type="button">Phone</button>' +
+          '<button id="btn_eav_cancel" type="button">Cancel</button>' +
+        '</div>' +
+      '</div>';
+    document.body.appendChild(m);
+
+    m.addEventListener('click', (e) => { if (e.target === m) closeEavModal(); });
+    document.addEventListener('keydown', (e) => { if (e.key === 'Escape') closeEavModal(); });
+    document.getElementById('btn_eav_cancel').addEventListener('click', closeEavModal);
+
+    document.getElementById('btn_eav_web').addEventListener('click', () => {
+      const uuid = window._eav_uuid;
+      closeEavModal();
+      if (uuid) openWebEavesdrop(uuid);
+    });
+
+    document.getElementById('btn_eav_phone').addEventListener('click', () => {
+      const uuid = window._eav_uuid;
+      closeEavModal();
+      if (uuid) doPhoneEavesdrop(uuid);
+    });
+  }
+
+  function closeEavModal() {
+    const ov = document.getElementById('eav_overlay');
+    if (ov) ov.classList.remove('show');
+    window._eav_uuid = '';
+  }
+
+  // Open the existing /app/calls_active/eavesdrop_listen.php iframe in a floating
+  // container. eavesdrop_listen.php looks for an element with id "cmd_response"
+  // in its parent and shows/hides/empties it on open/close — naming the container
+  // the same id means End button and iframe cleanup work without modification.
+  function openWebEavesdrop(uuid) {
+    const existing = document.getElementById('cmd_response');
+    if (existing) existing.remove();
+
+    const container = document.createElement('div');
+    container.id = 'cmd_response';
+    container.style.display = 'block';
+
+    const handle = document.createElement('div');
+    handle.id = 'eav_drag_handle';
+    handle.innerHTML = '<span class="grip">⋮⋮</span><span>Web Eavesdrop — drag to move</span>';
+
+    const iframe = document.createElement('iframe');
+    iframe.src = '/app/calls_active/eavesdrop_listen.php?chan_uuid=' + encodeURIComponent(uuid) + '&_t=' + Date.now();
+    iframe.style.cssText = 'width:100%;height:180px;border:none;display:block;';
+    iframe.setAttribute('allow', 'microphone;autoplay');
+
+    container.appendChild(handle);
+    container.appendChild(iframe);
+    document.body.appendChild(container);
+
+    makeDraggable(container, handle, iframe);
+  }
+
+  // Drag handler. Switches container from bottom/right anchoring to top/left on
+  // first mousedown so absolute coordinates can be tracked. Disables pointer
+  // events on the iframe while dragging — otherwise the iframe captures the
+  // mouse the instant the pointer crosses it and the drag ends prematurely.
+  function makeDraggable(el, handle, iframe) {
+    let dragging = false, sx = 0, sy = 0, startLeft = 0, startTop = 0;
+
+    const onMove = (e) => {
+      if (!dragging) return;
+      const rect = el.getBoundingClientRect();
+      let newLeft = startLeft + (e.clientX - sx);
+      let newTop  = startTop  + (e.clientY - sy);
+      newLeft = Math.max(0, Math.min(window.innerWidth  - rect.width,  newLeft));
+      newTop  = Math.max(0, Math.min(window.innerHeight - rect.height, newTop));
+      el.style.left = newLeft + 'px';
+      el.style.top  = newTop  + 'px';
+    };
+
+    const onUp = () => {
+      if (!dragging) return;
+      dragging = false;
+      handle.classList.remove('dragging');
+      if (iframe) iframe.style.pointerEvents = '';
+      document.removeEventListener('mousemove', onMove);
+      document.removeEventListener('mouseup',   onUp);
+    };
+
+    handle.addEventListener('mousedown', (e) => {
+      if (e.button !== 0) return;
+      const rect = el.getBoundingClientRect();
+      el.style.left   = rect.left + 'px';
+      el.style.top    = rect.top  + 'px';
+      el.style.right  = 'auto';
+      el.style.bottom = 'auto';
+      startLeft = rect.left;
+      startTop  = rect.top;
+      sx = e.clientX;
+      sy = e.clientY;
+      dragging = true;
+      handle.classList.add('dragging');
+      if (iframe) iframe.style.pointerEvents = 'none';
+      document.addEventListener('mousemove', onMove);
+      document.addEventListener('mouseup',   onUp);
+      e.preventDefault();
+    });
+  }
+
+  // Re-issue the same websocket request the page's own button handler would have
+  // sent. Page globals (client, extension) are visible to this script because all
+  // classic <script> tags share the same script-global scope.
+  function doPhoneEavesdrop(uuid) {
+    if (typeof client === 'undefined' || !client || typeof client.request !== 'function') {
+      console.warn('eavesdrop_web_intercept: websocket client not ready');
+      return;
+    }
+    if (typeof extension === 'undefined' || !extension || !extension.extension_destination) {
+      console.warn('eavesdrop_web_intercept: no extension attached to this user');
+      return;
+    }
+    const caller_id_num = (document.getElementById('caller_id_number_' + uuid) || {}).textContent || '';
+    const dest_num      = (document.getElementById('destination_'       + uuid) || {}).textContent || '';
+    client.request('active.calls', 'eavesdrop', {
+      unique_id:                  uuid,
+      origination_caller_id_name: EAV_LABEL,
+      origination_caller_contact: extension.extension_destination,
+      caller_caller_id_number:    caller_id_num,
+      caller_destination_number:  dest_num
+    });
+  }
+
+  // Capture-phase listener: fires BEFORE the page's own per-button click listener,
+  // so stopImmediatePropagation prevents the original phone originate from firing.
+  // Works for buttons added dynamically by new_call() too, since it listens on
+  // document rather than on specific buttons.
+  document.addEventListener('click', (e) => {
+    const btn = e.target.closest('button[id^="btn_eavesdrop_"]');
+    if (!btn) return;
+    const uuid = btn.id.substring('btn_eavesdrop_'.length);
+    // Ignore the hidden template button (id is exactly "btn_eavesdrop", no uuid suffix).
+    if (!uuid) return;
+
+    e.stopImmediatePropagation();
+    e.preventDefault();
+    ensureModal();
+    window._eav_uuid = uuid;
+    document.getElementById('eav_overlay').classList.add('show');
+    document.getElementById('btn_eav_web').focus();
+  }, true);
+})();
+</script>
+JSOVERRIDE;
+
+ob_start(function($output) use ($js_override) {
+    return $output . $js_override;
+});

--- a/app/calls_active/.user.ini
+++ b/app/calls_active/.user.ini
@@ -1,0 +1,1 @@
+auto_prepend_file = /var/www/fusionpbx/app/calls_active/eavesdrop_web_intercept.php

--- a/app/calls_active/eavesdrop_listen.php
+++ b/app/calls_active/eavesdrop_listen.php
@@ -1,0 +1,345 @@
+<?php
+/*
+ * eavesdrop_listen.php
+ * Renders a self-contained WebRTC page that connects to FreeSWITCH mod_verto
+ * (wss://host:8082) and eavesdrops on the specified call channel via WebRTC audio.
+ * Loaded inside an iframe injected by eavesdrop_web_intercept.php.
+ */
+
+// Require session + auth
+require_once dirname(__DIR__, 2) . '/resources/require.php';
+require_once 'resources/check_auth.php';
+
+if (!permission_exists('call_active_eavesdrop')) {
+    echo "access denied"; exit;
+}
+
+// Validate chan_uuid
+$chan_uuid = preg_replace('/[^a-f0-9-]/', '', strtolower($_GET['chan_uuid'] ?? ''));
+if (strlen($chan_uuid) !== 36) {
+    echo "invalid channel"; exit;
+}
+
+// Look up extension credentials
+$ext_number  = '';
+$ext_pass    = '';
+$domain_name = $_SESSION['domain_name'] ?? '';
+
+if (!empty($_SESSION['user']['extension'][0]['extension_uuid'])) {
+    $ext_uuid = $_SESSION['user']['extension'][0]['extension_uuid'];
+    $sql = "SELECT extension, password FROM v_extensions
+            WHERE extension_uuid = :extension_uuid
+            AND domain_uuid = :domain_uuid
+            LIMIT 1";
+    $params = ['extension_uuid' => $ext_uuid, 'domain_uuid' => $_SESSION['domain_uuid']];
+    $row = $database->select($sql, $params, 'row');
+    if (!empty($row)) {
+        $ext_number = $row['extension'];
+        $ext_pass   = $row['password'];
+    }
+}
+
+if (empty($ext_number) || empty($ext_pass)) {
+    echo "<p style='color:#f66;font-family:sans-serif;'>No extension found for your account.</p>"; exit;
+}
+
+// Determine the Verto WSS URL — use the server's own hostname
+$verto_host = $_SERVER['HTTP_HOST'] ?? $domain_name;
+// Strip port if present
+$verto_host = preg_replace('/:\d+$/', '', $verto_host);
+$verto_wss  = 'wss://' . $verto_host . ':8082';
+
+// Destination sent to FreeSWITCH dialplan
+$verto_dest = 'eavesdrop_web_' . $chan_uuid;
+
+// JSON-encode values safely for embedding in JS
+$js_ext      = json_encode($ext_number . '@' . $domain_name);
+$js_pass     = json_encode($ext_pass);
+$js_wss      = json_encode($verto_wss);
+$js_dest     = json_encode($verto_dest);
+$js_chan_uuid = json_encode($chan_uuid);
+
+?><!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body {
+    background: #1e1e2e;
+    color: #cdd6f4;
+    font-family: 'Segoe UI', sans-serif;
+    font-size: 13px;
+    padding: 10px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+  .title { font-size: 12px; color: #a6adc8; display: flex; align-items: center; gap: 6px; }
+  .title .dot { width: 8px; height: 8px; border-radius: 50%; background: #6c7086; display: inline-block; }
+  .title .dot.live { background: #a6e3a1; box-shadow: 0 0 4px #a6e3a1; animation: pulse 1.5s infinite; }
+  @keyframes pulse { 0%,100%{opacity:1} 50%{opacity:.4} }
+  #status { font-size: 11px; color: #a6adc8; min-height: 14px; }
+  .controls { display: flex; align-items: center; gap: 8px; }
+  input[type=range] { flex: 1; accent-color: #89b4fa; }
+  .btn {
+    background: #313244; border: none; color: #cdd6f4; padding: 4px 10px;
+    border-radius: 4px; cursor: pointer; font-size: 11px; flex-shrink: 0;
+  }
+  .btn:hover { background: #45475a; }
+  .btn.danger { background: #f38ba8; color: #1e1e2e; }
+  .btn.danger:hover { background: #eba0ac; }
+  /* Mic button */
+  #btn_mic { padding: 4px 8px; font-size: 15px; line-height: 1; }
+  #btn_mic.muted   { color: #f38ba8; }  /* red = muted  */
+  #btn_mic.talking { color: #a6e3a1; background: #2a3d2a; } /* green = live */
+  #vol_icon { font-size: 14px; }
+</style>
+</head>
+<body>
+<div class="title">
+  <span class="dot" id="status_dot"></span>
+  <span>Web Eavesdrop</span>
+  <span style="margin-left:auto;font-size:10px;color:#585b70;" id="chan_display"><?= htmlspecialchars(substr($chan_uuid, 0, 8)) ?>…</span>
+</div>
+<div id="status">Connecting…</div>
+<audio id="remote_audio" autoplay></audio>
+<div class="controls">
+  <span id="vol_icon">🔊</span>
+  <input type="range" id="volume" min="0" max="1" step="0.05" value="1"
+         oninput="document.getElementById('remote_audio').volume=this.value">
+  <!-- Mic muted by default; click to talk as participant -->
+  <button class="btn muted" id="btn_mic" onclick="toggleMic()" title="Click to unmute and talk">🎤̶</button>
+  <button class="btn danger" id="btn_stop" onclick="stopEavesdrop()">End</button>
+</div>
+
+<script>
+(function() {
+  'use strict';
+
+  const VERTO_WSS  = <?= $js_wss ?>;
+  const LOGIN      = <?= $js_ext ?>;
+  const PASSWD     = <?= $js_pass ?>;
+  const DEST       = <?= $js_dest ?>;
+  const CHAN_UUID  = <?= $js_chan_uuid ?>;
+
+  const sessId  = crypto.randomUUID ? crypto.randomUUID() : 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, c => {
+    const r = Math.random()*16|0; return (c==='x'?r:(r&0x3|0x8)).toString(16);
+  });
+  const callId  = crypto.randomUUID ? crypto.randomUUID() : sessId + '-call';
+
+  let ws       = null;
+  let pc       = null;
+  let msgId    = 1;
+  let micTrack = null;
+
+  const statusEl = document.getElementById('status');
+  const dotEl    = document.getElementById('status_dot');
+  const audioEl  = document.getElementById('remote_audio');
+  const micBtn   = document.getElementById('btn_mic');
+
+  // Show the parent #cmd_response div (it defaults to display:none)
+  try {
+    const par = window.parent.document.getElementById('cmd_response');
+    if (par) par.style.display = 'block';
+  } catch(e) {}
+
+  function setStatus(msg, live) {
+    statusEl.textContent = msg;
+    dotEl.className = 'dot' + (live ? ' live' : '');
+  }
+
+  function send(obj) {
+    if (ws && ws.readyState === WebSocket.OPEN) {
+      ws.send(JSON.stringify(obj));
+    }
+  }
+
+  function rpc(method, params) {
+    send({ jsonrpc: '2.0', method, params, id: msgId++ });
+  }
+
+  // Toggle microphone mute/unmute
+  window.toggleMic = function() {
+    if (!micTrack) return;
+    micTrack.enabled = !micTrack.enabled;
+    if (micTrack.enabled) {
+      micBtn.className = 'btn talking';
+      micBtn.title = 'Click to mute';
+      micBtn.textContent = '🎤';
+    } else {
+      micBtn.className = 'btn muted';
+      micBtn.title = 'Click to unmute and talk';
+      micBtn.textContent = '🎤̶';
+    }
+  };
+
+  function cleanup() {
+    if (micTrack) { micTrack.stop(); micTrack = null; }
+    if (pc) { pc.close(); pc = null; }
+    if (ws) { ws.close(); ws = null; }
+    audioEl.srcObject = null;
+    try {
+      const par = window.parent.document.getElementById('cmd_response');
+      if (par) { par.style.display = 'none'; par.innerHTML = ''; }
+    } catch(e) {}
+  }
+
+  window.stopEavesdrop = function() {
+    setStatus('Disconnected', false);
+    // Send verto.bye so FreeSWITCH tears down the channel, then clean up
+    if (ws && ws.readyState === WebSocket.OPEN) {
+      rpc('verto.bye', { callID: callId, dialogParams: { callID: callId } });
+      setTimeout(cleanup, 300);
+    } else {
+      cleanup();
+    }
+  };
+
+  async function startCall() {
+    setStatus('Creating audio connection…', false);
+
+    pc = new RTCPeerConnection({
+      iceServers: [{ urls: 'stun:stun.l.google.com:19302' }]
+    });
+
+    // Get microphone — start muted so supervisor is silent until they choose to talk
+    let localStream = null;
+    try {
+      localStream = await navigator.mediaDevices.getUserMedia({ audio: true, video: false });
+      micTrack = localStream.getAudioTracks()[0];
+      micTrack.enabled = false; // muted until user clicks the mic button
+      pc.addTrack(micTrack, localStream);
+      // addTrack creates a sendrecv transceiver automatically
+    } catch (e) {
+      // No mic permission — fall back to listen-only
+      pc.addTransceiver('audio', { direction: 'recvonly' });
+      micBtn.style.display = 'none';
+    }
+
+    // Prefer PCMU/PCMA — same codec as the calls, no transcoding needed
+    const audioTransceiver = pc.getTransceivers().find(t => t.receiver.track.kind === 'audio');
+    if (audioTransceiver && RTCRtpReceiver.getCapabilities) {
+      const caps = RTCRtpReceiver.getCapabilities('audio');
+      if (caps) {
+        const preferred = caps.codecs.filter(c =>
+          c.mimeType === 'audio/PCMU' || c.mimeType === 'audio/PCMA'
+        );
+        const rest = caps.codecs.filter(c =>
+          c.mimeType !== 'audio/PCMU' && c.mimeType !== 'audio/PCMA'
+        );
+        try { audioTransceiver.setCodecPreferences([...preferred, ...rest]); } catch(e) {}
+      }
+    }
+
+    pc.ontrack = (ev) => {
+      audioEl.srcObject = ev.streams[0];
+      setStatus('Listening live', true);
+    };
+
+    pc.oniceconnectionstatechange = () => {
+      if (pc && (pc.iceConnectionState === 'failed' || pc.iceConnectionState === 'disconnected')) {
+        setStatus('Connection lost', false);
+      }
+    };
+
+    const offer = await pc.createOffer();
+    await pc.setLocalDescription(offer);
+
+    // Wait for ICE gathering to complete before sending SDP
+    await new Promise(resolve => {
+      if (pc.iceGatheringState === 'complete') return resolve();
+      pc.addEventListener('icegatheringstatechange', function handler() {
+        if (pc.iceGatheringState === 'complete') {
+          pc.removeEventListener('icegatheringstatechange', handler);
+          resolve();
+        }
+      });
+      setTimeout(resolve, 4000);
+    });
+
+    setStatus('Requesting eavesdrop…', false);
+
+    rpc('verto.invite', {
+      callID: callId,
+      sdp: pc.localDescription.sdp,
+      dialogParams: {
+        callID:                callId,
+        destination_number:    DEST,
+        caller_id_name:        'WebEavesdrop',
+        caller_id_number:      '0000',
+        remote_caller_id_name: 'FreeSWITCH',
+        remote_caller_id_number: '0000',
+        useVideo:   false,
+        useStereo:  false,
+        dedEnc:     false,
+        useCamera:  false,
+        useMic:     true
+      }
+    });
+  }
+
+  function connect() {
+    setStatus('Connecting to server…', false);
+    ws = new WebSocket(VERTO_WSS);
+
+    ws.onopen = () => {
+      setStatus('Authenticating…', false);
+      rpc('login', { login: LOGIN, passwd: PASSWD, sessid: sessId });
+    };
+
+    ws.onmessage = async (ev) => {
+      let msg;
+      try { msg = JSON.parse(ev.data); } catch(e) { return; }
+
+      // Login response
+      if (msg.id && msg.result && msg.result.message === 'logged in') {
+        setStatus('Authenticated — starting audio…', false);
+        await startCall();
+        return;
+      }
+
+      // Auth error
+      if (msg.id && msg.error && msg.error.message && msg.error.message.toLowerCase().includes('auth')) {
+        setStatus('Auth error — check extension credentials', false);
+        return;
+      }
+
+      const method = msg.method || '';
+
+      // Answer from FreeSWITCH — set remote SDP
+      if (method === 'verto.answer' && msg.params && msg.params.callID === callId) {
+        try {
+          await pc.setRemoteDescription({ type: 'answer', sdp: msg.params.sdp });
+        } catch(e) {
+          setStatus('SDP error: ' + e.message, false);
+        }
+        return;
+      }
+
+      // Hangup from FreeSWITCH side
+      if (method === 'verto.bye' && msg.params && msg.params.callID === callId) {
+        setStatus('Call ended by remote', false);
+        if (pc) { pc.close(); pc = null; }
+        setTimeout(cleanup, 5000);
+        return;
+      }
+
+      // Respond to ping
+      if (method === 'verto.ping') {
+        send({ jsonrpc: '2.0', id: msg.id, result: { method: 'verto.pong' } });
+        return;
+      }
+    };
+
+    ws.onerror = () => setStatus('WebSocket error — is port 8082 open?', false);
+    ws.onclose = () => {
+      if (pc) setStatus('Connection closed', false);
+    };
+  }
+
+  connect();
+})();
+</script>
+</body>
+</html>

--- a/app/calls_active/eavesdrop_web_intercept.php
+++ b/app/calls_active/eavesdrop_web_intercept.php
@@ -1,0 +1,185 @@
+<?php
+/*
+ * eavesdrop_web_intercept.php
+ * Loaded via .user.ini auto_prepend_file — runs before every PHP script in
+ * the calls_active/ directory.
+ *
+ * Behaviour depends entirely on the call_active_eavesdrop_web permission:
+ *
+ *   PERMISSION OFF — this file does nothing. Every script runs exactly as
+ *                    FusionPBX shipped it (original confirm() dialog, phone
+ *                    originate, etc.).
+ *
+ *   PERMISSION ON  — two interception cases:
+ *
+ *   1. calls_active_inc.php — appends a <script> that replaces eavesdrop_call()
+ *      with a Web / Phone / Cancel modal, bypassing the original confirm() dialog.
+ *      Web opens the browser WebRTC listener; Phone falls through to the original
+ *      SIP phone originate; Cancel dismisses.
+ *
+ *   2. calls_exec.php?action=eavesdrop — returns the WebRTC iframe HTML instead
+ *      of letting calls_exec.php do a phone originate.
+ *      Passing &mode=phone bypasses the intercept and falls through to original.
+ *
+ * NO existing FusionPBX files were modified to enable this feature.
+ */
+
+$_script = basename($_SERVER['SCRIPT_FILENAME']);
+
+// Only intercept the two relevant scripts — exit immediately for everything else.
+if ($_script !== 'calls_active_inc.php' && $_script !== 'calls_exec.php') return;
+
+// Bootstrap FusionPBX so we can check the permission.
+// require.php is idempotent — safe to call before the main script runs.
+if (!class_exists('database')) {
+    require_once dirname(__DIR__, 2) . '/resources/require.php';
+}
+
+// If the web eavesdrop permission is not granted, do absolutely nothing —
+// let FusionPBX behave exactly as it did before this feature existed.
+if (!permission_exists('call_active_eavesdrop_web')) return;
+
+// ── Case 1: replace eavesdrop_call() in calls_active_inc.php ─────────────────
+if ($_script === 'calls_active_inc.php') {
+    $js_override = <<<'JSOVERRIDE'
+<script>
+(function() {
+  // Inject modal styles + DOM once (safe to re-run on AJAX refresh — guard by id)
+  if (!document.getElementById('eav_overlay')) {
+    var s = document.createElement('style');
+    s.textContent =
+      '#eav_overlay{display:none;position:fixed;inset:0;background:rgba(0,0,0,.5);z-index:10000;align-items:center;justify-content:center;}' +
+      '#eav_overlay.show{display:flex;}' +
+      '#eav_box{background:#1e1e2e;border-radius:10px;padding:22px 26px;color:#cdd6f4;font-family:"Segoe UI",sans-serif;font-size:14px;min-width:290px;box-shadow:0 4px 24px rgba(0,0,0,.7);}' +
+      '#eav_box h3{margin:0 0 4px;font-size:15px;}' +
+      '#eav_box p{margin:0 0 18px;font-size:12px;color:#a6adc8;}' +
+      '#eav_btns{display:flex;gap:10px;}' +
+      '#eav_btns button{flex:1;padding:8px 0;border:none;border-radius:6px;cursor:pointer;font-size:13px;font-weight:600;}' +
+      '#btn_eav_web{background:#89b4fa;color:#1e1e2e;}' +
+      '#btn_eav_web:hover{background:#74c7ec;}' +
+      '#btn_eav_phone{background:#313244;color:#cdd6f4;}' +
+      '#btn_eav_phone:hover,#btn_eav_cancel:hover{background:#45475a;}' +
+      '#btn_eav_cancel{background:#313244;color:#a6adc8;}';
+    document.head.appendChild(s);
+
+    var m = document.createElement('div');
+    m.id = 'eav_overlay';
+    m.innerHTML =
+      '<div id="eav_box">' +
+        '<h3>Eavesdrop on this call?</h3>' +
+        '<p>Choose how you want to listen in.</p>' +
+        '<div id="eav_btns">' +
+          '<button id="btn_eav_web">Web</button>' +
+          '<button id="btn_eav_phone">Phone</button>' +
+          '<button id="btn_eav_cancel">Cancel</button>' +
+        '</div>' +
+      '</div>';
+    document.body.appendChild(m);
+
+    m.addEventListener('click', function(e) { if (e.target === m) closeEavModal(); });
+    document.addEventListener('keydown', function(e) { if (e.key === 'Escape') closeEavModal(); });
+    document.getElementById('btn_eav_cancel').addEventListener('click', closeEavModal);
+
+    document.getElementById('btn_eav_web').addEventListener('click', function() {
+      var ext = window._eav_ext, uuid = window._eav_uuid;
+      closeEavModal();
+      if (!ext || !uuid) return;
+      send_cmd('calls_exec.php?action=eavesdrop&ext=' + encodeURIComponent(ext)
+             + '&chan_uuid=' + encodeURIComponent(uuid) + '&destination=');
+      var c = document.getElementById('cmd_response');
+      if (c) {
+        c.style.cssText = 'display:block;position:fixed;bottom:20px;right:20px;'
+          + 'z-index:9999;width:360px;background:#fff;padding:10px;'
+          + 'border-radius:8px;box-shadow:0 2px 12px rgba(0,0,0,.4);';
+      }
+    });
+
+    document.getElementById('btn_eav_phone').addEventListener('click', function() {
+      var ext = window._eav_ext, uuid = window._eav_uuid;
+      closeEavModal();
+      if (!ext || !uuid) return;
+      var dest = (document.getElementById('eavesdrop_dest') || {}).value || '';
+      send_cmd('calls_exec.php?action=eavesdrop&mode=phone&ext=' + encodeURIComponent(ext)
+             + '&chan_uuid=' + encodeURIComponent(uuid) + '&destination=' + encodeURIComponent(dest));
+    });
+  }
+
+  function closeEavModal() {
+    document.getElementById('eav_overlay').classList.remove('show');
+    window._eav_ext = ''; window._eav_uuid = '';
+  }
+
+  // Replace eavesdrop_call — shows Web/Phone/Cancel instead of the browser confirm()
+  window.eavesdrop_call = function(ext, chan_uuid) {
+    if (!ext || !chan_uuid) return;
+    window._eav_ext  = ext;
+    window._eav_uuid = chan_uuid;
+    document.getElementById('eav_overlay').classList.add('show');
+    document.getElementById('btn_eav_web').focus();
+  };
+
+  // Patch every eavesdrop button to bypass the confirm() baked into its onclick.
+  // This script runs after calls_active_inc.php HTML is inserted into the DOM,
+  // so the buttons are present. We extract ext/uuid from the onclick string and
+  // replace it with a direct call to our modal function.
+  document.querySelectorAll('button[onclick*="eavesdrop_call"]').forEach(function(btn) {
+    var m = btn.getAttribute('onclick').match(/eavesdrop_call\('([^']+)','([^']+)'\)/);
+    if (!m) return;
+    var ext = m[1], uuid = m[2];
+    btn.setAttribute('onclick', '');
+    btn.addEventListener('click', function(e) {
+      e.stopImmediatePropagation();
+      window.eavesdrop_call(ext, uuid);
+    });
+  });
+})();
+</script>
+JSOVERRIDE;
+    ob_start(function($output) use ($js_override) {
+        return $output . $js_override;
+    });
+    return; // let calls_active_inc.php run normally
+}
+
+// ── Case 2: intercept eavesdrop action in calls_exec.php ─────────────────────
+if (($_REQUEST['action'] ?? '') !== 'eavesdrop') return;
+
+// mode=phone → fall through to original phone originate
+if (($_GET['mode'] ?? '') === 'phone') return;
+
+// Validate chan_uuid
+$chan_uuid = preg_replace('/[^a-f0-9-]/', '', strtolower($_GET['chan_uuid'] ?? ''));
+if (strlen($chan_uuid) !== 36) return;
+
+// Look up the logged-in user's first extension + SIP password
+$ext_number  = '';
+$ext_pass    = '';
+$domain_name = $_SESSION['domain_name'] ?? '';
+
+if (!empty($_SESSION['user']['extension'][0]['extension_uuid'])) {
+    $ext_uuid = $_SESSION['user']['extension'][0]['extension_uuid'];
+    $sql = "SELECT extension, password FROM v_extensions
+            WHERE extension_uuid = :extension_uuid
+            AND domain_uuid = :domain_uuid
+            LIMIT 1";
+    $params = ['extension_uuid' => $ext_uuid, 'domain_uuid' => $_SESSION['domain_uuid']];
+    $row = $database->select($sql, $params, 'row');
+    if (!empty($row)) {
+        $ext_number = $row['extension'];
+        $ext_pass   = $row['password'];
+    }
+}
+
+// No extension credentials — fall through to original phone behaviour
+if (empty($ext_number) || empty($ext_pass)) return;
+
+$iframe_src = '/app/calls_active/eavesdrop_listen.php'
+    . '?chan_uuid=' . urlencode($chan_uuid)
+    . '&_t=' . time();
+
+echo '<iframe id="eavesdrop_web_frame" src="' . htmlspecialchars($iframe_src) . '"'
+    . ' style="width:340px;height:160px;border:none;"'
+    . ' allow="microphone;autoplay"'
+    . '></iframe>';
+
+exit;


### PR DESCRIPTION
## Summary

Adds a new option for users on the Active Calls page to eavesdrop on a live call directly from the browser via WebRTC, instead of having to originate the eavesdrop to a desk phone. Clicking the existing **Eavesdrop** button now shows a **Web / Phone / Cancel** modal:

- **Web** — opens an in-page WebRTC listener (mic muted by default, click to unmute and talk in as a third party via `three_way()`).
- **Phone** — falls through to the original SIP originate exactly as today.
- **Cancel** — closes the modal.

Behaviour is gated entirely on a new permission, `call_active_eavesdrop_web`. **With the permission off, every page in `app/calls_active` and `app/active_calls` behaves exactly as it does today** — the new files short-circuit and do nothing. With the permission on, the modal is shown.

Both the legacy AJAX-polling page (`app/calls_active`) and the newer websocket-based page (`app/active_calls`) are supported.

## Files added

- `app/calls_active/.user.ini`
- `app/calls_active/eavesdrop_web_intercept.php`
- `app/calls_active/eavesdrop_listen.php`
- `app/active_calls/.user.ini`
- `app/active_calls/eavesdrop_web_intercept.php`

No shipped FusionPBX file is modified. Each page directory uses a `.user.ini` `auto_prepend_file` hook so the override only injects markup/JS when the new permission is granted.

## How the Web listener works

The listener connects to `mod_verto` over WSS and joins the target channel as a participant via a dialplan extension matching `^eavesdrop_web_([0-9a-f-]{36})$` and routing to `answer; three_way($1)`. PCMU/PCMA codecs are preferred so audio passes through without transcoding from the existing SIP legs.

## Operator setup required (not yet wired into `app_defaults`)

To make this fully drop-in for other operators, follow-up commits should register the new permission and dialplan as install defaults. For now, manual setup is:

1. Insert a `v_permissions` row for `call_active_eavesdrop_web` and grant it to the groups that should see the **Web** option.
2. Insert a dialplan extension routing `^eavesdrop_web_([0-9a-f-]{36})$` to `answer; three_way($1)` in the appropriate domain context.
3. Ensure `mod_verto` and `mod_rtc` are loaded; `verto.conf.xml` has the correct `ext-rtp-ip` and PCMU/PCMA in inbound/outbound codec strings; firewall allows WSS on 8082.

## CLA

Signed: https://github.com/fusionpbx/open-source/pull/327

## Test plan

- [x] With `call_active_eavesdrop_web` permission **off**, both Active Calls pages behave identically to current `master` (original confirm dialog → phone originate).
- [x] With the permission **on**, clicking Eavesdrop shows the Web/Phone/Cancel modal.
- [x] **Web** opens a draggable floating WebRTC listener, mic muted by default; unmuting allows talking in as a participant.
- [x] **Phone** still does the original phone originate.
- [x] **Cancel** closes the modal.