### PR TITLE
Add Alternate Voicemail Location to voicemail box settings

### DIFF
--- a/app/switch/resources/scripts/app/voicemail/index.lua
+++ b/app/switch/resources/scripts/app/voicemail/index.lua
@@ -503,6 +503,61 @@
 		--valid voicemail
 			if (voicemail_uuid ~= nil) then
 
+				--check for an alternate voicemail location on this voicemail box; when
+				--enabled, divert the caller to that destination instead of leaving a
+				--message. caller id is preserved (session:transfer keeps channel vars).
+				--
+				--this is a per-voicemail-box setting (v_voicemails table) — it only
+				--fires when a call actually reaches this script with action=save, so
+				--it does NOT interfere with the dialplan's forward-on-no-answer or
+				--with call-center/ring-group/fifo no-answer handling. Those paths
+				--never enter this script in the first place if they're configured to
+				--route elsewhere before voicemail.
+				--
+				--the cc_side / ring_group_uuid / fifo_role / dialed_extension guard
+				--is kept as a safety net: if for any reason a call-center or
+				--ring-group leg lands here, we don't want a session:transfer to yank
+				--it out of the queue's control.
+					do
+						local group_signals = {
+							cc_side          = session:getVariable("cc_side"),
+							cc_queue         = session:getVariable("cc_queue"),
+							dialed_extension = session:getVariable("dialed_extension"),
+							ring_group_uuid  = session:getVariable("ring_group_uuid"),
+							fifo_role        = session:getVariable("fifo_role"),
+						};
+						local in_group_call = false;
+						for signal_name, signal_value in pairs(group_signals) do
+							if (signal_value ~= nil and signal_value ~= '') then
+								in_group_call = true;
+								freeswitch.consoleLog("notice", "[voicemail] alternate voicemail divert skipped: " .. signal_name .. "=" .. tostring(signal_value) .. " (call-center / ring-group / fifo leg)\n");
+								break;
+							end
+						end
+						if (not in_group_call) then
+							local alt_sql = [[SELECT
+								cast(alternate_voicemail_enabled as text) as alt_enabled,
+								alternate_voicemail_destination
+								FROM v_voicemails
+								WHERE voicemail_uuid = :voicemail_uuid
+								LIMIT 1]];
+							local alt_params = {voicemail_uuid = voicemail_uuid};
+							local alt_enabled = false;
+							local alt_destination = nil;
+							dbh:query(alt_sql, alt_params, function(row)
+								alt_enabled = (row["alt_enabled"] == "true");
+								alt_destination = row["alternate_voicemail_destination"];
+							end);
+							if (alt_enabled and alt_destination ~= nil and alt_destination ~= '') then
+								freeswitch.consoleLog("notice", "[voicemail] alternate voicemail location enabled — diverting caller " .. (caller_id_number or '') .. " to " .. alt_destination .. " instead of leaving a message for " .. voicemail_id .. "\n");
+								if (session ~= nil and session:ready()) then
+									session:transfer(alt_destination, "XML", context);
+								end
+								return;
+							end
+						end
+					end
+
 				--play the greeting
 					timeouts = 0;
 					play_greeting();

--- a/app/voicemails/app_config.php
+++ b/app/voicemails/app_config.php
@@ -501,6 +501,14 @@
 		$apps[$x]['db'][$y]['fields'][$z]['search'] = 'true';
 		$apps[$x]['db'][$y]['fields'][$z]['description']['en-us'] = "Enter the description.";
 		$z++;
+		$apps[$x]['db'][$y]['fields'][$z]['name'] = "alternate_voicemail_destination";
+		$apps[$x]['db'][$y]['fields'][$z]['type'] = "text";
+		$apps[$x]['db'][$y]['fields'][$z]['description']['en-us'] = "When set together with alternate_voicemail_enabled, callers reaching this voicemail box are transferred to this destination before the greeting plays. Caller ID is preserved.";
+		$z++;
+		$apps[$x]['db'][$y]['fields'][$z]['name'] = "alternate_voicemail_enabled";
+		$apps[$x]['db'][$y]['fields'][$z]['type'] = "boolean";
+		$apps[$x]['db'][$y]['fields'][$z]['description']['en-us'] = "When true and alternate_voicemail_destination is set, the call is diverted instead of leaving a message.";
+		$z++;
 		$apps[$x]['db'][$y]['fields'][$z]['name'] = "voicemail_name_base64";
 		$apps[$x]['db'][$y]['fields'][$z]['type'] = "text";
 		$apps[$x]['db'][$y]['fields'][$z]['description']['en-us'] = "";

--- a/app/voicemails/app_languages.php
+++ b/app/voicemails/app_languages.php
@@ -2672,4 +2672,10 @@ $text['message-emails_resent']['zh-cn'] = "电子邮件已重新发送";
 $text['message-emails_resent']['ja-jp'] = "再送信メール";
 $text['message-emails_resent']['ko-kr'] = "이메일 재전송";
 
+$text['label-alternate_voicemail']['en-us'] = "Alternate Voicemail Location";
+$text['label-alternate_voicemail']['en-gb'] = "Alternate Voicemail Location";
+
+$text['description-alternate_voicemail']['en-us'] = "When enabled, callers reaching this voicemail box are routed to this destination instead of leaving a message. The original Caller ID is preserved.";
+$text['description-alternate_voicemail']['en-gb'] = "When enabled, callers reaching this voicemail box are routed to this destination instead of leaving a message. The original Caller ID is preserved.";
+
 ?>

--- a/app/voicemails/voicemail_edit.php
+++ b/app/voicemails/voicemail_edit.php
@@ -60,6 +60,8 @@
 	$voicemail_option_digits = '';
 	$voicemail_option_description = '';
 	$voicemail_mail_to = '';
+	$alternate_voicemail_enabled = false;
+	$alternate_voicemail_destination = '';
 	$transcribe_enabled = $settings->get('transcribe', 'enabled', false);
 
 //set the domain variables
@@ -104,6 +106,8 @@
 			$voicemail_destination = $_POST["voicemail_destination"];
 			$voicemail_enabled = $_POST["voicemail_enabled"];
 			$voicemail_description = $_POST["voicemail_description"];
+			$alternate_voicemail_enabled = filter_var($_POST["alternate_voicemail_enabled"] ?? false, FILTER_VALIDATE_BOOLEAN);
+			$alternate_voicemail_destination = $_POST["alternate_voicemail_destination"] ?? '';
 			$voicemail_tutorial = $_POST["voicemail_tutorial"];
 			$voicemail_recording_instructions = $_POST["voicemail_recording_instructions"];
 			$voicemail_recording_options = $_POST["voicemail_recording_options"];
@@ -112,6 +116,9 @@
 
 		//remove the space
 			$voicemail_mail_to = str_replace(" ", "", $voicemail_mail_to);
+
+		//sanitise the alternate voicemail destination — digits and * only (matches forward_*_destination)
+			$alternate_voicemail_destination = preg_replace('#[^\*0-9]#', '', $alternate_voicemail_destination);
 	}
 
 //process the data
@@ -186,6 +193,8 @@
 					}
 					$array['voicemails'][0]['voicemail_enabled'] = $voicemail_enabled;
 					$array['voicemails'][0]['voicemail_description'] = $voicemail_description;
+					$array['voicemails'][0]['alternate_voicemail_enabled'] = $alternate_voicemail_enabled ? 'true' : 'false';
+					$array['voicemails'][0]['alternate_voicemail_destination'] = $alternate_voicemail_destination;
 
 				//create permissions object
 					$p = permissions::new();
@@ -341,7 +350,9 @@
 		$sql .= "voicemail_file, ";
 		$sql .= "voicemail_local_after_email, ";
 		$sql .= "voicemail_enabled, ";
-		$sql .= "voicemail_description ";
+		$sql .= "voicemail_description, ";
+		$sql .= "alternate_voicemail_enabled, ";
+		$sql .= "alternate_voicemail_destination ";
 		$sql .= "from v_voicemails ";
 		$sql .= "where domain_uuid = :domain_uuid ";
 		$sql .= "and voicemail_uuid = :voicemail_uuid ";
@@ -363,6 +374,8 @@
 			$voicemail_local_after_email = $row["voicemail_local_after_email"];
 			$voicemail_enabled = $row["voicemail_enabled"];
 			$voicemail_description = $row["voicemail_description"];
+			$alternate_voicemail_enabled = filter_var($row["alternate_voicemail_enabled"] ?? false, FILTER_VALIDATE_BOOLEAN);
+			$alternate_voicemail_destination = $row["alternate_voicemail_destination"] ?? '';
 		}
 		unset($sql, $parameters, $row);
 	}
@@ -825,6 +838,28 @@
 	echo "	<input class='formfld' type='text' name='voicemail_mail_to' maxlength='255' value=\"".escape($voicemail_mail_to)."\">\n";
 	echo "<br />\n";
 	echo $text['description-voicemail_mail_to']."\n";
+	echo "</td>\n";
+	echo "</tr>\n";
+
+	echo "<tr>\n";
+	echo "<td class='vncell' valign='top' align='left' nowrap='nowrap'>\n";
+	echo "	".$text['label-alternate_voicemail']."\n";
+	echo "</td>\n";
+	echo "<td class='vtable' align='left'>\n";
+	if ($input_toggle_style_switch) {
+		echo "	<span class='switch'>\n";
+	}
+	echo "		<select class='formfld' id='alternate_voicemail_enabled' name='alternate_voicemail_enabled'>\n";
+	echo "			<option value='true' ".($alternate_voicemail_enabled === true ? "selected='selected'" : '').">".$text['option-true']."</option>\n";
+	echo "			<option value='false' ".($alternate_voicemail_enabled === false ? "selected='selected'" : '').">".$text['option-false']."</option>\n";
+	echo "		</select>\n";
+	if ($input_toggle_style_switch) {
+		echo "		<span class='slider'></span>\n";
+		echo "	</span>\n";
+		echo "&nbsp;";
+	}
+	echo "	<input class='formfld' type='text' name='alternate_voicemail_destination' id='alternate_voicemail_destination' ".($input_toggle_style_switch ? "style='margin-top: -21px;'" : null)." maxlength='255' placeholder=\"".$text['label-destination']."\" value=\"".escape($alternate_voicemail_destination ?? '')."\">\n";
+	echo "	<br />".$text['description-alternate_voicemail']."\n";
 	echo "</td>\n";
 	echo "</tr>\n";
 


### PR DESCRIPTION
## Summary

Adds a new **per-voicemail-box** option that diverts callers reaching a voicemail to an arbitrary dialable destination instead of leaving a message. Useful for handing voicemail off to an external service (e.g. Microsoft Teams, a paging group, an answering service) while keeping the caller's original Caller-ID intact for downstream logging.

The setting lives on the **voicemail box** (`v_voicemails`) — not on the extension's follow-me / forwarding settings — so it only fires when a call actually reaches `voicemail.lua`. It does **not** interact with the existing "No Answer" forward on the call-forward page, nor with call-center, ring-group, or FIFO no-answer handling: those mechanisms route the call elsewhere before `voicemail.lua` ever runs, so the divert never triggers on those paths in the first place.

## Why

Operators frequently want voicemail handled by an external service (Microsoft Teams, paging group, answering service) rather than FusionPBX's built-in box. Today this requires hand-edited dialplan or a custom Lua wrapper. This change makes it a one-checkbox-plus-text-field setting per voicemail box.

## Behaviour

- When `alternate_voicemail_enabled = true` and `alternate_voicemail_destination` is non-empty, `voicemail.lua` transfers the caller to that destination **before the greeting plays**. The voicemail box is not written to.
- When disabled or empty, voicemail behaves exactly as today.
- The `voicemail_action == "check"` path (extension owner logging in to review messages) is unaffected — owners can still retrieve any messages already in the box.
- Override semantics: when enabled, the alternate location always wins. No fallback / chained logic.

## Why on the voicemail box, not on follow-me

An earlier iteration of this PR placed the field on the call-forward / follow-me page. That had a footgun: the same toggle would have influenced both the dialplan-level "no answer" forward and the Lua-level voicemail divert, which made it hard to use in environments that already disable the "No Answer" forward for call-center agents (because the dialplan-level forward fires on the loopback agent leg even when the queue is the one doing the no-answer handling).

Putting the field on the voicemail box itself sidesteps all of that: the divert is checked **only** when a call has organically arrived at `voicemail.lua` to leave a message. Queue legs, ring-group legs, and FIFO legs don't reach that path under normal configuration, so the new setting doesn't influence them.

## Group-call safety net

The divert is **intentionally skipped** if the leg is somehow part of a call-center, ring-group, or FIFO bridge when it lands in `voicemail.lua`. Detection is by channel variable: any of `cc_side`, `cc_queue`, `dialed_extension`, `ring_group_uuid`, `fifo_role` being set causes the divert to be skipped (and a notice logged).

In normal use those paths don't reach the voicemail Lua at all — the queue / group manages its own no-answer behaviour upstream. But if one does land here for any reason, we don't want a `session:transfer` out of the script yanking the leg out of the queue's control.

## Schema

Two new columns on `v_voicemails` (registered in `app/voicemails/app_config.php` for upgrade-driven creation):

| column | type |
|---|---|
| `alternate_voicemail_destination` | text |
| `alternate_voicemail_enabled` | boolean |

Field sanitisation matches existing `forward_*_destination` fields (`[^\*0-9]` stripped).

## Caller-ID

`session:transfer(destination, "XML", context)` retains all channel variables, so `caller_id_name` / `caller_id_number` / `effective_caller_*` flow into the diverted leg unchanged. No extra rewrite logic needed.

## Files changed (4)

- `app/voicemails/app_config.php` — register the two new columns on `v_voicemails`
- `app/voicemails/voicemail_edit.php` — read/write the fields, render a UI row directly under "Mail To"
- `app/voicemails/app_languages.php` — `label-alternate_voicemail` and `description-alternate_voicemail` (en-us / en-gb; other locales TBD)
- `app/switch/resources/scripts/app/voicemail/index.lua` — query the two fields from `v_voicemails` by `voicemail_uuid`, and `session:transfer` before `play_greeting()` when the divert is active and the leg is not part of a group bridge

## CLA

Signed: https://github.com/fusionpbx/open-source/pull/327

## Test plan

- [x] Existing voicemail box with no alt-voicemail set: caller hits voicemail → greeting plays → message left, exactly like today.
- [x] Voicemail box with alt-voicemail enabled + destination set (e.g. `9202201`): caller hits voicemail directly → call is transferred to `9202201` before the greeting plays. Caller-ID on the diverted leg is the original caller's number. Verified live: log line `[voicemail] alternate voicemail location enabled — diverting caller 14843351444 to 9202201 instead of leaving a message for 201`.
- [x] Voicemail box with alt-voicemail enabled + destination blank: behaves like disabled (no divert).
- [x] Extension owner dials voicemail-check: still gets normal voicemail menu, can retrieve any existing messages.
- [x] Schema picks up the new columns via the registered fields in `app_config.php` on upgrade.
- [x] **Call-center call** that for any reason lands in `voicemail.lua` with `cc_side=agent` set: divert is skipped. Log shows `[voicemail] alternate voicemail divert skipped: cc_side=agent (call-center / ring-group / fifo leg)`.
