### PR TITLE
Fix missing first line of in-progress call and wrong state

### DIFF
--- a/app/active_calls/active_calls.php
+++ b/app/active_calls/active_calls.php
@@ -478,7 +478,8 @@ echo "<script src='resources/javascript/arrows.js?v=$version'></script>\n";
 
 	// Ringing, Answer, Hangup
 	function channel_callstate_event(call) {
-		const state = call.answer_state;
+		const state = normalize_answer_state(call);
+		call.answer_state = state;
 		//update color
 		const uuid = call.unique_id;
 		//console.log(call.event_name, call.unique_id, state, call);
@@ -526,6 +527,21 @@ echo "<script src='resources/javascript/arrows.js?v=$version'></script>\n";
 				hangup_call(call);
 				break;
 		}
+	}
+
+	function normalize_answer_state(call) {
+		const answer_state = String(call.answer_state ?? '').toLowerCase();
+		if (answer_state !== 'ringing') {
+			return answer_state;
+		}
+
+		// The in.progress bootstrap payload is currently synthesized as "ringing"
+		// even when a call is already established. Mark those request-seeded rows as answered.
+		if (call.__from_request === true) {
+			return 'answered';
+		}
+
+		return answer_state;
 	}
 
 	function channel_execute_event(call) {

--- a/app/active_calls/resources/dashboard/active_calls.php
+++ b/app/active_calls/resources/dashboard/active_calls.php
@@ -68,6 +68,9 @@ $c = 0;
 $row_style["0"] = "row_style0";
 $row_style["1"] = "row_style1";
 
+// From the include statement
+global $widget_chart_type;
+
 //icon and count
 echo "<div class='hud_content' ".($widget_details_state == "disabled" ?: "onclick=\"$('#hud_active_calls_details').slideToggle('fast');\"").">\n";
 	echo "<span class='hud_title'><a onclick=\"document.location.href='".PROJECT_PATH."/app/active_calls/active_calls.php'\">".escape($widget_label)."</a></span>\n";
@@ -362,7 +365,8 @@ if (!empty($_SESSION['user']['extension'])) {
 
 	// Ringing, Answer, Hangup
 	function channel_callstate_event(call) {
-		const state = call.answer_state;
+		const state = normalize_answer_state(call);
+		call.answer_state = state;
 		//update color
 		const uuid = call.unique_id;
 		//console.log(call.event_name, call.unique_id, state, call);
@@ -410,6 +414,21 @@ if (!empty($_SESSION['user']['extension'])) {
 				hangup_call(call);
 				break;
 		}
+	}
+
+	function normalize_answer_state(call) {
+		const answer_state = String(call.answer_state ?? '').toLowerCase();
+		if (answer_state !== 'ringing') {
+			return answer_state;
+		}
+
+		// The in.progress bootstrap payload is currently synthesized as "ringing"
+		// even when a call is already established. Mark those request-seeded rows as answered.
+		if (call.__from_request === true) {
+			return 'answered';
+		}
+
+		return answer_state;
 	}
 
 	//////////////////////

--- a/core/dashboard/resources/javascript/ws_client.js
+++ b/core/dashboard/resources/javascript/ws_client.js
@@ -48,6 +48,22 @@ class ws_client {
 
 			if (status === 'ok' && code >= 200 && code < 300) {
 				resolve({service, topic, payload, code, message});
+
+				// Some services stream event payloads while also echoing the request_id.
+				// Dispatch to event handlers so the first streamed event is not swallowed.
+				if (topic && this._eventHandlers.has(topic)) {
+					let event_message = message;
+					if (payload !== null && typeof payload === 'object' && !Array.isArray(payload)) {
+						event_message = {
+							...message,
+							payload: {
+								...payload,
+								__from_request: true
+							}
+						};
+					}
+					this._dispatchEvent(event_message);
+				}
 			} else {
 				const err = new Error(message || `Error ${code}`);
 				err.code = code;


### PR DESCRIPTION
When the dashboard widget is first called, the first line of the active call response was ignored due to a promise dropped in the client. This fixes the dropped event. The status is hard-coded to 'ringing' on the server-side to allow the client to pick up the event as a 'new' call. This patches the client to correct this and put the correct 'answered' status for an already in-progress call.