### PR TITLE
Fix: Stop incrementing MWI Account when adding extensions

### DIFF
--- a/app/extensions/extension_edit.php
+++ b/app/extensions/extension_edit.php
@@ -834,13 +834,6 @@ if (!empty($_POST) && empty($_POST["persistformvar"])) {
 					$number_alias++;
 					$voicemail_id = $number_alias;
 				}
-
-				if (!empty($mwi_account)) {
-					$mwi_account_array = explode('@', $mwi_account);
-					$mwi_account_array[0]++;
-					$mwi_account = implode('@', $mwi_account_array);
-					unset($mwi_account_array);
-				}
 			}
 		}
 


### PR DESCRIPTION
- MWI Account is empty by default.
- When adding multiple extensions with the range, the MWI Account should be the same on all of them.