### PR TITLE
Fix active_calls crash on reload

### DIFF
--- a/app/active_calls/resources/classes/active_calls_service.php
+++ b/app/active_calls/resources/classes/active_calls_service.php
@@ -394,10 +394,18 @@ class active_calls_service extends service implements websocket_service_interfac
 			if (!empty($read)) {
 				$write = $except = [];
 				// Wait for an event and timeout at 1/3 of a second so we can re-check all connections
-				if (false === stream_select($read, $write, $except, 0, 333333)) {
-					// severe error encountered so exit
+				$select_result = @stream_select($read, $write, $except, 0, 333333);
+				if ($select_result === false) {
+					// SIGUSR1/SIGHUP can interrupt stream_select during reload
+					$last_error = error_get_last();
+					$last_error_message = $last_error['message'] ?? '';
+					$error_message = strtolower((string)$last_error_message);
+					if (str_contains($error_message, 'interrupted system call')) {
+						continue;
+					}
+
+					// real fatal select error
 					$this->running = false;
-					// Exit with non-zero exit code
 					return 1;
 				}
 

--- a/core/websockets/resources/classes/websocket_service.php
+++ b/core/websockets/resources/classes/websocket_service.php
@@ -582,8 +582,15 @@ class websocket_service extends service {
 			//
 			// Wait for activity on the sockets and timeout about 3 times per second
 			//
-			$result = stream_select($read, $write, $except, 0, 333333);
+			$result = @stream_select($read, $write, $except, 0, 333333);
 			if ($result === false) {
+				// Reload signals (for example SIGUSR1) can interrupt stream_select.
+				// Do not treat as a fatal socket error without checking the error message for "interrupted system call" and retrying a few times.
+				$last_error = error_get_last();
+				$error_message = strtolower((string)($last_error['message'] ?? ''));
+				if (str_contains($error_message, 'interrupted system call')) {
+					continue;
+				}
 				// Check for error status 3 times in a row
 				if (++$stream_select_tries > 3) {
 					throw new \RuntimeException("Error occured reading socket");


### PR DESCRIPTION
Active calls and websocket services could crash when the SIGHUP or SIGUSR1 was received. This was caused when the `stream_select` received a `false` return value while in a wait-state.
This patch adds an extra check to see if the received `false` was caused by the interrupt and if it was, retry the wait-state on the stream.