### PR TITLE
Ring Groups: Add CSV import and export

### DIFF
--- a/app/ring_groups/app_config.php
+++ b/app/ring_groups/app_config.php
@@ -146,6 +146,18 @@
 		$apps[$x]['permissions'][$y]['name'] = "ring_group_call_screen_enabled";
 		$apps[$x]['permissions'][$y]['groups'][] = "superadmin";
 		$apps[$x]['permissions'][$y]['groups'][] = "admin";
+		$y++;
+		$apps[$x]['permissions'][$y]['name'] = "ring_group_import";
+		$apps[$x]['permissions'][$y]['groups'][] = "superadmin";
+		$apps[$x]['permissions'][$y]['groups'][] = "admin";
+		$y++;
+		$apps[$x]['permissions'][$y]['name'] = "ring_group_upload";
+		$apps[$x]['permissions'][$y]['groups'][] = "superadmin";
+		$apps[$x]['permissions'][$y]['groups'][] = "admin";
+		$y++;
+		$apps[$x]['permissions'][$y]['name'] = "ring_group_export";
+		$apps[$x]['permissions'][$y]['groups'][] = "superadmin";
+		$apps[$x]['permissions'][$y]['groups'][] = "admin";
 
 	//default settings
 		$y=0;

--- a/app/ring_groups/app_languages.php
+++ b/app/ring_groups/app_languages.php
@@ -2455,4 +2455,20 @@ $text['button-view_all']['zh-cn'] = "查看全部";
 $text['button-view_all']['ja-jp'] = "すべて見る";
 $text['button-view_all']['ko-kr'] = "모두보기";
 
+$text['title-ring_group_import']['en-us'] = "Ring Group Import";
+$text['header-ring_group_import']['en-us'] = "Ring Group Import";
+$text['description-ring_group_import']['en-us'] = "Upload delimited data to add multiple ring groups. List multiple destinations in a single column separated by the pipe character (|), e.g. 1001|1002|1003.";
+$text['label-destinations']['en-us'] = "Destinations";
+$text['description-destinations']['en-us'] = "Separate multiple destination numbers with the pipe character (|).";
+$text['label-destination_separator']['en-us'] = "Destination Separator";
+$text['description-destination_separator']['en-us'] = "Character used to separate multiple destination numbers within a single cell.";
+$text['label-destination_delay']['en-us'] = "Destination Delay";
+$text['description-destination_delay']['en-us'] = "Default delay (seconds) applied to each imported destination.";
+$text['label-destination_timeout']['en-us'] = "Destination Timeout";
+$text['description-destination_timeout']['en-us'] = "Default timeout (seconds) applied to each imported destination.";
+
+$text['title-ring_group_export']['en-us'] = "Ring Group Export";
+$text['header-ring_group_export']['en-us'] = "Ring Group Export";
+$text['description-ring_group_export']['en-us'] = "Select the columns to include in the exported CSV file.";
+
 ?>

--- a/app/ring_groups/app_languages.php
+++ b/app/ring_groups/app_languages.php
@@ -2466,6 +2466,7 @@ $text['label-destination_delay']['en-us'] = "Destination Delay";
 $text['description-destination_delay']['en-us'] = "Default delay (seconds) applied to each imported destination.";
 $text['label-destination_timeout']['en-us'] = "Destination Timeout";
 $text['description-destination_timeout']['en-us'] = "Default timeout (seconds) applied to each imported destination.";
+$text['description-destination_prompt']['en-us'] = "When enabled, the answering party must press 1 to accept the call.";
 
 $text['title-ring_group_export']['en-us'] = "Ring Group Export";
 $text['header-ring_group_export']['en-us'] = "Ring Group Export";

--- a/app/ring_groups/ring_group_download.php
+++ b/app/ring_groups/ring_group_download.php
@@ -70,6 +70,7 @@
 		'ring_group_description',
 	];
 	$destination_column = 'destinations';
+	$destination_prompt_column = 'destination_prompt';
 
 //define the functions
 	function array2csv(array &$array) {
@@ -112,6 +113,7 @@
 		//validate submitted columns
 			$selected_columns = [];
 			$include_destinations = false;
+			$include_prompt = false;
 			foreach ($_REQUEST["column_group"] as $column_name) {
 				if (in_array($column_name, $available_columns)) {
 					$selected_columns[] = $column_name;
@@ -119,11 +121,14 @@
 				else if ($column_name === $destination_column) {
 					$include_destinations = true;
 				}
+				else if ($column_name === $destination_prompt_column) {
+					$include_prompt = true;
+				}
 			}
 
-		if (!empty($selected_columns) || $include_destinations) {
-			//ensure ring_group_uuid is selected when destinations are included
-			if ($include_destinations && !in_array('ring_group_uuid', $selected_columns)) {
+		if (!empty($selected_columns) || $include_destinations || $include_prompt) {
+			//ensure ring_group_uuid is selected when joins are needed
+			if (($include_destinations || $include_prompt) && !in_array('ring_group_uuid', $selected_columns)) {
 				array_unshift($selected_columns, 'ring_group_uuid');
 				$prepended_uuid = true;
 			}
@@ -135,8 +140,8 @@
 			$ring_groups = $database->select($sql, $parameters, 'all');
 			unset($sql, $parameters);
 
-			if ($include_destinations && is_array($ring_groups)) {
-				$sql = "select ring_group_uuid, destination_number from v_ring_group_destinations ";
+			if (($include_destinations || $include_prompt) && is_array($ring_groups)) {
+				$sql = "select ring_group_uuid, destination_number, destination_prompt from v_ring_group_destinations ";
 				$sql .= "where domain_uuid = :domain_uuid ";
 				$sql .= "order by ring_group_uuid, destination_number ";
 				$parameters['domain_uuid'] = $domain_uuid;
@@ -144,14 +149,23 @@
 				unset($sql, $parameters);
 
 				$dest_map = [];
+				$prompt_map = [];
 				if (is_array($rows)) {
 					foreach ($rows as $r) {
 						$dest_map[$r['ring_group_uuid']][] = $r['destination_number'];
+						if ((string)$r['destination_prompt'] === '1') {
+							$prompt_map[$r['ring_group_uuid']] = true;
+						}
 					}
 				}
 
 				foreach ($ring_groups as $i => $rg) {
-					$ring_groups[$i][$destination_column] = isset($dest_map[$rg['ring_group_uuid']]) ? implode('|', $dest_map[$rg['ring_group_uuid']]) : '';
+					if ($include_destinations) {
+						$ring_groups[$i][$destination_column] = isset($dest_map[$rg['ring_group_uuid']]) ? implode('|', $dest_map[$rg['ring_group_uuid']]) : '';
+					}
+					if ($include_prompt) {
+						$ring_groups[$i][$destination_prompt_column] = !empty($prompt_map[$rg['ring_group_uuid']]) ? 'true' : 'false';
+					}
 				}
 
 				if (!empty($prepended_uuid)) {
@@ -200,6 +214,7 @@
 
 	$all_columns = $available_columns;
 	$all_columns[] = $destination_column;
+	$all_columns[] = $destination_prompt_column;
 
 	$x = 0;
 	foreach ($all_columns as $column_name) {

--- a/app/ring_groups/ring_group_download.php
+++ b/app/ring_groups/ring_group_download.php
@@ -1,0 +1,225 @@
+<?php
+/*
+	FusionPBX
+	Version: MPL 1.1
+
+	The contents of this file are subject to the Mozilla Public License Version
+	1.1 (the "License"); you may not use this file except in compliance with
+	the License. You may obtain a copy of the License at
+	http://www.mozilla.org/MPL/
+
+	Software distributed under the License is distributed on an "AS IS" basis,
+	WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License
+	for the specific language governing rights and limitations under the
+	License.
+
+	The Original Code is FusionPBX
+
+	The Initial Developer of the Original Code is
+	Mark J Crane <markjcrane@fusionpbx.com>
+	Portions created by the Initial Developer are Copyright (C) 2008-2026
+	the Initial Developer. All Rights Reserved.
+
+	Contributor(s):
+	Mark J Crane <markjcrane@fusionpbx.com>
+*/
+
+//includes files
+	require_once dirname(__DIR__, 2) . "/resources/require.php";
+	require_once "resources/check_auth.php";
+
+//check permissions
+	if (!permission_exists('ring_group_export')) {
+		echo "access denied";
+		exit;
+	}
+
+//add multi-lingual support
+	$language = new text;
+	$text = $language->get();
+
+//define available columns
+	$available_columns = [
+		'ring_group_uuid',
+		'domain_uuid',
+		'dialplan_uuid',
+		'ring_group_name',
+		'ring_group_extension',
+		'ring_group_greeting',
+		'ring_group_exit_key',
+		'ring_group_call_timeout',
+		'ring_group_strategy',
+		'ring_group_caller_id_name',
+		'ring_group_caller_id_number',
+		'ring_group_cid_name_prefix',
+		'ring_group_cid_number_prefix',
+		'ring_group_distinctive_ring',
+		'ring_group_ringback',
+		'ring_group_call_screen_enabled',
+		'ring_group_call_forward_enabled',
+		'ring_group_follow_me_enabled',
+		'ring_group_missed_call_app',
+		'ring_group_missed_call_data',
+		'ring_group_forward_enabled',
+		'ring_group_forward_destination',
+		'ring_group_forward_toll_allow',
+		'ring_group_timeout_app',
+		'ring_group_timeout_data',
+		'ring_group_context',
+		'ring_group_enabled',
+		'ring_group_description',
+	];
+	$destination_column = 'destinations';
+
+//define the functions
+	function array2csv(array &$array) {
+		if (count($array) == 0) {
+			return null;
+		}
+		ob_start();
+		$df = fopen("php://output", 'w');
+		fputcsv($df, array_keys(reset($array)));
+		foreach ($array as $row) {
+			fputcsv($df, $row);
+		}
+		fclose($df);
+		return ob_get_clean();
+	}
+
+	function download_send_headers($filename) {
+		$now = gmdate("D, d M Y H:i:s");
+		header("Expires: Tue, 03 Jul 2001 06:00:00 GMT");
+		header("Cache-Control: max-age=0, no-cache, must-revalidate, proxy-revalidate");
+		header("Last-Modified: {$now} GMT");
+		header("Content-Type: application/force-download");
+		header("Content-Type: application/octet-stream");
+		header("Content-Type: application/download");
+		header("Content-Disposition: attachment;filename={$filename}");
+		header("Content-Transfer-Encoding: binary");
+	}
+
+//get the ring groups from the database and send them as output
+	if (!empty($_REQUEST["column_group"]) && is_array($_REQUEST["column_group"]) && @sizeof($_REQUEST["column_group"]) != 0) {
+
+		//validate the token
+			$token = new token;
+			if (!$token->validate($_SERVER['PHP_SELF'])) {
+				message::add($text['message-invalid_token'], 'negative');
+				header('Location: ring_group_download.php');
+				exit;
+			}
+
+		//validate submitted columns
+			$selected_columns = [];
+			$include_destinations = false;
+			foreach ($_REQUEST["column_group"] as $column_name) {
+				if (in_array($column_name, $available_columns)) {
+					$selected_columns[] = $column_name;
+				}
+				else if ($column_name === $destination_column) {
+					$include_destinations = true;
+				}
+			}
+
+		if (!empty($selected_columns) || $include_destinations) {
+			//ensure ring_group_uuid is selected when destinations are included
+			if ($include_destinations && !in_array('ring_group_uuid', $selected_columns)) {
+				array_unshift($selected_columns, 'ring_group_uuid');
+				$prepended_uuid = true;
+			}
+
+			$sql = "select ".implode(', ', $selected_columns)." from v_ring_groups ";
+			$sql .= "where domain_uuid = :domain_uuid ";
+			$sql .= "order by ring_group_extension asc ";
+			$parameters['domain_uuid'] = $domain_uuid;
+			$ring_groups = $database->select($sql, $parameters, 'all');
+			unset($sql, $parameters);
+
+			if ($include_destinations && is_array($ring_groups)) {
+				$sql = "select ring_group_uuid, destination_number from v_ring_group_destinations ";
+				$sql .= "where domain_uuid = :domain_uuid ";
+				$sql .= "order by ring_group_uuid, destination_number ";
+				$parameters['domain_uuid'] = $domain_uuid;
+				$rows = $database->select($sql, $parameters, 'all');
+				unset($sql, $parameters);
+
+				$dest_map = [];
+				if (is_array($rows)) {
+					foreach ($rows as $r) {
+						$dest_map[$r['ring_group_uuid']][] = $r['destination_number'];
+					}
+				}
+
+				foreach ($ring_groups as $i => $rg) {
+					$ring_groups[$i][$destination_column] = isset($dest_map[$rg['ring_group_uuid']]) ? implode('|', $dest_map[$rg['ring_group_uuid']]) : '';
+				}
+
+				if (!empty($prepended_uuid)) {
+					foreach ($ring_groups as $i => $rg) {
+						unset($ring_groups[$i]['ring_group_uuid']);
+					}
+				}
+			}
+
+			download_send_headers("ring_group_export_".date("Y-m-d").".csv");
+			echo array2csv($ring_groups);
+			exit;
+		}
+	}
+
+//create token
+	$object = new token;
+	$token = $object->create($_SERVER['PHP_SELF']);
+
+//include the header
+	$document['title'] = $text['title-ring_group_export'];
+	require_once "resources/header.php";
+
+//show the content
+	echo "<form method='post' name='frm' id='frm'>\n";
+	echo "<div class='action_bar' id='action_bar'>\n";
+	echo "	<div class='heading'><b>".$text['header-ring_group_export']."</b></div>\n";
+	echo "	<div class='actions'>\n";
+	echo button::create(['type'=>'button','label'=>$text['button-back'],'icon'=>$settings->get('theme', 'button_icon_back'),'id'=>'btn_back','link'=>'ring_groups.php']);
+	echo button::create(['type'=>'submit','label'=>$text['button-export'],'icon'=>$settings->get('theme', 'button_icon_export'),'id'=>'btn_save','style'=>'margin-left: 15px;']);
+	echo "	</div>\n";
+	echo "	<div style='clear: both;'></div>\n";
+	echo "</div>\n";
+
+	echo $text['description-ring_group_export'];
+	echo "<br /><br />\n";
+
+	echo "<div class='card'>\n";
+	echo "<table class='list'>\n";
+	echo "<tr class='list-header'>\n";
+	echo "	<th class='checkbox'>\n";
+	echo "		<input type='checkbox' id='checkbox_all' name='checkbox_all' onclick='list_all_toggle();' ".(empty($available_columns) ? "style='visibility: hidden;'" : null).">\n";
+	echo "	</th>\n";
+	echo "	<th>".$text['label-column_name']."</th>\n";
+	echo "</tr>\n";
+
+	$all_columns = $available_columns;
+	$all_columns[] = $destination_column;
+
+	$x = 0;
+	foreach ($all_columns as $column_name) {
+		$list_row_onclick = "if (!this.checked) { document.getElementById('checkbox_all').checked = false; }";
+		echo "<tr class='list-row'>\n";
+		echo "	<td class='checkbox'>\n";
+		echo "		<input type='checkbox' name='column_group[]' id='checkbox_".$x."' value=\"".$column_name."\" onclick=\"".$list_row_onclick."\">\n";
+		echo "	</td>\n";
+		echo "	<td onclick=\"document.getElementById('checkbox_".$x."').checked = document.getElementById('checkbox_".$x."').checked ? false : true; ".$list_row_onclick."\">".$column_name."</td>";
+		echo "</tr>";
+		$x++;
+	}
+
+	echo "</table>\n";
+	echo "</div>\n";
+	echo "<br />\n";
+	echo "<input type='hidden' name='".$token['name']."' value='".$token['hash']."'>\n";
+	echo "</form>\n";
+
+//include the footer
+	require_once "resources/footer.php";
+
+?>

--- a/app/ring_groups/ring_group_imports.php
+++ b/app/ring_groups/ring_group_imports.php
@@ -48,6 +48,7 @@
 	$destination_separator = $_POST["destination_separator"] ?? '|';
 	$destination_delay = $_POST["destination_delay"] ?? '0';
 	$destination_timeout = $_POST["destination_timeout"] ?? '30';
+	$destination_prompt = ($_POST["destination_prompt"] ?? '') === '1' ? '1' : '';
 
 //save pasted data to a csv file
 	if (isset($_POST['data']) && !empty($_POST['data'])) {
@@ -205,6 +206,7 @@
 							$array['ring_groups'][$row_id]['ring_group_destinations'][$y]['destination_number'] = $destination_number;
 							$array['ring_groups'][$row_id]['ring_group_destinations'][$y]['destination_delay'] = $destination_delay;
 							$array['ring_groups'][$row_id]['ring_group_destinations'][$y]['destination_timeout'] = $destination_timeout;
+							$array['ring_groups'][$row_id]['ring_group_destinations'][$y]['destination_prompt'] = $destination_prompt;
 							$array['ring_groups'][$row_id]['ring_group_destinations'][$y]['destination_enabled'] = 'true';
 							$y++;
 						}
@@ -487,6 +489,18 @@
 			echo "	<td class='vtable' align='left'>\n";
 			echo "		<input class='formfld' type='number' name='destination_timeout' min='1' value=\"".escape($destination_timeout)."\">\n";
 			echo "		<br />".$text['description-destination_timeout']."\n";
+			echo "	</td>\n";
+			echo "</tr>\n";
+
+			//destination prompt (confirm)
+			echo "<tr>\n";
+			echo "	<td class='vncell' valign='top' align='left' nowrap='nowrap'>".$text['label-destination_prompt']."</td>\n";
+			echo "	<td class='vtable' align='left'>\n";
+			echo "		<select class='formfld' name='destination_prompt'>\n";
+			echo "			<option value='' ".($destination_prompt === '' ? "selected='selected'" : null).">".$text['option-false']."</option>\n";
+			echo "			<option value='1' ".($destination_prompt === '1' ? "selected='selected'" : null).">".$text['option-true']."</option>\n";
+			echo "		</select>\n";
+			echo "		<br />".$text['description-destination_prompt']."\n";
 			echo "	</td>\n";
 			echo "</tr>\n";
 

--- a/app/ring_groups/ring_group_imports.php
+++ b/app/ring_groups/ring_group_imports.php
@@ -1,0 +1,629 @@
+<?php
+/*
+	FusionPBX
+	Version: MPL 1.1
+
+	The contents of this file are subject to the Mozilla Public License Version
+	1.1 (the "License"); you may not use this file except in compliance with
+	the License. You may obtain a copy of the License at
+	http://www.mozilla.org/MPL/
+
+	Software distributed under the License is distributed on an "AS IS" basis,
+	WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License
+	for the specific language governing rights and limitations under the
+	License.
+
+	The Original Code is FusionPBX
+
+	The Initial Developer of the Original Code is
+	Mark J Crane <markjcrane@fusionpbx.com>
+	Portions created by the Initial Developer are Copyright (C) 2018-2026
+	the Initial Developer. All Rights Reserved.
+
+	Contributor(s):
+	Mark J Crane <markjcrane@fusionpbx.com>
+*/
+
+//includes files
+	require_once dirname(__DIR__, 2) . "/resources/require.php";
+	require_once "resources/check_auth.php";
+
+//check permissions
+	if (!permission_exists('ring_group_import')) {
+		echo "access denied";
+		exit;
+	}
+
+//add multi-lingual support
+	$language = new text;
+	$text = $language->get();
+
+//get the http post values
+	$action = $_POST["action"] ?? null;
+	$from_row = $_POST["from_row"] ?? '2';
+	$delimiter = $_POST["data_delimiter"] ?? null;
+	$enclosure = $_POST["data_enclosure"] ?? null;
+	$ring_group_enabled = $_POST["ring_group_enabled"] ?? 'true';
+	$ring_group_context = $_POST["ring_group_context"] ?? $_SESSION['domain_name'];
+	$destination_separator = $_POST["destination_separator"] ?? '|';
+	$destination_delay = $_POST["destination_delay"] ?? '0';
+	$destination_timeout = $_POST["destination_timeout"] ?? '30';
+
+//save pasted data to a csv file
+	if (isset($_POST['data']) && !empty($_POST['data'])) {
+		$file = $settings->get('server', 'temp')."/ring_groups-".$_SESSION['domain_name'].".csv";
+		file_put_contents($file, $_POST['data']);
+		$_SESSION['file'] = $file;
+		$_SESSION['file_name'] = !empty($_FILES['ulfile']['name']) ? $_FILES['ulfile']['name'] : 'pasted-data.csv';
+	}
+
+//copy the uploaded csv file
+	if (!empty($_FILES['ulfile']['tmp_name']) && is_uploaded_file($_FILES['ulfile']['tmp_name']) && permission_exists('ring_group_upload')) {
+		if (($_POST['type'] ?? '') == 'csv') {
+			move_uploaded_file($_FILES['ulfile']['tmp_name'], $settings->get('server', 'temp').'/'.$_FILES['ulfile']['name']);
+			$file = $settings->get('server', 'temp').'/'.$_FILES['ulfile']['name'];
+			$_SESSION['file'] = $file;
+			$_SESSION['file_name'] = $_FILES['ulfile']['name'];
+		}
+	}
+
+//build the schema array (limited to ring_groups and ring_group_destinations)
+	$line_fields = [];
+	$schema = [];
+	if (!empty($delimiter) && !empty($_SESSION['file']) && file_exists($_SESSION['file'])) {
+		$line = fgets(fopen($_SESSION['file'], 'r'));
+		$line_fields = explode($delimiter, $line);
+
+		$x = 0;
+		$apps = [];
+		include "app/ring_groups/app_config.php";
+		$i = 0;
+		foreach ($apps[0]['db'] as $table) {
+			$table_name = $table['table']['name'];
+			$parent_name = $table['table']['parent'];
+			if (substr($table_name, 0, 2) == 'v_') { $table_name = substr($table_name, 2); }
+			if (substr($parent_name, 0, 2) == 'v_') { $parent_name = substr($parent_name, 2); }
+			if ($table_name == 'ring_groups' || $table_name == 'ring_group_destinations') {
+				$schema[$i]['table'] = $table_name;
+				$schema[$i]['parent'] = $parent_name;
+				foreach ($table['fields'] as $row) {
+					if (!empty($row['deprecated']) && $row['deprecated'] === 'true') { continue; }
+					$field_name = is_array($row['name']) ? $row['name']['text'] : $row['name'];
+					//skip system/internal fields
+					if (in_array($field_name, ['domain_uuid', 'ring_group_uuid', 'ring_group_destination_uuid', 'dialplan_uuid', 'insert_date', 'insert_user', 'update_date', 'update_user'])) {
+						continue;
+					}
+					$schema[$i]['fields'][] = $field_name;
+				}
+				$i++;
+			}
+		}
+	}
+
+//get the parent table name for a given table
+	function get_parent($schema, $table_name) {
+		foreach ($schema as $row) {
+			if ($row['table'] == $table_name) {
+				return $row['parent'];
+			}
+		}
+		return null;
+	}
+
+//process the import
+	if (!empty($_SESSION['file']) && file_exists($_SESSION['file']) && $action == 'add') {
+
+		//validate the token
+			$token = new token;
+			if (!$token->validate($_SERVER['PHP_SELF'])) {
+				message::add($text['message-invalid_token'], 'negative');
+				header('Location: ring_group_imports.php');
+				exit;
+			}
+
+		//user selected fields
+			$fields = $_POST['fields'] ?? [];
+			$domain_uuid = $_SESSION['domain_uuid'];
+
+		//grant temporary dialplan permissions
+			$p = permissions::new();
+			$p->add('dialplan_add', 'temp');
+			$p->add('dialplan_edit', 'temp');
+
+		//process the csv file
+			$handle = @fopen($_SESSION['file'], "r");
+			if ($handle) {
+				$row_id = 0;
+				$row_number = 1;
+				$array = [];
+
+				while (($line = fgets($handle, 4096)) !== false) {
+					$line = mb_convert_encoding($line, 'UTF-8');
+
+					if ($from_row <= $row_number) {
+
+						$result = str_getcsv($line, $delimiter, $enclosure);
+						$ring_group_uuid = uuid();
+						$dialplan_uuid = uuid();
+						$row_destinations_raw = '';
+						$row_data = [];
+
+						//map columns to fields
+						foreach ($fields as $key => $value) {
+							if (empty($value)) { continue; }
+
+							$field_array = explode('.', $value);
+							$table_name = $field_array[0] ?? null;
+							$field_name = $field_array[1] ?? null;
+							$cell = $result[$key] ?? '';
+
+							if ($table_name === 'ring_group_destinations' && $field_name === 'destination_number') {
+								$row_destinations_raw = $cell;
+								continue;
+							}
+
+							if ($table_name === 'ring_groups' && !empty($field_name)) {
+								$row_data[$field_name] = $cell;
+							}
+						}
+
+						//required: extension and at least one destination
+						if (empty($row_data['ring_group_extension']) || $row_destinations_raw === '') {
+							$row_number++;
+							continue;
+						}
+
+						//apply defaults
+						$row_data['ring_group_uuid'] = $ring_group_uuid;
+						$row_data['domain_uuid'] = $domain_uuid;
+						$row_data['dialplan_uuid'] = $dialplan_uuid;
+						if (empty($row_data['ring_group_name'])) {
+							$row_data['ring_group_name'] = $row_data['ring_group_extension'];
+						}
+						if (empty($row_data['ring_group_strategy'])) {
+							$row_data['ring_group_strategy'] = 'simultaneous';
+						}
+						if (!isset($row_data['ring_group_call_timeout']) || $row_data['ring_group_call_timeout'] === '') {
+							$row_data['ring_group_call_timeout'] = '30';
+						}
+						if (!isset($row_data['ring_group_enabled']) || $row_data['ring_group_enabled'] === '') {
+							$row_data['ring_group_enabled'] = $ring_group_enabled;
+						}
+						if (!isset($row_data['ring_group_context']) || $row_data['ring_group_context'] === '') {
+							$row_data['ring_group_context'] = $ring_group_context;
+						}
+
+						$array['ring_groups'][$row_id] = $row_data;
+
+						//build destinations
+						$destination_numbers = array_filter(array_map('trim', explode($destination_separator, $row_destinations_raw)));
+						$y = 0;
+						foreach ($destination_numbers as $destination_number) {
+							$array['ring_groups'][$row_id]['ring_group_destinations'][$y]['ring_group_destination_uuid'] = uuid();
+							$array['ring_groups'][$row_id]['ring_group_destinations'][$y]['domain_uuid'] = $domain_uuid;
+							$array['ring_groups'][$row_id]['ring_group_destinations'][$y]['ring_group_uuid'] = $ring_group_uuid;
+							$array['ring_groups'][$row_id]['ring_group_destinations'][$y]['destination_number'] = $destination_number;
+							$array['ring_groups'][$row_id]['ring_group_destinations'][$y]['destination_delay'] = $destination_delay;
+							$array['ring_groups'][$row_id]['ring_group_destinations'][$y]['destination_timeout'] = $destination_timeout;
+							$array['ring_groups'][$row_id]['ring_group_destinations'][$y]['destination_enabled'] = 'true';
+							$y++;
+						}
+
+						//build the dialplan xml
+						$dialplan_xml = "<extension name=\"".xml::sanitize($row_data['ring_group_name'])."\" continue=\"\" uuid=\"".xml::sanitize($dialplan_uuid)."\">\n";
+						$dialplan_xml .= "	<condition field=\"destination_number\" expression=\"^".xml::sanitize($row_data['ring_group_extension'])."$\">\n";
+						if ($settings->get('ring_group', 'ring_ready', true)) {
+							$dialplan_xml .= "		<action application=\"ring_ready\" data=\"\"/>\n";
+						}
+						$dialplan_xml .= "		<action application=\"set\" data=\"ring_group_uuid=".xml::sanitize($ring_group_uuid)."\"/>\n";
+						$dialplan_xml .= "		<action application=\"set\" data=\"record_stereo=true\"/>\n";
+						$dialplan_xml .= "		<action application=\"lua\" data=\"app.lua ring_groups\"/>\n";
+						$dialplan_xml .= "	</condition>\n";
+						$dialplan_xml .= "</extension>\n";
+
+						$array['dialplans'][$row_id]['domain_uuid'] = $domain_uuid;
+						$array['dialplans'][$row_id]['dialplan_uuid'] = $dialplan_uuid;
+						$array['dialplans'][$row_id]['app_uuid'] = '1d61fb65-1eec-bc73-a6ee-a6203b4fe6f2';
+						$array['dialplans'][$row_id]['dialplan_name'] = $row_data['ring_group_name'];
+						$array['dialplans'][$row_id]['dialplan_number'] = $row_data['ring_group_extension'];
+						$array['dialplans'][$row_id]['dialplan_context'] = $row_data['ring_group_context'];
+						$array['dialplans'][$row_id]['dialplan_continue'] = 'false';
+						$array['dialplans'][$row_id]['dialplan_xml'] = $dialplan_xml;
+						$array['dialplans'][$row_id]['dialplan_order'] = '101';
+						$array['dialplans'][$row_id]['dialplan_enabled'] = $row_data['ring_group_enabled'];
+						$array['dialplans'][$row_id]['dialplan_description'] = $row_data['ring_group_description'] ?? '';
+
+						$row_id++;
+
+						//flush every 500 rows
+						if ($row_id >= 500) {
+							$database->save($array);
+							unset($array);
+							$row_id = 0;
+						}
+					}
+					$row_number++;
+				}
+				fclose($handle);
+
+				if (!empty($array) && is_array($array)) {
+					$database->save($array);
+				}
+			}
+
+		//remove the temporary permissions
+			$p->delete('dialplan_add', 'temp');
+			$p->delete('dialplan_edit', 'temp');
+
+		//apply settings reminder
+			$_SESSION['reload_xml'] = true;
+
+		//clear cache
+			$cache = new cache;
+			$cache->delete('dialplan:'.$ring_group_context);
+
+		//notify and redirect
+			message::add($text['message-add']);
+			header("Location: ring_groups.php");
+			exit;
+	}
+
+//delete ring groups via csv
+	if (!empty($_SESSION['file']) && file_exists($_SESSION['file']) && $action == 'delete') {
+
+		//validate the token
+			$token = new token;
+			if (!$token->validate($_SERVER['PHP_SELF'])) {
+				message::add($text['message-invalid_token'], 'negative');
+				header('Location: ring_group_imports.php');
+				exit;
+			}
+
+		//user selected fields
+			$fields = $_POST['fields'] ?? [];
+			$domain_uuid = $_SESSION['domain_uuid'];
+
+		//grant temporary permissions
+			$p = permissions::new();
+			$p->add('dialplan_delete', 'temp');
+			$p->add('ring_group_delete', 'temp');
+
+		//process the csv file
+			$deleted_count = 0;
+			$handle = @fopen($_SESSION['file'], "r");
+			if ($handle) {
+				$row_number = 1;
+
+				while (($line = fgets($handle, 4096)) !== false) {
+					$line = mb_convert_encoding($line, 'UTF-8');
+
+					if ($from_row <= $row_number) {
+						$result = str_getcsv($line, $delimiter, $enclosure);
+
+						$row_extension = '';
+						$row_uuid = '';
+
+						foreach ($fields as $key => $value) {
+							if (empty($value)) { continue; }
+							$field_array = explode('.', $value);
+							$table_name = $field_array[0] ?? null;
+							$field_name = $field_array[1] ?? null;
+							$cell = $result[$key] ?? '';
+
+							if ($table_name === 'ring_groups' && $field_name === 'ring_group_extension') {
+								$row_extension = $cell;
+							}
+							if ($table_name === 'ring_groups' && $field_name === 'ring_group_uuid') {
+								$row_uuid = $cell;
+							}
+						}
+
+						//resolve the ring_group_uuid + dialplan_uuid
+						$lookup_uuid = '';
+						$lookup_dialplan_uuid = '';
+						if (is_uuid($row_uuid)) {
+							$sql = "select ring_group_uuid, dialplan_uuid from v_ring_groups ";
+							$sql .= "where domain_uuid = :domain_uuid and ring_group_uuid = :ring_group_uuid ";
+							$parameters['domain_uuid'] = $domain_uuid;
+							$parameters['ring_group_uuid'] = $row_uuid;
+							$row = $database->select($sql, $parameters, 'row');
+							unset($sql, $parameters);
+							if (!empty($row)) {
+								$lookup_uuid = $row['ring_group_uuid'];
+								$lookup_dialplan_uuid = $row['dialplan_uuid'];
+							}
+						}
+						else if (!empty($row_extension)) {
+							$sql = "select ring_group_uuid, dialplan_uuid from v_ring_groups ";
+							$sql .= "where domain_uuid = :domain_uuid and ring_group_extension = :ring_group_extension ";
+							$parameters['domain_uuid'] = $domain_uuid;
+							$parameters['ring_group_extension'] = $row_extension;
+							$row = $database->select($sql, $parameters, 'row');
+							unset($sql, $parameters);
+							if (!empty($row)) {
+								$lookup_uuid = $row['ring_group_uuid'];
+								$lookup_dialplan_uuid = $row['dialplan_uuid'];
+							}
+						}
+
+						if (is_uuid($lookup_uuid)) {
+							//delete destinations
+							$sql = "delete from v_ring_group_destinations where ring_group_uuid = :ring_group_uuid ";
+							$parameters['ring_group_uuid'] = $lookup_uuid;
+							$database->execute($sql, $parameters);
+							unset($sql, $parameters);
+
+							//delete ring group users
+							$sql = "delete from v_ring_group_users where ring_group_uuid = :ring_group_uuid ";
+							$parameters['ring_group_uuid'] = $lookup_uuid;
+							$database->execute($sql, $parameters);
+							unset($sql, $parameters);
+
+							//delete the ring group
+							$sql = "delete from v_ring_groups where ring_group_uuid = :ring_group_uuid ";
+							$parameters['ring_group_uuid'] = $lookup_uuid;
+							$database->execute($sql, $parameters);
+							unset($sql, $parameters);
+
+							//delete the dialplan
+							if (is_uuid($lookup_dialplan_uuid)) {
+								$sql = "delete from v_dialplan_details where dialplan_uuid = :dialplan_uuid ";
+								$parameters['dialplan_uuid'] = $lookup_dialplan_uuid;
+								$database->execute($sql, $parameters);
+								unset($sql, $parameters);
+
+								$sql = "delete from v_dialplans where dialplan_uuid = :dialplan_uuid ";
+								$parameters['dialplan_uuid'] = $lookup_dialplan_uuid;
+								$database->execute($sql, $parameters);
+								unset($sql, $parameters);
+							}
+
+							$deleted_count++;
+						}
+					}
+					$row_number++;
+				}
+				fclose($handle);
+			}
+
+		//remove the temporary permissions
+			$p->delete('dialplan_delete', 'temp');
+			$p->delete('ring_group_delete', 'temp');
+
+		//apply settings reminder
+			$_SESSION['reload_xml'] = true;
+
+		//clear cache
+			$cache = new cache;
+			$cache->delete('dialplan:'.$ring_group_context);
+
+		//notify and redirect
+			message::add($text['message-delete'].': '.$deleted_count, 'positive');
+			header("Location: ring_groups.php");
+			exit;
+	}
+
+//field mapping form (after delimiter has been chosen)
+	if (!empty($delimiter) && !empty($_SESSION['file']) && file_exists($_SESSION['file']) && $action !== 'add') {
+
+		//create token
+			$object = new token;
+			$token = $object->create($_SERVER['PHP_SELF']);
+
+		//include the header
+			$document['title'] = $text['title-ring_group_import'];
+			require_once "resources/header.php";
+
+			echo "<form name='frmUpload' method='post' enctype='multipart/form-data'>\n";
+
+			echo "<div class='action_bar' id='action_bar'>\n";
+			echo "	<div class='heading'><b>".$text['header-ring_group_import']."</b></div>\n";
+			echo "	<div class='actions'>\n";
+			echo button::create(['type'=>'button','label'=>$text['button-back'],'icon'=>$settings->get('theme', 'button_icon_back'),'id'=>'btn_back','style'=>'margin-right: 15px;','link'=>'ring_group_imports.php']);
+			echo button::create(['type'=>'submit','label'=>$text['button-import'],'icon'=>$settings->get('theme', 'button_icon_import'),'id'=>'btn_save']);
+			echo "	</div>\n";
+			echo "	<div style='clear: both;'></div>\n";
+			echo "</div>\n";
+
+			echo $text['description-ring_group_import']."\n";
+			echo "<br /><br />\n";
+
+			echo "<div class='card'>\n";
+			echo "<table width='100%' border='0' cellpadding='0' cellspacing='0'>\n";
+
+			if (!empty($_SESSION['file_name'])) {
+				echo "<tr>\n";
+				echo "	<td class='vncell' valign='top' align='left' nowrap='nowrap'>".$text['label-file_name']."</td>\n";
+				echo "	<td class='vtable' align='left'><b>".escape($_SESSION['file_name'])."</b></td>\n";
+				echo "</tr>\n";
+			}
+
+			//map each csv column to a field
+			$x = 0;
+			foreach ($line_fields as $line_field) {
+				$line_field = preg_replace('#[^a-zA-Z0-9_]#', '', $line_field);
+				echo "<tr>\n";
+				echo "	<td class='vncell' valign='top' align='left' nowrap='nowrap'>".escape($line_field)."</td>\n";
+				echo "	<td class='vtable' align='left'>\n";
+				echo "		<select class='formfld' name='fields[$x]'>\n";
+				echo "			<option value=''></option>\n";
+				foreach ($schema as $group) {
+					echo "			<optgroup label='".escape($group['table'])."'>\n";
+					if (!empty($group['fields'])) {
+						foreach ($group['fields'] as $field) {
+							$selected = ($field == $line_field) ? "selected='selected'" : null;
+							echo "				<option value='".escape($group['table']).".".escape($field)."' $selected>".escape($field)."</option>\n";
+						}
+					}
+					echo "			</optgroup>\n";
+				}
+				echo "		</select>\n";
+				echo "	</td>\n";
+				echo "</tr>\n";
+				$x++;
+			}
+
+			//destination separator
+			echo "<tr>\n";
+			echo "	<td class='vncell' valign='top' align='left' nowrap='nowrap'>".$text['label-destination_separator']."</td>\n";
+			echo "	<td class='vtable' align='left'>\n";
+			echo "		<input class='formfld' type='text' name='destination_separator' maxlength='1' style='width: 60px;' value=\"".escape($destination_separator)."\">\n";
+			echo "		<br />".$text['description-destination_separator']."\n";
+			echo "	</td>\n";
+			echo "</tr>\n";
+
+			//destination delay
+			echo "<tr>\n";
+			echo "	<td class='vncell' valign='top' align='left' nowrap='nowrap'>".$text['label-destination_delay']."</td>\n";
+			echo "	<td class='vtable' align='left'>\n";
+			echo "		<input class='formfld' type='number' name='destination_delay' min='0' value=\"".escape($destination_delay)."\">\n";
+			echo "		<br />".$text['description-destination_delay']."\n";
+			echo "	</td>\n";
+			echo "</tr>\n";
+
+			//destination timeout
+			echo "<tr>\n";
+			echo "	<td class='vncell' valign='top' align='left' nowrap='nowrap'>".$text['label-destination_timeout']."</td>\n";
+			echo "	<td class='vtable' align='left'>\n";
+			echo "		<input class='formfld' type='number' name='destination_timeout' min='1' value=\"".escape($destination_timeout)."\">\n";
+			echo "		<br />".$text['description-destination_timeout']."\n";
+			echo "	</td>\n";
+			echo "</tr>\n";
+
+			//ring group context
+			echo "<tr>\n";
+			echo "	<td class='vncell' valign='top' align='left' nowrap='nowrap'>".$text['label-context']."</td>\n";
+			echo "	<td class='vtable' align='left'>\n";
+			echo "		<input class='formfld' type='text' name='ring_group_context' maxlength='128' value=\"".escape($ring_group_context)."\">\n";
+			echo "	</td>\n";
+			echo "</tr>\n";
+
+			//enabled
+			echo "<tr>\n";
+			echo "	<td class='vncell' valign='top' align='left' nowrap='nowrap'>".$text['label-enabled']."</td>\n";
+			echo "	<td class='vtable' align='left'>\n";
+			echo "		<select class='formfld' name='ring_group_enabled'>\n";
+			echo "			<option value='true' ".($ring_group_enabled === 'true' ? "selected='selected'" : null).">".$text['option-true']."</option>\n";
+			echo "			<option value='false' ".($ring_group_enabled === 'false' ? "selected='selected'" : null).">".$text['option-false']."</option>\n";
+			echo "		</select>\n";
+			echo "	</td>\n";
+			echo "</tr>\n";
+
+			//action: add or delete
+			echo "<tr>\n";
+			echo "	<td class='vncell' valign='top' align='left' nowrap='nowrap'>".$text['label-actions']."</td>\n";
+			echo "	<td class='vtable' align='left'>\n";
+			echo "		<select class='formfld' name='action'>\n";
+			echo "			<option value='add' selected='selected'>".$text['label-add']."</option>\n";
+			echo "			<option value='delete'>".$text['label-delete']."</option>\n";
+			echo "		</select>\n";
+			echo "	</td>\n";
+			echo "</tr>\n";
+
+			echo "</table>\n";
+			echo "</div>\n";
+			echo "<br /><br />\n";
+
+			echo "<input type='hidden' name='from_row' value='".escape($from_row)."'>\n";
+			echo "<input type='hidden' name='data_delimiter' value=\"".escape($delimiter)."\">\n";
+			echo "<input type='hidden' name='data_enclosure' value=\"".escape($enclosure)."\">\n";
+			echo "<input type='hidden' name='".$token['name']."' value='".$token['hash']."'>\n";
+
+			echo "</form>\n";
+
+			require_once "resources/footer.php";
+			exit;
+	}
+
+//create token
+	$object = new token;
+	$token = $object->create($_SERVER['PHP_SELF']);
+
+//include the header
+	$document['title'] = $text['title-ring_group_import'];
+	require_once "resources/header.php";
+
+//upload form (initial step)
+	echo "<form name='frmUpload' method='post' enctype='multipart/form-data'>\n";
+
+	echo "<div class='action_bar' id='action_bar'>\n";
+	echo "	<div class='heading'><b>".$text['header-ring_group_import']."</b></div>\n";
+	echo "	<div class='actions'>\n";
+	echo button::create(['type'=>'button','label'=>$text['button-back'],'icon'=>$settings->get('theme', 'button_icon_back'),'id'=>'btn_back','style'=>'margin-right: 15px;','link'=>'ring_groups.php']);
+	echo button::create(['type'=>'submit','label'=>$text['button-continue'],'icon'=>$settings->get('theme', 'button_icon_upload'),'id'=>'btn_save']);
+	echo "	</div>\n";
+	echo "	<div style='clear: both;'></div>\n";
+	echo "</div>\n";
+
+	echo $text['description-ring_group_import']."\n";
+	echo "<br /><br />\n";
+
+	echo "<div class='card'>\n";
+	echo "<table border='0' cellpadding='0' cellspacing='0' width='100%'>\n";
+
+	echo "<tr>\n";
+	echo "	<td width='30%' class='vncell' valign='top' align='left' nowrap='nowrap'>".$text['label-import_data']."</td>\n";
+	echo "	<td width='70%' class='vtable' align='left'>\n";
+	echo "		<textarea name='data' id='data' class='formfld' style='width: 100%; min-height: 150px;' wrap='off'></textarea>\n";
+	echo "		<br />".$text['description-import_data']."\n";
+	echo "	</td>\n";
+	echo "</tr>\n";
+
+	echo "<tr>\n";
+	echo "	<td class='vncell' valign='top' align='left' nowrap='nowrap'>".$text['label-from_row']."</td>\n";
+	echo "	<td class='vtable' align='left'>\n";
+	echo "		<select class='formfld' name='from_row'>\n";
+	for ($i = 2; $i <= 99; $i++) {
+		$selected = ($i == $from_row) ? "selected" : null;
+		echo "			<option value='$i' ".$selected.">$i</option>\n";
+	}
+	echo "		</select>\n";
+	echo "		<br />".$text['description-from_row']."\n";
+	echo "	</td>\n";
+	echo "</tr>\n";
+
+	echo "<tr>\n";
+	echo "	<td class='vncell' valign='top' align='left' nowrap='nowrap'>".$text['label-import_delimiter']."</td>\n";
+	echo "	<td class='vtable' align='left'>\n";
+	echo "		<select class='formfld' style='width: 60px;' name='data_delimiter'>\n";
+	echo "			<option value=','>,</option>\n";
+	echo "			<option value=';'>;</option>\n";
+	echo "			<option value='\t'>TAB</option>\n";
+	echo "		</select>\n";
+	echo "		<br />".$text['description-import_delimiter']."\n";
+	echo "	</td>\n";
+	echo "</tr>\n";
+
+	echo "<tr>\n";
+	echo "	<td class='vncell' valign='top' align='left' nowrap='nowrap'>".$text['label-import_enclosure']."</td>\n";
+	echo "	<td class='vtable' align='left'>\n";
+	echo "		<select class='formfld' style='width: 60px;' name='data_enclosure'>\n";
+	echo "			<option value='\"'>\"</option>\n";
+	echo "			<option value=''></option>\n";
+	echo "		</select>\n";
+	echo "		<br />".$text['description-import_enclosure']."\n";
+	echo "	</td>\n";
+	echo "</tr>\n";
+
+	if (permission_exists('ring_group_upload')) {
+		echo "<tr>\n";
+		echo "	<td class='vncell' valign='top' align='left' nowrap='nowrap'>".$text['label-import_file_upload']."</td>\n";
+		echo "	<td class='vtable' align='left'>\n";
+		echo "		<input name='ulfile' type='file' class='formfld fileinput' id='ulfile'>\n";
+		echo "	</td>\n";
+		echo "</tr>\n";
+	}
+
+	echo "</table>\n";
+	echo "</div>\n";
+	echo "<br><br>";
+
+	echo "<input name='type' type='hidden' value='csv'>\n";
+	echo "<input type='hidden' name='".$token['name']."' value='".$token['hash']."'>\n";
+
+	echo "</form>\n";
+
+//include the footer
+	require_once "resources/footer.php";
+
+?>

--- a/app/ring_groups/ring_groups.php
+++ b/app/ring_groups/ring_groups.php
@@ -203,6 +203,12 @@
 	echo "<div class='action_bar' id='action_bar'>\n";
 	echo "	<div class='heading'><b>".$text['title-ring_groups']."</b><div class='count'>".number_format($num_rows)."</div></div>\n";
 	echo "	<div class='actions'>\n";
+	if (permission_exists('ring_group_import')) {
+		echo button::create(['type'=>'button','label'=>$text['button-import'],'icon'=>$settings->get('theme', 'button_icon_import'),'link'=>'ring_group_imports.php']);
+	}
+	if (permission_exists('ring_group_export')) {
+		echo button::create(['type'=>'button','label'=>$text['button-export'],'icon'=>$settings->get('theme', 'button_icon_export'),'link'=>'ring_group_download.php']);
+	}
 	if (permission_exists('ring_group_add')) {
 		echo button::create(['type'=>'button','label'=>$text['button-add'],'icon'=>$settings->get('theme', 'button_icon_add'),'id'=>'btn_add','link'=>'ring_group_edit.php'.($query_string ? '?'.$query_string : '')]);
 	}


### PR DESCRIPTION
Adds Import and Export buttons on the ring groups list, modeled on the destinations import/export. New permissions ring_group_import, ring_group_upload and ring_group_export gate the feature. Import supports a two-step CSV mapping flow with Add or Delete actions, and multiple destinations per ring group via a configurable separator. Export emits a CSV with all ring_group columns plus a synthetic destinations column joined with '|'.