### PR TITLE
Fix pass by reference xml_cdr

### DIFF
--- a/app/xml_cdr/resources/classes/xml_cdr.php
+++ b/app/xml_cdr/resources/classes/xml_cdr.php
@@ -285,7 +285,8 @@ class xml_cdr {
 
 		if (!empty($this->settings->get('cdr', 'field'))) {
 			foreach ($this->settings->get('cdr', 'field') as $field) {
-				$field_name     = end(explode(',', $field));
+				$fields = explode(',', $field);
+				$field_name     = end($fields);
 				$this->fields[] = $field_name;
 			}
 		}

--- a/app/xml_cdr/resources/classes/xml_cdr.php
+++ b/app/xml_cdr/resources/classes/xml_cdr.php
@@ -286,7 +286,7 @@ class xml_cdr {
 		if (!empty($this->settings->get('cdr', 'field'))) {
 			foreach ($this->settings->get('cdr', 'field') as $field) {
 				$fields = explode(',', $field);
-				$field_name     = end($fields);
+				$field_name = end($fields);
 				$this->fields[] = $field_name;
 			}
 		}


### PR DESCRIPTION
A PHP error will occur when not passed by reference using a variable.