### PR TITLE
speech: show banner when voice list API is unreachable

### DIFF
--- a/app/recordings/recording_edit.php
+++ b/app/recordings/recording_edit.php
@@ -486,7 +486,11 @@
 			}
 		}
 		else {
-			echo "		<input class='formfld' type='text' name='recording_voice' maxlength='255' value=\"".escape($recording_voice)."\">\n";
+			$engine_label = ucfirst($speech_engine);
+			echo "<div style='background-color: #fff4d6; border: 1px solid #e0b800; padding: 10px; border-radius: 4px; max-width: 500px;'>\n";
+			echo "<strong>Voice list unavailable.</strong> Unable to load voices from the ".escape($engine_label)." speech API. The service may be temporarily unreachable. Please refresh in a few minutes.\n";
+			echo "</div>\n";
+			echo "<input type='hidden' name='recording_voice' value=\"".escape($recording_voice ?? '')."\">\n";
 		}
 		echo "<br />\n";
 		echo $text['description-voice']."\n";

--- a/app/voicemail_greetings/voicemail_greeting_edit.php
+++ b/app/voicemail_greetings/voicemail_greeting_edit.php
@@ -423,7 +423,11 @@ if (!empty($_POST) && empty($_POST["persistformvar"])) {
 			}
 		}
 		else {
-			echo "		<input class='formfld' type='text' name='greeting_voice' maxlength='255' value=\"".escape($greeting_voice ?? '')."\">\n";
+			$engine_label = ucfirst($speech_engine);
+			echo "<div style='background-color: #fff4d6; border: 1px solid #e0b800; padding: 10px; border-radius: 4px; max-width: 500px;'>\n";
+			echo "<strong>Voice list unavailable.</strong> Unable to load voices from the ".escape($engine_label)." speech API. The service may be temporarily unreachable. Please refresh in a few minutes.\n";
+			echo "</div>\n";
+			echo "<input type='hidden' name='greeting_voice' value=\"".escape($greeting_voice ?? '')."\">\n";
 		}
 		echo "<br />\n";
 		echo $text['description-voice']."\n";


### PR DESCRIPTION
When the configured speech engine's get_voices() returns empty (e.g. upstream API outage), the voice field silently fell back to a free-text input. Users could save typo'd voice IDs that would then fail at speech generation time with no obvious cause.

Replace the fallback with a visible warning banner naming the configured engine, and preserve the existing voice value via a hidden input so saving the form during an outage does not wipe the prior selection.

Applies to both recording_edit.php and voicemail_greeting_edit.php. Engine-agnostic: triggers for any speech provider whose voice list comes from a remote API (inworld, elevenlabs); harmless for providers with locally-hardcoded voice lists (openai, local) since their list cannot be empty.