### PR TITLE
Fix music on hold upload, delete, and file display bugs

### DIFF
--- a/app/music_on_hold/music_on_hold.php
+++ b/app/music_on_hold/music_on_hold.php
@@ -288,7 +288,17 @@
 
 				//check target folder, move uploaded file
 					if (!is_dir($stream_path)) {
-						mkdir($stream_path, 0770, true);
+						if (!@mkdir($stream_path, 0770, true)) {
+							$err = error_get_last();
+							if (stripos($err['message'] ?? '', 'read-only') !== false) {
+								message::add("Failed to create directory: the file system is read-only. Check the systemd ProtectSystem setting for PHP-FPM.", 'negative');
+							}
+							else {
+								message::add("Failed to create directory: ".($err['message'] ?? 'unknown error'), 'negative');
+							}
+							header("Location: music_on_hold.php");
+							exit;
+						}
 
 						// 14.03.22 freeswitch bug - shouldn't be needed with freeswitch 1.10.8
 			                       if (preg_match('|^(/usr/share/freeswitch/sounds/music/(.*?\._loc.*?))/|', $stream_path, $m)) {
@@ -534,6 +544,7 @@
 
 				//get the music on hold path and files
 					$stream_path = str_replace("\$\${sounds_dir}",$settings->get('switch', 'sounds') ?? '', $row['music_on_hold_path']);
+					$stream_files = [];
 					if (file_exists($stream_path)) {
 						$stream_files = array_merge(glob($stream_path.'/*.wav'), glob($stream_path.'/*.mp3'), glob($stream_path.'/*.ogg'));
 					}

--- a/app/music_on_hold/resources/classes/switch_music_on_hold.php
+++ b/app/music_on_hold/resources/classes/switch_music_on_hold.php
@@ -444,7 +444,8 @@ class switch_music_on_hold {
 
 							//delete name (category) folder, if empty
 							$name_path = dirname($stream_path);
-							if (@sizeof(scandir($name_path)) == 2) { //empty (only /.. and /. remaining)
+							$name_path_contents = @scandir($name_path);
+							if (is_array($name_path_contents) && count($name_path_contents) == 2) { //empty (only /.. and /. remaining)
 								@rmdir($name_path);
 							}
 						}


### PR DESCRIPTION
Debian systemd service file for php-fpm was blocking write access to music on hold files in `/usr/share/freeswitch/sounds` using the systemd  ProtectSystem=full

This led to Music On Hold category creation and file upload errors.  This PR gracefully handles write errors and displays an error message to the user so that write errors no longer fail silently.

Individual changes:
- Reset `$stream_files` between loop iterations so files from a previous category no longer carry over to the next when its directory is missing
- Guard `scandir()` return value before passing to count() to prevent TypeError on PHP 8+ when the directory does not exist
- Show an error message when `mkdir` fails during upload (e.g. read-only filesystem due to systemd ProtectSystem)