### PR TITLE
Fix IPv6 SIP URI corruption in follow_me enterprise originate parsing

### DIFF
--- a/app/switch/resources/scripts/app/follow_me/index.lua
+++ b/app/switch/resources/scripts/app/follow_me/index.lua
@@ -542,8 +542,14 @@
 		--execute the bridge
 			if (app_data ~= nil) then
 				if (follow_me_strategy == "enterprise") then
-					app_data = app_data:gsub("%[", "{");
-					app_data = app_data:gsub("%]", "}");
+					app_data = app_data:gsub("(%b[])", function(segment)
+                        if segment:match("%[[0-9A-Fa-f:]+%]") then
+                            return segment
+                        end
+                        segment = segment:gsub("^%[", "{")
+                        segment = segment:gsub("%]$", "}")
+                        return segment
+            		end)
 				end
 				freeswitch.consoleLog("NOTICE", "[follow me] app_data: "..app_data.."\n");
 				session:execute("bridge", app_data);


### PR DESCRIPTION
Preserve IPv6 address brackets while converting enterprise originate variable blocks from [] to {}.

Previously all square brackets were globally rewritten, which corrupted valid IPv6 SIP URIs such as:

sip:user@[2001:db8::1]:5061

into invalid Sofia destinations:

sip:user@{2001:db8::1}:5061

causing HANDLE creation failures and DESTINATION_OUT_OF_ORDER errors for IPv6 endpoints.

This change keeps enterprise bridge delay/originate behavior intact while safely excluding IPv6 host literals from bracket conversion.