### PR TITLE
Add Previous/Next navigation arrows to record edit pages

### DIFF
--- a/app/call_forward/call_forward.php
+++ b/app/call_forward/call_forward.php
@@ -182,6 +182,9 @@
 	$sql .= order_by($order_by, $order, 'extension', 'asc', $sort);
 	$sql .= limit_offset($rows_per_page, $offset);
 	$extensions = $database->select($sql, $parameters ?? null, 'all');
+
+	//snapshot the rendered uuids so call_forward_edit.php can offer Previous/Next arrows
+	edit_nav::snapshot('call_forward', $extensions, 'extension_uuid');
 	unset($parameters);
 
 	//if there are no extensions then set to empty array

--- a/app/call_forward/call_forward_edit.php
+++ b/app/call_forward/call_forward_edit.php
@@ -560,6 +560,9 @@
 	echo "	<div class='actions'>\n";
 	echo button::create(['type'=>'button','label'=>$text['button-back'],'icon'=>$settings->get('theme', 'button_icon_back'),'id'=>'btn_back','link'=>'call_forward.php'.($query_string ? '?'.$query_string : '')]);
 	echo button::create(['type'=>'submit','label'=>$text['button-save'],'icon'=>$settings->get('theme', 'button_icon_save'),'id'=>'btn_save','style'=>'margin-left: 15px;']);
+	if ($action == 'update' && !empty($extension_uuid) && is_uuid($extension_uuid)) {
+		echo edit_nav::render(['module_key'=>'call_forward','script'=>'call_forward_edit.php','id'=>$extension_uuid]);
+	}
 	echo "	</div>\n";
 	echo "	<div style='clear: both;'></div>\n";
 	echo "</div>\n";

--- a/app/destinations/destination_edit.php
+++ b/app/destinations/destination_edit.php
@@ -1725,6 +1725,9 @@
 	if (permission_exists('destination_add') || permission_exists('destination_edit')) {
 		echo button::create(['type'=>'submit','label'=>$text['button-save'],'icon'=>$settings->get('theme', 'button_icon_save'),'id'=>'btn_save']);
 	}
+	if ($action == 'update' && !empty($destination_uuid) && is_uuid($destination_uuid)) {
+		echo edit_nav::render(['module_key'=>'destinations','script'=>'destination_edit.php','id'=>$destination_uuid,'passthrough'=>['order_by','order','page','search','type','show']]);
+	}
 	echo "	</div>\n";
 	echo "	<div style='clear: both;'></div>\n";
 	echo "</div>\n";

--- a/app/destinations/destinations.php
+++ b/app/destinations/destinations.php
@@ -247,6 +247,9 @@
 	$destinations = $database->select($sql, $parameters, 'all');
 	unset($sql, $parameters);
 
+//snapshot the rendered uuids so destination_edit.php can offer Previous/Next arrows
+	edit_nav::snapshot('destinations', $destinations, 'destination_uuid');
+
 //update the array to add the actions
 	if ($show != "all") {
 		$x = 0;

--- a/app/devices/device_edit.php
+++ b/app/devices/device_edit.php
@@ -1115,6 +1115,9 @@
 		}
 	}
 	echo button::create(['type'=>'submit','label'=>$text['button-save'],'icon'=>$settings->get('theme', 'button_icon_save', ''),'id'=>'btn_save','style'=>'margin-left: 15px;','onclick'=>'submit_form();']);
+	if ($action == 'update' && !empty($device_uuid) && is_uuid($device_uuid)) {
+		echo edit_nav::render(['module_key'=>'devices','script'=>'device_edit.php','id'=>$device_uuid]);
+	}
 	echo "	</div>\n";
 	echo "	<div style='clear: both;'></div>\n";
 	echo "</div>\n";

--- a/app/devices/devices.php
+++ b/app/devices/devices.php
@@ -303,6 +303,9 @@
 	$devices = $database->select($sql, $parameters, 'all');
 	unset($sql, $parameters);
 
+//snapshot the rendered uuids so device_edit.php can offer Previous/Next arrows
+	edit_nav::snapshot('devices', $devices, 'device_uuid');
+
 //alternate_found
 	$device_alternate = false;
 	if (is_array($devices)) {

--- a/app/dialplans/dialplan_edit.php
+++ b/app/dialplans/dialplan_edit.php
@@ -613,6 +613,9 @@
 		}
 	}
 	echo button::create(['type'=>'submit','label'=>$text['button-save'],'icon'=>$settings->get('theme', 'button_icon_save'),'id'=>'btn_save','style'=>'margin-left: 15px;']);
+	if ($action == 'update' && !empty($dialplan_uuid) && is_uuid($dialplan_uuid)) {
+		echo edit_nav::render(['module_key'=>'dialplans'.(!empty($app_uuid) ? ':'.$app_uuid : ''),'script'=>'dialplan_edit.php','id'=>$dialplan_uuid,'passthrough'=>['order_by','order','page','search','app_uuid','context','show']]);
+	}
 	echo "	</div>\n";
 	echo "	<div style='clear: both;'></div>\n";
 	echo "</div>\n";

--- a/app/dialplans/dialplans.php
+++ b/app/dialplans/dialplans.php
@@ -280,6 +280,10 @@
 	$dialplans = $database->select($sql, $parameters ?? null, 'all');
 	unset($sql, $parameters);
 
+//snapshot the rendered uuids so dialplan_edit.php can offer Previous/Next arrows
+//(per-view key so Inbound Routes / Outbound Routes / Dialplan Manager each get their own snapshot)
+	edit_nav::snapshot('dialplans'.(!empty($app_uuid) ? ':'.$app_uuid : ''), $dialplans, 'dialplan_uuid');
+
 //get the list of all dialplan contexts
 	$sql = "select dc.* from ( ";
 	$sql .= "select distinct dialplan_context from v_dialplans ";

--- a/app/extensions/extension_edit.php
+++ b/app/extensions/extension_edit.php
@@ -1280,6 +1280,9 @@ if ($action == 'update') {
 if (permission_exists('extension_add') || permission_exists('extension_edit')) {
 	echo button::create(['type' => 'button', 'label' => $text['button-save'], 'icon' => $settings->get('theme', 'button_icon_save'), 'id' => 'btn_save', 'style' => 'margin-left: 15px;', 'onclick' => 'submit_form();']);
 }
+if ($action == 'update' && !empty($extension_uuid) && is_uuid($extension_uuid)) {
+	echo edit_nav::render(['module_key' => 'extensions', 'script' => 'extension_edit.php', 'id' => $extension_uuid]);
+}
 echo "	</div>\n";
 echo "	<div style='clear: both;'></div>\n";
 echo "</div>\n";

--- a/app/extensions/extensions.php
+++ b/app/extensions/extensions.php
@@ -268,6 +268,9 @@
 	$extensions = $database->select($sql, $parameters ?? null, 'all');
 	unset($sql, $parameters);
 
+//snapshot the rendered uuids so extension_edit.php can offer Previous/Next arrows
+	edit_nav::snapshot('extensions', $extensions, 'extension_uuid');
+
 //get the registrations
 	if (permission_exists('extension_registered')) {
 		$obj = new registrations;

--- a/resources/classes/edit_nav.php
+++ b/resources/classes/edit_nav.php
@@ -1,0 +1,209 @@
+<?php
+/*
+	FusionPBX
+	Version: MPL 1.1
+
+	The contents of this file are subject to the Mozilla Public License Version
+	1.1 (the "License"); you may not use this file except in compliance with
+	the License. You may obtain a copy of the License at
+	http://www.mozilla.org/MPL/
+
+	Software distributed under the License is distributed on an "AS IS" basis,
+	WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License
+	for the specific language governing rights and limitations under the
+	License.
+
+	The Original Code is FusionPBX
+*/
+
+/**
+ * edit_nav
+ *
+ * Adds Previous/Next arrow buttons to record edit pages so the user can walk
+ * from one record to the next without bouncing back to the list page. The
+ * navigation walks the *exact* list the user last saw on the list page —
+ * including search filters, sort order, pagination and (where applicable)
+ * Show All cross-domain views.
+ *
+ * Mechanism:
+ *
+ *   - List pages call edit_nav::snapshot() once per request, immediately after
+ *     fetching their rows. The ordered list of record uuids is stored in the
+ *     session under a per-module key.
+ *
+ *   - Edit pages call edit_nav::render() inside the action bar. It looks up
+ *     the snapshot, finds the current record's neighbours, and emits two
+ *     icon-only chevron buttons plus a small "n / N" position indicator.
+ *     Alt+Left / Alt+Right keyboard shortcuts are also wired up.
+ *
+ *   - If no fresh snapshot exists (deep link, expired session, etc.) the
+ *     render call returns an empty string and the page is unchanged.
+ *
+ * Behaviour is therefore strictly additive — no change for users who never
+ * visit the list page first.
+ */
+class edit_nav {
+
+	/** How long a snapshot is considered fresh (seconds). */
+	const TTL_SECONDS = 3600;
+
+	/** Top-level session key under which all snapshots are stored. */
+	const SESSION_KEY = 'edit_nav';
+
+	/**
+	 * Capture the ordered list of uuids rendered on a list page. Call once
+	 * per request from the list script, right after the rows have been
+	 * loaded.
+	 *
+	 * @param string $module_key  Unique key for this list view (e.g. 'extensions',
+	 *                            'dialplans:<app_uuid>'). Edit pages must use the
+	 *                            same key when calling render().
+	 * @param array  $rows        Array of associative rows from the list query.
+	 * @param string $uuid_column Name of the primary-key column on each row.
+	 */
+	public static function snapshot($module_key, $rows, $uuid_column) {
+		if (empty($module_key) || empty($uuid_column) || !is_array($rows)) {
+			return;
+		}
+		if (session_status() !== PHP_SESSION_ACTIVE) {
+			return;
+		}
+		$order = [];
+		$seen = [];
+		foreach ($rows as $row) {
+			if (!is_array($row) || empty($row[$uuid_column])) {
+				continue;
+			}
+			$uuid = strtolower($row[$uuid_column]);
+			if (!isset($seen[$uuid])) {
+				$seen[$uuid] = true;
+				$order[] = $uuid;
+			}
+		}
+		if (empty($order)) {
+			return;
+		}
+		$_SESSION[self::SESSION_KEY][$module_key] = [
+			'order' => $order,
+			'time'  => time(),
+		];
+	}
+
+	/**
+	 * Render the Previous / Next / position controls for an edit page's
+	 * action bar. Returns '' (the empty string) when there is nothing to
+	 * render so callers can safely 'echo' the result unconditionally.
+	 *
+	 * @param array $options Keys:
+	 *   - module_key  (string) session key set by snapshot()
+	 *   - script      (string) basename of the edit script (e.g. 'extension_edit.php')
+	 *   - id          (string) uuid of the record currently being edited
+	 *   - passthrough (array)  optional: GET param names to preserve in the
+	 *                          generated prev/next URLs. Defaults to
+	 *                          ['order_by', 'order', 'page', 'search'].
+	 *
+	 * @return string HTML, or '' if nothing should be rendered.
+	 */
+	public static function render($options) {
+		$module_key  = $options['module_key'] ?? '';
+		$script      = $options['script'] ?? '';
+		$id          = strtolower((string)($options['id'] ?? ''));
+		$passthrough = $options['passthrough'] ?? ['order_by', 'order', 'page', 'search'];
+
+		if ($module_key === '' || $script === '' || $id === '') {
+			return '';
+		}
+
+		$snap = $_SESSION[self::SESSION_KEY][$module_key] ?? null;
+		if (!is_array($snap) || empty($snap['order']) || !is_array($snap['order'])) {
+			return '';
+		}
+		if ((time() - ($snap['time'] ?? 0)) > self::TTL_SECONDS) {
+			return '';
+		}
+
+		$order = $snap['order'];
+		$total = count($order);
+		if ($total < 2) {
+			return '';
+		}
+
+		$idx = array_search($id, $order, true);
+		if ($idx === false) {
+			return '';
+		}
+
+		$position  = $idx + 1;
+		$prev_uuid = $idx > 0          ? $order[$idx - 1] : '';
+		$next_uuid = $idx < $total - 1 ? $order[$idx + 1] : '';
+
+		//build the URL query string that preserves list-page filters
+		$query = [];
+		foreach ($passthrough as $key) {
+			if (!empty($_REQUEST[$key])) {
+				$query[$key] = $_REQUEST[$key];
+			}
+		}
+
+		$build_url = function ($uuid) use ($script, $query) {
+			return $script . '?' . http_build_query(array_merge(['id' => $uuid], $query));
+		};
+
+		$prev_url = $prev_uuid !== '' ? $build_url($prev_uuid) : '';
+		$next_url = $next_uuid !== '' ? $build_url($next_uuid) : '';
+
+		$prev_title = 'Previous record  ('.$position.' of '.$total.')';
+		$next_title = 'Next record  ('.$position.' of '.$total.')';
+
+		$html  = '';
+		$html .= self::button('btn_edit_nav_prev', 'chevron-left',  $prev_url, $prev_title, '15px');
+		$html .= self::button('btn_edit_nav_next', 'chevron-right', $next_url, $next_title, '2px');
+		$html .= "<span id='edit_nav_position' style='margin-left: 10px; font-size: 12px; color: #888; vertical-align: middle;'>"
+		      .  htmlspecialchars($position.' / '.$total, ENT_QUOTES)
+		      .  "</span>";
+
+		//keyboard shortcuts: Alt+Left / Alt+Right
+		$payload = json_encode(['prev' => $prev_url, 'next' => $next_url], JSON_UNESCAPED_SLASHES);
+		$html .= "<script>"
+		      .  "(function(){var n=".$payload.";"
+		      .  "document.addEventListener('keydown',function(e){"
+		      .  "if(!e.altKey||e.ctrlKey||e.metaKey||e.shiftKey)return;"
+		      .  "var t=(e.target&&e.target.tagName)||'';"
+		      .  "if(t==='INPUT'||t==='TEXTAREA'||t==='SELECT')return;"
+		      .  "if(e.key==='ArrowLeft'&&n.prev){e.preventDefault();window.location.href=n.prev;}"
+		      .  "if(e.key==='ArrowRight'&&n.next){e.preventDefault();window.location.href=n.next;}"
+		      .  "});})();"
+		      .  "</script>";
+
+		return $html;
+	}
+
+	/**
+	 * Render a single icon-only navigation button.
+	 *
+	 * @param string $id          DOM id
+	 * @param string $icon        Font Awesome icon name (without "fa-" prefix)
+	 * @param string $url         Destination URL (empty = disabled state)
+	 * @param string $title       Tooltip / aria-label
+	 * @param string $margin_left CSS margin-left value
+	 *
+	 * @return string Button HTML.
+	 */
+	private static function button($id, $icon, $url, $title, $margin_left) {
+		$icon_html = "<span class='fa-solid fa-".htmlspecialchars($icon, ENT_QUOTES)." fa-fw'></span>";
+		$title_attr = htmlspecialchars($title, ENT_QUOTES);
+
+		if ($url === '') {
+			$style = "margin-left: ".$margin_left."; opacity: 0.4; cursor: not-allowed;";
+			return "<button type='button' id='".$id."' class='btn btn-default disabled' "
+			     . "disabled='disabled' title='".$title_attr."' aria-label='".$title_attr."' "
+			     . "style='".$style."'>".$icon_html."</button>";
+		}
+
+		$style = "margin-left: ".$margin_left.";";
+		return "<a href='".htmlspecialchars($url, ENT_QUOTES)."'>"
+		     . "<button type='button' id='".$id."' class='btn btn-default' "
+		     . "title='".$title_attr."' aria-label='".$title_attr."' "
+		     . "style='".$style."'>".$icon_html."</button></a>";
+	}
+}


### PR DESCRIPTION
## Summary

Adds compact Previous (◀) and Next (▶) chevron buttons to the action bar of these edit pages, so users can walk from one record to the next without bouncing back to the list page:

- Extensions
- Destinations
- Dialplan Manager
- Inbound Routes
- Outbound Routes
- Devices
- Follow Me (call_forward)

A small `n / N` position indicator sits next to the arrows. Keyboard shortcuts `Alt+◀` / `Alt+▶` also navigate (ignored while typing in a form field).

## Why

When triaging, onboarding or auditing it is common to open record after record from a filtered list. The current flow forces `list → edit → save → back → next row → edit` for every single record. This PR lets the user just keep clicking `▶` after each `Save`.

The navigation follows the **exact list the user last saw on the list page** — including the current `search` filter, `order_by` / `order` sort, `page`, and (where applicable) the `Show All` cross-domain view.

## Implementation

- New auto-loaded helper class `resources/classes/edit_nav.php` with two static methods (`snapshot()` and `render()`).
- Each list page calls `edit_nav::snapshot()` once, immediately after fetching its rows, which stores the ordered list of uuids in `$_SESSION['edit_nav'][<module_key>]` (one extra line per list page).
- Each edit page calls `edit_nav::render()` inside the action bar, which returns the prev / next / position HTML, or `''` when there is no fresh snapshot (one small block per edit page, right after the existing Save button).
- Snapshots have a 1-hour TTL guard so we never navigate via ancient state.
- The Dialplan Manager, Inbound Routes and Outbound Routes views are keyed separately by `app_uuid`, so switching between them never clobbers each other's snapshots.
- 100% server-side PHP — no JavaScript framework, no theme modifications, no `sessionStorage`. The only inline `<script>` is a 12-line `keydown` handler for the `Alt+Arrow` shortcuts.

## Backwards compatibility

Strictly additive. Users who deep-link straight to an edit page (bookmarks, new session, no list visited yet) see no change at all, because `edit_nav::render()` returns an empty string when no snapshot exists. No new permissions, no new settings, no schema change, no new language strings.

## Scope

- 1 new file: `resources/classes/edit_nav.php` (~190 lines, auto-loaded)
- 10 existing files touched, 3 lines added per file on average

## Manual test plan

1. Visit any list page above — page loads as before.
2. Click into a record — `◀ ▶ 3 / 47` appears in the action bar after Save.
3. Click `▶` — navigates to the next record in the same sort order, preserving the list-page search/sort.
4. Bookmark an edit URL directly, open it in a fresh session — arrows are not rendered (graceful no-op).
5. Press `Alt+◀` / `Alt+▶` while focused outside any form field — navigates.
