### PR TITLE
Add T38 variables to Inbound routes

### DIFF
--- a/app/destinations/destination_edit.php
+++ b/app/destinations/destination_edit.php
@@ -602,6 +602,10 @@
 								if (!empty($destination_distinctive_ring)) {
 									$dialplan["dialplan_xml"] .= "		<action application=\"export\" data=\"sip_h_Alert-Info=".xml::sanitize($destination_distinctive_ring)."\" inline=\"true\"/>\n";
 								}
+								if (!empty($destination_type_fax)) {
+									$dialplan["dialplan_xml"] .= "		<action application=\"set\" data=\"fax_enable_t38=true\"/>\n";
+									$dialplan["dialplan_xml"] .= "		<action application=\"set\" data=\"t38-passthru=once\"/>\n";
+								}
 								if (!empty($destination_ringback) && $ringbacks->valid($destination_ringback)) {
 									$dialplan["dialplan_xml"] .= "		<action application=\"export\" data=\"ringback=".$destination_ringback."\" inline=\"true\"/>\n";
 									$dialplan["dialplan_xml"] .= "		<action application=\"export\" data=\"transfer_ringback=".$destination_ringback."\" inline=\"true\"/>\n";
@@ -940,6 +944,37 @@
 											$dialplan["dialplan_details"][$y]["dialplan_detail_type"] = "export";
 											$dialplan["dialplan_details"][$y]["dialplan_detail_data"] = "sip_h_Alert-Info=".$destination_distinctive_ring;
 											$dialplan["dialplan_details"][$y]["dialplan_detail_inline"] = "true";
+											$dialplan["dialplan_details"][$y]["dialplan_detail_group"] = $dialplan_detail_group;
+											$dialplan["dialplan_details"][$y]["dialplan_detail_order"] = $dialplan_detail_order;
+											$dialplan["dialplan_details"][$y]["dialplan_detail_enabled"] = "true";
+											$y++;
+
+											//increment the dialplan detail order
+											$dialplan_detail_order = $dialplan_detail_order + 10;
+										}
+
+									//set fax t38
+										if (!empty($destination_type_fax)) {
+											$dialplan["dialplan_details"][$y]["domain_uuid"] = $domain_uuid;
+											$dialplan["dialplan_details"][$y]["dialplan_uuid"] = $dialplan_uuid;
+											$dialplan["dialplan_details"][$y]["dialplan_detail_tag"] = "action";
+											$dialplan["dialplan_details"][$y]["dialplan_detail_type"] = "set";
+											$dialplan["dialplan_details"][$y]["dialplan_detail_data"] = "fax_enable_t38=true";
+											$dialplan["dialplan_details"][$y]["dialplan_detail_inline"] = "";
+											$dialplan["dialplan_details"][$y]["dialplan_detail_group"] = $dialplan_detail_group;
+											$dialplan["dialplan_details"][$y]["dialplan_detail_order"] = $dialplan_detail_order;
+											$dialplan["dialplan_details"][$y]["dialplan_detail_enabled"] = "true";
+											$y++;
+
+											//increment the dialplan detail order
+											$dialplan_detail_order = $dialplan_detail_order + 10;
+
+											$dialplan["dialplan_details"][$y]["domain_uuid"] = $domain_uuid;
+											$dialplan["dialplan_details"][$y]["dialplan_uuid"] = $dialplan_uuid;
+											$dialplan["dialplan_details"][$y]["dialplan_detail_tag"] = "action";
+											$dialplan["dialplan_details"][$y]["dialplan_detail_type"] = "set";
+											$dialplan["dialplan_details"][$y]["dialplan_detail_data"] = "t38-passthru=once";
+											$dialplan["dialplan_details"][$y]["dialplan_detail_inline"] = "";
 											$dialplan["dialplan_details"][$y]["dialplan_detail_group"] = $dialplan_detail_group;
 											$dialplan["dialplan_details"][$y]["dialplan_detail_order"] = $dialplan_detail_order;
 											$dialplan["dialplan_details"][$y]["dialplan_detail_enabled"] = "true";


### PR DESCRIPTION
### What
When an inbound destination has it's `Fax` type checkbox activated, we need to add t38 variables to the inbound dialplan. Currently we have to do this manually and resaving a destination wipes this for us.

### How
When the type is Fax for a destinations it adds these 2 variables to the inbound route in the `public` context:
* fax_enable_t38=true
* t38-passthrough=once
