### PR TITLE
Enforce permissions and validate payload in active_calls websocket handlers

### DIFF
--- a/app/active_calls/resources/classes/active_calls_service.php
+++ b/app/active_calls/resources/classes/active_calls_service.php
@@ -448,8 +448,9 @@ class active_calls_service extends service implements websocket_service_interfac
 	private function on_in_progress(websocket_message $websocket_message) {
 		// Check permission
 		if (!$websocket_message->has_permission('call_active_view')) {
-			$this->warning("Permission 'call_active_show' not found in subscriber request");
+			$this->warning("Permission 'call_active_view' not found in subscriber request");
 			websocket_client::send($this->ws_client->socket(), websocket_message::request_forbidden($websocket_message->request_id, SERVICE_NAME, $websocket_message->topic));
+			return;
 		}
 
 		// Set up the response array
@@ -485,6 +486,7 @@ class active_calls_service extends service implements websocket_service_interfac
 		if (!$websocket_message->has_permission('call_active_hangup')) {
 			$this->warning("Permission 'call_active_hangup' not found in subscriber request");
 			websocket_client::send($this->ws_client->socket(), websocket_message::request_forbidden($websocket_message->request_id, SERVICE_NAME, $websocket_message->topic));
+			return;
 		}
 
 		// Get the payload
@@ -499,6 +501,7 @@ class active_calls_service extends service implements websocket_service_interfac
 		// Respond with bad command
 		if (empty($uuid)) {
 			websocket_client::send($this->ws_client->socket(), websocket_message::request_is_bad($request_id, SERVICE_NAME, 'hangup'));
+			return;
 		}
 
 		$host = self::$switch_host ?? parent::$config->get('switch.event_socket.host', '127.0.0.1');
@@ -546,6 +549,7 @@ class active_calls_service extends service implements websocket_service_interfac
 		if (!$websocket_message->has_permission('call_active_eavesdrop')) {
 			$this->warning("Permission 'call_active_eavesdrop' not found in subscriber request");
 			websocket_client::send($this->ws_client->socket(), websocket_message::request_forbidden($websocket_message->request_id, SERVICE_NAME, $websocket_message->topic));
+			return;
 		}
 
 		// Make sure we are connected
@@ -569,6 +573,29 @@ class active_calls_service extends service implements websocket_service_interfac
 		$origination_caller_id_name = $payload['origination_caller_id_name'] ?? '';
 		$caller_caller_id_number = $payload['caller_caller_id_number'] ?? '';
 		$origination_caller_contact = $payload['origination_caller_contact'] ?? '';
+
+		//
+		// All four values below are interpolated into a single FreeSWITCH command:
+		//     bgapi originate {caller_id_name=NAME,caller_id_number=NUMBER}user/CONTACT@DOMAIN &eavesdrop(UUID)
+		// A client could otherwise inject extra originate variables or commands using
+		// the structural characters of that string ( { } , & / @ ' ( ) and whitespace ).
+		// Each value is checked against an allowlist of only the characters it legitimately
+		// needs, so those structural characters are rejected. Bail out if any value is invalid.
+		//
+		$valid =
+			// unique_id: must be exactly a UUID (8-4-4-4-12 hex, case insensitive)
+			preg_match('/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i', $uuid)
+			// caller contact: an extension / number alias - digits, letters and * # + . _ - (required)
+			&& preg_match('/^[0-9A-Za-z*#+._-]+$/', $origination_caller_contact)
+			// caller id number: a dial string - digits and * # + (may be empty)
+			&& preg_match('/^[0-9*#+]*$/', $caller_caller_id_number)
+			// caller id name: a display name - any unicode letter/number plus space . _ - (may be empty)
+			&& preg_match('/^[\p{L}\p{N} ._-]*$/u', $origination_caller_id_name);
+		if (!$valid) {
+			$this->warning("Eavesdrop request rejected because of an invalid payload");
+			websocket_client::send($this->ws_client->socket(), websocket_message::request_is_bad($websocket_message->request_id, SERVICE_NAME, $websocket_message->topic));
+			return;
+		}
 
 		$response['status_message'] = 'success';
 		$response['status_code'] = 200;


### PR DESCRIPTION
The active calls websocket handlers sends a forbidden response on a failed permission check but does not return, so the privileged operation runs anyway. This defeats the separation between call_active_view, call_active_hangup, and call_active_eavesdrop, letting a view-only subscriber hang up calls and start eavesdrop sessions. Add the missing returns so a denied request actually stops.

Also validate the eavesdrop payload before it is interpolated into the event socket originate command, so a crafted client cannot inject additional originate variables or commands. The empty unique_id guard in on_hangup now returns as well, so uuid_kill is no longer called with an empty uuid.