### PR TITLE
Concurrent Registration for Yealink T54w - Removal of Redundant Blank "fallback.redundancy_type" Setting

### DIFF
--- a/resources/templates/provision/yealink/t54w/{$mac}.cfg
+++ b/resources/templates/provision/yealink/t54w/{$mac}.cfg
@@ -264,7 +264,6 @@ account.{$row.line_number}.static_cache_pri=
 account.{$row.line_number}.dns_cache_type=
 account.{$row.line_number}.naptr_build=
 account.{$row.line_number}.fallback.timeout = {$yealink_outbound_proxy_fallback_interval}
-account.{$row.line_number}.fallback.redundancy_type=
 account.{$row.line_number}.reg_failed_retry_max_time=
 account.{$row.line_number}.reg_failed_retry_min_time=
 account.{$row.line_number}.redundancy_with_reg_fail.enable =


### PR DESCRIPTION
Yealink phones support Concurrent Registration where two SIP servers can be specified for an account on the phone. The default FusionPBX template for other Yealink models has Concurrent Registration set to default on, but in the T54w template there is a duplicate line with a blank value that causes the first one in the account loop, which is set to 0, to be ignored, with the phone taking the blank value and disabling the setting altogether.

This removes the duplicate blank setting, allowing the one higher up in the account line loop to take effect.