### PR TITLE
Replace htmlentities with htmlspecialchars in escape function

### DIFF
--- a/resources/functions.php
+++ b/resources/functions.php
@@ -2555,20 +2555,20 @@ function event_socket_mkdir($dir) {
 
 /**
 * Escape the user data
-* <p>Escapes all characters that have HTML character entity
+* <p>Escapes & " ' < and > characters</p>
 * @param string $string the value to escape
 * @return string
-* @link https://www.php.net/htmlentities
+* @link https://www.php.net/htmlspecialchars
 */
 function escape($string) {
 	if (is_string($string)) {
-		return htmlentities($string, ENT_QUOTES | ENT_HTML5, 'UTF-8');
+		return htmlspecialchars($string, ENT_QUOTES | ENT_HTML5, 'UTF-8');
 	} elseif (is_numeric($string)) {
 		return $string;
 	} else {
 		$string = (array) $string;
 		if (isset($string[0])) {
-			return htmlentities($string[0], ENT_QUOTES | ENT_HTML5, 'UTF-8');
+			return htmlspecialchars($string[0], ENT_QUOTES | ENT_HTML5, 'UTF-8');
 		}
 	}
 	return false;


### PR DESCRIPTION
htmlspecialchars is faster because it converts fewer characters.