### PR TITLE
Add background wallpaper config options for Polycom 5.x & 6.x templates

### DIFF
--- a/app/polycom/app_config.php
+++ b/app/polycom/app_config.php
@@ -951,5 +951,13 @@
 		$apps[$x]['default_settings'][$y]['default_setting_value'] = "0";
 		$apps[$x]['default_settings'][$y]['default_setting_enabled'] = "true";
 		$apps[$x]['default_settings'][$y]['default_setting_description'] = "Siren22 at 64 kbps codec priority order. 0 disables, 1+ sets preference order.";
+		$y++;
+		$apps[$x]['default_settings'][$y]['default_setting_uuid'] = "cb56e58f-f359-4f3f-9b26-c1cd7ca6e988";
+		$apps[$x]['default_settings'][$y]['default_setting_category'] = "provision";
+		$apps[$x]['default_settings'][$y]['default_setting_subcategory'] = "polycom_background_url";
+		$apps[$x]['default_settings'][$y]['default_setting_name'] = "text";
+		$apps[$x]['default_settings'][$y]['default_setting_value'] = "https://server.domain.local/app/polycom/resources/background/background.jpg";
+		$apps[$x]['default_settings'][$y]['default_setting_enabled'] = "false";
+		$apps[$x]['default_settings'][$y]['default_setting_description'] = "URL of the image to be set as the phone background wallpaper.";
 
 ?>

--- a/resources/templates/provision/polycom/5.x/{$mac}.cfg
+++ b/resources/templates/provision/polycom/5.x/{$mac}.cfg
@@ -416,11 +416,11 @@
 		{/if}
 	/>
 
-	<BG 
+	<BG
 		{if isset($polycom_background_url)}
-	    bg.background.enabled="1" 
-	    bg.color.selection="2,1" 
-	    bg.color.bm.1.name="{$polycom_background_url}"
+		bg.background.enabled="1"
+		bg.color.selection="2,1"
+		bg.color.bm.1.name="{$polycom_background_url}"
 		{/if}
-    />
+	/>
 </PHONE>

--- a/resources/templates/provision/polycom/5.x/{$mac}.cfg
+++ b/resources/templates/provision/polycom/5.x/{$mac}.cfg
@@ -415,4 +415,12 @@
 		device.dhcp.dhcpVlanDiscUseOpt="{$polycom_dhcp_vlan_discovery}"
 		{/if}
 	/>
+
+	<BG 
+		{if isset($polycom_background_url)}
+	    bg.background.enabled="1" 
+	    bg.color.selection="2,1" 
+	    bg.color.bm.1.name="{$polycom_background_url}"
+		{/if}
+    />
 </PHONE>

--- a/resources/templates/provision/polycom/6.x/{$mac}.cfg
+++ b/resources/templates/provision/polycom/6.x/{$mac}.cfg
@@ -416,11 +416,12 @@
 		{/if}
 	/>
 
-	<BG
+	<BG
 		{if isset($polycom_background_url)}
-		bg.background.enabled="1"
-		bg.color.selection="2,1"
-		bg.color.bm.1.name="{$polycom_background_url}"
+		bg.background.enabled="1"
+		bg.color.selection="2,1"
+		bg.color.bm.1.name="{$polycom_background_url}"
 		{/if}
-	/>
+	/>
+
 </PHONE>

--- a/resources/templates/provision/polycom/6.x/{$mac}.cfg
+++ b/resources/templates/provision/polycom/6.x/{$mac}.cfg
@@ -415,4 +415,12 @@
 		device.dhcp.dhcpVlanDiscUseOpt="{$polycom_dhcp_vlan_discovery}"
 		{/if}
 	/>
+
+	<BG 
+		{if isset($polycom_background_url)}
+	    bg.background.enabled="1" 
+	    bg.color.selection="2,1" 
+	    bg.color.bm.1.name="{$polycom_background_url}"
+		{/if}
+    />
 </PHONE>

--- a/resources/templates/provision/polycom/6.x/{$mac}.cfg
+++ b/resources/templates/provision/polycom/6.x/{$mac}.cfg
@@ -416,11 +416,11 @@
 		{/if}
 	/>
 
-	<BG 
+	<BG
 		{if isset($polycom_background_url)}
-	    bg.background.enabled="1" 
-	    bg.color.selection="2,1" 
-	    bg.color.bm.1.name="{$polycom_background_url}"
+		bg.background.enabled="1"
+		bg.color.selection="2,1"
+		bg.color.bm.1.name="{$polycom_background_url}"
 		{/if}
-    />
+	/>
 </PHONE>

--- a/resources/templates/provision/polycom/vvx450/{$mac}.cfg
+++ b/resources/templates/provision/polycom/vvx450/{$mac}.cfg
@@ -416,11 +416,11 @@
 		{/if}
 	/>
 
-	<BG 
+	<BG
 		{if isset($polycom_background_url)}
-	    bg.background.enabled="1" 
-	    bg.color.selection="2,1" 
-	    bg.color.bm.1.name="{$polycom_background_url}"
+		bg.background.enabled="1"
+		bg.color.selection="2,1"
+		bg.color.bm.1.name="{$polycom_background_url}"
 		{/if}
-    />
+	/>
 </PHONE>

--- a/resources/templates/provision/polycom/vvx450/{$mac}.cfg
+++ b/resources/templates/provision/polycom/vvx450/{$mac}.cfg
@@ -415,4 +415,12 @@
 		device.dhcp.dhcpVlanDiscUseOpt="{$polycom_dhcp_vlan_discovery}"
 		{/if}
 	/>
+
+	<BG 
+		{if isset($polycom_background_url)}
+	    bg.background.enabled="1" 
+	    bg.color.selection="2,1" 
+	    bg.color.bm.1.name="{$polycom_background_url}"
+		{/if}
+    />
 </PHONE>


### PR DESCRIPTION
This PR adds the background wallpaper configuration options to the 5.x, 6.x and vvx-450 templates. (these were the templates i was able to test with the phones i have)