### PR TITLE
Restrict call recording download to the current domain

### DIFF
--- a/app/xml_cdr/resources/classes/xml_cdr.php
+++ b/app/xml_cdr/resources/classes/xml_cdr.php
@@ -2133,6 +2133,12 @@ class xml_cdr {
 		//get call recording from database
 		$sql = "select record_name, record_path from v_xml_cdr ";
 		$sql .= "where xml_cdr_uuid = :xml_cdr_uuid ";
+		//restrict to the current domain unless the user can view all domains, so a
+		//recording from another domain cannot be downloaded by guessing its uuid
+		if (!permission_exists('xml_cdr_all')) {
+			$sql .= "and domain_uuid = :domain_uuid ";
+			$parameters['domain_uuid'] = $this->domain_uuid;
+		}
 		$parameters['xml_cdr_uuid'] = $this->recording_uuid;
 		$row = $this->database->select($sql, $parameters, 'row');
 		if (!empty($row) && is_array($row)) {

--- a/app/xml_cdr/resources/classes/xml_cdr.php
+++ b/app/xml_cdr/resources/classes/xml_cdr.php
@@ -124,7 +124,7 @@ class xml_cdr {
 	private $json;
 
 	/**
-	 * Initializes the object with setting array.
+	 * Initializes the object with the setting array.
 	 *
 	 * @param array $setting_array An array containing settings for domain, user, and database connections. Defaults to
 	 *                             an empty array.
@@ -2124,7 +2124,7 @@ class xml_cdr {
 			return;
 		}
 
-		//check for a valid uuid
+		//check for a valid UUID
 		if (!is_uuid($this->recording_uuid)) {
 			//echo "invalid uuid";
 			return;
@@ -2133,8 +2133,6 @@ class xml_cdr {
 		//get call recording from database
 		$sql = "select record_name, record_path from v_xml_cdr ";
 		$sql .= "where xml_cdr_uuid = :xml_cdr_uuid ";
-		//restrict to the current domain unless the user can view all domains, so a
-		//recording from another domain cannot be downloaded by guessing its uuid
 		if (!permission_exists('xml_cdr_all')) {
 			$sql .= "and domain_uuid = :domain_uuid ";
 			$parameters['domain_uuid'] = $this->domain_uuid;


### PR DESCRIPTION
xml_cdr::download() looked up the recording by xml_cdr_uuid alone, with no domain_uuid filter, so a user with xml_cdr_view could download a recording belonging to another domain by supplying its uuid. Add the domain_uuid restriction unless the user has xml_cdr_all, matching the existing behavior in xml_cdr_details.php.