### PR TITLE
Destroy session when xml_cdr_import.php is done

### DIFF
--- a/app/provision/index.php
+++ b/app/provision/index.php
@@ -501,4 +501,8 @@
 		require_once "app/device_logs/resources/device_logs.php";
 	}
 
+//destroy session
+       session_unset();
+       session_destroy();
+
 ?>

--- a/app/xml_cdr/xml_cdr_import.php
+++ b/app/xml_cdr/xml_cdr_import.php
@@ -57,4 +57,8 @@
 	$cdr->post();
 	$cdr->read_files();
 
+//destroy session
+        session_unset();
+        session_destroy();
+
 ?>


### PR DESCRIPTION
I added this change a few years ago to clean up php sessions needlessly being left in /tmp long after they were no longer needed.