### PR TITLE
Fix file upload path traversal issues

### DIFF
--- a/app/access_controls/access_control_import.php
+++ b/app/access_controls/access_control_import.php
@@ -81,7 +81,7 @@
 	//$_POST['submit'] == "Upload" &&
 	if (!empty($_FILES['ulfile']['tmp_name']) &&  is_uploaded_file($_FILES['ulfile']['tmp_name']) && permission_exists('access_control_node_add')) {
 		if (!empty($_POST['type']) &&$_POST['type'] == 'csv') {
-			$file = $settings->get('server', 'temp').'/'.$_FILES['ulfile']['name'];
+			$file = $settings->get('server', 'temp').'/'.basename($_FILES['ulfile']['name']);
 			if (move_uploaded_file($_FILES['ulfile']['tmp_name'], $file)) {
 				$_SESSION['file'] = $file;
 			}

--- a/app/bridges/bridge_imports.php
+++ b/app/bridges/bridge_imports.php
@@ -69,11 +69,12 @@
 //copy the csv file
 	if (!empty($_FILES['ulfile']['tmp_name']) && is_uploaded_file($_FILES['ulfile']['tmp_name']) && permission_exists('bridge_import')) {
 		if ($_POST['type'] == 'csv') {
-			move_uploaded_file($_FILES['ulfile']['tmp_name'], $settings->get('server', 'temp').'/'.$_FILES['ulfile']['name']);
-			$save_msg = "Uploaded file to ".$settings->get('server', 'temp')."/". htmlentities($_FILES['ulfile']['name']);
+			$upload_name = basename($_FILES['ulfile']['name']);
+			move_uploaded_file($_FILES['ulfile']['tmp_name'], $settings->get('server', 'temp').'/'.$upload_name);
+			$save_msg = "Uploaded file to ".$settings->get('server', 'temp')."/". htmlentities($upload_name);
 			//system('chmod -R 744 '.$settings->get('server', 'temp').'*');
 			unset($_POST['txtCommand']);
-			$file = $settings->get('server', 'temp').'/'.$_FILES['ulfile']['name'];
+			$file = $settings->get('server', 'temp').'/'.$upload_name;
 			$_SESSION['file'] = $file;
 		}
 	}

--- a/app/destinations/destination_imports.php
+++ b/app/destinations/destination_imports.php
@@ -61,18 +61,19 @@
 		$file = $settings->get('server', 'temp')."/destinations-".$_SESSION['domain_name'].".csv";
 		file_put_contents($file, $_POST['data']);
 		$_SESSION['file'] = $file;
-		$_SESSION['file_name'] = $_FILES['ulfile']['name'];
+		$_SESSION['file_name'] = basename($_FILES['ulfile']['name']);
 	}
 
 //copy the csv file
 	//$_POST['submit'] == "Upload" &&
 	if (!empty($_FILES['ulfile']['tmp_name']) && is_uploaded_file($_FILES['ulfile']['tmp_name']) && permission_exists('destination_upload')) {
 		if ($_POST['type'] == 'csv') {
-			move_uploaded_file($_FILES['ulfile']['tmp_name'], $settings->get('server', 'temp').'/'.$_FILES['ulfile']['name']);
-			$save_msg = "Uploaded file to ".$settings->get('server', 'temp')."/". htmlentities($_FILES['ulfile']['name']);
+			$upload_name = basename($_FILES['ulfile']['name']);
+			move_uploaded_file($_FILES['ulfile']['tmp_name'], $settings->get('server', 'temp').'/'.$upload_name);
+			$save_msg = "Uploaded file to ".$settings->get('server', 'temp')."/". htmlentities($upload_name);
 			//system('chmod -R 744 '.$settings->get('server', 'temp').'*');
 			unset($_POST['txtCommand']);
-			$file = $settings->get('server', 'temp').'/'.$_FILES['ulfile']['name'];
+			$file = $settings->get('server', 'temp').'/'.$upload_name;
 			$_SESSION['file'] = $file;
 		}
 	}

--- a/app/extensions/extension_imports.php
+++ b/app/extensions/extension_imports.php
@@ -55,11 +55,12 @@
 	//$_POST['submit'] == "Upload" &&
 	if (!empty($_FILES['ulfile']['tmp_name']) && is_uploaded_file($_FILES['ulfile']['tmp_name']) && permission_exists('extension_import')) {
 		if ($_POST['type'] == 'csv') {
-			move_uploaded_file($_FILES['ulfile']['tmp_name'], $settings->get('server', 'temp').'/'.$_FILES['ulfile']['name']);
-			$save_msg = "Uploaded file to ".$settings->get('server', 'temp')."/". htmlentities($_FILES['ulfile']['name']);
+			$upload_name = basename($_FILES['ulfile']['name']);
+			move_uploaded_file($_FILES['ulfile']['tmp_name'], $settings->get('server', 'temp').'/'.$upload_name);
+			$save_msg = "Uploaded file to ".$settings->get('server', 'temp')."/". htmlentities($upload_name);
 			//system('chmod -R 744 '.$settings->get('server', 'temp').'*');
 			unset($_POST['txtCommand']);
-			$file = $settings->get('server', 'temp').'/'.$_FILES['ulfile']['name'];
+			$file = $settings->get('server', 'temp').'/'.$upload_name;
 			$_SESSION['file'] = $file;
 		}
 	}

--- a/app/voicemails/voicemail_imports.php
+++ b/app/voicemails/voicemail_imports.php
@@ -70,11 +70,12 @@
 	//$_POST['submit'] == "Upload" &&
 	if (!empty($_FILES['ulfile']['tmp_name']) && is_uploaded_file($_FILES['ulfile']['tmp_name']) && permission_exists('voicemail_import')) {
 		if ($_POST['type'] == 'csv') {
-			move_uploaded_file($_FILES['ulfile']['tmp_name'], $temp_dir.'/'.$_FILES['ulfile']['name']);
-			$save_msg = "Uploaded file to ".$temp_dir."/". htmlentities($_FILES['ulfile']['name']);
+			$upload_name = basename($_FILES['ulfile']['name']);
+			move_uploaded_file($_FILES['ulfile']['tmp_name'], $temp_dir.'/'.$upload_name);
+			$save_msg = "Uploaded file to ".$temp_dir."/". htmlentities($upload_name);
 			//system('chmod -R 744 '.$temp_dir.'*');
 			unset($_POST['txtCommand']);
-			$file = $temp_dir.'/'.$_FILES['ulfile']['name'];
+			$file = $temp_dir.'/'.$upload_name;
 			$_SESSION['file'] = $file;
 		}
 	}

--- a/core/contacts/contact_import.php
+++ b/core/contacts/contact_import.php
@@ -58,10 +58,11 @@
 	//$_POST['submit'] == "Upload" &&
 	if (!empty($_FILES['ulfile']['tmp_name']) && is_uploaded_file($_FILES['ulfile']['tmp_name']) && permission_exists('contact_upload')) {
 		if ($_POST['type'] == 'csv') {
-			move_uploaded_file($_FILES['ulfile']['tmp_name'], $settings->get('server', 'temp').'/'.$_FILES['ulfile']['name']);
-			$save_msg = "Uploaded file to ".$settings->get('server', 'temp')."/". htmlentities($_FILES['ulfile']['name']);
+			$upload_name = basename($_FILES['ulfile']['name']);
+			move_uploaded_file($_FILES['ulfile']['tmp_name'], $settings->get('server', 'temp').'/'.$upload_name);
+			$save_msg = "Uploaded file to ".$settings->get('server', 'temp')."/". htmlentities($upload_name);
 			//system('chmod -R 744 '.$settings->get('server', 'temp').'*');
-			$file = $settings->get('server', 'temp').'/'.$_FILES['ulfile']['name'];
+			$file = $settings->get('server', 'temp').'/'.$upload_name;
 			$_SESSION['file'] = $file;
 		}
 	}


### PR DESCRIPTION
Wrap basename() around ['ulfile']['name'] in 6 CSV import files to prevent directory traversal via malicious filenames.

Affected files:
- core/contacts/contact_import.php
- app/voicemails/voicemail_imports.php
- app/extensions/extension_imports.php
- app/access_controls/access_control_import.php
- app/destinations/destination_imports.php
- app/bridges/bridge_imports.php

The affected functionality requires admin and/or superadmin permissions to reach, but even in the case of superadmin we want to protect against a compromised superadmin account escalating into raw system access.