### PR TITLE
Sanitize filename/dir input in recording download endpoints

### DIFF
--- a/app/recordings/recording_play.php
+++ b/app/recordings/recording_play.php
@@ -38,8 +38,8 @@
 	}
 
 //get the variables
-	$filename = $_GET['filename'];
-	$type = $_GET['type']; //moh //rec
+	$filename = basename($_GET['filename'] ?? '');
+	$type = $_GET['type'] ?? ''; //moh //rec
 
 //show the content
 ?>

--- a/app/recordings/recordings.php
+++ b/app/recordings/recordings.php
@@ -119,7 +119,7 @@
 					}
 					unset($sql, $parameters, $row, $recording_decoded);
 				} elseif ($_GET['filename']) {
-					$recording_filename = $_GET['filename'];
+					$recording_filename = basename($_GET['filename']);
 				}
 
 			// build full path

--- a/app/recordings/waveform.php
+++ b/app/recordings/waveform.php
@@ -64,7 +64,7 @@
 			unset($sql, $parameters, $row, $recording_decoded);
 		}
 		else if ($_GET['data']) {
-			$recording_filename = str_replace($path, '', $_GET['data']);
+			$recording_filename = basename($_GET['data']);
 		}
 
 		//build full path


### PR DESCRIPTION
This PR fixes several arbitrary file read vulnerabilities.  Authenticated users can download any file the php service has read access to, including system files like /etc/passwd