### PR TITLE
Fix: Exclude child IVR menu from parent menu dropdown

### DIFF
--- a/app/ivr_menus/ivr_menu_edit.php
+++ b/app/ivr_menus/ivr_menu_edit.php
@@ -926,14 +926,14 @@
 	echo "</td>\n";
 	echo "</tr>\n";
 
-	echo "	<tr>";
-	echo "		<td class='vncell'>".$text['label-ivr_menu_parent_uuid']."</td>";
-	echo "		<td class='vtable'>";
-	echo "<select name=\"ivr_menu_parent_uuid\" class='formfld'>\n";
-	echo "<option value=\"\"></option>\n";
+	echo "<tr>";
+	echo "	<td class='vncell'>".$text['label-ivr_menu_parent_uuid']."</td>";
+	echo "	<td class='vtable'>";
+	echo "		<select name=\"ivr_menu_parent_uuid\" class='formfld'>\n";
+	echo "			<option value=\"\"></option>\n";
 	if (!empty($ivr_menus)) {
 		foreach($ivr_menus as $field) {
-			if ($field['ivr_menu_uuid'] != $ivr_menu_uuid) {
+			if ($ivr_menu_uuid != $field['ivr_menu_uuid'] && $ivr_menu_uuid != $field['ivr_menu_parent_uuid']) {
 				if (!empty($ivr_menu_parent_uuid) && $ivr_menu_parent_uuid == $field['ivr_menu_uuid']) {
 					echo "<option value='".escape($field['ivr_menu_uuid'])."' selected='selected'>".escape($field['ivr_menu_name'])."</option>\n";
 				}
@@ -943,9 +943,9 @@
 			}
 		}
 	}
-	echo "</select>";
-	echo "		</td>";
-	echo "	</tr>";
+	echo "		</select>";
+	echo "	</td>";
+	echo "</tr>";
 
 	echo "<tr>\n";
 	echo "<td class='vncell' valign='top' align='left' nowrap>\n";

--- a/core/authentication/resources/classes/authentication.php
+++ b/core/authentication/resources/classes/authentication.php
@@ -690,9 +690,6 @@ class authentication {
 			$_SESSION['username'] = trim($_REQUEST["username"]);
 		}
 
-		//set a default value for unqiue
-		$_SESSION["users"]["unique"]["text"] = $this->settings->get('users', 'unique', '');
-
 		//get the domain name from the username
 		if (!empty($_SESSION['username']) && $this->settings->get('users', 'unique', '') != "global") {
 			$username_array = explode("@", $_SESSION['username']);

--- a/core/authentication/resources/classes/plugins/email.php
+++ b/core/authentication/resources/classes/plugins/email.php
@@ -286,11 +286,11 @@ class plugin_email {
 			$email_body = str_replace('${auth_code}', $_SESSION["user"]["authentication"]["email"]["code"], $email_body);
 
 			//get the email from name and address
-			$email_from_address = $_SESSION['email']['smtp_from']['text'];
-			$email_from_name = $_SESSION['email']['smtp_from_name']['text'];
+			$email_from_address = $settings->get('email', 'smtp_from');
+			$email_from_name = $settings->get('email', 'smtp_from_name');
 
 			//get the email send mode options: direct or email_queue
-			$email_send_mode = $_SESSION['authentication']['email_send_mode']['text'] ?? 'email_queue';
+			$email_send_mode = $settings->get('authentication', 'email_send_mode', 'email_queue');
 
 			//send the email
 			if ($email_send_mode == 'email_queue') {

--- a/core/authentication/resources/classes/plugins/totp.php
+++ b/core/authentication/resources/classes/plugins/totp.php
@@ -184,7 +184,7 @@ class plugin_totp {
 			$sql .= "	username = :username\n";
 			$sql .= "	or user_email = :username\n";
 			$sql .= ")\n";
-			if (empty($_SESSION["users"]["unique"]["text"]) || $_SESSION["users"]["unique"]["text"] != "global") {
+			if (empty($users_unique) || $users_unique != "global") {
 				//unique username per domain (not globally unique across system - example: email address)
 				$sql .= "and domain_uuid = :domain_uuid ";
 				$parameters['domain_uuid'] = $this->domain_uuid;

--- a/resources/classes/domains.php
+++ b/resources/classes/domains.php
@@ -559,32 +559,46 @@ class domains {
 								$v_needle = 'v_';
 							}
 
-							//delete the dialplan
-							@unlink($_SESSION['switch']['dialplan']['dir'] . '/' . $domain_name . '.xml');
-							if (!empty($_SESSION['switch']['dialplan']['dir'])) {
-								recursive_delete($_SESSION['switch']['dialplan']['dir'] . '/' . $domain_name);
+							//define the setting switch directories
+							$switch_dialplan = $this->settings->get('switch', 'dialplan');
+							$switch_extensions = $this->settings->get('switch', 'extensions');
+							$switch_storage = $this->settings->get('switch', 'storage');
+							$switch_sip_profiles = $this->settings->get('switch', 'sip_profiles');
+							$switch_conf = $this->settings->get('switch', 'conf');
+							$switch_recordings = $this->settings->get('switch', 'recordings');
+							$switch_voicemail = $this->settings->get('switch', 'voicemail');
+
+							//delete the dialplan directories
+							if (!empty($switch_dialplan)) {
+								//delete the main dialplan directories
+								@unlink($switch_dialplan . '/' . $domain_name . '.xml');
+								if (file_exists($switch_dialplan . '/' . $domain_name)) {
+									recursive_delete($switch_dialplan . '/' . $domain_name);
+								}
+
+								//delete the dialplan public
+								@unlink($switch_dialplan . '/public/' . $domain_name . '.xml');
+								if (file_exists($switch_dialplan . '/public/' . $domain_name)) {
+									recursive_delete($switch_dialplan . '/public/' . $domain_name);
+								}
 							}
 
-							//delete the dialplan public
-							@unlink($_SESSION['switch']['dialplan']['dir'] . '/public/' . $domain_name . '.xml');
-							if (!empty($_SESSION['switch']['dialplan']['dir'])) {
-								recursive_delete($_SESSION['switch']['dialplan']['dir'] . '/public/' . $domain_name);
-							}
-
-							//delete the extension
-							@unlink($_SESSION['switch']['extensions']['dir'] . '/' . $domain_name . '.xml');
-							if (!empty($_SESSION['switch']['extensions']['dir'])) {
-								recursive_delete($_SESSION['switch']['extensions']['dir'] . '/' . $domain_name);
+							//delete the extensions
+							if (!empty($switch_extensions)) {
+								@unlink($switch_extensions . '/' . $domain_name . '.xml');
+								if (file_exists($switch_extensions . '/' . $domain_name)) {
+									recursive_delete($switch_extensions . '/' . $domain_name);
+								}
 							}
 
 							//delete fax
-							if (!empty($_SESSION['switch']['storage']['dir'])) {
-								recursive_delete($_SESSION['switch']['storage']['dir'] . '/fax/' . $domain_name);
+							if (!empty($switch_storage) && file_exists($switch_storage . '/fax/' . $domain_name)) {
+								recursive_delete($switch_storage . '/fax/' . $domain_name);
 							}
 
 							//delete the gateways
-							if (!empty($_SESSION['switch']['sip_profiles']['dir'])) {
-								if ($dh = opendir($_SESSION['switch']['sip_profiles']['dir'])) {
+							if (!empty($switch_sip_profiles)) {
+								if ($dh = opendir($switch_sip_profiles)) {
 									$files = [];
 									while ($file = readdir($dh)) {
 										if ($file != "." && $file != ".." && $file[0] != '.') {
@@ -593,7 +607,7 @@ class domains {
 											} else {
 												//check if file extension is xml
 												if (strpos($file, $v_needle) !== false && substr($file, -4) == '.xml') {
-													@unlink($_SESSION['switch']['sip_profiles']['dir'] . "/" . $file);
+													@unlink($switch_sip_profiles . "/" . $file);
 												}
 											}
 										}
@@ -603,8 +617,8 @@ class domains {
 							}
 
 							//delete the ivr menu
-							if (!empty($_SESSION['switch']['conf']['dir'])) {
-								if ($dh = opendir($_SESSION['switch']['conf']['dir'] . "/ivr_menus")) {
+							if (!empty($switch_conf)) {
+								if ($dh = opendir($switch_conf . "/ivr_menus")) {
 									$files = [];
 									while ($file = readdir($dh)) {
 										if ($file != "." && $file != ".." && $file[0] != '.') {
@@ -612,7 +626,7 @@ class domains {
 												//this is a directory
 											} else {
 												if (strpos($file, $v_needle) !== false && substr($file, -4) == '.xml') {
-													@unlink($_SESSION['switch']['conf']['dir'] . "/ivr_menus/" . $file);
+													@unlink($switch_conf . "/ivr_menus/" . $file);
 												}
 											}
 										}
@@ -622,13 +636,13 @@ class domains {
 							}
 
 							//delete the recordings
-							if (!empty($_SESSION['switch']['recordings']['dir'])) {
-								recursive_delete($_SESSION['switch']['recordings']['dir'] . '/' . $_SESSION['domain_name'] . '/' . $domain_name);
+							if (!empty($switch_recordings) && file_exists($switch_recordings . '/' . $domain_name)) {
+								recursive_delete($switch_recordings . '/' . $domain_name);
 							}
 
 							//delete voicemail
-							if (!empty($_SESSION['switch']['voicemail']['dir'])) {
-								recursive_delete($_SESSION['switch']['voicemail']['dir'] . '/' . $domain_name);
+							if (!empty($switch_voicemail) && file_exists($switch_voicemail . '/' . $domain_name)) {
+								recursive_delete($switch_voicemail . '/' . $domain_name);
 							}
 						}
 

--- a/resources/classes/message.php
+++ b/resources/classes/message.php
@@ -77,9 +77,12 @@ class message {
 	 * @return void
 	 */
 	static function add($message, $mood = null, $delay = null) {
+		//set the global variables
+		global $settings;
+
 		//set mood and delay
 		$mood = $mood ?: 'positive';
-		$delay = $delay ?: (1000 * (float)$_SESSION['theme']['message_delay']['text']);
+		$delay = $delay ?: (1000 * (float)$settings->get('theme', 'message_delay', '3'));
 		//ignore duplicate messages
 		if (isset($_SESSION["messages"]) && !empty($_SESSION["messages"][$mood]['message'])) {
 			if (!in_array($message, $_SESSION["messages"][$mood]['message'])) {

--- a/resources/classes/sounds.php
+++ b/resources/classes/sounds.php
@@ -27,6 +27,29 @@ class sounds {
 	private $database;
 
 	/**
+	 * Settings object set in the constructor. Must be a settings object and cannot be null.
+	 *
+	 * @var settings Settings Object
+	 */
+	private $settings;
+
+	/**
+	 * Domain name set in the constructor. This can be passed in through the $settings_array associative array or set
+	 * in the session global array
+	 *
+	 * @var string
+	 */
+	private $domain_name;
+
+	/**
+	 * User UUID set in the constructor. This can be passed in through the $settings_array associative array or set in
+	 * the session global array
+	 *
+	 * @var string
+	 */
+	private $user_uuid;
+
+	/**
 	 * Constructor for the class.
 	 *
 	 * This method initializes the object with setting_array and session data.
@@ -34,11 +57,21 @@ class sounds {
 	 * @param array $setting_array An optional array of settings to override default values. Defaults to [].
 	 */
 	public function __construct(array $setting_array = []) {
-		//set domain and user UUIDs
+
+		//set the domain details and the user UUID
 		$this->domain_uuid = $setting_array['domain_uuid'] ?? $_SESSION['domain_uuid'] ?? '';
+		$this->domain_name = $setting_array['domain_name'] ?? $_SESSION['domain_name'] ?? '';
+		$this->user_uuid = $setting_array['user_uuid'] ?? $_SESSION['user_uuid'] ?? '';
 
 		//set objects
 		$this->database = $setting_array['database'] ?? database::new();
+
+		//load the settings
+		if (empty($setting_array['settings'])) {
+			$this->settings = new settings(['database' => $this->database, 'domain_uuid' => $this->domain_uuid, 'user_uuid' => $this->user_uuid]);
+		} else {
+			$this->settings = $setting_array['settings'];
+		}
 	}
 
 	/**
@@ -60,6 +93,7 @@ class sounds {
 				$array['miscellaneous'][$x]['value'] = "tone_stream:";
 			}
 		}
+
 		//recordings
 		if ((empty($this->sound_types) || (is_array($this->sound_types) && in_array('recordings', $this->sound_types))) && file_exists(dirname(__DIR__, 2) . "/app/recordings/app_config.php")) {
 			$sql = "select recording_name, recording_filename from v_recordings ";
@@ -71,13 +105,14 @@ class sounds {
 				foreach ($recordings as $x => $row) {
 					$recording_name = $row["recording_name"];
 					$recording_filename = $row["recording_filename"];
-					$recording_path = !empty($this->full_path) && is_array($this->full_path) && in_array('recordings', $this->full_path) ? $_SESSION['switch']['recordings']['dir'] . '/' . $_SESSION['domain_name'] . '/' : null;
+					$recording_path = !empty($this->full_path) && is_array($this->full_path) && in_array('recordings', $this->full_path) ? $this->settings->get('switch', 'recordings') . '/' . $this->domain_name . '/' : null;
 					$array['recordings'][$x]['name'] = $recording_name;
 					$array['recordings'][$x]['value'] = $recording_path . $recording_filename;
 				}
 			}
 			unset($sql, $parameters, $recordings, $row);
 		}
+
 		//phrases
 		if ((empty($this->sound_types) || (is_array($this->sound_types) && in_array('phrases', $this->sound_types))) && file_exists(dirname(__DIR__, 2) . "/app/phrases/app_config.php")) {
 			$sql = "select * from v_phrases ";
@@ -93,6 +128,7 @@ class sounds {
 			}
 			unset($sql, $parameters, $phrases, $row);
 		}
+
 		//sounds
 		if ((empty($this->sound_types) || (is_array($this->sound_types) && in_array('sounds', $this->sound_types))) && file_exists(dirname(__DIR__, 2) . "/app/phrases/app_config.php")) {
 			$file = new file;
@@ -108,6 +144,7 @@ class sounds {
 				}
 			}
 		}
+
 		//send the results
 		return $array;
 

--- a/resources/functions.php
+++ b/resources/functions.php
@@ -96,7 +96,9 @@ if (!function_exists('check_str')) {
 	 * @internal Use parameterized queries
 	 */
 	function check_str($string, $trim = true) {
+		//set global variables
 		global $db_type, $db;
+
 		//when code in db is urlencoded the ' does not need to be modified
 		if ($db_type == "sqlite") {
 			if (function_exists('sqlite_escape_string')) {
@@ -1065,10 +1067,11 @@ function format_string(string $format, string $data): string {
  * @return string|null The formatted phone number if the input matches any defined format, otherwise the original input.
  */
 function format_phone(?string $phone_number): ?string {
+	global $settings;
 	if (is_numeric(trim($phone_number ?? '', ' +'))) {
-		if (isset($_SESSION["format"]["phone"])) {
+		if (!empty($settings->get('format', 'phone'))) {
 			$phone_number = trim($phone_number, ' +');
-			foreach ($_SESSION["format"]["phone"] as $format) {
+			foreach ($settings->get('format', 'phone') as $format) {
 				$format_count = substr_count($format, 'x');
 				$format_count = $format_count + substr_count($format, 'R');
 				$format_count = $format_count + substr_count($format, 'r');

--- a/themes/default/app_config.php
+++ b/themes/default/app_config.php
@@ -356,7 +356,7 @@
 		$apps[$x]['default_settings'][$y]['default_setting_category'] = "theme";
 		$apps[$x]['default_settings'][$y]['default_setting_subcategory'] = "message_delay";
 		$apps[$x]['default_settings'][$y]['default_setting_name'] = "text";
-		$apps[$x]['default_settings'][$y]['default_setting_value'] = "1.75";
+		$apps[$x]['default_settings'][$y]['default_setting_value'] = "3";
 		$apps[$x]['default_settings'][$y]['default_setting_enabled'] = "true";
 		$apps[$x]['default_settings'][$y]['default_setting_description'] = "Set the hide delay of the message bar (seconds).";
 		$y++;


### PR DESCRIPTION
If you set the parent menu on IVR1 to IVR2, then the parent menu on IVR2 to IVR1, it causes a loop that breaks the web GUI.