### PR TITLE
Restrict group delegation to membership at the same level

### DIFF
--- a/core/users/user_edit.php
+++ b/core/users/user_edit.php
@@ -477,7 +477,10 @@
 				$parameters['domain_uuid'] = $_SESSION['domain_uuid'];
 				$parameters['group_uuid'] = $group_uuid;
 				$row = $database->select($sql, $parameters, 'row');
-				if ($row['group_level'] <= $_SESSION['user']['group_level']) {
+				//delegation rule: groups in a lower level are open (hierarchy), but a group at your own level
+				//may only be assigned if you are a member of it (you can only give out groups you are part of)
+				$my_group_uuids = array_column($_SESSION['user']['groups'] ?? [], 'group_uuid');
+				if ($row['group_level'] < $_SESSION['user']['group_level'] || in_array($group_uuid, $my_group_uuids)) {
 					$array['user_groups'][$n]['user_group_uuid'] = uuid();
 					$array['user_groups'][$n]['domain_uuid'] = $domain_uuid;
 					$array['user_groups'][$n]['group_name'] = $group_name;
@@ -1165,8 +1168,11 @@
 			if (isset($assigned_groups)) { echo "<br />\n"; }
 			echo "<select name='group_uuid_name' class='formfld' style='width: auto; margin-right: 3px;' ".($action == 'add' ? "required='required'" : null).">\n";
 			echo "	<option value=''></option>\n";
+			//delegation rule: lower levels are open (hierarchy), but a group at your own level is only
+			//offered if you are a member of it (you can only give out groups you are part of)
+			$my_group_uuids = array_column($_SESSION['user']['groups'] ?? [], 'group_uuid');
 			foreach($groups as $field) {
-				if ($field['group_level'] <= $_SESSION['user']['group_level']) {
+				if ($field['group_level'] < $_SESSION['user']['group_level'] || in_array($field['group_uuid'], $my_group_uuids)) {
 					if (!isset($assigned_groups) || (isset($assigned_groups) && !in_array($field["group_uuid"], $assigned_groups))) {
 						if (isset($group_uuid_name) && $group_uuid_name == $field['group_uuid']."|".$field['group_name']) { $selected = "selected='selected'"; } else { $selected = ''; }
 						echo "	<option value='".$field['group_uuid']."|".$field['group_name']."' $selected>".$field['group_name'].((!empty($field['domain_uuid'])) ? "@".$_SESSION['domains'][$field['domain_uuid']]['domain_name'] : null)."</option>\n";


### PR DESCRIPTION
The group assignment gate in user_edit.php previously allowed a user to assign any group at or below their own group_level. Because a user's group_level is the maximum level across all their groups, being placed in a single higher-level "feature" group let that user hand out every group in that level band to themselves or other users in the domain.

Change the rule so lower levels remain open (the existing hierarchy), but a group at the user's own level may only be assigned if the user is a member of that group. This keeps "an admin can make another admin" working while preventing a feature-group holder from delegating unrelated groups at the same level.

Applied at both the dropdown render and the server-side save enforcement.