### PR TITLE
Add escapeshellarg to call recording symlink command

### DIFF
--- a/app/call_recordings/resources/classes/call_recordings.php
+++ b/app/call_recordings/resources/classes/call_recordings.php
@@ -752,7 +752,7 @@ class call_recordings {
 									$call_recording_name_download = str_replace('${time}', $call_recording_time, $call_recording_name_download);
 
 									//create a symbolic link with custom name
-									$command = 'ln -s ' . $call_recording_path . '/' . $call_recording_name . ' ' . $call_recording_path . '/' . $call_recording_name_download;
+									$command = 'ln -s ' . escapeshellarg($call_recording_path . '/' . $call_recording_name) . ' ' . escapeshellarg($call_recording_path . '/' . $call_recording_name_download);
 									system($command);
 
 									//build the array for all the call recording with the new file name


### PR DESCRIPTION
The `call_recording_name_download` variable can include the caller id name from a call:

 `$call_recording_name_download = str_replace('${caller_id_name}', $caller_id_name, $call_recording_name_download);`

Unless properly escaped via `escapeshellarg`, this is a potential remote code execution via caller id.