### PR TITLE
Add W60B Music on Hold provisioning settings

### DIFF
--- a/resources/templates/provision/yealink/w60b/y000000000077.cfg
+++ b/resources/templates/provision/yealink/w60b/y000000000077.cfg
@@ -171,6 +171,9 @@ auto_provision.aes_key_16.mac =
 #Enable or disable the phone to keep sending the SIP messages to the outbound server; 0-Disabled, 1-Enabled (default);
 sip.use_out_bound_in_dialog =
 
+# SIP hold signaling: 0 = RFC 3264; 1 = RFC 2543 / c=0.0.0.0
+sip.rfc2543_hold = 0
+
 #Configure the registration random time (in seconds). It ranges from 0 (default) to 60.
 sip.reg_surge_prevention =
 

--- a/resources/templates/provision/yealink/w60b/{$mac}.cfg
+++ b/resources/templates/provision/yealink/w60b/{$mac}.cfg
@@ -104,6 +104,9 @@ account.1.session_timer.refresher =
 #Enable or disable the "user=phone"; 0-Disabled (default), 1-Enabled;
 account.1.enable_user_equal_phone =
 
+# 0 = a=sendonly; 1 = a=inactive
+account.1.hold_use_inactive = 0
+
 #Configure the way of encrypting the message; 0-Disabled (default), 1-Forced, 2-Negotiated;
 account.1.srtp_encryption = {$yealink_srtp_encryption}
 


### PR DESCRIPTION
Adding SIP hold settings to the W60B template so cordless handsets use PBX-hosted Music on Hold instead of local handset hold behavior.