### PR TITLE
Allow menu items sort orders

### DIFF
--- a/core/menu/menu_item_list.php
+++ b/core/menu/menu_item_list.php
@@ -105,7 +105,7 @@
 		$sql = "select * from v_menu_items ";
 		$sql .= "where menu_uuid = :menu_uuid ";
 		$sql .= "and menu_item_parent_uuid = :menu_item_parent_uuid ";
-		$sql .= "order by menu_item_title, menu_item_order asc ";
+		$sql .= "order by menu_item_order, menu_item_title asc";
 		$parameters['menu_uuid'] = $menu_uuid;
 		$parameters['menu_item_parent_uuid'] = $menu_item_uuid;
 		$result2 = $database->select($sql, $parameters, 'all');

--- a/resources/classes/menu.php
+++ b/resources/classes/menu.php
@@ -781,7 +781,7 @@ class menu {
 			$sql .= ") ";
 		}
 		$sql .= ") ";
-		$sql .= "order by l.menu_item_title, i.menu_item_order asc ";
+		$sql .= "order by i.menu_item_order, l.menu_item_title asc ";
 		$parameters['menu_language'] = $this->settings->get('domain', 'language', 'en-us');
 		$parameters['menu_uuid'] = $this->menu_uuid;
 		$parameters['menu_item_parent_uuid'] = $menu_item_uuid;


### PR DESCRIPTION
I have wanted this level of control for many years. This pull request adds the ability to sort menu items first by the order number and second by the item name. If no order is set for the menu item then the current alpha-numeric sorting will be applied.

This allows for more finite controls of the menus as illustrated in the following menu image.
<img width="324" height="409" alt="image" src="https://github.com/user-attachments/assets/1cd23123-88a5-4b40-9b16-8466145b4b36" />

The order in menu_edit.php also honors the new sorting order.
<img width="304" height="508" alt="image" src="https://github.com/user-attachments/assets/60cad7b8-6cc0-4708-8a35-fb7da82a30f5" />

