### PR TITLE
Fix ring group bind_digit_action with empty values

### DIFF
--- a/app/switch/resources/scripts/app/ring_groups/index.lua
+++ b/app/switch/resources/scripts/app/ring_groups/index.lua
@@ -327,14 +327,14 @@
 	end
 
 --set exit key action
-	if (ring_group_timeout_app and ring_group_timeout_data) then
-		if (ring_group_exit_key) then
-			--use the user defined exit key
-			session:execute("bind_digit_action", "exit_key,"..ring_group_exit_key..",exec:"..ring_group_timeout_app..","..ring_group_timeout_data..",both,self");
-		else
+	if (ring_group_timeout_app and #ring_group_timeout_app > 0 and ring_group_timeout_data and #ring_group_timeout_data > 0) then
+		if (not ring_group_exit_key or #ring_group_exit_key == 0) then
 			--use a default exit key of 9
-			session:execute("bind_digit_action", "exit_key,9,exec:"..ring_group_timeout_app..","..ring_group_timeout_data..",both,self");
+			ring_group_exit_key = "9";
 		end
+
+		--use the user defined or default exit key
+		session:execute("bind_digit_action", "exit_key,"..ring_group_exit_key..",exec:"..ring_group_timeout_app..","..ring_group_timeout_data..",both,self");
 	end
 
 --play the greeting


### PR DESCRIPTION
Summary

Fixes a Ring Groups Lua warning caused by empty-string handling when binding the Ring Group exit key action.

Lua treats empty strings as truthy, so the previous checks could allow bind_digit_action to execute with an empty exit key or empty timeout app/data values. This produced malformed FreeSWITCH commands and a mod_dptools syntax warning.

Change

Require ring_group_timeout_app and ring_group_timeout_data to be non-empty before executing bind_digit_action.
Preserve the existing default exit key behavior by using 9 when ring_group_exit_key is empty.
Continue using the configured exit key when one is provided.

Validation

Reviewed the single affected file: app/switch/resources/scripts/app/ring_groups/index.lua
luac was unavailable on the test system.
Runtime tested by copying the patched repository file to the active FreeSWITCH scripts path.
Tested blank exit key, configured exit key 9, and configured exit key 8.
All tests generated valid bind_digit_action commands with no mod_dptools syntax warning.
Restored the active runtime script after testing and ran reloadxml.
