### PR TITLE
Fix incorrect greeting format

### DIFF
--- a/app/voicemail_greetings/voicemail_greeting_edit.php
+++ b/app/voicemail_greetings/voicemail_greeting_edit.php
@@ -181,7 +181,8 @@ if (!empty($_POST) && empty($_POST["persistformvar"])) {
 		$greeting_files = glob($greeting_path.'/greeting_*');
 
 		if (empty($greeting_format) && !empty($greeting_files)) {
-			$greeting_format = pathinfo($greeting_files[0], PATHINFO_EXTENSION);
+			$index = $greeting_id - 1;
+			$greeting_format = pathinfo($greeting_files[$index], PATHINFO_EXTENSION);
 		} else {
 			$greeting_format = $greeting_format ?? 'wav';
 		}


### PR DESCRIPTION
- upload 2 greetings with different file formats
- edit and save the second greeting and it saves the wrong format

$greeting_files[0] uses the first greeting as a reference of what the file format should be. 

Changed to be based on the greeting id.