### PR TITLE
Fix grandstream cloud disconnect after provision

### DIFF
--- a/app/grandstream/app_config.php
+++ b/app/grandstream/app_config.php
@@ -956,9 +956,9 @@
 		$apps[$x]['default_settings'][$y]['default_setting_category'] = "provision";
 		$apps[$x]['default_settings'][$y]['default_setting_subcategory'] = "grandstream_tr069_enable";
 		$apps[$x]['default_settings'][$y]['default_setting_name'] = "numeric";
-		$apps[$x]['default_settings'][$y]['default_setting_value'] = "0";
+		$apps[$x]['default_settings'][$y]['default_setting_value'] = "1";
 		$apps[$x]['default_settings'][$y]['default_setting_enabled'] = "true";
-		$apps[$x]['default_settings'][$y]['default_setting_description'] = "Enable tr-069 provisioning for grandstream devices 0-disable, 1-enable";
+		$apps[$x]['default_settings'][$y]['default_setting_description'] = "Enable tr-069 provisioning for grandstream devices 0-disable, 1-enable. Disable to remove cloud provisioning";
 		$y++;
 		$apps[$x]['default_settings'][$y]['default_setting_uuid'] = "bad2bcef-4117-4aa3-ad29-ffd2b6b832aa";
 		$apps[$x]['default_settings'][$y]['default_setting_category'] = "provision";

--- a/resources/templates/provision/grandstream/ghp6xx/{$mac}.xml
+++ b/resources/templates/provision/grandstream/ghp6xx/{$mac}.xml
@@ -1916,7 +1916,7 @@
 		<!-- ############################################################################## -->
 		<!-- # Enable TR-069 -->
 		<!-- Yes, No -->
-		<item name="tr069.enable">Yes</item>
+		<item name="tr069.enable">{$grandstream_tr069_enable}</item>
 
 		<!-- ACS URL -->
 		<item name="tr069.url">https://acs.gdms.cloud</item>

--- a/resources/templates/provision/grandstream/grp2612/{$mac}.xml
+++ b/resources/templates/provision/grandstream/grp2612/{$mac}.xml
@@ -2105,7 +2105,7 @@
 		<!-- ############################################################################## -->
 		<!-- Enable TR-069 -->
 		<!-- Pvalue P1409 -->
-		<item name="tr069.enable">Yes</item>
+		<item name="tr069.enable">{$grandstream_tr069_enable}</item>
 		<!-- ACS URL -->
 		<!-- Pvalue P4503 -->
 		<item name="tr069.url">https://acs.gdms.cloud</item>

--- a/resources/templates/provision/grandstream/grp2612w/{$mac}.xml
+++ b/resources/templates/provision/grandstream/grp2612w/{$mac}.xml
@@ -2081,7 +2081,7 @@
 		<!-- ############################################################################## -->
 		<!-- Enable TR-069 -->
 		<!-- Pvalue P1409 -->
-		<item name="tr069.enable">Yes</item>
+		<item name="tr069.enable">{$grandstream_tr069_enable}</item>
 		<!-- ACS URL -->
 		<!-- Pvalue P4503 -->
 		<item name="tr069.url">https://acs.gdms.cloud</item>

--- a/resources/templates/provision/grandstream/grp2613/{$mac}.xml
+++ b/resources/templates/provision/grandstream/grp2613/{$mac}.xml
@@ -2105,7 +2105,7 @@
 		<!-- ############################################################################## -->
 		<!-- Enable TR-069 -->
 		<!-- Pvalue P1409 -->
-		<item name="tr069.enable">Yes</item>
+		<item name="tr069.enable">{$grandstream_tr069_enable}</item>
 		<!-- ACS URL -->
 		<!-- Pvalue P4503 -->
 		<item name="tr069.url">https://acs.gdms.cloud</item>

--- a/resources/templates/provision/grandstream/grp2614/{$mac}.xml
+++ b/resources/templates/provision/grandstream/grp2614/{$mac}.xml
@@ -2105,7 +2105,7 @@
 		<!-- ############################################################################## -->
 		<!-- Enable TR-069 -->
 		<!-- Pvalue P1409 -->
-		<item name="tr069.enable">Yes</item>
+		<item name="tr069.enable">{$grandstream_tr069_enable}</item>
 		<!-- ACS URL -->
 		<!-- Pvalue P4503 -->
 		<item name="tr069.url">https://acs.gdms.cloud</item>

--- a/resources/templates/provision/grandstream/grp2615/{$mac}.xml
+++ b/resources/templates/provision/grandstream/grp2615/{$mac}.xml
@@ -2105,7 +2105,7 @@
 		<!-- ############################################################################## -->
 		<!-- Enable TR-069 -->
 		<!-- Pvalue P1409 -->
-		<item name="tr069.enable">Yes</item>
+		<item name="tr069.enable">{$grandstream_tr069_enable}</item>
 		<!-- ACS URL -->
 		<!-- Pvalue P4503 -->
 		<item name="tr069.url">https://acs.gdms.cloud</item>

--- a/resources/templates/provision/grandstream/grp2616/{$mac}.xml
+++ b/resources/templates/provision/grandstream/grp2616/{$mac}.xml
@@ -2105,7 +2105,7 @@
 		<!-- ############################################################################## -->
 		<!-- Enable TR-069 -->
 		<!-- Pvalue P1409 -->
-		<item name="tr069.enable">Yes</item>
+		<item name="tr069.enable">{$grandstream_tr069_enable}</item>
 		<!-- ACS URL -->
 		<!-- Pvalue P4503 -->
 		<item name="tr069.url">https://acs.gdms.cloud</item>

--- a/resources/templates/provision/grandstream/gxp2130/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp2130/{$mac}.xml
@@ -1341,7 +1341,7 @@
 		<!-- ############################################################################## -->
 		<!-- Enable TR-069 -->
 		<!-- Yes, No -->
-		<item name="tr069.enable">No</item>
+		<item name="tr069.enable">{$grandstream_tr069_enable}</item>
 
 		<!-- ACS URL -->
 		<item name="tr069.url">https://acs.gdms.cloud</item>

--- a/resources/templates/provision/grandstream/gxp2135/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp2135/{$mac}.xml
@@ -1359,7 +1359,7 @@
 		<!-- ############################################################################## -->
 		<!-- Enable TR-069 -->
 		<!-- Yes, No -->
-		<item name="tr069.enable">No</item>
+		<item name="tr069.enable">{$grandstream_tr069_enable}</item>
 
 		<!-- ACS URL -->
 		<item name="tr069.url">https://acs.gdms.cloud</item>

--- a/resources/templates/provision/grandstream/gxp2140/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp2140/{$mac}.xml
@@ -1341,7 +1341,7 @@
 		<!-- ############################################################################## -->
 		<!-- Enable TR-069 -->
 		<!-- Yes, No -->
-		<item name="tr069.enable">No</item>
+		<item name="tr069.enable">{$grandstream_tr069_enable}</item>
 
 		<!-- ACS URL -->
 		<item name="tr069.url">https://acs.gdms.cloud</item>

--- a/resources/templates/provision/grandstream/gxp2160/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp2160/{$mac}.xml
@@ -1341,7 +1341,7 @@
 		<!-- ############################################################################## -->
 		<!-- Enable TR-069 -->
 		<!-- Yes, No -->
-		<item name="tr069.enable">No</item>
+		<item name="tr069.enable">{$grandstream_tr069_enable}</item>
 
 		<!-- ACS URL -->
 		<item name="tr069.url">https://acs.gdms.cloud</item>

--- a/resources/templates/provision/grandstream/gxp2170/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxp2170/{$mac}.xml
@@ -1341,7 +1341,7 @@
 		<!-- ############################################################################## -->
 		<!-- Enable TR-069 -->
 		<!-- Yes, No -->
-		<item name="tr069.enable">No</item>
+		<item name="tr069.enable">{$grandstream_tr069_enable}</item>
 
 		<!-- ACS URL -->
 		<item name="tr069.url">https://acs.gdms.cloud</item>

--- a/resources/templates/provision/grandstream/gxv3370/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxv3370/{$mac}.xml
@@ -1030,7 +1030,7 @@
 		<!-- System Settings - TR069 -->
 		<!-- Enable TR-069 -->
 		<!-- Yes, No -->
-		<item name="tr069.enable">No</item>
+		<item name="tr069.enable">{$grandstream_tr069_enable}</item>
 		<!-- ACS URL -->
 		<item name="tr069.url"></item>
 		<!-- ACS Username -->

--- a/resources/templates/provision/grandstream/gxv3380
+++ b/resources/templates/provision/grandstream/gxv3380
@@ -1188,7 +1188,7 @@
 		<!-- System Settings - TR069 -->
 		<!-- Enable TR-069 -->
 		<!-- Yes, No -->
-		<item name="tr069.enable">No</item>
+		<item name="tr069.enable">{$grandstream_tr069_enable}</item>
 		<!-- ACS URL -->
 		<item name="tr069.url"></item>
 		<!-- ACS Username -->

--- a/resources/templates/provision/grandstream/gxv3480/{$mac}.xml
+++ b/resources/templates/provision/grandstream/gxv3480/{$mac}.xml
@@ -1068,7 +1068,7 @@
 		<!-- System Settings - TR069 -->
 		<!-- Enable TR-069 -->
 		<!-- Yes, No -->
-		<item name="tr069.enable">Yes</item>
+		<item name="tr069.enable">{$grandstream_tr069_enable}</item>
 		<!-- ACS URL -->
 		<item name="tr069.url">https://acs.gdms.cloud/</item>
 		<!-- ACS Username -->


### PR DESCRIPTION
After provisioning the Grandstream Cloud (GDMS) will no longer be connected to the device provisioned. This is due to the `tr069.enable` setting in the template set to "No" or "0". This adds the variable already in the default settings provisioning to the template files and sets the default value to enabled by default so the cloud connection will continue to work after provisioning.