### PR TITLE
Update MN_{$mac}.cfg

### DIFF
--- a/resources/templates/provision/mitel/5330/MN_{$mac}.cfg
+++ b/resources/templates/provision/mitel/5330/MN_{$mac}.cfg
@@ -32,7 +32,7 @@
 	<rss_feed></rss_feed>
 	<host_ip>{$domain_name}</host_ip>
 	<video_ip>{$domain_name}</video_ip>
-	<sntp>ca.pool.ntp.org</sntp>
+	<sntp>{$ntp_server_primary}</sntp>
 	<time_zone>{$mitel_time_zone}</time_zone>
 	<auth_method>2</auth_method>
 	<register_expire>120</register_expire>

--- a/resources/templates/provision/mitel/5330/MN_{$mac}.cfg
+++ b/resources/templates/provision/mitel/5330/MN_{$mac}.cfg
@@ -9,7 +9,7 @@
 	<local_sip_port>5060</local_sip_port>
 	<tos>0</tos>
 	<e802_priority>-1</e802_priority>
-	{if isset($mitel_vlan_id)}<vlan_id>{$mitel_vlan_id}</vlan_id>{else}<vlan_id>0</vlan_id>
+	{if isset($mitel_vlan_id)}<vlan_id>{$mitel_vlan_id}</vlan_id>{else}<vlan_id>-1</vlan_id>
 	{/if}<host_name>{$account.1.user_id}</host_name>
 	<domain>{$domain_name}</domain>
 	<addr_type>0</addr_type>
@@ -39,7 +39,7 @@
 	<emerg_number></emerg_number>
 	<emerg_ip>0.0.0.0</emerg_ip>
 	<emerg_port>5060</emerg_port>
-	<audio_codec>0</audio_codec>
+	<audio_codec>5</audio_codec>
 	<audio_pkt_size>20</audio_pkt_size>
 	<video_codec>0</video_codec>
 	<dtmf_type>0</dtmf_type>
@@ -63,6 +63,7 @@
 	<adminId>admin</adminId>
 	<admin_dispname>Administrator</admin_dispname>
 	<admin_passwd>29c4a0e4ef7d1969a94a5f4aadd20690</admin_passwd>
+	<-- Password for Web Interface is 5220 -->
 	<busy_fwd_mode>0</busy_fwd_mode>
 	<busy_fwd_addr></busy_fwd_addr>
 	<always_fwd_mode>0</always_fwd_mode>
@@ -322,7 +323,9 @@
 		EventSvr=""
 		EventPort="{$row.sip_port}"
 		EventScheme="1"
-		BlfGroup="100,*21100,*45100*600">
+		BlfGroup="share_presence"
+		NatMode="0"
+		NatType="option"
 		NatIp="0">
 		</User>
 		{/foreach}

--- a/resources/templates/provision/mitel/5330/MN_{$mac}.cfg
+++ b/resources/templates/provision/mitel/5330/MN_{$mac}.cfg
@@ -62,8 +62,7 @@
 	<pbIndex>0</pbIndex>
 	<adminId>admin</adminId>
 	<admin_dispname>Administrator</admin_dispname>
-	<admin_passwd>29c4a0e4ef7d1969a94a5f4aadd20690</admin_passwd>
-	<-- Password for Web Interface is 5220 -->
+	<admin_passwd>{$admin_password|@md5}</admin_passwd>
 	<busy_fwd_mode>0</busy_fwd_mode>
 	<busy_fwd_addr></busy_fwd_addr>
 	<always_fwd_mode>0</always_fwd_mode>


### PR DESCRIPTION
Here's a summary of the changes in __Pull Request #8133__ for the FusionPBX project:

### Changes

1. __VLAN ID Default Value__ (line ~12)

   - __Before:__ `<vlan_id> 0 </vlan_id>`
   - __After:__ `<vlan_id> -1 </vlan_id>`
   - This changes the default VLAN ID fallback from `0` to `-1` when `$mitel_vlan_id` is not set. A value of `-1` typically means "no VLAN tagging" or "disabled" in many Mitel device configurations, which is a more appropriate default than `0`.

2. __Audio Codec Default__ (line ~42)

   - __Before:__ `<audio_codec> 0 </audio_codec>` 0

   - __After:__ `<audio_codec> 5 </audio_codec>`
   - This changes the default audio codec from `0` to `5`. 

3. __New Comment Added__ (line ~66)

   - __Added:__ `<!-- Password for Web Interface is 5220 -->`
   - A helpful comment was added after the `<admin_passwd>` line to document the default web interface password for the Mitel 5330 phone.

4. __BLF Group Configuration__ (line ~323)

   - __Before:__ `BlfGroup="100,*21100,*45100*600">`
   - __After:__ `BlfGroup="share_presence"`
   - This changes the Busy Lamp Field (BLF) group configuration from a hardcoded numeric group to use the `share_presence` setting, which likely enables presence sharing functionality instead of traditional BLF group dialing.

---

### Overall Purpose

This PR makes several configuration improvements to the Mitel 5330 phone provisioning template, primarily fixing default values for VLAN tagging and audio codec, documenting the admin password, and updating the BLF group to use presence sharing.
