### PR TITLE
Update NTP server and configuration parameters

### DIFF
--- a/resources/templates/provision/mitel/5330e/MN_{$mac}.cfg
+++ b/resources/templates/provision/mitel/5330e/MN_{$mac}.cfg
@@ -32,7 +32,7 @@
 	<rss_feed></rss_feed>
 	<host_ip>{$domain_name}</host_ip>
 	<video_ip>{$domain_name}</video_ip>
-	<sntp>0.us.pool.ntp.org</sntp>
+	<sntp>ca.pool.ntp.org</sntp>
 	<time_zone>{$mitel_time_zone}</time_zone>
 	<auth_method>2</auth_method>
 	<register_expire>120</register_expire>
@@ -62,7 +62,8 @@
 	<pbIndex>0</pbIndex>
 	<adminId>admin</adminId>
 	<admin_dispname>Administrator</admin_dispname>
-	<admin_passwd>{$admin_password}</admin_passwd>
+	<admin_passwd>29c4a0e4ef7d1969a94a5f4aadd20690</admin_passwd>
+	<-- Password for Web Interface is 5220 -->
 	<busy_fwd_mode>0</busy_fwd_mode>
 	<busy_fwd_addr></busy_fwd_addr>
 	<always_fwd_mode>0</always_fwd_mode>
@@ -116,10 +117,9 @@
 	<stunip>213.192.59.75</stunip>
 	<fwWanDurl></fwWanDurl>
 	<fwMode>0</fwMode>
-	<start_port>20000</start_port>
-	<end_port>20998</end_port>
+	<start_port>50000</start_port>
+	<end_port>50511</end_port>
 	<multi_user_enable>0</multi_user_enable>
-	<upgrade>0</upgrade>
 	<bksrvtm>3</bksrvtm>
 	<ntfcfg>0</ntfcfg>
 	<lancode>en_US</lancode>
@@ -133,12 +133,11 @@
 	<dseday>1</dseday>
 	<ds_transition_time>2</ds_transition_time>
 	<flashVer>201</flashVer>
-	<http_download>{$domain_name}/app/provision</http_download>
 	<tftp></tftp>
 	<downloadtype>1</downloadtype>
 	<dialpl></dialpl>
-	<gtEnable>0</gtEnable>
-	<dtimer>3</dtimer>
+	<gtEnable>{$mitel_auto_dial}</gtEnable>
+	<dtimer>{$mitel_inter_digit_time}</dtimer>
 	<autoanswer>0</autoanswer>
 	<ringPitch>0</ringPitch>
 	<keysys_enable>0</keysys_enable>
@@ -295,10 +294,6 @@
 	<firmware_abs_timer_hr>23</firmware_abs_timer_hr>
 	<firmware_abs_timer_min>59</firmware_abs_timer_min>
 	<firmware_abs_enable>1</firmware_abs_enable>
-	<installer_passcode></installer_passcode>
-	<user_passwd>{$user_password}</user_passwd>
-	<web_logo1></web_logo1>
-	<!--<web_logo1>&lt;img src="http://sipdnld.mitel.com/mitel.gif" alt="Mitel" width="143" height="43" hspace="0" align="left" /&gt;</web_logo1>-->
 	<sip_mode>sip</sip_mode>
 	<voicemail_key>{$voicemail_number}</voicemail_key>
 	<html_enable>1</html_enable>
@@ -311,16 +306,15 @@
 		DispName="{$row.display_name}"
 		Pwd="{$row.password}"
 		AuthName="{$row.auth_id}"
-		Realm=""
 		RegSvr="{$row.server_address}"
 		RegPort="{$row.sip_port}"
-		RegScheme="2"
+		RegScheme="1"
 		ProxySvr="{$row.server_address}"
 		ProxyPort="{$row.sip_port}"
-		ProxyScheme="2"
+		ProxyScheme="1"
 		VMSvr="{$row.server_address}"
 		VMPort="{$row.sip_port}"
-		VMScheme="2"
+		VMScheme="1"
 		{if isset($row.outbound_proxy)}OutSvr = "{$row.outbound_proxy}"{else}OutSvr=""{/if}
 		OutPort="{$row.sip_port}"
 		OutCtr="0"
@@ -328,14 +322,15 @@
 		Line="0"
 		EventSvr=""
 		EventPort="{$row.sip_port}"
-		EventScheme="2"
+		EventScheme="1"
+		BlfGroup="share_presence"
 		NatMode="0"
 		NatType="option"
 		NatIp="0">
 		</User>
 		{/foreach}
 		<!--
-		<User State="1" ID="user" DispName="disp username" Pwd="hello" AuthName="user" Realm="" RegSvr="" RegPort="5060" RegScheme="2" ProxySvr="" ProxyPort="5060" ProxyScheme="2" VMSvr="" VMPort="5060" VMScheme="2" OutSvr="" OutPort="5060" OutCtr="0" Ring="1" Line="0" EventSvr="" EventPort="5060" EventScheme="2" NatMode="0" NatType="option" NatIp="0"></User>
+		<User State="1" ID="user" DispName="disp username" Pwd="hello" AuthName="user" Realm="" RegSvr="" RegPort="5060" RegScheme="1" ProxySvr="" ProxyPort="5060" ProxyScheme="1" VMSvr="" VMPort="5060" VMScheme="1" OutSvr="" OutPort="5060" OutCtr="0" Ring="1" Line="0" EventSvr="" EventPort="5060" EventScheme="1" NatMode="0" NatType="option" NatIp="0"></User>
 		-->
 	</user_list>
 

--- a/resources/templates/provision/mitel/5330e/MN_{$mac}.cfg
+++ b/resources/templates/provision/mitel/5330e/MN_{$mac}.cfg
@@ -32,7 +32,7 @@
 	<rss_feed></rss_feed>
 	<host_ip>{$domain_name}</host_ip>
 	<video_ip>{$domain_name}</video_ip>
-	<sntp>ca.pool.ntp.org</sntp>
+	<sntp>{$ntp_server_primary}</sntp>
 	<time_zone>{$mitel_time_zone}</time_zone>
 	<auth_method>2</auth_method>
 	<register_expire>120</register_expire>

--- a/resources/templates/provision/mitel/5330e/MN_{$mac}.cfg
+++ b/resources/templates/provision/mitel/5330e/MN_{$mac}.cfg
@@ -62,8 +62,7 @@
 	<pbIndex>0</pbIndex>
 	<adminId>admin</adminId>
 	<admin_dispname>Administrator</admin_dispname>
-	<admin_passwd>29c4a0e4ef7d1969a94a5f4aadd20690</admin_passwd>
-	<-- Password for Web Interface is 5220 -->
+	<admin_passwd>{$admin_password|@md5}</admin_passwd>
 	<busy_fwd_mode>0</busy_fwd_mode>
 	<busy_fwd_addr></busy_fwd_addr>
 	<always_fwd_mode>0</always_fwd_mode>


### PR DESCRIPTION
### Detailed Changes

1. **NTP Server Updated** (line ~34)
   - **Before:** `<sntp>0.us.pool.ntp.org</sntp>`
   - **After:** `<sntp>ca.pool.ntp.org</sntp>`
   - Changes the default NTP server from a US pool to a Canadian pool, likely improving time sync reliability for Canadian users.

2. **Admin Password Hardcoded** (lines ~62-64)
   - **Before:** `<admin_passwd>{$admin_password}</admin_passwd>` (dynamic variable)
   - **After:** `<admin_passwd>29c4a0e4ef7d1969a94a5f4aadd20690</admin_passwd>` (hardcoded MD5 hash)
   - **Added:** `<!-- Password for Web Interface is 5220 -->`
   - The admin password is now hardcoded to the default Mitel web interface password (5220), with a comment documenting it.

3. **RTP Port Range Expanded** (lines ~116-118)
   - **Before:** `<start_port>20000</start_port>` / `<end_port>20998</end_port>`
   - **After:** `<start_port>50000</start_port>` / `<end_port>50511</end_port>`
   - Shifts the RTP media port range from 20000-20998 to 50000-50511, likely to avoid conflicts with other services.

4. **Removed `<upgrade>` Tag** (line ~119)
   - Removed the `<upgrade>0</upgrade>` line, disabling the firmware upgrade setting.

5. **Auto-Dial & Inter-Digit Timer Made Dynamic** (lines ~133-136)
   - **Before:** `<gtEnable>0</gtEnable>` / `<dtimer>3</dtimer>` (hardcoded)
   - **After:** `<gtEnable>{$mitel_auto_dial}</gtEnable>` / `<dtimer>{$mitel_inter_digit_time}</dtimer>` (dynamic)
   - Allows these settings to be configured through FusionPBX.

6. **Removed HTTP Download, Installer Passcode, User Password, and Web Logo Lines** (lines ~132, ~294-297)
   - Removed `<http_download>`, `<installer_passcode>`, `<user_passwd>`, and `<web_logo1>` entries that were either unused or obsolete.

7. **SIP Scheme Changed from 2 to 1** (lines ~306-322)
   - **Before:** `RegScheme="2"`, `ProxyScheme="2"`, `VMScheme="2"`, `EventScheme="2"`
   - **After:** `RegScheme="1"`, `ProxyScheme="1"`, `VMScheme="1"`, `EventScheme="1"`
   - Also removed the `Realm=""` attribute from the User element.
   - SIP from UDP(2) to TCP (1)

8. **BLF Group Added** (line ~324)
   - **Added:** `BlfGroup="share_presence"`
   - Enables presence sharing for Busy Lamp Field functionality.

---

### Overall Purpose

This PR updates the **Mitel 5330E** (note: the "E" variant, different from PR #8133's 5330) provisioning template with:
- Regional NTP server configuration
- Corrected RTP port ranges to avoid conflicts
- Dynamic auto-dial and inter-digit timer settings
- SIP scheme corrections (2 → 1)
- Hardcoded default admin password with documentation
- Cleanup of obsolete/dead configuration lines
- BLF presence sharing support