### PR TITLE
Improvement/make vm phrases interruptable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 .project
 .vscode
 /phpinfo.php
+/AGENTS.md
+/CLAUDE.md
 resources/config.php
 secure/mailto.bat
 secure/*.db

--- a/app/switch/resources/scripts/app/voicemail/resources/functions/listen_to_recording.lua
+++ b/app/switch/resources/scripts/app/voicemail/resources/functions/listen_to_recording.lua
@@ -30,14 +30,20 @@
 	function listen_to_recording(message_number, uuid, created_epoch, caller_id_name, caller_id_number, message_status, message_play)
 
 		--set default values
-			dtmf_digits = '';
 			max_digits = 1;
 			if (message_play == nil) then
 				message_play = 'true';
 			end
 
-		--flush dtmf digits from the input buffer
-			session:flushDigits();
+		--act on the digit pressed during the previous acknowledgement, otherwise
+		--start with an empty buffer and discard anything typed before this message
+			if (dtmf_carry ~= nil and string.len(dtmf_carry) > 0) then
+				dtmf_digits = dtmf_carry;
+				dtmf_carry = '';
+			else
+				dtmf_digits = '';
+				session:flushDigits();
+			end
 
 		--set the callback function
 			if (session:ready()) then
@@ -257,24 +263,30 @@
 
 		--process the dtmf
 			if (session:ready()) then
-				if (dtmf_digits == "1") then
+				--keep the action then empty the buffer so that a digit pressed during the
+				--acknowledgement is carried to the next message instead of being discarded
+					local action = dtmf_digits;
+					dtmf_digits = '';
+
+				if (action == "1") then
 					return listen_to_recording(message_number, uuid, created_epoch, caller_id_name, caller_id_number, message_status);
-				elseif (dtmf_digits == "2") then
+				elseif (action == "2") then
 					message_saved(voicemail_id, uuid);
 					session:streamFile("phrase:voicemail_ack:saved");
-				elseif (dtmf_digits == "3") then
+				elseif (action == "3") then
 					session:streamFile(sounds_dir.."/"..default_language.."/"..default_dialect.."/"..default_voice.."/voicemail/vm-from.wav");
 					session:say(caller_id_number, default_language, "name_spelled", "iterated");
 					if (current_time_zone ~= nil) then
 						session:execute("set", "timezone="..current_time_zone.."");
 					end
 					session:say(created_epoch, default_language, "current_date_time", "pronounced");
-					session:execute("sleep", "1000");
+					session:sleep(1000);
+					dtmf_carry = dtmf_digits;
 					return listen_to_recording(message_number, uuid, created_epoch, caller_id_name, caller_id_number, message_status, 'false');
-				elseif (dtmf_digits == "5") then
+				elseif (action == "5") then
 					message_saved(voicemail_id, uuid);
 					return_call(caller_id_number);
-				elseif (dtmf_digits == "7") then
+				elseif (action == "7") then
 					if (use_deletion_queue == "true" and message_status ~= "deleted") then
 						message_saved(voicemail_id, uuid, "deleted");
 						session:streamFile("phrase:voicemail_ack:deleted");
@@ -286,25 +298,34 @@
 						if (voicemail_id_copy ~= voicemail_id  and voicemail_id_copy ~= nil) then
 							message_waiting(voicemail_id_copy, domain_uuid);
 						end
-				elseif (dtmf_digits == "8") then
+				elseif (action == "8") then
 					forward_to_extension(voicemail_id, uuid);
 					dtmf_digits = '';
-				elseif (dtmf_digits == "9") then
+				elseif (action == "9") then
 					send_email(voicemail_id, uuid);
 					dtmf_digits = '';
 					session:streamFile("phrase:voicemail_ack:emailed");
-				elseif (dtmf_digits == "*") then
+				elseif (action == "*") then
 					timeouts = 0;
 					return main_menu();
-				elseif (dtmf_digits == "0") then
+				elseif (action == "0") then
 					message_saved(voicemail_id, uuid);
 					session:transfer("0", "XML", context);
-				elseif (dtmf_digits == "#") then
+				elseif (action == "#") then
 					return;
 				else
 					message_saved(voicemail_id, uuid);
 					session:streamFile("phrase:voicemail_ack:saved");
 				end
-				session:execute("sleep", "400");
+				session:sleep(400);
+
+				--carry the digit pressed during the acknowledgement to the next message,
+				--except 5 which would return the call to the next caller rather than this one
+					if (dtmf_digits == "5") then
+						dtmf_carry = '';
+					else
+						dtmf_carry = dtmf_digits;
+					end
+					dtmf_digits = '';
 			end
 	end

--- a/app/switch/resources/scripts/app/voicemail/resources/functions/listen_to_recording.lua
+++ b/app/switch/resources/scripts/app/voicemail/resources/functions/listen_to_recording.lua
@@ -56,13 +56,17 @@
 				--say the message number
 					if (session:ready()) then
 						if (string.len(dtmf_digits) == 0) then
-							session:execute("playback", "phrase:voicemail_say_message_number:" .. message_status .. ":" .. message_number);
+							--keep 4, 5 and 6 as transport keys so they don't reach the menu
+							stream_seek = true;
+							session:streamFile("phrase:voicemail_say_message_number:" .. message_status .. ":" .. message_number);
+							stream_seek = false;
 						end
 					end
 
 				--say the caller id number first (default)
 					if (
 						session:ready() and
+						string.len(dtmf_digits) == 0 and
 						caller_id_number ~= nil and (
 							vm_say_caller_id_number == nil or
 							vm_say_caller_id_number == "true" or
@@ -257,7 +261,7 @@
 					return listen_to_recording(message_number, uuid, created_epoch, caller_id_name, caller_id_number, message_status);
 				elseif (dtmf_digits == "2") then
 					message_saved(voicemail_id, uuid);
-					session:execute("playback", "phrase:voicemail_ack:saved");
+					session:streamFile("phrase:voicemail_ack:saved");
 				elseif (dtmf_digits == "3") then
 					session:streamFile(sounds_dir.."/"..default_language.."/"..default_dialect.."/"..default_voice.."/voicemail/vm-from.wav");
 					session:say(caller_id_number, default_language, "name_spelled", "iterated");
@@ -273,7 +277,7 @@
 				elseif (dtmf_digits == "7") then
 					if (use_deletion_queue == "true" and message_status ~= "deleted") then
 						message_saved(voicemail_id, uuid, "deleted");
-						session:execute("playback", "phrase:voicemail_ack:deleted");
+						session:streamFile("phrase:voicemail_ack:deleted");
 					else
 						delete_recording(voicemail_id, uuid);
 					end
@@ -288,7 +292,7 @@
 				elseif (dtmf_digits == "9") then
 					send_email(voicemail_id, uuid);
 					dtmf_digits = '';
-					session:execute("playback", "phrase:voicemail_ack:emailed");
+					session:streamFile("phrase:voicemail_ack:emailed");
 				elseif (dtmf_digits == "*") then
 					timeouts = 0;
 					return main_menu();
@@ -299,7 +303,7 @@
 					return;
 				else
 					message_saved(voicemail_id, uuid);
-					session:execute("playback", "phrase:voicemail_ack:saved");
+					session:streamFile("phrase:voicemail_ack:saved");
 				end
 				session:execute("sleep", "400");
 			end

--- a/app/switch/resources/scripts/app/voicemail/resources/functions/menu_messages.lua
+++ b/app/switch/resources/scripts/app/voicemail/resources/functions/menu_messages.lua
@@ -34,6 +34,7 @@
 			timeout = 2000;
 		--clear the dtmf
 			dtmf_digits = '';
+			dtmf_carry = '';
 		--flush dtmf digits from the input buffer
 			--session:flushDigits();
 		--set the message number


### PR DESCRIPTION
This allows for much faster skipping through voicemail messages by not forcing the user to listen to the message saved and message number 1 phrases. There is also a .gitignore for claude code so if using claude for development help it's settings don't get tracked and pushed to git servers.

