### PR TITLE
Fix issues with Ring group exit key not being cleared from the realm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 .project
 .vscode
 /phpinfo.php
+/AGENTS.md
+/CLAUDE.md
 resources/config.php
 secure/mailto.bat
 secure/*.db

--- a/app/switch/resources/conf/languages/ar/vm/voicemail.xml
+++ b/app/switch/resources/conf/languages/ar/vm/voicemail.xml
@@ -256,4 +256,12 @@
     </input>
   </macro>
 
+  <macro name="voicemail_invalid_option">
+   <input>
+      <match>
+        <action function="play-file" data="ivr/ivr-that_was_an_invalid_entry.wav"/>
+      </match>
+   </input>
+  </macro>
+
 </include>

--- a/app/switch/resources/conf/languages/ar/vm/voicemail.xml
+++ b/app/switch/resources/conf/languages/ar/vm/voicemail.xml
@@ -40,7 +40,7 @@
 
   <!-- similar to voicemail_listen_file_check in vm/sounds.xml, but maintains previous order -->
   <macro name="voicemail_listen_file_options">
-    <input pattern="^([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):(.*)$">
+    <input pattern="^([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):(.*)$">
       <match>
         <action function="play-file" data="voicemail/vm-listen_to_recording.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
@@ -60,12 +60,9 @@
         <action function="play-file" data="voicemail/vm-to_forward.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
         <action function="say" data="$6" method="pronounced" type="name_spelled"/>
-        <action function="play-file" data="voicemail/vm-forward_to_email.wav"/>
-        <action function="play-file" data="voicemail/vm-press.wav"/>
-        <action function="say" data="$7" method="pronounced" type="name_spelled"/>
       </match>
     </input>
-    <input pattern="^deleted:([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):(.*)$">
+    <input pattern="^deleted:([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):(.*)$">
       <match>
         <action function="play-file" data="voicemail/vm-listen_to_recording.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
@@ -85,9 +82,6 @@
         <action function="play-file" data="voicemail/vm-to_forward.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
         <action function="say" data="$6" method="pronounced" type="name_spelled"/>
-        <action function="play-file" data="voicemail/vm-forward_to_email.wav"/>
-        <action function="play-file" data="voicemail/vm-press.wav"/>
-        <action function="say" data="$7" method="pronounced" type="name_spelled"/>
       </match>
     </input>
   </macro>
@@ -237,6 +231,19 @@
         <action function="play-file" data="voicemail/vm-press.wav"/>
         <action function="say" data="$1" method="pronounced" type="name_spelled"/>
         <action function="play-file" data="voicemail/vm-save_message.wav"/>
+        <action function="play-file" data="voicemail/vm-press.wav"/>
+        <action function="say" data="$2" method="pronounced" type="name_spelled"/>
+      </match>
+    </input>
+  </macro>
+
+  <macro name="voicemail_forward_message_options">
+    <input pattern="^([0-9#*]):(.*)$">
+      <match>
+        <action function="play-file" data="voicemail/vm-to_forward.wav"/>
+        <action function="play-file" data="voicemail/vm-press.wav"/>
+        <action function="say" data="$1" method="pronounced" type="name_spelled"/>
+        <action function="play-file" data="voicemail/vm-forward_to_email.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
         <action function="say" data="$2" method="pronounced" type="name_spelled"/>
       </match>

--- a/app/switch/resources/conf/languages/ar/vm/voicemail.xml
+++ b/app/switch/resources/conf/languages/ar/vm/voicemail.xml
@@ -40,7 +40,7 @@
 
   <!-- similar to voicemail_listen_file_check in vm/sounds.xml, but maintains previous order -->
   <macro name="voicemail_listen_file_options">
-    <input pattern="^([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):(.*)$">
+    <input pattern="^([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):(.*)$">
       <match>
         <action function="play-file" data="voicemail/vm-listen_to_recording.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
@@ -60,9 +60,12 @@
         <action function="play-file" data="voicemail/vm-to_forward.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
         <action function="say" data="$6" method="pronounced" type="name_spelled"/>
+        <action function="play-file" data="voicemail/vm-play_next_message.wav"/>
+        <action function="play-file" data="voicemail/vm-press.wav"/>
+        <action function="say" data="$7" method="pronounced" type="name_spelled"/>
       </match>
     </input>
-    <input pattern="^deleted:([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):(.*)$">
+    <input pattern="^deleted:([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):(.*)$">
       <match>
         <action function="play-file" data="voicemail/vm-listen_to_recording.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
@@ -82,6 +85,9 @@
         <action function="play-file" data="voicemail/vm-to_forward.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
         <action function="say" data="$6" method="pronounced" type="name_spelled"/>
+        <action function="play-file" data="voicemail/vm-play_next_message.wav"/>
+        <action function="play-file" data="voicemail/vm-press.wav"/>
+        <action function="say" data="$7" method="pronounced" type="name_spelled"/>
       </match>
     </input>
   </macro>

--- a/app/switch/resources/conf/languages/de/vm/voicemail.xml
+++ b/app/switch/resources/conf/languages/de/vm/voicemail.xml
@@ -256,4 +256,12 @@
     </input>
   </macro>
 
+  <macro name="voicemail_invalid_option">
+   <input>
+      <match>
+        <action function="play-file" data="ivr/ivr-that_was_an_invalid_entry.wav"/>
+      </match>
+   </input>
+  </macro>
+
 </include>

--- a/app/switch/resources/conf/languages/de/vm/voicemail.xml
+++ b/app/switch/resources/conf/languages/de/vm/voicemail.xml
@@ -40,7 +40,7 @@
 
   <!-- similar to voicemail_listen_file_check in vm/sounds.xml, but maintains previous order -->
   <macro name="voicemail_listen_file_options">
-    <input pattern="^([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):(.*)$">
+    <input pattern="^([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):(.*)$">
       <match>
         <action function="play-file" data="voicemail/vm-listen_to_recording.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
@@ -60,12 +60,9 @@
         <action function="play-file" data="voicemail/vm-to_forward.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
         <action function="say" data="$6" method="pronounced" type="name_spelled"/>
-        <action function="play-file" data="voicemail/vm-forward_to_email.wav"/>
-        <action function="play-file" data="voicemail/vm-press.wav"/>
-        <action function="say" data="$7" method="pronounced" type="name_spelled"/>
       </match>
     </input>
-    <input pattern="^deleted:([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):(.*)$">
+    <input pattern="^deleted:([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):(.*)$">
       <match>
         <action function="play-file" data="voicemail/vm-listen_to_recording.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
@@ -85,9 +82,6 @@
         <action function="play-file" data="voicemail/vm-to_forward.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
         <action function="say" data="$6" method="pronounced" type="name_spelled"/>
-        <action function="play-file" data="voicemail/vm-forward_to_email.wav"/>
-        <action function="play-file" data="voicemail/vm-press.wav"/>
-        <action function="say" data="$7" method="pronounced" type="name_spelled"/>
       </match>
     </input>
   </macro>
@@ -237,6 +231,19 @@
         <action function="play-file" data="voicemail/vm-press.wav"/>
         <action function="say" data="$1" method="pronounced" type="name_spelled"/>
         <action function="play-file" data="voicemail/vm-save_message.wav"/>
+        <action function="play-file" data="voicemail/vm-press.wav"/>
+        <action function="say" data="$2" method="pronounced" type="name_spelled"/>
+      </match>
+    </input>
+  </macro>
+
+  <macro name="voicemail_forward_message_options">
+    <input pattern="^([0-9#*]):(.*)$">
+      <match>
+        <action function="play-file" data="voicemail/vm-to_forward.wav"/>
+        <action function="play-file" data="voicemail/vm-press.wav"/>
+        <action function="say" data="$1" method="pronounced" type="name_spelled"/>
+        <action function="play-file" data="voicemail/vm-forward_to_email.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
         <action function="say" data="$2" method="pronounced" type="name_spelled"/>
       </match>

--- a/app/switch/resources/conf/languages/de/vm/voicemail.xml
+++ b/app/switch/resources/conf/languages/de/vm/voicemail.xml
@@ -40,7 +40,7 @@
 
   <!-- similar to voicemail_listen_file_check in vm/sounds.xml, but maintains previous order -->
   <macro name="voicemail_listen_file_options">
-    <input pattern="^([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):(.*)$">
+    <input pattern="^([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):(.*)$">
       <match>
         <action function="play-file" data="voicemail/vm-listen_to_recording.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
@@ -60,9 +60,12 @@
         <action function="play-file" data="voicemail/vm-to_forward.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
         <action function="say" data="$6" method="pronounced" type="name_spelled"/>
+        <action function="play-file" data="voicemail/vm-play_next_message.wav"/>
+        <action function="play-file" data="voicemail/vm-press.wav"/>
+        <action function="say" data="$7" method="pronounced" type="name_spelled"/>
       </match>
     </input>
-    <input pattern="^deleted:([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):(.*)$">
+    <input pattern="^deleted:([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):(.*)$">
       <match>
         <action function="play-file" data="voicemail/vm-listen_to_recording.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
@@ -82,6 +85,9 @@
         <action function="play-file" data="voicemail/vm-to_forward.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
         <action function="say" data="$6" method="pronounced" type="name_spelled"/>
+        <action function="play-file" data="voicemail/vm-play_next_message.wav"/>
+        <action function="play-file" data="voicemail/vm-press.wav"/>
+        <action function="say" data="$7" method="pronounced" type="name_spelled"/>
       </match>
     </input>
   </macro>

--- a/app/switch/resources/conf/languages/el/vm/voicemail.xml
+++ b/app/switch/resources/conf/languages/el/vm/voicemail.xml
@@ -256,4 +256,12 @@
     </input>
   </macro>
 
+  <macro name="voicemail_invalid_option">
+   <input>
+      <match>
+        <action function="play-file" data="ivr/ivr-that_was_an_invalid_entry.wav"/>
+      </match>
+   </input>
+  </macro>
+
 </include>

--- a/app/switch/resources/conf/languages/el/vm/voicemail.xml
+++ b/app/switch/resources/conf/languages/el/vm/voicemail.xml
@@ -40,7 +40,7 @@
 
   <!-- similar to voicemail_listen_file_check in vm/sounds.xml, but maintains previous order -->
   <macro name="voicemail_listen_file_options">
-    <input pattern="^([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):(.*)$">
+    <input pattern="^([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):(.*)$">
       <match>
         <action function="play-file" data="voicemail/vm-listen_to_recording.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
@@ -60,12 +60,9 @@
         <action function="play-file" data="voicemail/vm-to_forward.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
         <action function="say" data="$6" method="pronounced" type="name_spelled"/>
-        <action function="play-file" data="voicemail/vm-forward_to_email.wav"/>
-        <action function="play-file" data="voicemail/vm-press.wav"/>
-        <action function="say" data="$7" method="pronounced" type="name_spelled"/>
       </match>
     </input>
-    <input pattern="^deleted:([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):(.*)$">
+    <input pattern="^deleted:([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):(.*)$">
       <match>
         <action function="play-file" data="voicemail/vm-listen_to_recording.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
@@ -85,9 +82,6 @@
         <action function="play-file" data="voicemail/vm-to_forward.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
         <action function="say" data="$6" method="pronounced" type="name_spelled"/>
-        <action function="play-file" data="voicemail/vm-forward_to_email.wav"/>
-        <action function="play-file" data="voicemail/vm-press.wav"/>
-        <action function="say" data="$7" method="pronounced" type="name_spelled"/>
       </match>
     </input>
   </macro>
@@ -237,6 +231,19 @@
         <action function="play-file" data="voicemail/vm-press.wav"/>
         <action function="say" data="$1" method="pronounced" type="name_spelled"/>
         <action function="play-file" data="voicemail/vm-save_message.wav"/>
+        <action function="play-file" data="voicemail/vm-press.wav"/>
+        <action function="say" data="$2" method="pronounced" type="name_spelled"/>
+      </match>
+    </input>
+  </macro>
+
+  <macro name="voicemail_forward_message_options">
+    <input pattern="^([0-9#*]):(.*)$">
+      <match>
+        <action function="play-file" data="voicemail/vm-to_forward.wav"/>
+        <action function="play-file" data="voicemail/vm-press.wav"/>
+        <action function="say" data="$1" method="pronounced" type="name_spelled"/>
+        <action function="play-file" data="voicemail/vm-forward_to_email.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
         <action function="say" data="$2" method="pronounced" type="name_spelled"/>
       </match>

--- a/app/switch/resources/conf/languages/el/vm/voicemail.xml
+++ b/app/switch/resources/conf/languages/el/vm/voicemail.xml
@@ -40,7 +40,7 @@
 
   <!-- similar to voicemail_listen_file_check in vm/sounds.xml, but maintains previous order -->
   <macro name="voicemail_listen_file_options">
-    <input pattern="^([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):(.*)$">
+    <input pattern="^([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):(.*)$">
       <match>
         <action function="play-file" data="voicemail/vm-listen_to_recording.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
@@ -60,9 +60,12 @@
         <action function="play-file" data="voicemail/vm-to_forward.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
         <action function="say" data="$6" method="pronounced" type="name_spelled"/>
+        <action function="play-file" data="voicemail/vm-play_next_message.wav"/>
+        <action function="play-file" data="voicemail/vm-press.wav"/>
+        <action function="say" data="$7" method="pronounced" type="name_spelled"/>
       </match>
     </input>
-    <input pattern="^deleted:([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):(.*)$">
+    <input pattern="^deleted:([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):(.*)$">
       <match>
         <action function="play-file" data="voicemail/vm-listen_to_recording.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
@@ -82,6 +85,9 @@
         <action function="play-file" data="voicemail/vm-to_forward.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
         <action function="say" data="$6" method="pronounced" type="name_spelled"/>
+        <action function="play-file" data="voicemail/vm-play_next_message.wav"/>
+        <action function="play-file" data="voicemail/vm-press.wav"/>
+        <action function="say" data="$7" method="pronounced" type="name_spelled"/>
       </match>
     </input>
   </macro>

--- a/app/switch/resources/conf/languages/en/vm/voicemail.xml
+++ b/app/switch/resources/conf/languages/en/vm/voicemail.xml
@@ -256,4 +256,12 @@
     </input>
   </macro>
 
+  <macro name="voicemail_invalid_option">
+   <input>
+      <match>
+        <action function="play-file" data="ivr/ivr-that_was_an_invalid_entry.wav"/>
+      </match>
+   </input>
+  </macro>
+
 </include>

--- a/app/switch/resources/conf/languages/en/vm/voicemail.xml
+++ b/app/switch/resources/conf/languages/en/vm/voicemail.xml
@@ -40,7 +40,7 @@
 
   <!-- similar to voicemail_listen_file_check in vm/sounds.xml, but maintains previous order -->
   <macro name="voicemail_listen_file_options">
-    <input pattern="^([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):(.*)$">
+    <input pattern="^([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):(.*)$">
       <match>
         <action function="play-file" data="voicemail/vm-listen_to_recording.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
@@ -60,12 +60,9 @@
         <action function="play-file" data="voicemail/vm-to_forward.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
         <action function="say" data="$6" method="pronounced" type="name_spelled"/>
-        <action function="play-file" data="voicemail/vm-forward_to_email.wav"/>
-        <action function="play-file" data="voicemail/vm-press.wav"/>
-        <action function="say" data="$7" method="pronounced" type="name_spelled"/>
       </match>
     </input>
-    <input pattern="^deleted:([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):(.*)$">
+    <input pattern="^deleted:([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):(.*)$">
       <match>
         <action function="play-file" data="voicemail/vm-listen_to_recording.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
@@ -85,9 +82,6 @@
         <action function="play-file" data="voicemail/vm-to_forward.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
         <action function="say" data="$6" method="pronounced" type="name_spelled"/>
-        <action function="play-file" data="voicemail/vm-forward_to_email.wav"/>
-        <action function="play-file" data="voicemail/vm-press.wav"/>
-        <action function="say" data="$7" method="pronounced" type="name_spelled"/>
       </match>
     </input>
   </macro>
@@ -237,6 +231,19 @@
         <action function="play-file" data="voicemail/vm-press.wav"/>
         <action function="say" data="$1" method="pronounced" type="name_spelled"/>
         <action function="play-file" data="voicemail/vm-save_message.wav"/>
+        <action function="play-file" data="voicemail/vm-press.wav"/>
+        <action function="say" data="$2" method="pronounced" type="name_spelled"/>
+      </match>
+    </input>
+  </macro>
+
+  <macro name="voicemail_forward_message_options">
+    <input pattern="^([0-9#*]):(.*)$">
+      <match>
+        <action function="play-file" data="voicemail/vm-to_forward.wav"/>
+        <action function="play-file" data="voicemail/vm-press.wav"/>
+        <action function="say" data="$1" method="pronounced" type="name_spelled"/>
+        <action function="play-file" data="voicemail/vm-forward_to_email.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
         <action function="say" data="$2" method="pronounced" type="name_spelled"/>
       </match>

--- a/app/switch/resources/conf/languages/en/vm/voicemail.xml
+++ b/app/switch/resources/conf/languages/en/vm/voicemail.xml
@@ -40,7 +40,7 @@
 
   <!-- similar to voicemail_listen_file_check in vm/sounds.xml, but maintains previous order -->
   <macro name="voicemail_listen_file_options">
-    <input pattern="^([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):(.*)$">
+    <input pattern="^([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):(.*)$">
       <match>
         <action function="play-file" data="voicemail/vm-listen_to_recording.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
@@ -60,9 +60,12 @@
         <action function="play-file" data="voicemail/vm-to_forward.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
         <action function="say" data="$6" method="pronounced" type="name_spelled"/>
+        <action function="play-file" data="voicemail/vm-play_next_message.wav"/>
+        <action function="play-file" data="voicemail/vm-press.wav"/>
+        <action function="say" data="$7" method="pronounced" type="name_spelled"/>
       </match>
     </input>
-    <input pattern="^deleted:([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):(.*)$">
+    <input pattern="^deleted:([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):(.*)$">
       <match>
         <action function="play-file" data="voicemail/vm-listen_to_recording.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
@@ -82,6 +85,9 @@
         <action function="play-file" data="voicemail/vm-to_forward.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
         <action function="say" data="$6" method="pronounced" type="name_spelled"/>
+        <action function="play-file" data="voicemail/vm-play_next_message.wav"/>
+        <action function="play-file" data="voicemail/vm-press.wav"/>
+        <action function="say" data="$7" method="pronounced" type="name_spelled"/>
       </match>
     </input>
   </macro>

--- a/app/switch/resources/conf/languages/es/vm/voicemail.xml
+++ b/app/switch/resources/conf/languages/es/vm/voicemail.xml
@@ -256,4 +256,12 @@
     </input>
   </macro>
 
+  <macro name="voicemail_invalid_option">
+   <input>
+      <match>
+        <action function="play-file" data="ivr/ivr-that_was_an_invalid_entry.wav"/>
+      </match>
+   </input>
+  </macro>
+
 </include>

--- a/app/switch/resources/conf/languages/es/vm/voicemail.xml
+++ b/app/switch/resources/conf/languages/es/vm/voicemail.xml
@@ -40,7 +40,7 @@
 
   <!-- similar to voicemail_listen_file_check in vm/sounds.xml, but maintains previous order -->
   <macro name="voicemail_listen_file_options">
-    <input pattern="^([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):(.*)$">
+    <input pattern="^([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):(.*)$">
       <match>
         <action function="play-file" data="voicemail/vm-listen_to_recording.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
@@ -60,12 +60,9 @@
         <action function="play-file" data="voicemail/vm-to_forward.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
         <action function="say" data="$6" method="pronounced" type="name_spelled"/>
-        <action function="play-file" data="voicemail/vm-forward_to_email.wav"/>
-        <action function="play-file" data="voicemail/vm-press.wav"/>
-        <action function="say" data="$7" method="pronounced" type="name_spelled"/>
       </match>
     </input>
-    <input pattern="^deleted:([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):(.*)$">
+    <input pattern="^deleted:([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):(.*)$">
       <match>
         <action function="play-file" data="voicemail/vm-listen_to_recording.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
@@ -85,9 +82,6 @@
         <action function="play-file" data="voicemail/vm-to_forward.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
         <action function="say" data="$6" method="pronounced" type="name_spelled"/>
-        <action function="play-file" data="voicemail/vm-forward_to_email.wav"/>
-        <action function="play-file" data="voicemail/vm-press.wav"/>
-        <action function="say" data="$7" method="pronounced" type="name_spelled"/>
       </match>
     </input>
   </macro>
@@ -237,6 +231,19 @@
         <action function="play-file" data="voicemail/vm-press.wav"/>
         <action function="say" data="$1" method="pronounced" type="name_spelled"/>
         <action function="play-file" data="voicemail/vm-save_message.wav"/>
+        <action function="play-file" data="voicemail/vm-press.wav"/>
+        <action function="say" data="$2" method="pronounced" type="name_spelled"/>
+      </match>
+    </input>
+  </macro>
+
+  <macro name="voicemail_forward_message_options">
+    <input pattern="^([0-9#*]):(.*)$">
+      <match>
+        <action function="play-file" data="voicemail/vm-to_forward.wav"/>
+        <action function="play-file" data="voicemail/vm-press.wav"/>
+        <action function="say" data="$1" method="pronounced" type="name_spelled"/>
+        <action function="play-file" data="voicemail/vm-forward_to_email.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
         <action function="say" data="$2" method="pronounced" type="name_spelled"/>
       </match>

--- a/app/switch/resources/conf/languages/es/vm/voicemail.xml
+++ b/app/switch/resources/conf/languages/es/vm/voicemail.xml
@@ -40,7 +40,7 @@
 
   <!-- similar to voicemail_listen_file_check in vm/sounds.xml, but maintains previous order -->
   <macro name="voicemail_listen_file_options">
-    <input pattern="^([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):(.*)$">
+    <input pattern="^([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):(.*)$">
       <match>
         <action function="play-file" data="voicemail/vm-listen_to_recording.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
@@ -60,9 +60,12 @@
         <action function="play-file" data="voicemail/vm-to_forward.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
         <action function="say" data="$6" method="pronounced" type="name_spelled"/>
+        <action function="play-file" data="voicemail/vm-play_next_message.wav"/>
+        <action function="play-file" data="voicemail/vm-press.wav"/>
+        <action function="say" data="$7" method="pronounced" type="name_spelled"/>
       </match>
     </input>
-    <input pattern="^deleted:([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):(.*)$">
+    <input pattern="^deleted:([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):(.*)$">
       <match>
         <action function="play-file" data="voicemail/vm-listen_to_recording.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
@@ -82,6 +85,9 @@
         <action function="play-file" data="voicemail/vm-to_forward.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
         <action function="say" data="$6" method="pronounced" type="name_spelled"/>
+        <action function="play-file" data="voicemail/vm-play_next_message.wav"/>
+        <action function="play-file" data="voicemail/vm-press.wav"/>
+        <action function="say" data="$7" method="pronounced" type="name_spelled"/>
       </match>
     </input>
   </macro>

--- a/app/switch/resources/conf/languages/fr/vm/voicemail.xml
+++ b/app/switch/resources/conf/languages/fr/vm/voicemail.xml
@@ -256,4 +256,12 @@
     </input>
   </macro>
 
+  <macro name="voicemail_invalid_option">
+   <input>
+      <match>
+        <action function="play-file" data="ivr/ivr-that_was_an_invalid_entry.wav"/>
+      </match>
+   </input>
+  </macro>
+
 </include>

--- a/app/switch/resources/conf/languages/fr/vm/voicemail.xml
+++ b/app/switch/resources/conf/languages/fr/vm/voicemail.xml
@@ -40,7 +40,7 @@
 
   <!-- similar to voicemail_listen_file_check in vm/sounds.xml, but maintains previous order -->
   <macro name="voicemail_listen_file_options">
-    <input pattern="^([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):(.*)$">
+    <input pattern="^([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):(.*)$">
       <match>
         <action function="play-file" data="voicemail/vm-listen_to_recording.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
@@ -60,12 +60,9 @@
         <action function="play-file" data="voicemail/vm-to_forward.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
         <action function="say" data="$6" method="pronounced" type="name_spelled"/>
-        <action function="play-file" data="voicemail/vm-forward_to_email.wav"/>
-        <action function="play-file" data="voicemail/vm-press.wav"/>
-        <action function="say" data="$7" method="pronounced" type="name_spelled"/>
       </match>
     </input>
-    <input pattern="^deleted:([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):(.*)$">
+    <input pattern="^deleted:([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):(.*)$">
       <match>
         <action function="play-file" data="voicemail/vm-listen_to_recording.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
@@ -85,9 +82,6 @@
         <action function="play-file" data="voicemail/vm-to_forward.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
         <action function="say" data="$6" method="pronounced" type="name_spelled"/>
-        <action function="play-file" data="voicemail/vm-forward_to_email.wav"/>
-        <action function="play-file" data="voicemail/vm-press.wav"/>
-        <action function="say" data="$7" method="pronounced" type="name_spelled"/>
       </match>
     </input>
   </macro>
@@ -237,6 +231,19 @@
         <action function="play-file" data="voicemail/vm-press.wav"/>
         <action function="say" data="$1" method="pronounced" type="name_spelled"/>
         <action function="play-file" data="voicemail/vm-save_message.wav"/>
+        <action function="play-file" data="voicemail/vm-press.wav"/>
+        <action function="say" data="$2" method="pronounced" type="name_spelled"/>
+      </match>
+    </input>
+  </macro>
+
+  <macro name="voicemail_forward_message_options">
+    <input pattern="^([0-9#*]):(.*)$">
+      <match>
+        <action function="play-file" data="voicemail/vm-to_forward.wav"/>
+        <action function="play-file" data="voicemail/vm-press.wav"/>
+        <action function="say" data="$1" method="pronounced" type="name_spelled"/>
+        <action function="play-file" data="voicemail/vm-forward_to_email.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
         <action function="say" data="$2" method="pronounced" type="name_spelled"/>
       </match>

--- a/app/switch/resources/conf/languages/fr/vm/voicemail.xml
+++ b/app/switch/resources/conf/languages/fr/vm/voicemail.xml
@@ -40,7 +40,7 @@
 
   <!-- similar to voicemail_listen_file_check in vm/sounds.xml, but maintains previous order -->
   <macro name="voicemail_listen_file_options">
-    <input pattern="^([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):(.*)$">
+    <input pattern="^([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):(.*)$">
       <match>
         <action function="play-file" data="voicemail/vm-listen_to_recording.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
@@ -60,9 +60,12 @@
         <action function="play-file" data="voicemail/vm-to_forward.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
         <action function="say" data="$6" method="pronounced" type="name_spelled"/>
+        <action function="play-file" data="voicemail/vm-play_next_message.wav"/>
+        <action function="play-file" data="voicemail/vm-press.wav"/>
+        <action function="say" data="$7" method="pronounced" type="name_spelled"/>
       </match>
     </input>
-    <input pattern="^deleted:([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):(.*)$">
+    <input pattern="^deleted:([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):(.*)$">
       <match>
         <action function="play-file" data="voicemail/vm-listen_to_recording.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
@@ -82,6 +85,9 @@
         <action function="play-file" data="voicemail/vm-to_forward.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
         <action function="say" data="$6" method="pronounced" type="name_spelled"/>
+        <action function="play-file" data="voicemail/vm-play_next_message.wav"/>
+        <action function="play-file" data="voicemail/vm-press.wav"/>
+        <action function="say" data="$7" method="pronounced" type="name_spelled"/>
       </match>
     </input>
   </macro>

--- a/app/switch/resources/conf/languages/he/vm/voicemail.xml
+++ b/app/switch/resources/conf/languages/he/vm/voicemail.xml
@@ -256,4 +256,12 @@
     </input>
   </macro>
 
+  <macro name="voicemail_invalid_option">
+   <input>
+      <match>
+        <action function="play-file" data="ivr/ivr-that_was_an_invalid_entry.wav"/>
+      </match>
+   </input>
+  </macro>
+
 </include>

--- a/app/switch/resources/conf/languages/he/vm/voicemail.xml
+++ b/app/switch/resources/conf/languages/he/vm/voicemail.xml
@@ -40,7 +40,7 @@
 
   <!-- similar to voicemail_listen_file_check in vm/sounds.xml, but maintains previous order -->
   <macro name="voicemail_listen_file_options">
-    <input pattern="^([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):(.*)$">
+    <input pattern="^([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):(.*)$">
       <match>
         <action function="play-file" data="voicemail/vm-listen_to_recording.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
@@ -60,12 +60,9 @@
         <action function="play-file" data="voicemail/vm-to_forward.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
         <action function="say" data="$6" method="pronounced" type="name_spelled"/>
-        <action function="play-file" data="voicemail/vm-forward_to_email.wav"/>
-        <action function="play-file" data="voicemail/vm-press.wav"/>
-        <action function="say" data="$7" method="pronounced" type="name_spelled"/>
       </match>
     </input>
-    <input pattern="^deleted:([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):(.*)$">
+    <input pattern="^deleted:([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):(.*)$">
       <match>
         <action function="play-file" data="voicemail/vm-listen_to_recording.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
@@ -85,9 +82,6 @@
         <action function="play-file" data="voicemail/vm-to_forward.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
         <action function="say" data="$6" method="pronounced" type="name_spelled"/>
-        <action function="play-file" data="voicemail/vm-forward_to_email.wav"/>
-        <action function="play-file" data="voicemail/vm-press.wav"/>
-        <action function="say" data="$7" method="pronounced" type="name_spelled"/>
       </match>
     </input>
   </macro>
@@ -237,6 +231,19 @@
         <action function="play-file" data="voicemail/vm-press.wav"/>
         <action function="say" data="$1" method="pronounced" type="name_spelled"/>
         <action function="play-file" data="voicemail/vm-save_message.wav"/>
+        <action function="play-file" data="voicemail/vm-press.wav"/>
+        <action function="say" data="$2" method="pronounced" type="name_spelled"/>
+      </match>
+    </input>
+  </macro>
+
+  <macro name="voicemail_forward_message_options">
+    <input pattern="^([0-9#*]):(.*)$">
+      <match>
+        <action function="play-file" data="voicemail/vm-to_forward.wav"/>
+        <action function="play-file" data="voicemail/vm-press.wav"/>
+        <action function="say" data="$1" method="pronounced" type="name_spelled"/>
+        <action function="play-file" data="voicemail/vm-forward_to_email.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
         <action function="say" data="$2" method="pronounced" type="name_spelled"/>
       </match>

--- a/app/switch/resources/conf/languages/he/vm/voicemail.xml
+++ b/app/switch/resources/conf/languages/he/vm/voicemail.xml
@@ -40,7 +40,7 @@
 
   <!-- similar to voicemail_listen_file_check in vm/sounds.xml, but maintains previous order -->
   <macro name="voicemail_listen_file_options">
-    <input pattern="^([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):(.*)$">
+    <input pattern="^([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):(.*)$">
       <match>
         <action function="play-file" data="voicemail/vm-listen_to_recording.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
@@ -60,9 +60,12 @@
         <action function="play-file" data="voicemail/vm-to_forward.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
         <action function="say" data="$6" method="pronounced" type="name_spelled"/>
+        <action function="play-file" data="voicemail/vm-play_next_message.wav"/>
+        <action function="play-file" data="voicemail/vm-press.wav"/>
+        <action function="say" data="$7" method="pronounced" type="name_spelled"/>
       </match>
     </input>
-    <input pattern="^deleted:([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):(.*)$">
+    <input pattern="^deleted:([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):(.*)$">
       <match>
         <action function="play-file" data="voicemail/vm-listen_to_recording.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
@@ -82,6 +85,9 @@
         <action function="play-file" data="voicemail/vm-to_forward.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
         <action function="say" data="$6" method="pronounced" type="name_spelled"/>
+        <action function="play-file" data="voicemail/vm-play_next_message.wav"/>
+        <action function="play-file" data="voicemail/vm-press.wav"/>
+        <action function="say" data="$7" method="pronounced" type="name_spelled"/>
       </match>
     </input>
   </macro>

--- a/app/switch/resources/conf/languages/it/vm/voicemail.xml
+++ b/app/switch/resources/conf/languages/it/vm/voicemail.xml
@@ -256,4 +256,12 @@
     </input>
   </macro>
 
+  <macro name="voicemail_invalid_option">
+   <input>
+      <match>
+        <action function="play-file" data="ivr/ivr-that_was_an_invalid_entry.wav"/>
+      </match>
+   </input>
+  </macro>
+
 </include>

--- a/app/switch/resources/conf/languages/it/vm/voicemail.xml
+++ b/app/switch/resources/conf/languages/it/vm/voicemail.xml
@@ -40,7 +40,7 @@
 
   <!-- similar to voicemail_listen_file_check in vm/sounds.xml, but maintains previous order -->
   <macro name="voicemail_listen_file_options">
-    <input pattern="^([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):(.*)$">
+    <input pattern="^([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):(.*)$">
       <match>
         <action function="play-file" data="voicemail/vm-listen_to_recording.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
@@ -60,12 +60,9 @@
         <action function="play-file" data="voicemail/vm-to_forward.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
         <action function="say" data="$6" method="pronounced" type="name_spelled"/>
-        <action function="play-file" data="voicemail/vm-forward_to_email.wav"/>
-        <action function="play-file" data="voicemail/vm-press.wav"/>
-        <action function="say" data="$7" method="pronounced" type="name_spelled"/>
       </match>
     </input>
-    <input pattern="^deleted:([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):(.*)$">
+    <input pattern="^deleted:([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):(.*)$">
       <match>
         <action function="play-file" data="voicemail/vm-listen_to_recording.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
@@ -85,9 +82,6 @@
         <action function="play-file" data="voicemail/vm-to_forward.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
         <action function="say" data="$6" method="pronounced" type="name_spelled"/>
-        <action function="play-file" data="voicemail/vm-forward_to_email.wav"/>
-        <action function="play-file" data="voicemail/vm-press.wav"/>
-        <action function="say" data="$7" method="pronounced" type="name_spelled"/>
       </match>
     </input>
   </macro>
@@ -237,6 +231,19 @@
         <action function="play-file" data="voicemail/vm-press.wav"/>
         <action function="say" data="$1" method="pronounced" type="name_spelled"/>
         <action function="play-file" data="voicemail/vm-save_message.wav"/>
+        <action function="play-file" data="voicemail/vm-press.wav"/>
+        <action function="say" data="$2" method="pronounced" type="name_spelled"/>
+      </match>
+    </input>
+  </macro>
+
+  <macro name="voicemail_forward_message_options">
+    <input pattern="^([0-9#*]):(.*)$">
+      <match>
+        <action function="play-file" data="voicemail/vm-to_forward.wav"/>
+        <action function="play-file" data="voicemail/vm-press.wav"/>
+        <action function="say" data="$1" method="pronounced" type="name_spelled"/>
+        <action function="play-file" data="voicemail/vm-forward_to_email.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
         <action function="say" data="$2" method="pronounced" type="name_spelled"/>
       </match>

--- a/app/switch/resources/conf/languages/it/vm/voicemail.xml
+++ b/app/switch/resources/conf/languages/it/vm/voicemail.xml
@@ -40,7 +40,7 @@
 
   <!-- similar to voicemail_listen_file_check in vm/sounds.xml, but maintains previous order -->
   <macro name="voicemail_listen_file_options">
-    <input pattern="^([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):(.*)$">
+    <input pattern="^([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):(.*)$">
       <match>
         <action function="play-file" data="voicemail/vm-listen_to_recording.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
@@ -60,9 +60,12 @@
         <action function="play-file" data="voicemail/vm-to_forward.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
         <action function="say" data="$6" method="pronounced" type="name_spelled"/>
+        <action function="play-file" data="voicemail/vm-play_next_message.wav"/>
+        <action function="play-file" data="voicemail/vm-press.wav"/>
+        <action function="say" data="$7" method="pronounced" type="name_spelled"/>
       </match>
     </input>
-    <input pattern="^deleted:([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):(.*)$">
+    <input pattern="^deleted:([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):(.*)$">
       <match>
         <action function="play-file" data="voicemail/vm-listen_to_recording.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
@@ -82,6 +85,9 @@
         <action function="play-file" data="voicemail/vm-to_forward.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
         <action function="say" data="$6" method="pronounced" type="name_spelled"/>
+        <action function="play-file" data="voicemail/vm-play_next_message.wav"/>
+        <action function="play-file" data="voicemail/vm-press.wav"/>
+        <action function="say" data="$7" method="pronounced" type="name_spelled"/>
       </match>
     </input>
   </macro>

--- a/app/switch/resources/conf/languages/nl/vm/voicemail.xml
+++ b/app/switch/resources/conf/languages/nl/vm/voicemail.xml
@@ -256,4 +256,12 @@
     </input>
   </macro>
 
+  <macro name="voicemail_invalid_option">
+   <input>
+      <match>
+        <action function="play-file" data="ivr/ivr-that_was_an_invalid_entry.wav"/>
+      </match>
+   </input>
+  </macro>
+
 </include>

--- a/app/switch/resources/conf/languages/nl/vm/voicemail.xml
+++ b/app/switch/resources/conf/languages/nl/vm/voicemail.xml
@@ -40,7 +40,7 @@
 
   <!-- similar to voicemail_listen_file_check in vm/sounds.xml, but maintains previous order -->
   <macro name="voicemail_listen_file_options">
-    <input pattern="^([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):(.*)$">
+    <input pattern="^([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):(.*)$">
       <match>
         <action function="play-file" data="voicemail/vm-listen_to_recording.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
@@ -60,12 +60,9 @@
         <action function="play-file" data="voicemail/vm-to_forward.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
         <action function="say" data="$6" method="pronounced" type="name_spelled"/>
-        <action function="play-file" data="voicemail/vm-forward_to_email.wav"/>
-        <action function="play-file" data="voicemail/vm-press.wav"/>
-        <action function="say" data="$7" method="pronounced" type="name_spelled"/>
       </match>
     </input>
-    <input pattern="^deleted:([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):(.*)$">
+    <input pattern="^deleted:([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):(.*)$">
       <match>
         <action function="play-file" data="voicemail/vm-listen_to_recording.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
@@ -85,9 +82,6 @@
         <action function="play-file" data="voicemail/vm-to_forward.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
         <action function="say" data="$6" method="pronounced" type="name_spelled"/>
-        <action function="play-file" data="voicemail/vm-forward_to_email.wav"/>
-        <action function="play-file" data="voicemail/vm-press.wav"/>
-        <action function="say" data="$7" method="pronounced" type="name_spelled"/>
       </match>
     </input>
   </macro>
@@ -237,6 +231,19 @@
         <action function="play-file" data="voicemail/vm-press.wav"/>
         <action function="say" data="$1" method="pronounced" type="name_spelled"/>
         <action function="play-file" data="voicemail/vm-save_message.wav"/>
+        <action function="play-file" data="voicemail/vm-press.wav"/>
+        <action function="say" data="$2" method="pronounced" type="name_spelled"/>
+      </match>
+    </input>
+  </macro>
+
+  <macro name="voicemail_forward_message_options">
+    <input pattern="^([0-9#*]):(.*)$">
+      <match>
+        <action function="play-file" data="voicemail/vm-to_forward.wav"/>
+        <action function="play-file" data="voicemail/vm-press.wav"/>
+        <action function="say" data="$1" method="pronounced" type="name_spelled"/>
+        <action function="play-file" data="voicemail/vm-forward_to_email.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
         <action function="say" data="$2" method="pronounced" type="name_spelled"/>
       </match>

--- a/app/switch/resources/conf/languages/nl/vm/voicemail.xml
+++ b/app/switch/resources/conf/languages/nl/vm/voicemail.xml
@@ -40,7 +40,7 @@
 
   <!-- similar to voicemail_listen_file_check in vm/sounds.xml, but maintains previous order -->
   <macro name="voicemail_listen_file_options">
-    <input pattern="^([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):(.*)$">
+    <input pattern="^([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):(.*)$">
       <match>
         <action function="play-file" data="voicemail/vm-listen_to_recording.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
@@ -60,9 +60,12 @@
         <action function="play-file" data="voicemail/vm-to_forward.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
         <action function="say" data="$6" method="pronounced" type="name_spelled"/>
+        <action function="play-file" data="voicemail/vm-play_next_message.wav"/>
+        <action function="play-file" data="voicemail/vm-press.wav"/>
+        <action function="say" data="$7" method="pronounced" type="name_spelled"/>
       </match>
     </input>
-    <input pattern="^deleted:([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):(.*)$">
+    <input pattern="^deleted:([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):(.*)$">
       <match>
         <action function="play-file" data="voicemail/vm-listen_to_recording.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
@@ -82,6 +85,9 @@
         <action function="play-file" data="voicemail/vm-to_forward.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
         <action function="say" data="$6" method="pronounced" type="name_spelled"/>
+        <action function="play-file" data="voicemail/vm-play_next_message.wav"/>
+        <action function="play-file" data="voicemail/vm-press.wav"/>
+        <action function="say" data="$7" method="pronounced" type="name_spelled"/>
       </match>
     </input>
   </macro>

--- a/app/switch/resources/conf/languages/pt/vm/voicemail.xml
+++ b/app/switch/resources/conf/languages/pt/vm/voicemail.xml
@@ -256,4 +256,12 @@
     </input>
   </macro>
 
+  <macro name="voicemail_invalid_option">
+   <input>
+      <match>
+        <action function="play-file" data="ivr/ivr-that_was_an_invalid_entry.wav"/>
+      </match>
+   </input>
+  </macro>
+
 </include>

--- a/app/switch/resources/conf/languages/pt/vm/voicemail.xml
+++ b/app/switch/resources/conf/languages/pt/vm/voicemail.xml
@@ -40,7 +40,7 @@
 
   <!-- similar to voicemail_listen_file_check in vm/sounds.xml, but maintains previous order -->
   <macro name="voicemail_listen_file_options">
-    <input pattern="^([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):(.*)$">
+    <input pattern="^([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):(.*)$">
       <match>
         <action function="play-file" data="voicemail/vm-listen_to_recording.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
@@ -60,12 +60,9 @@
         <action function="play-file" data="voicemail/vm-to_forward.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
         <action function="say" data="$6" method="pronounced" type="name_spelled"/>
-        <action function="play-file" data="voicemail/vm-forward_to_email.wav"/>
-        <action function="play-file" data="voicemail/vm-press.wav"/>
-        <action function="say" data="$7" method="pronounced" type="name_spelled"/>
       </match>
     </input>
-    <input pattern="^deleted:([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):(.*)$">
+    <input pattern="^deleted:([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):(.*)$">
       <match>
         <action function="play-file" data="voicemail/vm-listen_to_recording.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
@@ -85,9 +82,6 @@
         <action function="play-file" data="voicemail/vm-to_forward.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
         <action function="say" data="$6" method="pronounced" type="name_spelled"/>
-        <action function="play-file" data="voicemail/vm-forward_to_email.wav"/>
-        <action function="play-file" data="voicemail/vm-press.wav"/>
-        <action function="say" data="$7" method="pronounced" type="name_spelled"/>
       </match>
     </input>
   </macro>
@@ -237,6 +231,19 @@
         <action function="play-file" data="voicemail/vm-press.wav"/>
         <action function="say" data="$1" method="pronounced" type="name_spelled"/>
         <action function="play-file" data="voicemail/vm-save_message.wav"/>
+        <action function="play-file" data="voicemail/vm-press.wav"/>
+        <action function="say" data="$2" method="pronounced" type="name_spelled"/>
+      </match>
+    </input>
+  </macro>
+
+  <macro name="voicemail_forward_message_options">
+    <input pattern="^([0-9#*]):(.*)$">
+      <match>
+        <action function="play-file" data="voicemail/vm-to_forward.wav"/>
+        <action function="play-file" data="voicemail/vm-press.wav"/>
+        <action function="say" data="$1" method="pronounced" type="name_spelled"/>
+        <action function="play-file" data="voicemail/vm-forward_to_email.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
         <action function="say" data="$2" method="pronounced" type="name_spelled"/>
       </match>

--- a/app/switch/resources/conf/languages/pt/vm/voicemail.xml
+++ b/app/switch/resources/conf/languages/pt/vm/voicemail.xml
@@ -40,7 +40,7 @@
 
   <!-- similar to voicemail_listen_file_check in vm/sounds.xml, but maintains previous order -->
   <macro name="voicemail_listen_file_options">
-    <input pattern="^([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):(.*)$">
+    <input pattern="^([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):(.*)$">
       <match>
         <action function="play-file" data="voicemail/vm-listen_to_recording.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
@@ -60,9 +60,12 @@
         <action function="play-file" data="voicemail/vm-to_forward.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
         <action function="say" data="$6" method="pronounced" type="name_spelled"/>
+        <action function="play-file" data="voicemail/vm-play_next_message.wav"/>
+        <action function="play-file" data="voicemail/vm-press.wav"/>
+        <action function="say" data="$7" method="pronounced" type="name_spelled"/>
       </match>
     </input>
-    <input pattern="^deleted:([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):(.*)$">
+    <input pattern="^deleted:([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):(.*)$">
       <match>
         <action function="play-file" data="voicemail/vm-listen_to_recording.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
@@ -82,6 +85,9 @@
         <action function="play-file" data="voicemail/vm-to_forward.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
         <action function="say" data="$6" method="pronounced" type="name_spelled"/>
+        <action function="play-file" data="voicemail/vm-play_next_message.wav"/>
+        <action function="play-file" data="voicemail/vm-press.wav"/>
+        <action function="say" data="$7" method="pronounced" type="name_spelled"/>
       </match>
     </input>
   </macro>

--- a/app/switch/resources/conf/languages/ro/vm/voicemail.xml
+++ b/app/switch/resources/conf/languages/ro/vm/voicemail.xml
@@ -256,4 +256,12 @@
     </input>
   </macro>
 
+  <macro name="voicemail_invalid_option">
+   <input>
+      <match>
+        <action function="play-file" data="ivr/ivr-that_was_an_invalid_entry.wav"/>
+      </match>
+   </input>
+  </macro>
+
 </include>

--- a/app/switch/resources/conf/languages/ro/vm/voicemail.xml
+++ b/app/switch/resources/conf/languages/ro/vm/voicemail.xml
@@ -40,7 +40,7 @@
 
   <!-- similar to voicemail_listen_file_check in vm/sounds.xml, but maintains previous order -->
   <macro name="voicemail_listen_file_options">
-    <input pattern="^([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):(.*)$">
+    <input pattern="^([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):(.*)$">
       <match>
         <action function="play-file" data="voicemail/vm-listen_to_recording.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
@@ -60,12 +60,9 @@
         <action function="play-file" data="voicemail/vm-to_forward.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
         <action function="say" data="$6" method="pronounced" type="name_spelled"/>
-        <action function="play-file" data="voicemail/vm-forward_to_email.wav"/>
-        <action function="play-file" data="voicemail/vm-press.wav"/>
-        <action function="say" data="$7" method="pronounced" type="name_spelled"/>
       </match>
     </input>
-    <input pattern="^deleted:([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):(.*)$">
+    <input pattern="^deleted:([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):(.*)$">
       <match>
         <action function="play-file" data="voicemail/vm-listen_to_recording.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
@@ -85,9 +82,6 @@
         <action function="play-file" data="voicemail/vm-to_forward.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
         <action function="say" data="$6" method="pronounced" type="name_spelled"/>
-        <action function="play-file" data="voicemail/vm-forward_to_email.wav"/>
-        <action function="play-file" data="voicemail/vm-press.wav"/>
-        <action function="say" data="$7" method="pronounced" type="name_spelled"/>
       </match>
     </input>
   </macro>
@@ -237,6 +231,19 @@
         <action function="play-file" data="voicemail/vm-press.wav"/>
         <action function="say" data="$1" method="pronounced" type="name_spelled"/>
         <action function="play-file" data="voicemail/vm-save_message.wav"/>
+        <action function="play-file" data="voicemail/vm-press.wav"/>
+        <action function="say" data="$2" method="pronounced" type="name_spelled"/>
+      </match>
+    </input>
+  </macro>
+
+  <macro name="voicemail_forward_message_options">
+    <input pattern="^([0-9#*]):(.*)$">
+      <match>
+        <action function="play-file" data="voicemail/vm-to_forward.wav"/>
+        <action function="play-file" data="voicemail/vm-press.wav"/>
+        <action function="say" data="$1" method="pronounced" type="name_spelled"/>
+        <action function="play-file" data="voicemail/vm-forward_to_email.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
         <action function="say" data="$2" method="pronounced" type="name_spelled"/>
       </match>

--- a/app/switch/resources/conf/languages/ro/vm/voicemail.xml
+++ b/app/switch/resources/conf/languages/ro/vm/voicemail.xml
@@ -40,7 +40,7 @@
 
   <!-- similar to voicemail_listen_file_check in vm/sounds.xml, but maintains previous order -->
   <macro name="voicemail_listen_file_options">
-    <input pattern="^([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):(.*)$">
+    <input pattern="^([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):(.*)$">
       <match>
         <action function="play-file" data="voicemail/vm-listen_to_recording.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
@@ -60,9 +60,12 @@
         <action function="play-file" data="voicemail/vm-to_forward.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
         <action function="say" data="$6" method="pronounced" type="name_spelled"/>
+        <action function="play-file" data="voicemail/vm-play_next_message.wav"/>
+        <action function="play-file" data="voicemail/vm-press.wav"/>
+        <action function="say" data="$7" method="pronounced" type="name_spelled"/>
       </match>
     </input>
-    <input pattern="^deleted:([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):(.*)$">
+    <input pattern="^deleted:([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):(.*)$">
       <match>
         <action function="play-file" data="voicemail/vm-listen_to_recording.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
@@ -82,6 +85,9 @@
         <action function="play-file" data="voicemail/vm-to_forward.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
         <action function="say" data="$6" method="pronounced" type="name_spelled"/>
+        <action function="play-file" data="voicemail/vm-play_next_message.wav"/>
+        <action function="play-file" data="voicemail/vm-press.wav"/>
+        <action function="say" data="$7" method="pronounced" type="name_spelled"/>
       </match>
     </input>
   </macro>

--- a/app/switch/resources/conf/languages/ru/vm/voicemail.xml
+++ b/app/switch/resources/conf/languages/ru/vm/voicemail.xml
@@ -256,4 +256,12 @@
     </input>
   </macro>
 
+  <macro name="voicemail_invalid_option">
+   <input>
+      <match>
+        <action function="play-file" data="ivr/ivr-that_was_an_invalid_entry.wav"/>
+      </match>
+   </input>
+  </macro>
+
 </include>

--- a/app/switch/resources/conf/languages/ru/vm/voicemail.xml
+++ b/app/switch/resources/conf/languages/ru/vm/voicemail.xml
@@ -40,7 +40,7 @@
 
   <!-- similar to voicemail_listen_file_check in vm/sounds.xml, but maintains previous order -->
   <macro name="voicemail_listen_file_options">
-    <input pattern="^([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):(.*)$">
+    <input pattern="^([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):(.*)$">
       <match>
         <action function="play-file" data="voicemail/vm-listen_to_recording.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
@@ -60,12 +60,9 @@
         <action function="play-file" data="voicemail/vm-to_forward.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
         <action function="say" data="$6" method="pronounced" type="name_spelled"/>
-        <action function="play-file" data="voicemail/vm-forward_to_email.wav"/>
-        <action function="play-file" data="voicemail/vm-press.wav"/>
-        <action function="say" data="$7" method="pronounced" type="name_spelled"/>
       </match>
     </input>
-    <input pattern="^deleted:([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):(.*)$">
+    <input pattern="^deleted:([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):(.*)$">
       <match>
         <action function="play-file" data="voicemail/vm-listen_to_recording.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
@@ -85,9 +82,6 @@
         <action function="play-file" data="voicemail/vm-to_forward.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
         <action function="say" data="$6" method="pronounced" type="name_spelled"/>
-        <action function="play-file" data="voicemail/vm-forward_to_email.wav"/>
-        <action function="play-file" data="voicemail/vm-press.wav"/>
-        <action function="say" data="$7" method="pronounced" type="name_spelled"/>
       </match>
     </input>
   </macro>
@@ -237,6 +231,19 @@
         <action function="play-file" data="voicemail/vm-press.wav"/>
         <action function="say" data="$1" method="pronounced" type="name_spelled"/>
         <action function="play-file" data="voicemail/vm-save_message.wav"/>
+        <action function="play-file" data="voicemail/vm-press.wav"/>
+        <action function="say" data="$2" method="pronounced" type="name_spelled"/>
+      </match>
+    </input>
+  </macro>
+
+  <macro name="voicemail_forward_message_options">
+    <input pattern="^([0-9#*]):(.*)$">
+      <match>
+        <action function="play-file" data="voicemail/vm-to_forward.wav"/>
+        <action function="play-file" data="voicemail/vm-press.wav"/>
+        <action function="say" data="$1" method="pronounced" type="name_spelled"/>
+        <action function="play-file" data="voicemail/vm-forward_to_email.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
         <action function="say" data="$2" method="pronounced" type="name_spelled"/>
       </match>

--- a/app/switch/resources/conf/languages/ru/vm/voicemail.xml
+++ b/app/switch/resources/conf/languages/ru/vm/voicemail.xml
@@ -40,7 +40,7 @@
 
   <!-- similar to voicemail_listen_file_check in vm/sounds.xml, but maintains previous order -->
   <macro name="voicemail_listen_file_options">
-    <input pattern="^([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):(.*)$">
+    <input pattern="^([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):(.*)$">
       <match>
         <action function="play-file" data="voicemail/vm-listen_to_recording.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
@@ -60,9 +60,12 @@
         <action function="play-file" data="voicemail/vm-to_forward.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
         <action function="say" data="$6" method="pronounced" type="name_spelled"/>
+        <action function="play-file" data="voicemail/vm-play_next_message.wav"/>
+        <action function="play-file" data="voicemail/vm-press.wav"/>
+        <action function="say" data="$7" method="pronounced" type="name_spelled"/>
       </match>
     </input>
-    <input pattern="^deleted:([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):(.*)$">
+    <input pattern="^deleted:([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):(.*)$">
       <match>
         <action function="play-file" data="voicemail/vm-listen_to_recording.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
@@ -82,6 +85,9 @@
         <action function="play-file" data="voicemail/vm-to_forward.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
         <action function="say" data="$6" method="pronounced" type="name_spelled"/>
+        <action function="play-file" data="voicemail/vm-play_next_message.wav"/>
+        <action function="play-file" data="voicemail/vm-press.wav"/>
+        <action function="say" data="$7" method="pronounced" type="name_spelled"/>
       </match>
     </input>
   </macro>

--- a/app/switch/resources/conf/languages/sv/vm/voicemail.xml
+++ b/app/switch/resources/conf/languages/sv/vm/voicemail.xml
@@ -256,4 +256,12 @@
     </input>
   </macro>
 
+  <macro name="voicemail_invalid_option">
+   <input>
+      <match>
+        <action function="play-file" data="ivr/ivr-that_was_an_invalid_entry.wav"/>
+      </match>
+   </input>
+  </macro>
+
 </include>

--- a/app/switch/resources/conf/languages/sv/vm/voicemail.xml
+++ b/app/switch/resources/conf/languages/sv/vm/voicemail.xml
@@ -40,7 +40,7 @@
 
   <!-- similar to voicemail_listen_file_check in vm/sounds.xml, but maintains previous order -->
   <macro name="voicemail_listen_file_options">
-    <input pattern="^([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):(.*)$">
+    <input pattern="^([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):(.*)$">
       <match>
         <action function="play-file" data="voicemail/vm-listen_to_recording.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
@@ -60,12 +60,9 @@
         <action function="play-file" data="voicemail/vm-to_forward.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
         <action function="say" data="$6" method="pronounced" type="name_spelled"/>
-        <action function="play-file" data="voicemail/vm-forward_to_email.wav"/>
-        <action function="play-file" data="voicemail/vm-press.wav"/>
-        <action function="say" data="$7" method="pronounced" type="name_spelled"/>
       </match>
     </input>
-    <input pattern="^deleted:([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):(.*)$">
+    <input pattern="^deleted:([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):(.*)$">
       <match>
         <action function="play-file" data="voicemail/vm-listen_to_recording.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
@@ -85,9 +82,6 @@
         <action function="play-file" data="voicemail/vm-to_forward.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
         <action function="say" data="$6" method="pronounced" type="name_spelled"/>
-        <action function="play-file" data="voicemail/vm-forward_to_email.wav"/>
-        <action function="play-file" data="voicemail/vm-press.wav"/>
-        <action function="say" data="$7" method="pronounced" type="name_spelled"/>
       </match>
     </input>
   </macro>
@@ -237,6 +231,19 @@
         <action function="play-file" data="voicemail/vm-press.wav"/>
         <action function="say" data="$1" method="pronounced" type="name_spelled"/>
         <action function="play-file" data="voicemail/vm-save_message.wav"/>
+        <action function="play-file" data="voicemail/vm-press.wav"/>
+        <action function="say" data="$2" method="pronounced" type="name_spelled"/>
+      </match>
+    </input>
+  </macro>
+
+  <macro name="voicemail_forward_message_options">
+    <input pattern="^([0-9#*]):(.*)$">
+      <match>
+        <action function="play-file" data="voicemail/vm-to_forward.wav"/>
+        <action function="play-file" data="voicemail/vm-press.wav"/>
+        <action function="say" data="$1" method="pronounced" type="name_spelled"/>
+        <action function="play-file" data="voicemail/vm-forward_to_email.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
         <action function="say" data="$2" method="pronounced" type="name_spelled"/>
       </match>

--- a/app/switch/resources/conf/languages/sv/vm/voicemail.xml
+++ b/app/switch/resources/conf/languages/sv/vm/voicemail.xml
@@ -40,7 +40,7 @@
 
   <!-- similar to voicemail_listen_file_check in vm/sounds.xml, but maintains previous order -->
   <macro name="voicemail_listen_file_options">
-    <input pattern="^([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):(.*)$">
+    <input pattern="^([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):(.*)$">
       <match>
         <action function="play-file" data="voicemail/vm-listen_to_recording.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
@@ -60,9 +60,12 @@
         <action function="play-file" data="voicemail/vm-to_forward.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
         <action function="say" data="$6" method="pronounced" type="name_spelled"/>
+        <action function="play-file" data="voicemail/vm-play_next_message.wav"/>
+        <action function="play-file" data="voicemail/vm-press.wav"/>
+        <action function="say" data="$7" method="pronounced" type="name_spelled"/>
       </match>
     </input>
-    <input pattern="^deleted:([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):(.*)$">
+    <input pattern="^deleted:([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):(.*)$">
       <match>
         <action function="play-file" data="voicemail/vm-listen_to_recording.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
@@ -82,6 +85,9 @@
         <action function="play-file" data="voicemail/vm-to_forward.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
         <action function="say" data="$6" method="pronounced" type="name_spelled"/>
+        <action function="play-file" data="voicemail/vm-play_next_message.wav"/>
+        <action function="play-file" data="voicemail/vm-press.wav"/>
+        <action function="say" data="$7" method="pronounced" type="name_spelled"/>
       </match>
     </input>
   </macro>

--- a/app/switch/resources/conf/languages/tr/vm/voicemail.xml
+++ b/app/switch/resources/conf/languages/tr/vm/voicemail.xml
@@ -256,4 +256,12 @@
     </input>
   </macro>
 
+  <macro name="voicemail_invalid_option">
+   <input>
+      <match>
+        <action function="play-file" data="ivr/ivr-that_was_an_invalid_entry.wav"/>
+      </match>
+   </input>
+  </macro>
+
 </include>

--- a/app/switch/resources/conf/languages/tr/vm/voicemail.xml
+++ b/app/switch/resources/conf/languages/tr/vm/voicemail.xml
@@ -40,7 +40,7 @@
 
   <!-- similar to voicemail_listen_file_check in vm/sounds.xml, but maintains previous order -->
   <macro name="voicemail_listen_file_options">
-    <input pattern="^([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):(.*)$">
+    <input pattern="^([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):(.*)$">
       <match>
         <action function="play-file" data="voicemail/vm-listen_to_recording.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
@@ -60,12 +60,9 @@
         <action function="play-file" data="voicemail/vm-to_forward.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
         <action function="say" data="$6" method="pronounced" type="name_spelled"/>
-        <action function="play-file" data="voicemail/vm-forward_to_email.wav"/>
-        <action function="play-file" data="voicemail/vm-press.wav"/>
-        <action function="say" data="$7" method="pronounced" type="name_spelled"/>
       </match>
     </input>
-    <input pattern="^deleted:([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):(.*)$">
+    <input pattern="^deleted:([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):(.*)$">
       <match>
         <action function="play-file" data="voicemail/vm-listen_to_recording.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
@@ -85,9 +82,6 @@
         <action function="play-file" data="voicemail/vm-to_forward.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
         <action function="say" data="$6" method="pronounced" type="name_spelled"/>
-        <action function="play-file" data="voicemail/vm-forward_to_email.wav"/>
-        <action function="play-file" data="voicemail/vm-press.wav"/>
-        <action function="say" data="$7" method="pronounced" type="name_spelled"/>
       </match>
     </input>
   </macro>
@@ -237,6 +231,19 @@
         <action function="play-file" data="voicemail/vm-press.wav"/>
         <action function="say" data="$1" method="pronounced" type="name_spelled"/>
         <action function="play-file" data="voicemail/vm-save_message.wav"/>
+        <action function="play-file" data="voicemail/vm-press.wav"/>
+        <action function="say" data="$2" method="pronounced" type="name_spelled"/>
+      </match>
+    </input>
+  </macro>
+
+  <macro name="voicemail_forward_message_options">
+    <input pattern="^([0-9#*]):(.*)$">
+      <match>
+        <action function="play-file" data="voicemail/vm-to_forward.wav"/>
+        <action function="play-file" data="voicemail/vm-press.wav"/>
+        <action function="say" data="$1" method="pronounced" type="name_spelled"/>
+        <action function="play-file" data="voicemail/vm-forward_to_email.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
         <action function="say" data="$2" method="pronounced" type="name_spelled"/>
       </match>

--- a/app/switch/resources/conf/languages/tr/vm/voicemail.xml
+++ b/app/switch/resources/conf/languages/tr/vm/voicemail.xml
@@ -40,7 +40,7 @@
 
   <!-- similar to voicemail_listen_file_check in vm/sounds.xml, but maintains previous order -->
   <macro name="voicemail_listen_file_options">
-    <input pattern="^([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):(.*)$">
+    <input pattern="^([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):(.*)$">
       <match>
         <action function="play-file" data="voicemail/vm-listen_to_recording.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
@@ -60,9 +60,12 @@
         <action function="play-file" data="voicemail/vm-to_forward.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
         <action function="say" data="$6" method="pronounced" type="name_spelled"/>
+        <action function="play-file" data="voicemail/vm-play_next_message.wav"/>
+        <action function="play-file" data="voicemail/vm-press.wav"/>
+        <action function="say" data="$7" method="pronounced" type="name_spelled"/>
       </match>
     </input>
-    <input pattern="^deleted:([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):(.*)$">
+    <input pattern="^deleted:([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):(.*)$">
       <match>
         <action function="play-file" data="voicemail/vm-listen_to_recording.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
@@ -82,6 +85,9 @@
         <action function="play-file" data="voicemail/vm-to_forward.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
         <action function="say" data="$6" method="pronounced" type="name_spelled"/>
+        <action function="play-file" data="voicemail/vm-play_next_message.wav"/>
+        <action function="play-file" data="voicemail/vm-press.wav"/>
+        <action function="say" data="$7" method="pronounced" type="name_spelled"/>
       </match>
     </input>
   </macro>

--- a/app/switch/resources/conf/languages/uk/vm/voicemail.xml
+++ b/app/switch/resources/conf/languages/uk/vm/voicemail.xml
@@ -256,4 +256,12 @@
     </input>
   </macro>
 
+  <macro name="voicemail_invalid_option">
+   <input>
+      <match>
+        <action function="play-file" data="ivr/ivr-that_was_an_invalid_entry.wav"/>
+      </match>
+   </input>
+  </macro>
+
 </include>

--- a/app/switch/resources/conf/languages/uk/vm/voicemail.xml
+++ b/app/switch/resources/conf/languages/uk/vm/voicemail.xml
@@ -40,7 +40,7 @@
 
   <!-- similar to voicemail_listen_file_check in vm/sounds.xml, but maintains previous order -->
   <macro name="voicemail_listen_file_options">
-    <input pattern="^([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):(.*)$">
+    <input pattern="^([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):(.*)$">
       <match>
         <action function="play-file" data="voicemail/vm-listen_to_recording.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
@@ -60,12 +60,9 @@
         <action function="play-file" data="voicemail/vm-to_forward.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
         <action function="say" data="$6" method="pronounced" type="name_spelled"/>
-        <action function="play-file" data="voicemail/vm-forward_to_email.wav"/>
-        <action function="play-file" data="voicemail/vm-press.wav"/>
-        <action function="say" data="$7" method="pronounced" type="name_spelled"/>
       </match>
     </input>
-    <input pattern="^deleted:([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):(.*)$">
+    <input pattern="^deleted:([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):(.*)$">
       <match>
         <action function="play-file" data="voicemail/vm-listen_to_recording.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
@@ -85,9 +82,6 @@
         <action function="play-file" data="voicemail/vm-to_forward.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
         <action function="say" data="$6" method="pronounced" type="name_spelled"/>
-        <action function="play-file" data="voicemail/vm-forward_to_email.wav"/>
-        <action function="play-file" data="voicemail/vm-press.wav"/>
-        <action function="say" data="$7" method="pronounced" type="name_spelled"/>
       </match>
     </input>
   </macro>
@@ -237,6 +231,19 @@
         <action function="play-file" data="voicemail/vm-press.wav"/>
         <action function="say" data="$1" method="pronounced" type="name_spelled"/>
         <action function="play-file" data="voicemail/vm-save_message.wav"/>
+        <action function="play-file" data="voicemail/vm-press.wav"/>
+        <action function="say" data="$2" method="pronounced" type="name_spelled"/>
+      </match>
+    </input>
+  </macro>
+
+  <macro name="voicemail_forward_message_options">
+    <input pattern="^([0-9#*]):(.*)$">
+      <match>
+        <action function="play-file" data="voicemail/vm-to_forward.wav"/>
+        <action function="play-file" data="voicemail/vm-press.wav"/>
+        <action function="say" data="$1" method="pronounced" type="name_spelled"/>
+        <action function="play-file" data="voicemail/vm-forward_to_email.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
         <action function="say" data="$2" method="pronounced" type="name_spelled"/>
       </match>

--- a/app/switch/resources/conf/languages/uk/vm/voicemail.xml
+++ b/app/switch/resources/conf/languages/uk/vm/voicemail.xml
@@ -40,7 +40,7 @@
 
   <!-- similar to voicemail_listen_file_check in vm/sounds.xml, but maintains previous order -->
   <macro name="voicemail_listen_file_options">
-    <input pattern="^([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):(.*)$">
+    <input pattern="^([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):(.*)$">
       <match>
         <action function="play-file" data="voicemail/vm-listen_to_recording.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
@@ -60,9 +60,12 @@
         <action function="play-file" data="voicemail/vm-to_forward.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
         <action function="say" data="$6" method="pronounced" type="name_spelled"/>
+        <action function="play-file" data="voicemail/vm-play_next_message.wav"/>
+        <action function="play-file" data="voicemail/vm-press.wav"/>
+        <action function="say" data="$7" method="pronounced" type="name_spelled"/>
       </match>
     </input>
-    <input pattern="^deleted:([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):(.*)$">
+    <input pattern="^deleted:([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):([0-9#*]):(.*)$">
       <match>
         <action function="play-file" data="voicemail/vm-listen_to_recording.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
@@ -82,6 +85,9 @@
         <action function="play-file" data="voicemail/vm-to_forward.wav"/>
         <action function="play-file" data="voicemail/vm-press.wav"/>
         <action function="say" data="$6" method="pronounced" type="name_spelled"/>
+        <action function="play-file" data="voicemail/vm-play_next_message.wav"/>
+        <action function="play-file" data="voicemail/vm-press.wav"/>
+        <action function="say" data="$7" method="pronounced" type="name_spelled"/>
       </match>
     </input>
   </macro>

--- a/app/switch/resources/scripts/app/ring_groups/index.lua
+++ b/app/switch/resources/scripts/app/ring_groups/index.lua
@@ -26,6 +26,7 @@
 --	Contributor(s):
 --	Mark J Crane <markjcrane@fusionpbx.com>
 --  Gill Abada <gill.abada@gmail.com>
+--	Norman King <norman@nsinnovations.net>
 
 --include the log
 	log = require "resources.functions.log".ring_group
@@ -323,6 +324,7 @@
 	end
 
 --set exit key action
+	exit_key_bound = false;
 	if (ring_group_timeout_app and #ring_group_timeout_app > 0 and ring_group_timeout_data and #ring_group_timeout_data > 0) then
 		if (not ring_group_exit_key or #ring_group_exit_key == 0) then
 			--use a default exit key of 9
@@ -331,6 +333,7 @@
 
 		--use the user defined or default exit key
 		session:execute("bind_digit_action", "exit_key,"..ring_group_exit_key..",exec:"..ring_group_timeout_app..","..ring_group_timeout_data..",both,self");
+		exit_key_bound = true;
 	end
 
 --play the greeting
@@ -1303,6 +1306,14 @@
 							end
 						end
 						-- log.noticef("bridge done: originate_disposition:%s answered:%s ready:%s bridged:%s", session:getVariable("originate_disposition"), session:answered() and "true" or "false", session:ready() and "true" or "false", session:bridged() and "true" or "false")
+					end
+
+				--release the exit key binding and return to the feature key realm so the exit
+				--key is not intercepted by the destination the call is sent to
+					if (exit_key_bound) then
+						session:execute("clear_digit_action", "exit_key,both");
+						session:execute("digit_action_set_realm", "local");
+						session:execute("digit_action_set_realm", "local,peer");
 					end
 
 				--timeout destination

--- a/app/switch/resources/scripts/app/ring_groups/index.lua
+++ b/app/switch/resources/scripts/app/ring_groups/index.lua
@@ -332,7 +332,7 @@
 		end
 
 		--use the user defined or default exit key
-		session:execute("bind_digit_action", "exit_key,"..ring_group_exit_key..",exec:"..ring_group_timeout_app..","..ring_group_timeout_data..",both,self");
+		session:execute("bind_digit_action", "exit_key,"..ring_group_exit_key..",exec:"..ring_group_timeout_app..","..ring_group_timeout_data..",self,self");
 		exit_key_bound = true;
 	end
 
@@ -1229,6 +1229,14 @@
 					end
 					session:execute("digit_action_set_realm", "local");
 
+				--select the exit key realm for the ring and return to the feature key realm
+				--when the call is answered, only one realm can be active at a time
+					if (exit_key_bound) then
+						session:execute("digit_action_set_realm", "exit_key");
+						session:setVariable("bridge_pre_execute_aleg_app", "digit_action_set_realm");
+						session:setVariable("bridge_pre_execute_aleg_data", "local");
+					end
+
 				--if the user is busy rollover to the next destination
 					if (ring_group_strategy == "rollover") then
 						timeout = 0;
@@ -1311,9 +1319,8 @@
 				--release the exit key binding and return to the feature key realm so the exit
 				--key is not intercepted by the destination the call is sent to
 					if (exit_key_bound) then
-						session:execute("clear_digit_action", "exit_key,both");
+						session:execute("clear_digit_action", "exit_key");
 						session:execute("digit_action_set_realm", "local");
-						session:execute("digit_action_set_realm", "local,peer");
 					end
 
 				--timeout destination

--- a/app/switch/resources/scripts/app/voicemail/index.lua
+++ b/app/switch/resources/scripts/app/voicemail/index.lua
@@ -356,6 +356,7 @@
 	require "app.voicemail.resources.functions.record_menu";
 	require "app.voicemail.resources.functions.forward_add_intro";
 	require "app.voicemail.resources.functions.forward_to_extension";
+	require "app.voicemail.resources.functions.forward_message";
 	require "app.voicemail.resources.functions.main_menu";
 	require "app.voicemail.resources.functions.listen_to_recording";
 	require "app.voicemail.resources.functions.message_waiting";

--- a/app/switch/resources/scripts/app/voicemail/resources/functions/forward_message.lua
+++ b/app/switch/resources/scripts/app/voicemail/resources/functions/forward_message.lua
@@ -1,0 +1,52 @@
+--	Part of FusionPBX
+--	Copyright (C) 2026 Mark J Crane <markjcrane@fusionpbx.com>
+--	All rights reserved.
+--
+--	Redistribution and use in source and binary forms, with or without
+--	modification, are permitted provided that the following conditions are met:
+--
+--	1. Redistributions of source code must retain the above copyright notice,
+--	  this list of conditions and the following disclaimer.
+--
+--	2. Redistributions in binary form must reproduce the above copyright
+--	  notice, this list of conditions and the following disclaimer in the
+--	  documentation and/or other materials provided with the distribution.
+--
+--	THIS SOFTWARE IS PROVIDED ''AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+--	INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+--	AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+--	AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+--	OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+--	SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+--	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+--	CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+--	ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+--	POSSIBILITY OF SUCH DAMAGE.
+
+--define a function to choose where to forward a message
+	function forward_message(voicemail_id, uuid)
+
+		--flush dtmf digits from the input buffer
+			session:flushDigits();
+
+		--to forward to another extension press 1, to forward to your email press 2
+			local action = '';
+			if (session:ready()) then
+				dtmf_digits = '';
+				action = session:playAndGetDigits(1, 1, max_tries, digit_timeout, "#", "phrase:voicemail_forward_message_options:1:2", "", "^[1-2]$");
+			end
+
+		--forward the message, anything else returns to the message options
+			if (session:ready()) then
+				if (action == "1") then
+					forward_to_extension(voicemail_id, uuid);
+				elseif (action == "2") then
+					send_email(voicemail_id, uuid);
+					session:streamFile("phrase:voicemail_ack:emailed");
+				end
+			end
+
+		--empty the buffer so the digit is not carried to the next message
+			dtmf_digits = '';
+
+	end

--- a/app/switch/resources/scripts/app/voicemail/resources/functions/listen_to_recording.lua
+++ b/app/switch/resources/scripts/app/voicemail/resources/functions/listen_to_recording.lua
@@ -247,9 +247,9 @@
 			if (session:ready()) then
 				if (string.len(dtmf_digits) == 0) then
 					if (use_deletion_queue == "true" and message_status == "deleted") then
-						dtmf_digits = session:playAndGetDigits(1, 1, max_tries, digit_timeout, "#", "phrase:voicemail_listen_file_options:deleted:1:2:3:5:7:8:9:0", "", "^[\\d\\*#]$");
+						dtmf_digits = session:playAndGetDigits(1, 1, max_tries, digit_timeout, "#", "phrase:voicemail_listen_file_options:deleted:1:2:3:5:7:8:0", "", "^[\\d\\*#]$");
 					else
-						dtmf_digits = session:playAndGetDigits(1, 1, max_tries, digit_timeout, "#", "phrase:voicemail_listen_file_options:1:2:3:5:7:8:9:0", "", "^[\\d\\*#]$");
+						dtmf_digits = session:playAndGetDigits(1, 1, max_tries, digit_timeout, "#", "phrase:voicemail_listen_file_options:1:2:3:5:7:8:0", "", "^[\\d\\*#]$");
 					end
 				end
 			end
@@ -299,12 +299,8 @@
 							message_waiting(voicemail_id_copy, domain_uuid);
 						end
 				elseif (action == "8") then
-					forward_to_extension(voicemail_id, uuid);
+					forward_message(voicemail_id, uuid);
 					dtmf_digits = '';
-				elseif (action == "9") then
-					send_email(voicemail_id, uuid);
-					dtmf_digits = '';
-					session:streamFile("phrase:voicemail_ack:emailed");
 				elseif (action == "*") then
 					timeouts = 0;
 					return main_menu();

--- a/app/switch/resources/scripts/app/voicemail/resources/functions/listen_to_recording.lua
+++ b/app/switch/resources/scripts/app/voicemail/resources/functions/listen_to_recording.lua
@@ -247,9 +247,9 @@
 			if (session:ready()) then
 				if (string.len(dtmf_digits) == 0) then
 					if (use_deletion_queue == "true" and message_status == "deleted") then
-						dtmf_digits = session:playAndGetDigits(1, 1, max_tries, digit_timeout, "#", "phrase:voicemail_listen_file_options:deleted:1:2:3:5:7:8:0", "", "^[\\d\\*#]$");
+						dtmf_digits = session:playAndGetDigits(1, 1, max_tries, digit_timeout, "#", "phrase:voicemail_listen_file_options:deleted:1:2:3:5:7:8:9:0", "", "^[\\d\\*#]$");
 					else
-						dtmf_digits = session:playAndGetDigits(1, 1, max_tries, digit_timeout, "#", "phrase:voicemail_listen_file_options:1:2:3:5:7:8:0", "", "^[\\d\\*#]$");
+						dtmf_digits = session:playAndGetDigits(1, 1, max_tries, digit_timeout, "#", "phrase:voicemail_listen_file_options:1:2:3:5:7:8:9:0", "", "^[\\d\\*#]$");
 					end
 				end
 			end
@@ -300,6 +300,9 @@
 						end
 				elseif (action == "8") then
 					forward_message(voicemail_id, uuid);
+					dtmf_digits = '';
+				elseif (action == "9") then
+					--skip to the next message, leaving the message status unchanged
 					dtmf_digits = '';
 				elseif (action == "*") then
 					timeouts = 0;

--- a/app/switch/resources/scripts/app/voicemail/resources/functions/listen_to_recording.lua
+++ b/app/switch/resources/scripts/app/voicemail/resources/functions/listen_to_recording.lua
@@ -30,14 +30,20 @@
 	function listen_to_recording(message_number, uuid, created_epoch, caller_id_name, caller_id_number, message_status, message_play)
 
 		--set default values
-			dtmf_digits = '';
 			max_digits = 1;
 			if (message_play == nil) then
 				message_play = 'true';
 			end
 
-		--flush dtmf digits from the input buffer
-			session:flushDigits();
+		--act on the digit pressed during the previous acknowledgement, otherwise
+		--start with an empty buffer and discard anything typed before this message
+			if (dtmf_carry ~= nil and string.len(dtmf_carry) > 0) then
+				dtmf_digits = dtmf_carry;
+				dtmf_carry = '';
+			else
+				dtmf_digits = '';
+				session:flushDigits();
+			end
 
 		--set the callback function
 			if (session:ready()) then
@@ -257,24 +263,30 @@
 
 		--process the dtmf
 			if (session:ready()) then
-				if (dtmf_digits == "1") then
+				--keep the action then empty the buffer so that a digit pressed during the
+				--acknowledgement is carried to the next message instead of being discarded
+					local action = dtmf_digits;
+					dtmf_digits = '';
+
+				if (action == "1") then
 					return listen_to_recording(message_number, uuid, created_epoch, caller_id_name, caller_id_number, message_status);
-				elseif (dtmf_digits == "2") then
+				elseif (action == "2") then
 					message_saved(voicemail_id, uuid);
 					session:streamFile("phrase:voicemail_ack:saved");
-				elseif (dtmf_digits == "3") then
+				elseif (action == "3") then
 					session:streamFile(sounds_dir.."/"..default_language.."/"..default_dialect.."/"..default_voice.."/voicemail/vm-from.wav");
 					session:say(caller_id_number, default_language, "name_spelled", "iterated");
 					if (current_time_zone ~= nil) then
 						session:execute("set", "timezone="..current_time_zone.."");
 					end
 					session:say(created_epoch, default_language, "current_date_time", "pronounced");
-					session:execute("sleep", "1000");
+					session:sleep(1000);
+					dtmf_carry = dtmf_digits;
 					return listen_to_recording(message_number, uuid, created_epoch, caller_id_name, caller_id_number, message_status, 'false');
-				elseif (dtmf_digits == "5") then
+				elseif (action == "5") then
 					message_saved(voicemail_id, uuid);
 					return_call(caller_id_number);
-				elseif (dtmf_digits == "7") then
+				elseif (action == "7") then
 					if (use_deletion_queue == "true" and message_status ~= "deleted") then
 						message_saved(voicemail_id, uuid, "deleted");
 						session:streamFile("phrase:voicemail_ack:deleted");
@@ -286,25 +298,34 @@
 						if (voicemail_id_copy ~= voicemail_id  and voicemail_id_copy ~= nil) then
 							message_waiting(voicemail_id_copy, domain_uuid);
 						end
-				elseif (dtmf_digits == "8") then
+				elseif (action == "8") then
 					forward_to_extension(voicemail_id, uuid);
 					dtmf_digits = '';
-				elseif (dtmf_digits == "9") then
+				elseif (action == "9") then
 					send_email(voicemail_id, uuid);
 					dtmf_digits = '';
 					session:streamFile("phrase:voicemail_ack:emailed");
-				elseif (dtmf_digits == "*") then
+				elseif (action == "*") then
 					timeouts = 0;
 					return main_menu();
-				elseif (dtmf_digits == "0") then
+				elseif (action == "0") then
 					message_saved(voicemail_id, uuid);
 					session:transfer("0", "XML", context);
-				elseif (dtmf_digits == "#") then
+				elseif (action == "#") then
 					return;
 				else
 					message_saved(voicemail_id, uuid);
 					session:streamFile("phrase:voicemail_ack:saved");
 				end
-				session:execute("sleep", "400");
+				session:sleep(400);
+
+				--carry the digit pressed during the acknowledgement to the next message,
+				--except 5 which would return the call to the next caller rather than this one
+					if (dtmf_digits == "5") then
+						dtmf_carry = '';
+					else
+						dtmf_carry = dtmf_digits;
+					end
+					dtmf_digits = '';
 			end
 	end

--- a/app/switch/resources/scripts/app/voicemail/resources/functions/listen_to_recording.lua
+++ b/app/switch/resources/scripts/app/voicemail/resources/functions/listen_to_recording.lua
@@ -269,6 +269,7 @@
 					dtmf_digits = '';
 
 				if (action == "1") then
+					timeouts = 0;
 					return listen_to_recording(message_number, uuid, created_epoch, caller_id_name, caller_id_number, message_status);
 				elseif (action == "2") then
 					message_saved(voicemail_id, uuid);
@@ -281,6 +282,7 @@
 					end
 					session:say(created_epoch, default_language, "current_date_time", "pronounced");
 					session:sleep(1000);
+					timeouts = 0;
 					dtmf_carry = dtmf_digits;
 					return listen_to_recording(message_number, uuid, created_epoch, caller_id_name, caller_id_number, message_status, 'false');
 				elseif (action == "5") then
@@ -312,10 +314,24 @@
 					session:transfer("0", "XML", context);
 				elseif (action == "#") then
 					return;
+				elseif (action ~= '') then
+					--an unhandled key says the entry was invalid and replays the options,
+					--giving up after max_timeouts so the mailbox is never stuck on one message
+					timeouts = timeouts + 1;
+					if (timeouts <= max_timeouts) then
+						session:streamFile("phrase:voicemail_invalid_option");
+						dtmf_carry = dtmf_digits;
+						return listen_to_recording(message_number, uuid, created_epoch, caller_id_name, caller_id_number, message_status, 'false');
+					end
+					timeouts = 0;
+					message_saved(voicemail_id, uuid);
+					session:streamFile("phrase:voicemail_ack:saved");
 				else
+					--the options timed out with no key pressed
 					message_saved(voicemail_id, uuid);
 					session:streamFile("phrase:voicemail_ack:saved");
 				end
+				timeouts = 0;
 				session:sleep(400);
 
 				--carry the digit pressed during the acknowledgement to the next message,

--- a/app/switch/resources/scripts/app/voicemail/resources/functions/listen_to_recording.lua
+++ b/app/switch/resources/scripts/app/voicemail/resources/functions/listen_to_recording.lua
@@ -56,13 +56,17 @@
 				--say the message number
 					if (session:ready()) then
 						if (string.len(dtmf_digits) == 0) then
-							session:execute("playback", "phrase:voicemail_say_message_number:" .. message_status .. ":" .. message_number);
+							--keep 4, 5 and 6 as transport keys so they don't reach the menu
+							stream_seek = true;
+							session:streamFile("phrase:voicemail_say_message_number:" .. message_status .. ":" .. message_number);
+							stream_seek = false;
 						end
 					end
 
 				--say the caller id number first (default)
 					if (
 						session:ready() and
+						string.len(dtmf_digits) == 0 and
 						caller_id_number ~= nil and (
 							vm_say_caller_id_number == nil or
 							vm_say_caller_id_number == "true" or
@@ -257,7 +261,7 @@
 					return listen_to_recording(message_number, uuid, created_epoch, caller_id_name, caller_id_number, message_status);
 				elseif (dtmf_digits == "2") then
 					message_saved(voicemail_id, uuid);
-					session:execute("playback", "phrase:voicemail_ack:saved");
+					session:streamFile("phrase:voicemail_ack:saved");
 				elseif (dtmf_digits == "3") then
 					session:streamFile(sounds_dir.."/"..default_language.."/"..default_dialect.."/"..default_voice.."/voicemail/vm-from.wav");
 					session:say(caller_id_number, default_language, "name_spelled", "iterated");
@@ -273,7 +277,7 @@
 				elseif (dtmf_digits == "7") then
 					if (use_deletion_queue == "true" and message_status ~= "deleted") then
 						message_saved(voicemail_id, uuid, "deleted");
-						session:execute("playback", "phrase:voicemail_ack:deleted");
+						session:streamFile("phrase:voicemail_ack:deleted");
 					else
 						delete_recording(voicemail_id, uuid);
 					end
@@ -288,7 +292,7 @@
 				elseif (dtmf_digits == "9") then
 					send_email(voicemail_id, uuid);
 					dtmf_digits = '';
-					session:execute("playback", "phrase:voicemail_ack:emailed");
+					session:streamFile("phrase:voicemail_ack:emailed");
 				elseif (dtmf_digits == "*") then
 					timeouts = 0;
 					return main_menu();
@@ -299,7 +303,7 @@
 					return;
 				else
 					message_saved(voicemail_id, uuid);
-					session:execute("playback", "phrase:voicemail_ack:saved");
+					session:streamFile("phrase:voicemail_ack:saved");
 				end
 				session:execute("sleep", "400");
 			end

--- a/app/switch/resources/scripts/app/voicemail/resources/functions/menu_messages.lua
+++ b/app/switch/resources/scripts/app/voicemail/resources/functions/menu_messages.lua
@@ -34,6 +34,7 @@
 			timeout = 2000;
 		--clear the dtmf
 			dtmf_digits = '';
+			dtmf_carry = '';
 		--flush dtmf digits from the input buffer
 			--session:flushDigits();
 		--set the message number

--- a/app/switch/resources/scripts/app/xml_handler/resources/scripts/languages/languages.lua
+++ b/app/switch/resources/scripts/app/xml_handler/resources/scripts/languages/languages.lua
@@ -46,8 +46,8 @@
 
 --get the action
 	--action = params:getHeader("action");
-	language = params:getHeader("lang");
-	macro_name = params:getHeader("macro_name");
+	language = params:getHeader("lang") or '';
+	macro_name = params:getHeader("macro_name") or '';
 
 --get the cache
 	local cache = require "resources.functions.cache"


### PR DESCRIPTION
This is to fix a bug where if a ring group had an exit key set, the exit was not being cleared after transferring or timing out to another destination. If timing out to an IVR with a key mapping the same as the ring group exit key, the IVR key mapping would not work.

This pull request has been tested on 5.5, but not master.
