### PR TITLE
disables the NAT Proxy and AVPF (Audio/Video Profile with Feedback) and related settings

### DIFF
--- a/resources/templates/provision/linphone/default/{$address}.xml
+++ b/resources/templates/provision/linphone/default/{$address}.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<config xmlns="http://www.linphone.org/xsds/lpconfig.xsd"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.linphone.org/xsds/lpconfig.xsd lpconfig.xsd">
+<config xmlns="http://www.linphone.org/xsds/lpconfig.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.linphone.org/xsds/lpconfig.xsd lpconfig.xsd">
 	<section name="sip">
 		<entry name="default_proxy" overwrite="true">0</entry>
 	</section>

--- a/resources/templates/provision/linphone/default/{$address}.xml
+++ b/resources/templates/provision/linphone/default/{$address}.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<config xmlns="http://www.linphone.org/xsds/lpconfig.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.linphone.org/xsds/lpconfig.xsd lpconfig.xsd">
+<config xmlns="http://www.linphone.org/xsds/lpconfig.xsd"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://www.linphone.org/xsds/lpconfig.xsd lpconfig.xsd">
 	<section name="sip">
 		<entry name="default_proxy" overwrite="true">0</entry>
 	</section>
 	<section name="net">
-		<entry name="friendlist_subscription_enabled">0</entry>
-		<entry name="nat_policy_ref" overwrite="true">xrcNnzyREll46fF0</entry>
+		<entry name="friendlist_subscription_enabled" overwrite="true">0</entry>
 	</section>
 	<section name="misc">
 		<entry name="transient_provisioning" overwrite="true">0</entry>
-		<!-- apply remote provisioning only once-->
 	</section>
 	<section name="nat_policy_default_values">
-		<entry name="stun_server">stun.linphone.org</entry>
-		<entry name="protocols">stun,ice</entry>
+		<entry name="stun_server" overwrite="true">stun.linphone.org</entry>
+		<entry name="protocols" overwrite="true"></entry>
 	</section>
 	<section name="video">
 		<entry name="displaytype">MSQOGL</entry>
@@ -29,12 +29,9 @@
 	</section>
 {foreach $lines as $row}
 	<section name="nat_policy_{$row.line_number - 1}">
-		<entry name="ref">xrcNnzyREll46fF{$row.line_number - 1}</entry>
-	</section>
-	<section name="nat_policy_{$row.line_number - 1}">
 		<entry name="ref" overwrite="true">xrcNnzyREll46fF{$row.line_number - 1}</entry>
 		<entry name="stun_server" overwrite="true">stun.linphone.org</entry>
-		<entry name="protocols" overwrite="true">stun,ice</entry>
+		<entry name="protocols" overwrite="true"></entry>
 	</section>
 	<section name="auth_info_{$row.line_number - 1}" overwrite="true">
 		<entry name="username" overwrite="true">{$row.user_id}</entry>
@@ -43,20 +40,19 @@
 		<entry name="realm" overwrite="true">{$row.server_address}</entry>
 		<entry name="domain" overwrite="true">{$row.server_address}</entry>
 		<entry name="algorithm" overwrite="true">MD5</entry>
-		<entry name="available_algorithms">MD5</entry>
+		<entry name="available_algorithms" overwrite="true">MD5</entry>
 	</section>
 	<section name="proxy_{$row.line_number - 1}" overwrite="true">
-		<entry name="reg_proxy" overwrite="true">sip:{$row.user_id}@{$row.server_address}:{$row.sip_port};transport={$row.sip_transport}</entry>
-		<entry name="reg_identity" overwrite="true">"{$row.display_name}" sip:{$row.user_id}@{$row.server_address}:{$row.sip_port}</entry>
-		<entry name="reg_route" overwrite="true">sip:{$row.server_address}:{$row.sip_port}</entry>
+		<entry name="reg_proxy" overwrite="true">sip:{$row.server_address}:{$row.sip_port};transport={$row.sip_transport}</entry>
+		<entry name="reg_identity" overwrite="true">"{$row.display_name}" &lt;sip:{$row.user_id}@{$row.server_address}&gt;</entry>
 		<entry name="realm" overwrite="true">{$row.server_address}</entry>
 		<entry name="reg_expires" overwrite="true">{$row.register_expires}</entry>
 		<entry name="reg_sendregister" overwrite="true">1</entry>
 		<entry name="publish" overwrite="true">1</entry>
-		<entry name="avpf" overwrite="true">1</entry>
-		<entry name="avpf_rr_interval" overwrite="true">1</entry>
+		<entry name="avpf" overwrite="true">0</entry>
+		<entry name="avpf_rr_interval" overwrite="true">0</entry>
 		<entry name="nat_policy_ref" overwrite="true">xrcNnzyREll46fF{$row.line_number - 1}</entry>
-		<entry name="available_algorithms">MD5</entry>
+		<entry name="available_algorithms" overwrite="true">MD5</entry>
 	</section>
 {/foreach}
 </config>


### PR DESCRIPTION
I've had tons of NAT issues with Linphone, These changes make changing between networks more reliable and fixes the one way audio issue. This disables the NAT Proxy and AVPF (Audio/Video Profile with Feedback) and related settings