### PR TITLE
Update xml_cdr.php

### DIFF
--- a/app/xml_cdr/resources/classes/xml_cdr.php
+++ b/app/xml_cdr/resources/classes/xml_cdr.php
@@ -2153,7 +2153,7 @@ class xml_cdr {
 
 		//download the file
 		if ($record_file != '/' && file_exists($record_file)) {
-			ob_clean();
+			$fd = ob_clean();
 			$fd = fopen($record_file, "rb");
 			if ($this->binary) {
 				header("Content-Type: application/force-download");


### PR DESCRIPTION
ob_clean() causes race conditions while fopen read file. Storing ob_clean() return guarantee that finished and fopen will work without interference