### PR TITLE
Fix card div position

### DIFF
--- a/themes/default/css.php
+++ b/themes/default/css.php
@@ -2974,6 +2974,7 @@ else { //default: white
 			echo "box-shadow: none;\n";
 		}
 		?>
+		position: initial;
 		}
 
 		div.card:has(.datetimepicker),


### PR DESCRIPTION
Weird bug when copying a default setting while using inline or static menu_style, the confirmation modal was under the .card divs.

Fixed by overwriting bootstrap .card position style.