### PR TITLE
Fix Unicode characters in caller ID name

### DIFF
--- a/app/xml_cdr/resources/classes/xml_cdr.php
+++ b/app/xml_cdr/resources/classes/xml_cdr.php
@@ -704,7 +704,7 @@ class xml_cdr {
 			}
 
 			//sanitize the caller ID
-			$caller_id_name   = preg_replace('#[^a-zA-Z0-9\-.\#*@ ]#', '', $caller_id_name);
+			$caller_id_name   = preg_replace('#[^\p{L}\p{N}\-.\#*@ ]#u', '', $caller_id_name);
 			$caller_id_number = preg_replace('#[^0-9\-\#\*]#', '', $caller_id_number);
 
 			//get the extension_uuid and then add it to the database fields array


### PR DESCRIPTION
The XML CDR caller ID name sanitization currently only allows ASCII letters:

preg_replace('#[^a-zA-Z0-9\-.\#*@ ]#', '', $caller_id_name);

This causes valid Unicode characters to be removed from caller ID names before they are stored in the database.

Examples:

João -> Joo
José -> Jos
Márcia -> Mrcia
ramàlzén -> ramlzn

FreeSWITCH correctly provides these values as UTF-8 / URL encoded strings, but FusionPBX strips the accented characters during XML CDR processing.

This change updates the regular expression to use Unicode character properties:

preg_replace('#[^\p{L}\p{N}\-.\#*@ ]#u', '', $caller_id_name);

This preserves the existing sanitization behavior while allowing Unicode letters and numbers.

Tested with:

João José Márcia Conceição ramàlzén

PHP syntax validation also passes successfully.