### PR TITLE
Fix: assign default groups to active_call_whisper/active_call_barge permissions

### DIFF
--- a/app/operator_panel/app_config.php
+++ b/app/operator_panel/app_config.php
@@ -97,8 +97,12 @@
 	$apps[$x]['permissions'][$y]['groups'][] = "admin";
 	$y++;
 	$apps[$x]['permissions'][$y]['name'] = "active_call_whisper";
+	$apps[$x]['permissions'][$y]['groups'][] = "superadmin";
+	$apps[$x]['permissions'][$y]['groups'][] = "admin";
 	$y++;
 	$apps[$x]['permissions'][$y]['name'] = "active_call_barge";
+	$apps[$x]['permissions'][$y]['groups'][] = "superadmin";
+	$apps[$x]['permissions'][$y]['groups'][] = "admin";
 	$y++;
 
 // Tab visibility permissions


### PR DESCRIPTION
These two permissions had no default groups assigned in app_config.php, unlike every other operator_panel permission (which defaults to superadmin/admin). As a result permission::restore() never created a v_group_permissions row for them, so the Whisper and Barge buttons never appeared for any group — including superadmin — and could not be enabled without a manual database insert.